### PR TITLE
feat(B3): 引入步骤级 Patch 机制，支持重试耗尽后的局部最小修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ data/logs/
 htmlcov/
 .idea/
 .vscode/
+AGENTS.md

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -1,6 +1,30 @@
 from __future__ import annotations
 
-from src.models.contracts import ProteinDesignTask, Plan, PlanStep
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Set
+
+from src.models.contracts import (
+    PatchRequest,
+    Plan,
+    PlanPatch,
+    PlanPatchOp,
+    PlanPatchOpType,
+    PlanStep,
+    ProteinDesignTask,
+    StepResult,
+)
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """简化版工具定义，模拟 ProteinToolKG 节点"""
+
+    id: str
+    capabilities: Sequence[str]
+    inputs: Sequence[str]
+    outputs: Sequence[str]
+    cost: int = 1
+    safety_level: int = 1
 
 
 class PlannerAgent:
@@ -9,6 +33,10 @@ class PlannerAgent:
     当前实现：固定生成一个单步计划，调用 dummy_tool
     后续将接入 KG 和 LLM 实现智能规划
     """
+
+    def __init__(self, tool_registry: Iterable[ToolSpec] | None = None) -> None:
+        # 允许注入自定义 registry，便于测试；默认使用内置 dummy 列表
+        self._tool_registry: List[ToolSpec] = list(tool_registry or _DEFAULT_TOOL_REGISTRY)
 
     def plan(self, task: ProteinDesignTask) -> Plan:
         """生成执行计划
@@ -39,3 +67,140 @@ class PlannerAgent:
             constraints=task.constraints,
             metadata={},
         )
+
+    # --- B3: 局部 Patch ---
+    def patch(self, request: PatchRequest) -> PlanPatch:
+        """基于 PatchRequest 生成最小 replace_step PlanPatch
+
+        策略（最小可用版）：
+        1. 锁定最近失败的 step 作为 target
+        2. 读取 target 对应的工具能力与输入需求
+        3. 在 registry 中筛选能力相同、输入可满足、成本/安全更优的候选
+        4. 选最优候选生成 replace_step PlanPatch，保持 step.id 不变
+        """
+        _ensure_task_match(request)
+        target_step = _locate_target_step(request)
+        target_spec = _find_tool_spec(self._tool_registry, target_step.tool)
+
+        available_inputs = _collect_available_inputs(request.context_step_results, target_step)
+        candidate = _select_candidate(
+            registry=self._tool_registry,
+            capability=target_spec.capabilities[0] if target_spec.capabilities else "",
+            available_inputs=available_inputs,
+            exclude_tool=target_step.tool,
+        )
+
+        patched_step = target_step.model_copy(
+            update={
+                "tool": candidate.id,
+                # 追加简单元数据，便于调试
+                "metadata": {**(target_step.metadata or {}), "patched_from": target_step.tool},
+            },
+            deep=True,
+        )
+        op = PlanPatchOp(
+            op="replace_step",
+            target=target_step.id,
+            step=patched_step,
+        )
+        return PlanPatch(task_id=request.task_id, operations=[op], metadata={"strategy": "cost_first"})
+
+
+# --- helpers ---
+
+def _ensure_task_match(request: PatchRequest) -> None:
+    if request.task_id != request.original_plan.task_id:
+        raise ValueError(
+            f"PatchRequest.task_id ({request.task_id}) does not match Plan.task_id ({request.original_plan.task_id})"
+        )
+
+
+def _locate_target_step(request: PatchRequest) -> PlanStep:
+    failed_ids = [
+        r.step_id for r in request.context_step_results if r.status == "failed"
+    ]
+    target_id = failed_ids[-1] if failed_ids else request.original_plan.steps[-1].id
+    for step in request.original_plan.steps:
+        if step.id == target_id:
+            return step
+    raise ValueError(f"Target step '{target_id}' not found in original plan")
+
+
+def _find_tool_spec(registry: Sequence[ToolSpec], tool_id: str) -> ToolSpec:
+    for spec in registry:
+        if spec.id == tool_id:
+            return spec
+    raise ValueError(f"Tool '{tool_id}' not found in registry")
+
+
+def _collect_available_inputs(results: Sequence[StepResult], target_step: PlanStep) -> Set[str]:
+    available: Set[str] = set()
+    for r in results:
+        available.update(r.outputs.keys())
+
+    # 解析 target_step 的输入引用/字面量，估计需要的字段
+    for val in target_step.inputs.values():
+        if isinstance(val, str) and "." in val:
+            _, field = val.split(".", 1)
+            available.add(field)
+        elif isinstance(val, str):
+            available.add(val)
+        else:
+            # 字面量键也可视为可用
+            pass
+    # 键名本身代表用户提供的输入
+    available.update(target_step.inputs.keys())
+    return available
+
+
+def _select_candidate(
+    registry: Sequence[ToolSpec],
+    capability: str,
+    available_inputs: Set[str],
+    exclude_tool: str,
+) -> ToolSpec:
+    candidates: List[ToolSpec] = []
+    for spec in registry:
+        if spec.id == exclude_tool:
+            continue
+        if capability and capability not in spec.capabilities:
+            continue
+        if not set(spec.inputs).issubset(available_inputs):
+            continue
+        candidates.append(spec)
+
+    if not candidates:
+        raise ValueError(f"No alternative tool found for capability '{capability}' with inputs {sorted(available_inputs)}")
+
+    # 简化策略：按 cost 优先，其次 safety_level
+    candidates.sort(key=lambda t: (t.cost, t.safety_level, t.id))
+    return candidates[0]
+
+
+# 默认工具注册表（可替换为 KG 查询）
+_DEFAULT_TOOL_REGISTRY: Sequence[ToolSpec] = (
+    ToolSpec(
+        id="dummy_tool",
+        capabilities=("design",),
+        inputs=("sequence",),
+        outputs=("dummy_output", "sequence"),
+        cost=5,
+        safety_level=2,
+    ),
+    ToolSpec(
+        id="dummy_tool_alt",
+        capabilities=("design",),
+        inputs=("sequence",),
+        outputs=("dummy_output", "sequence"),
+        cost=2,
+        safety_level=1,
+    ),
+    ToolSpec(
+        id="dummy_tool_safe",
+        capabilities=("design",),
+        inputs=("sequence",),
+        outputs=("dummy_output", "sequence"),
+        cost=3,
+        safety_level=0,
+    ),
+)

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
 class ProteinDesignTask(BaseModel):
     """上层TaskAPI / CLI 提交的任务对象
@@ -100,6 +100,12 @@ class ReplanRequest(BaseModel):
     safety_events: List[SafetyResult] = Field(default_factory=list)
     reason: str
 
+PlanPatchOpType = Literal[
+    "replace_step",
+    "insert_step_before",
+    "insert_step_after",
+]
+
 class PlanPatchOp(BaseModel):
     """单个 Plan Patch 操作
     
@@ -109,9 +115,39 @@ class PlanPatchOp(BaseModel):
     - "insert_step_after"
     """
 
-    op: Literal["replace_step", "insert_step_before", "insert_step_after"]
+    model_config = ConfigDict(extra="forbid")
+
+    op: PlanPatchOpType
     target: str # 目标 step_id
     step: PlanStep
+
+    @field_validator("step", mode="before")
+    @classmethod
+    def _fill_step_id(cls, value, info):
+        """允许 replace_step 省略 step.id，其余操作需要显式 id"""
+        if not isinstance(value, dict):
+            return value
+
+        op = info.data.get("op")
+        target = info.data.get("target")
+        has_id = "id" in value and value["id"]
+
+        if op == "replace_step":
+            # 默认为复用目标 step_id，保持局部修改语义
+            return {"id": target, **value} if not has_id else value
+
+        if not has_id:
+            raise ValueError("insert step operations require an explicit step.id")
+        return value
+
+    @model_validator(mode="after")
+    def _ensure_step_scope(self):
+        """replace_step 不允许更换 id，避免破坏 Plan/PlanStep 契约"""
+        if self.op == "replace_step" and self.step.id != self.target:
+            raise ValueError(
+                f"replace_step must keep the same id as target ({self.target})"
+            )
+        return self
 
 class PlanPatch(BaseModel):
     """PlannerAgent 针对局部问题生成的最小修改集合"""

--- a/src/workflow/patch.py
+++ b/src/workflow/patch.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import List, Set
+
+from src.models.contracts import (
+    PatchRequest,
+    Plan,
+    PlanPatch,
+    PlanPatchOp,
+    StepResult,
+)
+from src.workflow.context import WorkflowContext
+
+
+def apply_patch(plan: Plan, patch: PlanPatch) -> Plan:
+    """根据 PlanPatch 返回新的 Plan（不修改原 plan 实例）
+    
+    支持的操作:
+    - replace_step: 用新的 PlanStep 替换目标 id 的步骤（保持顺序不变）
+    - insert_step_before/after: 在目标步骤前/后插入新步骤，若 id 冲突则按稳定规则生成唯一 id
+    
+    Args:
+        plan: 原始 Plan
+        patch: PlanPatch 操作集合
+    Returns:
+        Plan: 应用 patch 后的新 Plan
+    Raises:
+        ValueError: task_id 不一致、目标步骤不存在或输入非法
+    """
+    if plan.task_id != patch.task_id:
+        raise ValueError(
+            f"PlanPatch.task_id ({patch.task_id}) does not match Plan.task_id ({plan.task_id})"
+        )
+
+    steps = [step.model_copy(deep=True) for step in plan.steps]
+    _ensure_unique_step_ids(steps)
+
+    for op in patch.operations:
+        steps = _apply_operation(steps, op)
+
+    return plan.model_copy(update={"steps": steps}, deep=True)
+
+
+def _apply_operation(steps: List, op: PlanPatchOp) -> List:
+    if op.op == "replace_step":
+        return _replace_step(steps, op)
+    if op.op == "insert_step_before":
+        return _insert_step(steps, op, position="before")
+    if op.op == "insert_step_after":
+        return _insert_step(steps, op, position="after")
+    raise ValueError(f"Unsupported PlanPatch operation: {op.op}")
+
+
+def _replace_step(steps: List, op: PlanPatchOp) -> List:
+    idx = _find_step_index(steps, op.target)
+    new_steps = list(steps)
+    new_steps[idx] = op.step.model_copy(deep=True)
+    return new_steps
+
+
+def _insert_step(steps: List, op: PlanPatchOp, position: str) -> List:
+    idx = _find_step_index(steps, op.target)
+    existing_ids: Set[str] = {s.id for s in steps}
+    step_to_insert = op.step.model_copy(deep=True)
+    allocated_id = _allocate_step_id(step_to_insert.id, existing_ids)
+    if allocated_id != step_to_insert.id:
+        step_to_insert = step_to_insert.model_copy(update={"id": allocated_id})
+
+    insert_at = idx if position == "before" else idx + 1
+    new_steps = list(steps)
+    new_steps.insert(insert_at, step_to_insert)
+    return new_steps
+
+
+def _find_step_index(steps: List, target: str) -> int:
+    for i, step in enumerate(steps):
+        if step.id == target:
+            return i
+    raise ValueError(f"Target step '{target}' not found in plan")
+
+
+def _ensure_unique_step_ids(steps: List) -> None:
+    seen: Set[str] = set()
+    for step in steps:
+        if step.id in seen:
+            raise ValueError(f"Duplicate step id '{step.id}' found in Plan")
+        seen.add(step.id)
+
+
+def _allocate_step_id(desired_id: str, existing_ids: Set[str]) -> str:
+    """稳定的 id 生成规则：若冲突则追加递增后缀 _1/_2/..."""
+    if desired_id not in existing_ids:
+        return desired_id
+
+    suffix = 1
+    while f"{desired_id}_{suffix}" in existing_ids:
+        suffix += 1
+    return f"{desired_id}_{suffix}"
+
+
+def build_patch_request(
+    plan: Plan,
+    failed_step_index: int,
+    failed_result: StepResult,
+    context: WorkflowContext,
+) -> PatchRequest:
+    """构造 PatchRequest，附带失败上下文与可用 IO 摘要"""
+    if plan.task_id != context.task.task_id:
+        raise ValueError(
+            f"WorkflowContext.task.task_id ({context.task.task_id}) does not match Plan.task_id ({plan.task_id})"
+        )
+
+    available_io: Set[str] = set()
+    for result in context.step_results.values():
+        available_io.update(result.outputs.keys())
+    available_io.update(failed_result.outputs.keys())
+
+    context_results = list(context.step_results.values())
+    # 将失败的 result 也纳入上下文，以便 Planner 参考失败模式
+    context_results.append(failed_result)
+
+    reason = (
+        f"step {failed_result.step_id} failed after retries exhausted "
+        f"(index={failed_step_index}, failure_type={failed_result.failure_type}, "
+        f"error={failed_result.error_message}); available_io={sorted(available_io)}"
+    )
+
+    return PatchRequest(
+        task_id=plan.task_id,
+        original_plan=plan,
+        context_step_results=context_results,
+        safety_events=list(context.safety_events),
+        reason=reason,
+    )

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Protocol, Tuple
+
+from src.agents.planner import PlannerAgent
+from src.models.contracts import Plan, StepResult
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType, StepRunError
+from src.workflow.patch import apply_patch, build_patch_request
+from src.workflow.step_runner import StepRunner
+from src.models.contracts import PlanPatch
+
+
+class StepRunnerLike(Protocol):
+    """最小化约束的 StepRunner 接口（便于注入/测试）"""
+
+    def run_step(self, step, context: WorkflowContext) -> StepResult:  # type: ignore
+        ...
+
+class PatchRunner:
+    """封装“重试 → Patch → 再执行一次”的最小闭环
+
+    - 依赖 StepRunner 执行步骤（含重试）
+    - 当重试耗尽仍失败，或失败类型属于可补丁范围时，调用 Planner.patch 生成 PlanPatch
+    - 本地 apply_patch 后对目标步骤再执行一次
+    - 不修改 FSM 状态机，交由 PlanRunner/上层管理
+    """
+
+    def __init__(
+        self,
+        step_runner: StepRunnerLike | None = None,
+        planner_agent: PlannerAgent | None = None,
+    ) -> None:
+        self._step_runner: StepRunnerLike = step_runner or StepRunner()
+        self._planner: PlannerAgent = planner_agent or PlannerAgent()
+
+    def run_step_with_patch(
+        self, plan: Plan, step_index: int, context: WorkflowContext
+    ) -> Tuple[Plan, StepResult]:
+        """执行指定 step；必要时进行一次 patch 并重新执行该 step"""
+        step = plan.steps[step_index]
+        result = self._step_runner.run_step(step, context)
+
+        if not self._should_patch(result):
+            return plan, result
+
+        patch_request = build_patch_request(
+            plan=plan,
+            failed_step_index=step_index,
+            failed_result=result,
+            context=context,
+        )
+        plan_patch = self._planner.patch(patch_request)
+        patched_plan = apply_patch(plan, plan_patch)
+
+        # 将最新的 plan 写回 context（如果 task_id 匹配）
+        if context.plan is None or context.plan.task_id == patched_plan.task_id:
+            context.plan = patched_plan
+
+        # 优先使用原 step id 定位（避免插入操作改变索引）
+        target_id = step.id
+        patched_step = next(s for s in patched_plan.steps if s.id == target_id)
+
+        patched_result = self._step_runner.run_step(patched_step, context)
+        self._attach_patch_meta(
+            patched_result,
+            original_step=step,
+            previous_result=result,
+            plan_patch=plan_patch,
+        )
+        return patched_plan, patched_result
+
+    def _should_patch(self, result: StepResult) -> bool:
+        if result.status != "failed":
+            return False
+        if result.failure_type == FailureType.SAFETY_BLOCK:
+            return False
+
+        retry_exhausted = result.metrics.get("retry_exhausted", False)
+        patchable_nonretryable = result.failure_type in (
+            FailureType.TOOL_ERROR,
+            FailureType.NON_RETRYABLE,
+        )
+        return bool(retry_exhausted or patchable_nonretryable)
+
+    def _attach_patch_meta(
+        self,
+        patched_result: StepResult,
+        *,
+        original_step,
+        previous_result: StepResult,
+        plan_patch: PlanPatch,
+    ) -> None:
+        """将 patch 关键信息写入 patched_result.metrics"""
+        patch_info = {
+            "applied": True,
+            "ops": [op.op for op in plan_patch.operations],
+            "from_tool": original_step.tool,
+            "to_tool": patched_result.tool,
+            "original_step_id": original_step.id,
+            "patched_step_id": patched_result.step_id,
+            "patched_status": patched_result.status,
+            "previous_attempt": _summarize_result(previous_result),
+        }
+        metrics = dict(patched_result.metrics)
+        metrics["patch"] = patch_info
+        patched_result.metrics = metrics
+
+
+def _summarize_result(result: StepResult) -> dict:
+    """提取失败结果的关键摘要，重用 attempt_history 结构"""
+    return {
+        "status": result.status,
+        "failure_type": result.failure_type,
+        "error_message": result.error_message,
+        "tool": result.tool,
+        "attempt_history": result.metrics.get("attempt_history"),
+    }

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 from typing import Protocol
+from src.agents.planner import PlannerAgent
 from src.models.contracts import Plan, StepResult
 from src.models.db import TaskStatus
 from src.workflow.context import WorkflowContext
 from src.workflow.step_runner import StepRunner
+from src.workflow.patch_runner import PatchRunner
 from src.agents.safety import SafetyAgent
 from src.workflow.errors import (
     FailureType,
@@ -12,6 +14,7 @@ from src.workflow.errors import (
     classify_exception,
     is_retryable_failure,
 )
+from src.workflow.patch import apply_patch, build_patch_request
 
 class StepRunnerLike(Protocol):
     """最小化约束的 StepRunner 接口，用于依赖注入和单元测试"""
@@ -94,11 +97,20 @@ class PlanRunner:
         self,
         step_runner: StepRunnerLike | None = None,
         safety_agent: SafetyAgent | None = None,
+        planner_agent: PlannerAgent | None = None,
+        patch_runner: PatchRunner | None = None,
     ) -> None:
         # 默认使用真实 StepRunner, 便于生产代码
         self._step_runner: StepRunnerLike = step_runner or StepRunner()
         # A4: 默认使用真实 SafetyAgent, 便于生产代码
         self._safety_agent: SafetyAgent = safety_agent or SafetyAgent()
+        # B3: 默认使用真实 PlannerAgent，用于 patch
+        self._planner: PlannerAgent = planner_agent or PlannerAgent()
+        # B3-5: PatchRunner，封装 patch 闭环
+        self._patch_runner: PatchRunner = patch_runner or PatchRunner(
+            step_runner=self._step_runner,
+            planner_agent=self._planner,
+        )
     
     def run_plan(self, plan: Plan, context: WorkflowContext) -> Plan:
         """执行给定的 Plan, 顺序遍历 plan.steps, 调用 StepRunner 并写入 WorkflowContext
@@ -152,20 +164,28 @@ class PlanRunner:
             context.plan = plan
         
         # 顺序执行 steps, 并将 StepResult 写回 context.step_results
-        for step in plan.steps:
+        step_index = 0
+        while step_index < len(plan.steps):
             try:
-                step_result = self._step_runner.run_step(step, context)
+                plan, step_result = self._patch_runner.run_step_with_patch(
+                    plan, step_index, context
+                )
             except StepRunError as exc:
+                step = plan.steps[step_index]
                 raise PlanRunError.from_step_error(step.id, exc) from exc
             except Exception as exc:
+                step = plan.steps[step_index]
                 failure_type = classify_exception(exc)
                 raise PlanRunError(
                     failure_type=failure_type,
-                    message=f"Unexpected error when executing step {step.id}: {exc}",
+                    message=(
+                        f"Unexpected error when executing step {step.id}: {exc}"
+                    ),
                     step_id=step.id,
                     code="STEP_EXECUTION_ERROR",
                     cause=exc,
                 ) from exc
+
             context.step_results[step_result.step_id] = step_result
             # 读取失败分类与可重试标记，供日志/上层使用（不改变控制流）
             step_result.metrics.setdefault("failure_type", step_result.failure_type)
@@ -175,6 +195,9 @@ class PlanRunner:
                 if step_result.failure_type is not None
                 else None,
             )
+
+            # 成功或 patch 成功后推进下一步
+            step_index += 1
         
         # A4: 安全检查 - 最终结果阶段
         final_safety_result = self._safety_agent.check_final_result(

--- a/tests/unit/test_patch_runner.py
+++ b/tests/unit/test_patch_runner.py
@@ -1,0 +1,118 @@
+import pytest
+
+from src.models.contracts import (
+    Plan,
+    PlanPatch,
+    PlanPatchOp,
+    PlanStep,
+    StepResult,
+    now_iso,
+)
+from src.models.db import TaskStatus
+from src.workflow.context import WorkflowContext
+from src.workflow.patch_runner import PatchRunner
+from src.workflow.errors import FailureType
+from src.agents.planner import PlannerAgent
+
+
+class FakeStepRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self.calls.append(step.tool)
+        if len(self.calls) == 1:
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.RETRYABLE,
+                error_message="boom",
+                error_details={},
+                outputs={},
+                metrics={
+                    "retry_exhausted": True,
+                    "attempt_history": [
+                        {"attempt": 1, "status": "failed", "failure_type": "RETRYABLE"}
+                    ],
+                },
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={"dummy_output": "ok"},
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+class FakePlanner(PlannerAgent):
+    def __init__(self) -> None:
+        super().__init__(tool_registry=[])
+        self.requests = []
+
+    def patch(self, request):  # type: ignore[override]
+        self.requests.append(request)
+        step = request.original_plan.steps[0]
+        patched_step = PlanStep(
+            id=step.id,
+            tool="patched_tool",
+            inputs=step.inputs,
+            metadata=step.metadata,
+        )
+        op = PlanPatchOp(op="replace_step", target=step.id, step=patched_step)
+        return PlanPatch(task_id=request.task_id, operations=[op], metadata={})
+
+
+def test_patch_runner_triggers_patch_and_records_meta(sample_task):
+    plan = Plan(
+        task_id=sample_task.task_id,
+        steps=[PlanStep(id="S1", tool="failing_tool", inputs={}, metadata={})],
+        constraints={},
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=sample_task,
+        plan=None,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=TaskStatus.CREATED,
+    )
+
+    step_runner = FakeStepRunner()
+    planner = FakePlanner()
+    patch_runner = PatchRunner(step_runner=step_runner, planner_agent=planner)
+
+    patched_plan, patched_result = patch_runner.run_step_with_patch(plan, 0, context)
+
+    # patch 应被触发
+    assert planner.requests, "Planner.patch should be called"
+    assert step_runner.calls == ["failing_tool", "patched_tool"]
+
+    # plan 应被替换为 patched 版本
+    assert patched_plan.steps[0].tool == "patched_tool"
+    assert context.plan is patched_plan
+
+    # patched step 应执行成功并返回
+    assert patched_result.status == "success"
+    assert patched_result.tool == "patched_tool"
+
+    patch_meta = patched_result.metrics.get("patch")
+    assert patch_meta and patch_meta["applied"] is True
+    assert patch_meta["from_tool"] == "failing_tool"
+    assert patch_meta["to_tool"] == "patched_tool"
+    assert patch_meta["patched_status"] == "success"
+    prev_attempt = patch_meta["previous_attempt"]
+    assert prev_attempt["attempt_history"][0]["failure_type"] == "RETRYABLE"

--- a/tests/unit/test_plan_patch.py
+++ b/tests/unit/test_plan_patch.py
@@ -1,0 +1,121 @@
+import pytest
+
+from src.models.contracts import Plan, PlanPatch, PlanPatchOp, PlanStep
+from src.workflow.patch import apply_patch
+
+
+def _build_plan() -> Plan:
+    return Plan(
+        task_id="task-001",
+        steps=[
+            PlanStep(id="S1", tool="tool_a", inputs={}, metadata={}),
+            PlanStep(id="S2", tool="tool_b", inputs={"y": "S1.out"}, metadata={}),
+        ],
+        constraints={},
+        metadata={},
+    )
+
+
+def test_replace_step_returns_new_plan_without_mutating_original():
+    plan = _build_plan()
+    patch = PlanPatch(
+        task_id=plan.task_id,
+        operations=[
+            PlanPatchOp(
+                op="replace_step",
+                target="S2",
+                step=PlanStep(
+                    id="S2",
+                    tool="tool_b_new",
+                    inputs={"y": "S1.out"},
+                    metadata={"patched": True},
+                ),
+            )
+        ],
+        metadata={},
+    )
+
+    new_plan = apply_patch(plan, patch)
+
+    assert new_plan is not plan
+    assert [s.tool for s in new_plan.steps] == ["tool_a", "tool_b_new"]
+    assert [s.tool for s in plan.steps] == ["tool_a", "tool_b"]
+
+
+def test_replace_step_missing_target_raises_value_error():
+    plan = _build_plan()
+    patch = PlanPatch(
+        task_id=plan.task_id,
+        operations=[
+            PlanPatchOp(
+                op="replace_step",
+                target="S3",
+                step=PlanStep(id="S3", tool="tool_c", inputs={}, metadata={}),
+            )
+        ],
+        metadata={},
+    )
+
+    with pytest.raises(ValueError):
+        apply_patch(plan, patch)
+
+
+def test_insert_before_allocates_unique_id_on_conflict():
+    plan = _build_plan()
+    patch = PlanPatch(
+        task_id=plan.task_id,
+        operations=[
+            PlanPatchOp(
+                op="insert_step_before",
+                target="S2",
+                step=PlanStep(
+                    id="S1",  # 故意冲突，触发稳定的后缀生成
+                    tool="tool_filter",
+                    inputs={"x": "S1.out"},
+                    metadata={},
+                ),
+            )
+        ],
+        metadata={},
+    )
+
+    new_plan = apply_patch(plan, patch)
+    assert [s.id for s in new_plan.steps] == ["S1", "S1_1", "S2"]
+    assert new_plan.steps[1].tool == "tool_filter"
+
+
+def test_insert_after_inserts_in_order():
+    plan = _build_plan()
+    patch = PlanPatch(
+        task_id=plan.task_id,
+        operations=[
+            PlanPatchOp(
+                op="insert_step_after",
+                target="S1",
+                step=PlanStep(
+                    id="S1_filter",
+                    tool="tool_filter",
+                    inputs={"x": "S1.out"},
+                    metadata={},
+                ),
+            )
+        ],
+        metadata={},
+    )
+
+    new_plan = apply_patch(plan, patch)
+    assert [s.id for s in new_plan.steps] == ["S1", "S1_filter", "S2"]
+    assert new_plan.steps[1].tool == "tool_filter"
+
+
+def test_task_id_mismatch_raises_value_error():
+    plan = _build_plan()
+    patch = PlanPatch(
+        task_id="other-task",
+        operations=[],
+        metadata={},
+    )
+
+    with pytest.raises(ValueError):
+        apply_patch(plan, patch)
+

--- a/tests/unit/test_plan_runner.py
+++ b/tests/unit/test_plan_runner.py
@@ -3,7 +3,10 @@ import pytest
 from src.models.contracts import (
     ProteinDesignTask,
     Plan,
+    PlanPatch,
+    PlanPatchOp,
     PlanStep,
+    PatchRequest,
     StepResult,
     now_iso,
 )
@@ -13,6 +16,7 @@ from src.workflow.context import WorkflowContext
 from src.workflow.plan_runner import PlanRunner, StepRunnerLike
 from src.workflow.errors import FailureType, PlanRunError, StepRunError
 from src.agents.safety import SafetyAgent
+from src.agents.planner import PlannerAgent
 
 class DummyStepRunner(StepRunnerLike):
     """用于测试简单的 StepRunner, 记录调用顺序并返回可控的 StepResult"""
@@ -362,6 +366,87 @@ def test_run_plan_with_empty_steps_updates_status(
     # 没有步骤执行
     assert runner.called_steps == []
     assert planned_context.step_results == {}
+
+
+def test_run_plan_triggers_patch_after_retry_exhausted(
+    single_step_plan: Plan,
+    planned_context: WorkflowContext,
+) -> None:
+    """重试耗尽失败时，PlanRunner 应构造 PatchRequest 并应用 PlanPatch"""
+
+    class TwoPhaseStepRunner(StepRunnerLike):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+            self.calls += 1
+            if self.calls == 1:
+                return StepResult(
+                    task_id=context.task.task_id,
+                    step_id=step.id,
+                    tool=step.tool,
+                    status="failed",
+                    failure_type=FailureType.RETRYABLE,
+                    error_message="boom",
+                    error_details={},
+                    outputs={},
+                    metrics={"retry_exhausted": True},
+                    risk_flags=[],
+                    logs_path=None,
+                    timestamp=now_iso(),
+                )
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="success",
+                failure_type=None,
+                error_message=None,
+                error_details={},
+                outputs={"dummy_output": "ok"},
+                metrics={},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+
+    class CapturingPlanner(PlannerAgent):
+        def __init__(self) -> None:
+            super().__init__(tool_registry=[])
+            self.requests = []
+
+        def patch(self, request: PatchRequest):  # type: ignore[override]
+            self.requests.append(request)
+            step = request.original_plan.steps[0]
+            patched_step = PlanStep(
+                id=step.id,
+                tool="patched_tool",
+                inputs=step.inputs,
+                metadata=step.metadata,
+            )
+            op = PlanPatchOp(op="replace_step", target=step.id, step=patched_step)
+            return PlanPatch(task_id=request.task_id, operations=[op], metadata={})
+
+    runner = TwoPhaseStepRunner()
+    planner = CapturingPlanner()
+    plan_runner = PlanRunner(step_runner=runner, planner_agent=planner)
+
+    returned_plan = plan_runner.run_plan(single_step_plan, planned_context)
+
+    assert runner.calls == 2
+    assert planner.requests, "Planner.patch 应被调用"
+    request = planner.requests[0]
+    assert "failure_type" in request.reason
+    assert returned_plan.steps[0].tool == "patched_tool"
+    assert planned_context.plan is returned_plan
+    assert planned_context.step_results["S1"].status == "success"
+    assert planned_context.step_results["S1"].tool == "patched_tool"
+    patch_meta = planned_context.step_results["S1"].metrics.get("patch")
+    assert patch_meta is not None
+    assert patch_meta["applied"] is True
+    assert patch_meta["from_tool"] == "dummy_tool"
+    assert patch_meta["to_tool"] == "patched_tool"
+    assert patch_meta["patched_status"] == "success"
 
 # A3: 完整状态机测试 - 覆盖所有状态转换场景
 

--- a/tests/unit/test_planner_patch_agent.py
+++ b/tests/unit/test_planner_patch_agent.py
@@ -1,0 +1,109 @@
+import pytest
+
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.models.contracts import PatchRequest, Plan, PlanStep, PlanPatch, StepResult, now_iso
+
+
+def _build_registry():
+    return [
+        ToolSpec(
+            id="t_fail",
+            capabilities=("fold",),
+            inputs=("sequence",),
+            outputs=("structure",),
+            cost=5,
+            safety_level=2,
+        ),
+        ToolSpec(
+            id="t_alt_high",
+            capabilities=("fold",),
+            inputs=("sequence",),
+            outputs=("structure",),
+            cost=3,
+            safety_level=1,
+        ),
+        ToolSpec(
+            id="t_alt_low",
+            capabilities=("fold",),
+            inputs=("sequence",),
+            outputs=("structure",),
+            cost=1,
+            safety_level=3,
+        ),
+    ]
+
+
+def _step_result(step_id: str, outputs: dict) -> StepResult:
+    return StepResult(
+        task_id="task-001",
+        step_id=step_id,
+        tool="t_prev",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        outputs=outputs,
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+
+def _build_request():
+    plan = Plan(
+        task_id="task-001",
+        steps=[
+            PlanStep(id="S1", tool="t_fail", inputs={"sequence": "S0.sequence"}, metadata={})
+        ],
+        constraints={},
+        metadata={},
+    )
+    return PatchRequest(
+        task_id=plan.task_id,
+        original_plan=plan,
+        context_step_results=[_step_result("S0", {"sequence": "AAA"})],
+        safety_events=[],
+        reason="tool_failed",
+    )
+
+
+def test_patch_returns_replace_step_with_cheapest_candidate():
+    agent = PlannerAgent(tool_registry=_build_registry())
+    request = _build_request()
+
+    patch = agent.patch(request)
+
+    assert isinstance(patch, PlanPatch)
+    assert len(patch.operations) == 1
+    op = patch.operations[0]
+    assert op.op == "replace_step"
+    assert op.target == "S1"
+    assert op.step.tool == "t_alt_low"  # 选择 cost 最低的候选
+
+
+def test_patch_raises_when_no_compatible_tool():
+    # registry 中的候选需要额外输入，无法满足
+    registry = [
+        ToolSpec(
+            id="t_fail",
+            capabilities=("fold",),
+            inputs=("sequence",),
+            outputs=("structure",),
+            cost=5,
+            safety_level=2,
+        ),
+        ToolSpec(
+            id="t_alt_need_extra",
+            capabilities=("fold",),
+            inputs=("sequence", "template"),
+            outputs=("structure",),
+            cost=1,
+            safety_level=1,
+        ),
+    ]
+    agent = PlannerAgent(tool_registry=registry)
+    request = _build_request()
+
+    with pytest.raises(ValueError):
+        agent.patch(request)


### PR DESCRIPTION
## What changed

- Introduced step-level Patch mechanism triggered after retry exhaustion
- Added Planner.patch to generate localized PlanPatch
- Implemented replace_step patch type and application logic
- Ensured patched step executes once without triggering replan or FSM
- Recorded patch metadata and added unit tests

## Design intent

This patch mechanism is intended as a minimal, localized recovery strategy when step retries are exhausted, avoiding full replanning.

## Codex reviewed focus
@codex Please review this PR focusing on:

- correctness of patch triggering conditions
- isolation between patch execution and FSM / replan logic
- potential edge cases in replace_step application
- long-term maintainability of step-level patching

Assume this is part of an  LLM-driven agent workflow engine

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a minimal step-level patch mechanism (replace/insert ops) with Planner.patch, apply_patch utilities, and PlanRunner integration to retry-exhaustion recovery, plus comprehensive tests.
> 
> - **Workflow**:
>   - **Patch Runner**: New `src/workflow/patch_runner.py` encapsulates "retry exhausted → Planner.patch → re-run once" loop and attaches patch metadata to `StepResult`.
>   - **Plan Runner Integration**: `src/workflow/plan_runner.py` uses `PatchRunner` per step; maintains status and safety checks while updating `context.plan` after patch.
>   - **Patch Utilities**: `src/workflow/patch.py` adds `apply_patch` (supports `replace_step`, `insert_step_before/after` with stable ID allocation) and `build_patch_request` (captures failure context/IO summary).
> - **Planner**:
>   - Adds `PlannerAgent.patch` with lightweight `ToolSpec` registry to pick alternative tools by capability/input and cost/safety; returns `replace_step` `PlanPatch` keeping step ID.
> - **Models/Contracts**:
>   - Extends contracts with `PlanPatchOpType`, validators for `PlanPatchOp` (ID fill/consistency), and `PatchRequest` fields.
> - **Tests**:
>   - New unit tests for patch application, patch runner behavior, planner patch selection, and PlanRunner patch flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2f1d8836bce959340721f81458c2d6aac1902b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->