### PR TITLE
fix(plan-runner): 调整 patch 执行顺序，insert_step_before现在会先执行新插入步骤，再回到目标步骤并补齐patch元信息

### DIFF
--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import Protocol, Tuple
+from dataclasses import dataclass
+from typing import Protocol
 
 from src.agents.planner import PlannerAgent
-from src.models.contracts import Plan, StepResult
+from src.models.contracts import Plan, PlanPatch, PlanStep, StepResult
 from src.workflow.context import WorkflowContext
-from src.workflow.errors import FailureType, StepRunError
+from src.workflow.errors import FailureType
 from src.workflow.patch import apply_patch, build_patch_request
 from src.workflow.step_runner import StepRunner
-from src.models.contracts import PlanPatch
 
 
 class StepRunnerLike(Protocol):
@@ -16,6 +16,23 @@ class StepRunnerLike(Protocol):
 
     def run_step(self, step, context: WorkflowContext) -> StepResult:  # type: ignore
         ...
+
+
+@dataclass(frozen=True)
+class PendingPatch:
+    target_step_id: str
+    original_step: PlanStep
+    previous_result: StepResult
+    plan_patch: PlanPatch
+
+
+@dataclass(frozen=True)
+class PatchRunOutcome:
+    plan: Plan
+    step_results: list[StepResult]
+    next_step_index: int
+    pending_patch: PendingPatch | None = None
+
 
 class PatchRunner:
     """封装“重试 → Patch → 再执行一次”的最小闭环
@@ -36,13 +53,17 @@ class PatchRunner:
 
     def run_step_with_patch(
         self, plan: Plan, step_index: int, context: WorkflowContext
-    ) -> Tuple[Plan, StepResult]:
+    ) -> PatchRunOutcome:
         """执行指定 step；必要时进行一次 patch 并重新执行该 step"""
         step = plan.steps[step_index]
         result = self._step_runner.run_step(step, context)
 
         if not self._should_patch(result):
-            return plan, result
+            return PatchRunOutcome(
+                plan=plan,
+                step_results=[result],
+                next_step_index=step_index + 1,
+            )
 
         patch_request = build_patch_request(
             plan=plan,
@@ -57,9 +78,26 @@ class PatchRunner:
         if context.plan is None or context.plan.task_id == patched_plan.task_id:
             context.plan = patched_plan
 
+        if _has_insert_before_target(plan_patch, step.id):
+            pending_patch = PendingPatch(
+                target_step_id=step.id,
+                original_step=step,
+                previous_result=result,
+                plan_patch=plan_patch,
+            )
+            return PatchRunOutcome(
+                plan=patched_plan,
+                step_results=[],
+                next_step_index=step_index,
+                pending_patch=pending_patch,
+            )
+
         # 优先使用原 step id 定位（避免插入操作改变索引）
         target_id = step.id
         patched_step = next(s for s in patched_plan.steps if s.id == target_id)
+        patched_index = next(
+            idx for idx, s in enumerate(patched_plan.steps) if s.id == target_id
+        )
 
         patched_result = self._step_runner.run_step(patched_step, context)
         self._attach_patch_meta(
@@ -68,7 +106,11 @@ class PatchRunner:
             previous_result=result,
             plan_patch=plan_patch,
         )
-        return patched_plan, patched_result
+        return PatchRunOutcome(
+            plan=patched_plan,
+            step_results=[patched_result],
+            next_step_index=patched_index + 1,
+        )
 
     def _should_patch(self, result: StepResult) -> bool:
         if result.status != "failed":
@@ -106,6 +148,19 @@ class PatchRunner:
         metrics["patch"] = patch_info
         patched_result.metrics = metrics
 
+    def attach_patch_meta(
+        self,
+        patched_result: StepResult,
+        pending_patch: PendingPatch,
+    ) -> None:
+        """对后续执行的目标步骤补齐 patch 元信息"""
+        self._attach_patch_meta(
+            patched_result,
+            original_step=pending_patch.original_step,
+            previous_result=pending_patch.previous_result,
+            plan_patch=pending_patch.plan_patch,
+        )
+
 
 def _summarize_result(result: StepResult) -> dict:
     """提取失败结果的关键摘要，重用 attempt_history 结构"""
@@ -116,3 +171,10 @@ def _summarize_result(result: StepResult) -> dict:
         "tool": result.tool,
         "attempt_history": result.metrics.get("attempt_history"),
     }
+
+
+def _has_insert_before_target(plan_patch: PlanPatch, target_id: str) -> bool:
+    return any(
+        op.op == "insert_step_before" and op.target == target_id
+        for op in plan_patch.operations
+    )

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -5,7 +5,7 @@ from src.models.contracts import Plan, StepResult
 from src.models.db import TaskStatus
 from src.workflow.context import WorkflowContext
 from src.workflow.step_runner import StepRunner
-from src.workflow.patch_runner import PatchRunner
+from src.workflow.patch_runner import PatchRunner, PendingPatch
 from src.agents.safety import SafetyAgent
 from src.workflow.errors import (
     FailureType,
@@ -14,7 +14,6 @@ from src.workflow.errors import (
     classify_exception,
     is_retryable_failure,
 )
-from src.workflow.patch import apply_patch, build_patch_request
 
 class StepRunnerLike(Protocol):
     """最小化约束的 StepRunner 接口，用于依赖注入和单元测试"""
@@ -164,10 +163,11 @@ class PlanRunner:
             context.plan = plan
         
         # 顺序执行 steps, 并将 StepResult 写回 context.step_results
+        pending_patches: dict[str, PendingPatch] = {}
         step_index = 0
         while step_index < len(plan.steps):
             try:
-                plan, step_result = self._patch_runner.run_step_with_patch(
+                outcome = self._patch_runner.run_step_with_patch(
                     plan, step_index, context
                 )
             except StepRunError as exc:
@@ -186,18 +186,33 @@ class PlanRunner:
                     cause=exc,
                 ) from exc
 
-            context.step_results[step_result.step_id] = step_result
-            # 读取失败分类与可重试标记，供日志/上层使用（不改变控制流）
-            step_result.metrics.setdefault("failure_type", step_result.failure_type)
-            step_result.metrics.setdefault(
-                "retryable",
-                is_retryable_failure(step_result.failure_type)
-                if step_result.failure_type is not None
-                else None,
-            )
+            plan = outcome.plan
+            if outcome.pending_patch:
+                pending_patches[outcome.pending_patch.target_step_id] = (
+                    outcome.pending_patch
+                )
+
+            for step_result in outcome.step_results:
+                pending_patch = pending_patches.pop(step_result.step_id, None)
+                if pending_patch and "patch" not in step_result.metrics:
+                    self._patch_runner.attach_patch_meta(
+                        step_result,
+                        pending_patch,
+                    )
+                context.step_results[step_result.step_id] = step_result
+                # 读取失败分类与可重试标记，供日志/上层使用（不改变控制流）
+                step_result.metrics.setdefault(
+                    "failure_type", step_result.failure_type
+                )
+                step_result.metrics.setdefault(
+                    "retryable",
+                    is_retryable_failure(step_result.failure_type)
+                    if step_result.failure_type is not None
+                    else None,
+                )
 
             # 成功或 patch 成功后推进下一步
-            step_index += 1
+            step_index = outcome.next_step_index
         
         # A4: 安全检查 - 最终结果阶段
         final_safety_result = self._safety_agent.check_final_result(

--- a/tests/unit/test_patch_runner.py
+++ b/tests/unit/test_patch_runner.py
@@ -95,7 +95,9 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task):
     planner = FakePlanner()
     patch_runner = PatchRunner(step_runner=step_runner, planner_agent=planner)
 
-    patched_plan, patched_result = patch_runner.run_step_with_patch(plan, 0, context)
+    outcome = patch_runner.run_step_with_patch(plan, 0, context)
+    patched_plan = outcome.plan
+    patched_result = outcome.step_results[0]
 
     # patch 应被触发
     assert planner.requests, "Planner.patch should be called"
@@ -104,6 +106,8 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task):
     # plan 应被替换为 patched 版本
     assert patched_plan.steps[0].tool == "patched_tool"
     assert context.plan is patched_plan
+    assert outcome.next_step_index == 1
+    assert outcome.pending_patch is None
 
     # patched step 应执行成功并返回
     assert patched_result.status == "success"

--- a/tests/unit/test_plan_runner.py
+++ b/tests/unit/test_plan_runner.py
@@ -448,6 +448,85 @@ def test_run_plan_triggers_patch_after_retry_exhausted(
     assert patch_meta["to_tool"] == "patched_tool"
     assert patch_meta["patched_status"] == "success"
 
+
+def test_run_plan_executes_insert_before_patch_steps(
+    single_step_plan: Plan,
+    planned_context: WorkflowContext,
+) -> None:
+    """insert_step_before 的补丁应先执行新插入步骤，再执行原目标步骤"""
+
+    class SequencedStepRunner(StepRunnerLike):
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+            self.calls.append(step.id)
+            if step.id == "S1" and self.calls.count("S1") == 1:
+                return StepResult(
+                    task_id=context.task.task_id,
+                    step_id=step.id,
+                    tool=step.tool,
+                    status="failed",
+                    failure_type=FailureType.RETRYABLE,
+                    error_message="boom",
+                    error_details={},
+                    outputs={},
+                    metrics={"retry_exhausted": True},
+                    risk_flags=[],
+                    logs_path=None,
+                    timestamp=now_iso(),
+                )
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="success",
+                failure_type=None,
+                error_message=None,
+                error_details={},
+                outputs={"dummy_output": "ok"},
+                metrics={},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+
+    class InsertBeforePlanner(PlannerAgent):
+        def __init__(self) -> None:
+            super().__init__(tool_registry=[])
+            self.requests = []
+
+        def patch(self, request: PatchRequest):  # type: ignore[override]
+            self.requests.append(request)
+            prep_step = PlanStep(
+                id="S0",
+                tool="prep_tool",
+                inputs={},
+                metadata={},
+            )
+            op = PlanPatchOp(
+                op="insert_step_before",
+                target="S1",
+                step=prep_step,
+            )
+            return PlanPatch(task_id=request.task_id, operations=[op], metadata={})
+
+    runner = SequencedStepRunner()
+    planner = InsertBeforePlanner()
+    plan_runner = PlanRunner(step_runner=runner, planner_agent=planner)
+
+    returned_plan = plan_runner.run_plan(single_step_plan, planned_context)
+
+    assert runner.calls == ["S1", "S0", "S1"]
+    assert planner.requests, "Planner.patch 应被调用"
+    assert returned_plan.steps[0].id == "S0"
+    assert planned_context.plan is returned_plan
+    assert "S0" in planned_context.step_results
+    assert planned_context.step_results["S1"].status == "success"
+    patch_meta = planned_context.step_results["S1"].metrics.get("patch")
+    assert patch_meta and patch_meta["applied"] is True
+    assert patch_meta["ops"] == ["insert_step_before"]
+
 # A3: 完整状态机测试 - 覆盖所有状态转换场景
 
 @pytest.fixture


### PR DESCRIPTION
- 通过 PatchRunOutcome/PendingPatch 让 insert_before
  时不立即重跑目标步骤，PlanRunner
  继续从插入位置执行，并让目标步骤完成时补齐 patch metadata
- 新增单测覆盖 insert_step_before 执行顺序与元信息写入，并同步更新
  patch_runner 单测以适配新返回结构
