### PR TITLE
refactor(fsm): 重构任务状态机，使其与 architecture.md 中定义的 FSM 完全一致。

### DIFF
--- a/src/models/db.py
+++ b/src/models/db.py
@@ -16,25 +16,34 @@ from .contracts import (
 
 # 任务 & 步骤状态定义
 
-class TaskStatus(str, Enum):
-    """任务生命周期状态
-    
-    对齐状态机设计
+class ExternalStatus(str, Enum):
+    """对外语义状态(ExternalStatus)
 
-    - CREATED: 任务已经在API层创建，但尚未进入规划流程
-    - PLANNING: PlannerAgent 正在生成初始Plan
-    - PLANNED: 初始 Plan 已经生成，等待执行
-    - RUNNING: ExecutorAgent 正在按照 Plan 执行步骤
-    - WAITING_PATCH: 某一步骤多次重试失败，等待Planner生成局部PlanPatch
-    - PATCHING: PlannerAgent 正在根据 PatchRequest 生成PlanPatch
-    - WAITING_REPLAN: 当前 Plan 无法局部修复，等待PlannerAgent生成新的子计划
-    - REPLANNING: PlannerAgent 正在根据 ReplanRequest 重新规划未完成子计划
-    - SUMMARIZING: SummarizerAgent 正在汇总结果并生成 DesignResult
-    - DONE: 任务成功完成，DesignResult 已生成并持久化
-    - FAILED: 任务执行失败且无法继续
+    对齐 architecture.md 定义的 FSM 状态。
     """
+
     CREATED = "CREATED"
     PLANNING = "PLANNING"
+    WAITING_PLAN_CONFIRM = "WAITING_PLAN_CONFIRM"
+    PLANNED = "PLANNED"
+    RUNNING = "RUNNING"
+    WAITING_PATCH_CONFIRM = "WAITING_PATCH_CONFIRM"
+    WAITING_REPLAN_CONFIRM = "WAITING_REPLAN_CONFIRM"
+    SUMMARIZING = "SUMMARIZING"
+    DONE = "DONE"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+
+
+class InternalStatus(str, Enum):
+    """内部执行状态(InternalStatus)
+
+    保留 PATCHING / REPLANNING / WAITING_* 等细粒度状态。
+    """
+
+    CREATED = "CREATED"
+    PLANNING = "PLANNING"
+    WAITING_PLAN_CONFIRM = "WAITING_PLAN_CONFIRM"
     PLANNED = "PLANNED"
     RUNNING = "RUNNING"
     WAITING_PATCH = "WAITING_PATCH"
@@ -44,8 +53,34 @@ class TaskStatus(str, Enum):
     SUMMARIZING = "SUMMARIZING"
     DONE = "DONE"
     FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
 
-TERMINAL_STATES = {TaskStatus.DONE, TaskStatus.FAILED}
+
+TERMINAL_EXTERNAL_STATUSES = {
+    ExternalStatus.DONE,
+    ExternalStatus.FAILED,
+    ExternalStatus.CANCELLED,
+}
+TERMINAL_INTERNAL_STATUSES = {
+    InternalStatus.DONE,
+    InternalStatus.FAILED,
+    InternalStatus.CANCELLED,
+}
+
+_INTERNAL_TO_EXTERNAL = {
+    InternalStatus.WAITING_PATCH: ExternalStatus.WAITING_PATCH_CONFIRM,
+    InternalStatus.PATCHING: ExternalStatus.WAITING_PATCH_CONFIRM,
+    InternalStatus.WAITING_REPLAN: ExternalStatus.WAITING_REPLAN_CONFIRM,
+    InternalStatus.REPLANNING: ExternalStatus.WAITING_REPLAN_CONFIRM,
+}
+
+
+def to_external_status(status: InternalStatus) -> ExternalStatus:
+    """将 InternalStatus 映射为对外语义状态."""
+    mapped = _INTERNAL_TO_EXTERNAL.get(status)
+    if mapped is not None:
+        return mapped
+    return ExternalStatus[status.name]
 
 class StepStatus(str, Enum):
     """单个步骤的生命周期状态
@@ -72,7 +107,8 @@ class TaskRecord(BaseModel):
     """
 
     id: str
-    status: TaskStatus
+    status: ExternalStatus
+    internal_status: Optional[InternalStatus] = None
     created_at: str = Field(default_factory=now_iso)
     updated_at: str = Field(default_factory=now_iso)
 
@@ -117,29 +153,28 @@ def derive_task_status(
     step_results: Dict[str, StepResult],
     safety_events: List[SafetyResult],
     design_result: Optional[DesignResult],
-) -> TaskStatus:
-    """根据当前上下文粗略推导 TaskStatus
+) -> InternalStatus:
+    """根据当前上下文粗略推导 InternalStatus
 
     约定：
     - 只返回 CREATED / PLANNED / RUNNING / DONE / FAILED 这五种状态
-    - 细粒度的 PLANNING / WAITING_PATCH / REPLANNING / SUMMARIZING 由LangGraph工作流在节点执行时
-    显式设置，不在这里推导
+    - 细粒度状态由工作流显式设置，不在这里推导
     """
 
     # 已有最终结果 ⇒ DONE
     if design_result is not None:
-        return TaskStatus.DONE
+        return InternalStatus.DONE
 
     # 强错误：有失败步骤 或 有 action == "block" 的安全事件 ⇒ FAILED
     has_failed_step = any(r.status == "failed" for r in step_results.values())
     has_block_safety = any(evt.action == "block" for evt in safety_events)
 
     if has_failed_step or has_block_safety:
-        return TaskStatus.FAILED
+        return InternalStatus.FAILED
     
     # 还没有 Plan ⇒ CREATED
     if plan is None:
-        return TaskStatus.CREATED
+        return InternalStatus.CREATED
     
     # 有 Plan 且已经至少成功/跳过了一些步骤 ⇒ RUNNING
     has_any_finished_step = any(
@@ -147,10 +182,10 @@ def derive_task_status(
     )
 
     if has_any_finished_step:
-        return TaskStatus.RUNNING
+        return InternalStatus.RUNNING
     
     # 有 Plan 但还没有执行任何一步 ⇒ PLANNED
-    return TaskStatus.PLANNED
+    return InternalStatus.PLANNED
 
 def step_result_to_record(result: StepResult) -> StepRecord:
     """将 StepResult 转化为 StepRecord 方便写入持久化层"""

--- a/src/workflow/context.py
+++ b/src/workflow/context.py
@@ -21,7 +21,7 @@ from src.models.contracts import (
     SafetyResult,
     StepResult,
 )
-from src.models.db import TaskStatus
+from src.models.db import InternalStatus
 
 __all__ = ["WorkflowContext"]
 
@@ -57,9 +57,9 @@ class WorkflowContext(BaseModel):
             SummarizerAgent 在 SUMMARIZING 阶段生成的最终设计成果
             在任务未完成前，此字段为 None数据契约
             
-        status: TaskStatus
+        status: InternalStatus
             任务的当前执行状态
-            初始值为 TaskStatus.CREATED
+            初始值为 InternalStatus.CREATED
             在任务执行过程中由各个 Agent 更新
     """
 
@@ -68,7 +68,7 @@ class WorkflowContext(BaseModel):
     step_results: Dict[str, StepResult] = Field(default_factory=dict)
     safety_events: List[SafetyResult] = Field(default_factory=list)
     design_result: Optional[DesignResult] = None
-    status: TaskStatus = TaskStatus.CREATED
+    status: InternalStatus = InternalStatus.CREATED
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -5,7 +5,7 @@ from typing import Protocol
 
 from src.agents.planner import PlannerAgent
 from src.models.contracts import Plan, PlanPatch, PlanStep, StepResult
-from src.models.db import TaskRecord, TaskStatus
+from src.models.db import TaskRecord, InternalStatus
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
 from src.workflow.patch import apply_patch, build_patch_request
@@ -72,7 +72,7 @@ class PatchRunner:
                 next_step_index=step_index + 1,
             )
 
-        if context.status != TaskStatus.RUNNING:
+        if context.status != InternalStatus.RUNNING:
             return PatchRunOutcome(
                 plan=plan,
                 step_results=[result],
@@ -87,13 +87,13 @@ class PatchRunner:
         transition_task_status(
             context,
             record,
-            TaskStatus.WAITING_PATCH,
+            InternalStatus.WAITING_PATCH,
             reason=patch_reason,
         )
         transition_task_status(
             context,
             record,
-            TaskStatus.PATCHING,
+            InternalStatus.PATCHING,
             reason="patch_start",
         )
         try:
@@ -109,7 +109,7 @@ class PatchRunner:
             transition_task_status(
                 context,
                 record,
-                TaskStatus.WAITING_REPLAN,
+                InternalStatus.WAITING_REPLAN,
                 reason="patch_failed",
             )
             raise

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Protocol
 from src.agents.planner import PlannerAgent
 from src.models.contracts import Plan, ReplanRequest, StepResult
-from src.models.db import TaskRecord, TaskStatus, TERMINAL_STATES
+from src.models.db import TaskRecord, InternalStatus, TERMINAL_INTERNAL_STATUSES
 from src.workflow.context import WorkflowContext
 from src.workflow.step_runner import StepRunner
 from src.workflow.patch_runner import PatchRunner, PendingPatch
@@ -16,21 +16,23 @@ from src.workflow.errors import (
     is_retryable_failure,
 )
 
+
 class StepRunnerLike(Protocol):
     """最小化约束的 StepRunner 接口，用于依赖注入和单元测试"""
 
-    def run_step(self, step, context: WorkflowContext) -> StepResult: # type: ignore
+    def run_step(self, step, context: WorkflowContext) -> StepResult:  # type: ignore
         """执行单个 PlanStep,返回 StepResult
-        
+
         真实实现由 src/workflow/step_runner.StepRunner 提供
         """
 
+
 class PlanRunner:
     """PlanRunner: 顺序执行 Plan.steps, 并回写 WorkflowContext, 管理任务状态
-    
+
     实现最小闭环的行为: 依次执行 Plan 中的步骤
     使用 StepRunner 执行每个步骤，并将执行结果写入 WorkflowContext
-    同时管理 TaskStatus 状态转换
+    同时管理 InternalStatus 状态转换
 
     Attributes:
         step_runner(StepRunner):
@@ -39,10 +41,10 @@ class PlanRunner:
         safety_agent(SafetyAgent):
             通过构造函数注入的安全检查器，用于执行安全检查
             A4 阶段：已接入，执行 task_input 和 final_result 检查
-    
+
     Version:
-        v2(A3扩展): 在 v1 基础上增加 TaskStatus 状态管理
-        
+        v2(C1扩展): 在 v1 基础上增加 InternalStatus 状态管理
+
         完整状态机流程 (CREATED → PLANNING → PLANNED → RUNNING → ... → SUMMARIZING → DONE/FAILED):
         - CREATED → PLANNING: 由 PlannerAgent 负责（任务创建后开始规划）
         - PLANNING → PLANNED: 由 PlannerAgent 负责（规划完成，生成 Plan）
@@ -51,7 +53,7 @@ class PlanRunner:
         - RUNNING → WAITING_REPLAN → REPLANNING → RUNNING/FAILED: 由 PlanRunner 负责（安全阻断或 patch 失败触发再规划）
         - RUNNING → SUMMARIZING: 由 PlanRunner 负责（执行完成，进入汇总阶段）
         - SUMMARIZING → DONE/FAILED: 由 SummarizerAgent 或上层负责（汇总完成，任务结束）
-        
+
         PlanRunner 的状态转换职责:
         - 主要职责: 当 ``context.status == PLANNED`` 时，更新为 ``RUNNING``
         - patch 流程: ``RUNNING → WAITING_PATCH → PATCHING → RUNNING``
@@ -62,7 +64,7 @@ class PlanRunner:
           （允许上层已经设置状态的情况，例如已经是 RUNNING 或终端状态）
         - 终端状态保护: 若 ``context.status`` 为 ``DONE`` 或 ``FAILED``，保持状态不变
           （终端状态不应被 PlanRunner 改变）
-        
+
         - 输入：
             - plan(Plan)
             - context(WorkflowContext)
@@ -89,11 +91,12 @@ class PlanRunner:
                 - 异常发生时，若当前不是终端态，则置为 ``FAILED``
         - 输出:
             - 返回原始 ``plan`` 对象(为未来支持 Patch/Replan 留接口)
-         
+
         Future Work:
             - Patch/Replan 的策略优化与完整前缀锁定逻辑
             - 状态回滚: 未来可能需要在异常时支持状态回滚机制
     """
+
     def __init__(
         self,
         step_runner: StepRunnerLike | None = None,
@@ -112,7 +115,7 @@ class PlanRunner:
             step_runner=self._step_runner,
             planner_agent=self._planner,
         )
-    
+
     def run_plan(
         self,
         plan: Plan,
@@ -124,13 +127,13 @@ class PlanRunner:
         resume_from_existing: bool = False,
     ) -> Plan:
         """执行给定的 Plan, 顺序遍历 plan.steps, 调用 StepRunner 并写入 WorkflowContext
-        
-        同时管理 TaskStatus 状态转换：
+
+        同时管理 InternalStatus 状态转换：
         - 如果 context.status 为 PLANNED，则更新为 RUNNING（主要职责）
         - 如果 context.status 不是 PLANNED，保持原状态不变（允许上层已设置状态）
         - 执行完成后，若 context.status 为 RUNNING，则更新为 SUMMARIZING
         - finalize_status=True 时继续更新为 DONE（最小汇总实现）
-        
+
         Args:
             plan: 要执行的计划对象
             context: 工作流上下文，包含任务信息、当前状态等
@@ -138,14 +141,14 @@ class PlanRunner:
             finalize_status: 是否在 SUMMARIZING 后自动置为 DONE
             max_replans: 允许触发再规划的最大次数（最小实现，默认 1）
             resume_from_existing: 是否基于既有成功结果跳过已完成步骤
-            
+
         Returns:
             Plan: 返回原始 plan 对象（为未来支持 Patch/Replan 预留接口）
-            
+
         Raises:
             ValueError: 当 context.task.task_id 与 plan.task_id 不一致时
             PlanRunError: 当步骤执行/安全阻断/工具异常时，携带统一失败分类
-            
+
         Note:
             - 状态转换遵循完整状态机流程（含 WAITING_PATCH/PATCHING/WAITING_REPLAN/REPLANNING）
             - PlanRunner 主要负责 PLANNED → RUNNING、patch/replan 的中间态推进
@@ -160,11 +163,11 @@ class PlanRunner:
             )
         try:
             # A3: 状态更新 - 如果状态为 PLANNED，则更新为 RUNNING
-            if context.status == TaskStatus.PLANNED:
+            if context.status == InternalStatus.PLANNED:
                 transition_task_status(
                     context,
                     record,
-                    TaskStatus.RUNNING,
+                    InternalStatus.RUNNING,
                     reason="plan_execution_start",
                 )
 
@@ -192,9 +195,7 @@ class PlanRunner:
             step_index = 0
             while step_index < len(plan.steps):
                 step = plan.steps[step_index]
-                if resume_from_existing and self._should_skip_step(
-                    step, context
-                ):
+                if resume_from_existing and self._should_skip_step(step, context):
                     step_index += 1
                     continue
                 try:
@@ -250,9 +251,10 @@ class PlanRunner:
                     failure_reason = "step_failed"
                     if failed_result.metrics.get("retry_exhausted"):
                         failure_reason = "retry_exhausted"
-                    if self._coerce_failure_type(
-                        failed_result.failure_type
-                    ) == FailureType.SAFETY_BLOCK:
+                    if (
+                        self._coerce_failure_type(failed_result.failure_type)
+                        == FailureType.SAFETY_BLOCK
+                    ):
                         failure_reason = "safety_block"
                     self._request_replan(
                         context,
@@ -270,13 +272,13 @@ class PlanRunner:
                     )
 
                 if (
-                    context.status == TaskStatus.PATCHING
+                    context.status == InternalStatus.PATCHING
                     and self._has_patch_applied(outcome.step_results)
                 ):
                     transition_task_status(
                         context,
                         record,
-                        TaskStatus.RUNNING,
+                        InternalStatus.RUNNING,
                         reason="patch_applied",
                     )
 
@@ -299,31 +301,26 @@ class PlanRunner:
                 )
 
             # A3: 执行完成后，推进 SUMMARIZING（必要时继续 DONE）
-            if context.status == TaskStatus.RUNNING:
+            if context.status == InternalStatus.RUNNING:
                 transition_task_status(
                     context,
                     record,
-                    TaskStatus.SUMMARIZING,
+                    InternalStatus.SUMMARIZING,
                     reason="plan_completed",
                 )
                 if finalize_status:
                     transition_task_status(
                         context,
                         record,
-                        TaskStatus.DONE,
+                        InternalStatus.DONE,
                         reason="summarizer_placeholder",
                     )
 
             # 返回原始 plan(为未来支持 Patch/Replan 预留接口)
             return plan
         except PlanRunError as exc:
-            if (
-                context.status == TaskStatus.WAITING_REPLAN
-                and max_replans > 0
-            ):
-                replanned_plan = self._perform_replan(
-                    plan, context, record, exc
-                )
+            if context.status == InternalStatus.WAITING_REPLAN and max_replans > 0:
+                replanned_plan = self._perform_replan(plan, context, record, exc)
                 return self.run_plan(
                     replanned_plan,
                     context,
@@ -340,7 +337,7 @@ class PlanRunner:
 
     def _add_safety_event(self, context: WorkflowContext, event) -> None:
         """安全事件写入上下文，兼容两种 WorkflowContext 形态"""
-        if hasattr(context, 'add_safety_event'):
+        if hasattr(context, "add_safety_event"):
             context.add_safety_event(event)
         else:
             context.safety_events.append(event)
@@ -387,11 +384,11 @@ class PlanRunner:
         step_id: str | None = None,
     ) -> None:
         """触发 WAITING_REPLAN，并抛出 PlanRunError 交给上层处理"""
-        if context.status != TaskStatus.WAITING_REPLAN:
+        if context.status != InternalStatus.WAITING_REPLAN:
             transition_task_status(
                 context,
                 record,
-                TaskStatus.WAITING_REPLAN,
+                InternalStatus.WAITING_REPLAN,
                 reason=reason,
             )
         raise PlanRunError(
@@ -412,7 +409,7 @@ class PlanRunner:
         transition_task_status(
             context,
             record,
-            TaskStatus.REPLANNING,
+            InternalStatus.REPLANNING,
             reason="replan_requested",
         )
         request = ReplanRequest(
@@ -428,7 +425,7 @@ class PlanRunner:
             transition_task_status(
                 context,
                 record,
-                TaskStatus.FAILED,
+                InternalStatus.FAILED,
                 reason="replan_failed",
             )
             raise PlanRunError(
@@ -443,7 +440,7 @@ class PlanRunner:
             transition_task_status(
                 context,
                 record,
-                TaskStatus.FAILED,
+                InternalStatus.FAILED,
                 reason="replan_failed",
             )
             raise PlanRunError(
@@ -463,7 +460,7 @@ class PlanRunner:
         transition_task_status(
             context,
             record,
-            TaskStatus.RUNNING,
+            InternalStatus.RUNNING,
             reason="replan_succeeded",
         )
         return replanned_plan
@@ -476,11 +473,11 @@ class PlanRunner:
         reason: str,
     ) -> None:
         """将任务状态置为 FAILED（仅对非终态生效）"""
-        if context.status in TERMINAL_STATES:
+        if context.status in TERMINAL_INTERNAL_STATUSES:
             return
         transition_task_status(
             context,
             record,
-            TaskStatus.FAILED,
+            InternalStatus.FAILED,
             reason=reason,
         )

--- a/src/workflow/status.py
+++ b/src/workflow/status.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from typing import Callable, Optional
 
 from src.models.contracts import now_iso
-from src.models.db import TERMINAL_STATES, TaskRecord, TaskStatus
+from src.models.db import (
+    ExternalStatus,
+    InternalStatus,
+    TERMINAL_INTERNAL_STATUSES,
+    TaskRecord,
+    to_external_status,
+)
 from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
 
@@ -19,29 +25,40 @@ def _default_status_logger(event: dict) -> None:
     append_event(task_id, event)
 
 # FSM 允许的状态迁移集合，用于基础校验。
-_ALLOWED_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
-    TaskStatus.CREATED: {TaskStatus.PLANNING},
-    TaskStatus.PLANNING: {TaskStatus.PLANNED},
-    TaskStatus.PLANNED: {TaskStatus.RUNNING},
-    TaskStatus.RUNNING: {
-        TaskStatus.SUMMARIZING,
-        TaskStatus.WAITING_PATCH,
-        TaskStatus.WAITING_REPLAN,
+_ALLOWED_TRANSITIONS: dict[InternalStatus, set[InternalStatus]] = {
+    InternalStatus.CREATED: {InternalStatus.PLANNING},
+    InternalStatus.PLANNING: {
+        InternalStatus.PLANNED,
+        InternalStatus.WAITING_PLAN_CONFIRM,
     },
-    TaskStatus.WAITING_PATCH: {TaskStatus.PATCHING},
-    TaskStatus.PATCHING: {TaskStatus.RUNNING, TaskStatus.WAITING_REPLAN},
-    TaskStatus.WAITING_REPLAN: {TaskStatus.REPLANNING},
-    TaskStatus.REPLANNING: {TaskStatus.RUNNING},
-    TaskStatus.SUMMARIZING: {TaskStatus.DONE},
-    TaskStatus.DONE: set(),
-    TaskStatus.FAILED: set(),
+    InternalStatus.WAITING_PLAN_CONFIRM: {
+        InternalStatus.PLANNED,
+        InternalStatus.PLANNING,
+    },
+    InternalStatus.PLANNED: {InternalStatus.RUNNING},
+    InternalStatus.RUNNING: {
+        InternalStatus.SUMMARIZING,
+        InternalStatus.WAITING_PATCH,
+        InternalStatus.WAITING_REPLAN,
+    },
+    InternalStatus.WAITING_PATCH: {InternalStatus.PATCHING},
+    InternalStatus.PATCHING: {
+        InternalStatus.RUNNING,
+        InternalStatus.WAITING_REPLAN,
+    },
+    InternalStatus.WAITING_REPLAN: {InternalStatus.REPLANNING},
+    InternalStatus.REPLANNING: {InternalStatus.RUNNING},
+    InternalStatus.SUMMARIZING: {InternalStatus.DONE},
+    InternalStatus.DONE: set(),
+    InternalStatus.FAILED: set(),
+    InternalStatus.CANCELLED: set(),
 }
 
 
 def transition_task_status(
     context: WorkflowContext,
     record: Optional[TaskRecord],
-    to_status: TaskStatus,
+    to_status: InternalStatus,
     *,
     logger: Optional[StatusLogger] = None,
     reason: Optional[str] = None,
@@ -60,22 +77,32 @@ def transition_task_status(
     Raises:
         ValueError: 当 context/record 状态不一致、终态被修改或非法跳转时。
     """
-    if record is not None and record.status != context.status:
-        raise ValueError(
-            "TaskStatus mismatch between record and context: "
-            f"{record.status} != {context.status}"
-        )
+    if record is not None:
+        expected_external = to_external_status(context.status)
+        if record.status != expected_external:
+            raise ValueError(
+                "ExternalStatus mismatch between record and context: "
+                f"{record.status} != {expected_external}"
+            )
+        if (
+            record.internal_status is not None
+            and record.internal_status != context.status
+        ):
+            raise ValueError(
+                "InternalStatus mismatch between record and context: "
+                f"{record.internal_status} != {context.status}"
+            )
 
     from_status = context.status
     if from_status == to_status:
         return
 
-    if from_status in TERMINAL_STATES:
+    if from_status in TERMINAL_INTERNAL_STATUSES:
         raise ValueError(
             f"Cannot transition from terminal status: {from_status}"
         )
 
-    if to_status == TaskStatus.FAILED:
+    if to_status in (InternalStatus.FAILED, InternalStatus.CANCELLED):
         _apply_status_update(
             context, record, from_status, to_status, logger, reason, update_timestamp
         )
@@ -101,8 +128,8 @@ def transition_task_status(
 def _apply_status_update(
     context: WorkflowContext,
     record: Optional[TaskRecord],
-    from_status: TaskStatus,
-    to_status: TaskStatus,
+    from_status: InternalStatus,
+    to_status: InternalStatus,
     logger: Optional[StatusLogger],
     reason: Optional[str],
     update_timestamp: bool,
@@ -110,7 +137,8 @@ def _apply_status_update(
     """内部辅助函数：更新状态并可选写入状态变更事件。"""
     context.status = to_status
     if record is not None:
-        record.status = to_status
+        record.status = to_external_status(to_status)
+        record.internal_status = to_status
         if update_timestamp:
             record.updated_at = now_iso()
 
@@ -122,6 +150,7 @@ def _apply_status_update(
             "from_status": from_status.value,
             "to_status": to_status.value,
             "state": context.status.value,
+            "external_status": to_external_status(context.status).value,
             "reason": reason,
         }
     )

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 from src.models.contracts import ProteinDesignTask, now_iso
 from src.adapters.builtins import ensure_builtin_adapters
-from src.models.db import TaskRecord, TaskStatus, TERMINAL_STATES, derive_task_status
+from src.models.db import (
+    ExternalStatus,
+    InternalStatus,
+    TaskRecord,
+    TERMINAL_INTERNAL_STATUSES,
+    derive_task_status,
+)
 from src.agents.planner import PlannerAgent
 from src.agents.executor import ExecutorAgent
 from src.agents.summarizer import SummarizerAgent
@@ -19,7 +25,8 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
     # 初始 TaskRecord
     record = TaskRecord(
         id=task.task_id,
-        status=TaskStatus.CREATED,
+        status=ExternalStatus.CREATED,
+        internal_status=InternalStatus.CREATED,
         created_at=now_iso(),
         updated_at=now_iso(),
         goal=task.goal,
@@ -36,16 +43,16 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.CREATED,
+        status=InternalStatus.CREATED,
     )
 
     def _mark_failed_if_needed() -> None:
-        if ctx.status in TERMINAL_STATES:
+        if ctx.status in TERMINAL_INTERNAL_STATUSES:
             return
         transition_task_status(
             ctx,
             record,
-            TaskStatus.FAILED,
+            InternalStatus.FAILED,
             reason="workflow_error",
         )
 
@@ -54,7 +61,7 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
         transition_task_status(
             ctx,
             record,
-            TaskStatus.PLANNING,
+            InternalStatus.PLANNING,
             reason="task_created",
         )
         plan = planner.plan(task)
@@ -63,7 +70,7 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
         transition_task_status(
             ctx,
             record,
-            TaskStatus.PLANNED,
+            InternalStatus.PLANNED,
             reason="plan_generated",
         )
     except Exception:
@@ -76,7 +83,7 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
         transition_task_status(
             ctx,
             record,
-            TaskStatus.RUNNING,
+            InternalStatus.RUNNING,
             reason="plan_execution_start",
         )
         executor.run_plan(plan, ctx, record=record, finalize_status=False)
@@ -89,7 +96,7 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
         transition_task_status(
             ctx,
             record,
-            TaskStatus.SUMMARIZING,
+            InternalStatus.SUMMARIZING,
             reason="plan_execution_completed",
         )
         design = summarizer.summarize(ctx)
@@ -110,7 +117,7 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
 
     final_reason = (
         "summarizer_completed"
-        if final_status == TaskStatus.DONE
+        if final_status == InternalStatus.DONE
         else "workflow_failed"
     )
     transition_task_status(ctx, record, final_status, reason=final_reason)

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -3,7 +3,7 @@ import pytest
 import httpx
 
 from src.api.main import app
-from src.models.db import TaskStatus
+from src.models.db import ExternalStatus
 
 
 @pytest.mark.api
@@ -39,7 +39,7 @@ class TestAPIEndpoints:
         data = response.json()
         assert "id" in data
         assert data["goal"] == "设计一个测试蛋白质"
-        assert data["status"] == TaskStatus.DONE.value
+        assert data["status"] == ExternalStatus.DONE.value
 
     async def test_create_task_with_minimal_data(self, client: httpx.AsyncClient):
         """测试使用最少数据创建任务"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from src.models.contracts import (
     now_iso,
 )
 from src.workflow.context import WorkflowContext
-from src.models.db import TaskStatus
+from src.models.db import InternalStatus
 
 
 @pytest.fixture
@@ -59,7 +59,7 @@ def sample_workflow_context(sample_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.CREATED,
+        status=InternalStatus.CREATED,
     )
 
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -3,7 +3,7 @@ import pytest
 from pathlib import Path
 from src.workflow.workflow import run_task_sync
 from src.models.contracts import ProteinDesignTask
-from src.models.db import TaskStatus, TaskRecord
+from src.models.db import ExternalStatus, TaskRecord
 
 
 @pytest.mark.integration
@@ -16,7 +16,7 @@ class TestWorkflowIntegration:
         
         assert isinstance(record, TaskRecord)
         assert record.id == sample_task.task_id
-        assert record.status == TaskStatus.DONE
+        assert record.status == ExternalStatus.DONE
 
     def test_run_task_sync_creates_plan(self, sample_task: ProteinDesignTask):
         """测试任务执行创建计划"""
@@ -48,9 +48,9 @@ class TestWorkflowIntegration:
         # 但可以验证最终状态是正确的
         record = run_task_sync(sample_task)
         
-        assert record.status in [TaskStatus.DONE, TaskStatus.FAILED]
+        assert record.status in [ExternalStatus.DONE, ExternalStatus.FAILED]
         # 对于成功的任务，应该是DONE
-        if record.status == TaskStatus.DONE:
+        if record.status == ExternalStatus.DONE:
             assert record.design_result is not None
 
     def test_run_task_sync_with_custom_constraints(self):
@@ -67,7 +67,7 @@ class TestWorkflowIntegration:
         
         record = run_task_sync(task)
         
-        assert record.status == TaskStatus.DONE
+        assert record.status == ExternalStatus.DONE
         assert record.goal == task.goal
         assert record.constraints == task.constraints
 
@@ -95,7 +95,7 @@ class TestWorkflowIntegration:
         
         record = run_task_sync(task)
         
-        assert record.status == TaskStatus.DONE
+        assert record.status == ExternalStatus.DONE
         assert record.constraints == {}
 
     def test_run_task_sync_preserves_metadata(self, sample_task: ProteinDesignTask):

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -11,7 +11,7 @@ from src.models.contracts import (
     now_iso,
 )
 from src.workflow.context import WorkflowContext
-from src.models.db import TaskStatus
+from src.models.db import InternalStatus
 
 
 @pytest.mark.unit  # pytest标记：这是单元测试
@@ -161,14 +161,14 @@ class TestWorkflowContext:
             step_results={},
             safety_events=[],
             design_result=None,
-            status=TaskStatus.CREATED,
+            status=InternalStatus.CREATED,
         )
         
         assert context.task == sample_task
         assert context.plan is None
         assert isinstance(context.step_results, dict)
         assert isinstance(context.safety_events, list)
-        assert context.status == TaskStatus.CREATED
+        assert context.status == InternalStatus.CREATED
 
 
 @pytest.mark.unit

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1,12 +1,14 @@
 """数据库模型单元测试"""
 import pytest
 from src.models.db import (
-    TaskStatus,
+    ExternalStatus,
+    InternalStatus,
     StepStatus,
     TaskRecord,
     StepRecord,
     derive_task_status,
     step_result_to_record,
+    to_external_status,
 )
 from src.models.contracts import (
     ProteinDesignTask,
@@ -22,13 +24,27 @@ from src.models.contracts import (
 
 @pytest.mark.unit
 class TestTaskStatus:
-    """TaskStatus枚举测试"""
+    """ExternalStatus / InternalStatus 枚举测试"""
 
     def test_task_status_values(self):
-        """测试任务状态值"""
-        expected_names = {
+        """测试 ExternalStatus 状态值"""
+        expected_external = {
             "CREATED",
             "PLANNING",
+            "WAITING_PLAN_CONFIRM",
+            "PLANNED",
+            "RUNNING",
+            "WAITING_PATCH_CONFIRM",
+            "WAITING_REPLAN_CONFIRM",
+            "SUMMARIZING",
+            "DONE",
+            "FAILED",
+            "CANCELLED",
+        }
+        expected_internal = {
+            "CREATED",
+            "PLANNING",
+            "WAITING_PLAN_CONFIRM",
             "PLANNED",
             "RUNNING",
             "WAITING_PATCH",
@@ -38,15 +54,54 @@ class TestTaskStatus:
             "SUMMARIZING",
             "DONE",
             "FAILED",
+            "CANCELLED",
         }
 
-        assert set(TaskStatus.__members__.keys()) == expected_names
-        assert {status.value for status in TaskStatus} == expected_names
+        assert set(ExternalStatus.__members__.keys()) == expected_external
+        assert {status.value for status in ExternalStatus} == expected_external
+        assert set(InternalStatus.__members__.keys()) == expected_internal
+        assert {status.value for status in InternalStatus} == expected_internal
 
     def test_terminal_states(self):
         """测试终端状态"""
-        from src.models.db import TERMINAL_STATES
-        assert TERMINAL_STATES == {TaskStatus.DONE, TaskStatus.FAILED}
+        from src.models.db import (
+            TERMINAL_EXTERNAL_STATUSES,
+            TERMINAL_INTERNAL_STATUSES,
+        )
+
+        assert TERMINAL_EXTERNAL_STATUSES == {
+            ExternalStatus.DONE,
+            ExternalStatus.FAILED,
+            ExternalStatus.CANCELLED,
+        }
+        assert TERMINAL_INTERNAL_STATUSES == {
+            InternalStatus.DONE,
+            InternalStatus.FAILED,
+            InternalStatus.CANCELLED,
+        }
+
+    def test_internal_to_external_mapping(self):
+        """测试内部状态到外部语义状态映射"""
+        assert (
+            to_external_status(InternalStatus.WAITING_PATCH)
+            == ExternalStatus.WAITING_PATCH_CONFIRM
+        )
+        assert (
+            to_external_status(InternalStatus.PATCHING)
+            == ExternalStatus.WAITING_PATCH_CONFIRM
+        )
+        assert (
+            to_external_status(InternalStatus.WAITING_REPLAN)
+            == ExternalStatus.WAITING_REPLAN_CONFIRM
+        )
+        assert (
+            to_external_status(InternalStatus.REPLANNING)
+            == ExternalStatus.WAITING_REPLAN_CONFIRM
+        )
+        assert (
+            to_external_status(InternalStatus.RUNNING)
+            == ExternalStatus.RUNNING
+        )
 
 
 @pytest.mark.unit
@@ -57,7 +112,8 @@ class TestTaskRecord:
         """测试任务记录创建"""
         record = TaskRecord(
             id=sample_task.task_id,
-            status=TaskStatus.CREATED,
+            status=ExternalStatus.CREATED,
+            internal_status=InternalStatus.CREATED,
             created_at=now_iso(),
             updated_at=now_iso(),
             goal=sample_task.goal,
@@ -69,7 +125,8 @@ class TestTaskRecord:
         )
         
         assert record.id == sample_task.task_id
-        assert record.status == TaskStatus.CREATED
+        assert record.status == ExternalStatus.CREATED
+        assert record.internal_status == InternalStatus.CREATED
         assert record.goal == sample_task.goal
 
 
@@ -97,7 +154,7 @@ class TestDeriveTaskStatus:
             design_result,
         )
         
-        assert status == TaskStatus.DONE
+        assert status == InternalStatus.DONE
 
     def test_derive_status_failed_with_failed_step(self, sample_task: ProteinDesignTask):
         """测试有失败步骤时状态为FAILED"""
@@ -124,7 +181,7 @@ class TestDeriveTaskStatus:
             None,
         )
         
-        assert status == TaskStatus.FAILED
+        assert status == InternalStatus.FAILED
 
     def test_derive_status_failed_with_block_safety(self, sample_task: ProteinDesignTask):
         """测试有block安全事件时状态为FAILED"""
@@ -145,7 +202,7 @@ class TestDeriveTaskStatus:
             None,
         )
         
-        assert status == TaskStatus.FAILED
+        assert status == InternalStatus.FAILED
 
     def test_derive_status_created_when_no_plan(self, sample_task: ProteinDesignTask):
         """测试没有计划时状态为CREATED"""
@@ -157,7 +214,7 @@ class TestDeriveTaskStatus:
             None,
         )
         
-        assert status == TaskStatus.CREATED
+        assert status == InternalStatus.CREATED
 
     def test_derive_status_planned_when_plan_exists_but_no_steps(self, sample_task: ProteinDesignTask):
         """测试有计划但无步骤执行时状态为PLANNED"""
@@ -176,7 +233,7 @@ class TestDeriveTaskStatus:
             None,
         )
         
-        assert status == TaskStatus.PLANNED
+        assert status == InternalStatus.PLANNED
 
     def test_derive_status_running_when_steps_executed(self, sample_task: ProteinDesignTask):
         """测试有步骤执行时状态为RUNNING"""
@@ -210,7 +267,7 @@ class TestDeriveTaskStatus:
             None,
         )
         
-        assert status == TaskStatus.RUNNING
+        assert status == InternalStatus.RUNNING
 
 
 @pytest.mark.unit

--- a/tests/unit/test_patch_runner.py
+++ b/tests/unit/test_patch_runner.py
@@ -8,7 +8,7 @@ from src.models.contracts import (
     StepResult,
     now_iso,
 )
-from src.models.db import TaskRecord, TaskStatus
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
 from src.workflow.context import WorkflowContext
 from src.workflow.patch_runner import PatchRunner
 from src.workflow.errors import FailureType
@@ -88,11 +88,12 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task):
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.RUNNING,
+        status=InternalStatus.RUNNING,
     )
     record = TaskRecord(
         id=sample_task.task_id,
-        status=TaskStatus.RUNNING,
+        status=ExternalStatus.RUNNING,
+        internal_status=InternalStatus.RUNNING,
         goal=sample_task.goal,
         constraints=sample_task.constraints,
         metadata=sample_task.metadata,

--- a/tests/unit/test_plan_runner.py
+++ b/tests/unit/test_plan_runner.py
@@ -12,7 +12,7 @@ from src.models.contracts import (
     StepResult,
     now_iso,
 )
-from src.models.db import TaskStatus
+from src.models.db import InternalStatus
 
 from src.workflow.context import WorkflowContext
 from src.workflow.plan_runner import PlanRunner, StepRunnerLike
@@ -170,7 +170,7 @@ def fresh_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.CREATED,
+        status=InternalStatus.CREATED,
     )
 
 @pytest.fixture
@@ -182,7 +182,7 @@ def planned_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.PLANNED,
+        status=InternalStatus.PLANNED,
     )
 
 # 核心行为测试
@@ -320,7 +320,7 @@ def test_run_plan_wraps_unknown_exception_as_tool_error(
     assert excinfo.value.step_id == "S1"
 
 
-# A3: TaskStatus 状态机测试
+# A3: InternalStatus 状态机测试
 
 def test_run_plan_updates_status_from_planned_to_done(
     single_step_plan: Plan,
@@ -331,12 +331,12 @@ def test_run_plan_updates_status_from_planned_to_done(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态应为 PLANNED
-    assert planned_context.status == TaskStatus.PLANNED
+    assert planned_context.status == InternalStatus.PLANNED
     
     plan_runner.run_plan(single_step_plan, planned_context)
     
     # 执行后状态应为 DONE
-    assert planned_context.status == TaskStatus.DONE
+    assert planned_context.status == InternalStatus.DONE
     # 确保步骤已执行
     assert "S1" in planned_context.step_results
 
@@ -350,12 +350,12 @@ def test_run_plan_does_not_change_status_if_not_planned(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 CREATED
-    assert fresh_context.status == TaskStatus.CREATED
+    assert fresh_context.status == InternalStatus.CREATED
     
     plan_runner.run_plan(single_step_plan, fresh_context)
     
     # 状态应保持为 CREATED（不自动更新为 RUNNING）
-    assert fresh_context.status == TaskStatus.CREATED
+    assert fresh_context.status == InternalStatus.CREATED
     # 但步骤应该已执行
     assert "S1" in fresh_context.step_results
 
@@ -371,7 +371,7 @@ def test_run_plan_updates_status_to_done_after_completion(
     plan_runner.run_plan(multi_step_plan, planned_context)
     
     # 执行后状态应为 DONE
-    assert planned_context.status == TaskStatus.DONE
+    assert planned_context.status == InternalStatus.DONE
     # 确保所有步骤已执行
     assert len(planned_context.step_results) == 3
 
@@ -385,14 +385,14 @@ def test_run_plan_maintains_status_on_exception(
     plan_runner = PlanRunner(step_runner=failing_runner)
     
     # 初始状态为 PLANNED
-    assert planned_context.status == TaskStatus.PLANNED
+    assert planned_context.status == InternalStatus.PLANNED
     
     # 执行会抛出异常
     with pytest.raises(PlanRunError) as excinfo:
         plan_runner.run_plan(single_step_plan, planned_context)
     
     # 根据实现，失败应将状态置为 FAILED
-    assert planned_context.status == TaskStatus.FAILED
+    assert planned_context.status == InternalStatus.FAILED
     # 确保没有步骤结果被写入
     assert planned_context.step_results == {}
     assert excinfo.value.failure_type == FailureType.RETRYABLE
@@ -410,7 +410,7 @@ def test_run_plan_with_empty_steps_updates_status(
     plan_runner.run_plan(empty_plan, planned_context)
     
     # 状态应更新为 DONE
-    assert planned_context.status == TaskStatus.DONE
+    assert planned_context.status == InternalStatus.DONE
     # 没有步骤执行
     assert runner.called_steps == []
     assert planned_context.step_results == {}
@@ -430,7 +430,7 @@ def test_run_plan_stops_at_summarizing_when_finalize_false(
         finalize_status=False,
     )
 
-    assert planned_context.status == TaskStatus.SUMMARIZING
+    assert planned_context.status == InternalStatus.SUMMARIZING
 
 
 def test_run_plan_triggers_patch_after_retry_exhausted(
@@ -603,7 +603,7 @@ def planning_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.PLANNING,
+        status=InternalStatus.PLANNING,
     )
 
 
@@ -616,7 +616,7 @@ def running_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.RUNNING,
+        status=InternalStatus.RUNNING,
     )
 
 
@@ -629,7 +629,7 @@ def summarizing_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.SUMMARIZING,
+        status=InternalStatus.SUMMARIZING,
     )
 
 
@@ -642,7 +642,7 @@ def done_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.DONE,
+        status=InternalStatus.DONE,
     )
 
 
@@ -655,7 +655,7 @@ def failed_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.FAILED,
+        status=InternalStatus.FAILED,
     )
 
 
@@ -668,12 +668,12 @@ def test_run_plan_from_planning_status_does_not_change_status(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 PLANNING
-    assert planning_context.status == TaskStatus.PLANNING
+    assert planning_context.status == InternalStatus.PLANNING
     
     plan_runner.run_plan(single_step_plan, planning_context)
     
     # 状态应保持为 PLANNING（PlanRunner 不负责 PLANNING 状态的管理）
-    assert planning_context.status == TaskStatus.PLANNING
+    assert planning_context.status == InternalStatus.PLANNING
     # 但步骤应该已执行
     assert "S1" in planning_context.step_results
 
@@ -687,12 +687,12 @@ def test_run_plan_from_running_status_updates_to_done(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 RUNNING
-    assert running_context.status == TaskStatus.RUNNING
+    assert running_context.status == InternalStatus.RUNNING
     
     plan_runner.run_plan(single_step_plan, running_context)
     
     # 状态应更新为 DONE
-    assert running_context.status == TaskStatus.DONE
+    assert running_context.status == InternalStatus.DONE
     # 确保步骤已执行
     assert "S1" in running_context.step_results
 
@@ -706,12 +706,12 @@ def test_run_plan_from_summarizing_status_does_not_change_status(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 SUMMARIZING
-    assert summarizing_context.status == TaskStatus.SUMMARIZING
+    assert summarizing_context.status == InternalStatus.SUMMARIZING
     
     plan_runner.run_plan(single_step_plan, summarizing_context)
     
     # 状态应保持为 SUMMARIZING（PlanRunner 不负责 SUMMARIZING 状态的管理）
-    assert summarizing_context.status == TaskStatus.SUMMARIZING
+    assert summarizing_context.status == InternalStatus.SUMMARIZING
     # 但步骤应该已执行
     assert "S1" in summarizing_context.step_results
 
@@ -725,12 +725,12 @@ def test_run_plan_from_done_status_does_not_change_status(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 DONE
-    assert done_context.status == TaskStatus.DONE
+    assert done_context.status == InternalStatus.DONE
     
     plan_runner.run_plan(single_step_plan, done_context)
     
     # 状态应保持为 DONE（终端状态不应被改变）
-    assert done_context.status == TaskStatus.DONE
+    assert done_context.status == InternalStatus.DONE
     # 但步骤应该已执行（允许在终端状态下执行，但状态不变）
     assert "S1" in done_context.step_results
 
@@ -744,12 +744,12 @@ def test_run_plan_from_failed_status_does_not_change_status(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 FAILED
-    assert failed_context.status == TaskStatus.FAILED
+    assert failed_context.status == InternalStatus.FAILED
     
     plan_runner.run_plan(single_step_plan, failed_context)
     
     # 状态应保持为 FAILED（终端状态不应被改变）
-    assert failed_context.status == TaskStatus.FAILED
+    assert failed_context.status == InternalStatus.FAILED
     # 但步骤应该已执行（允许在终端状态下执行，但状态不变）
     assert "S1" in failed_context.step_results
 
@@ -764,11 +764,11 @@ def test_run_plan_state_transition_planned_to_done_is_idempotent(
     
     # 第一次执行：PLANNED → DONE
     plan_runner.run_plan(single_step_plan, planned_context)
-    assert planned_context.status == TaskStatus.DONE
+    assert planned_context.status == InternalStatus.DONE
     
     # 第二次执行：应该保持 DONE
     plan_runner.run_plan(single_step_plan, planned_context)
-    assert planned_context.status == TaskStatus.DONE
+    assert planned_context.status == InternalStatus.DONE
     
     # 确保步骤被执行了两次
     assert len(runner.called_steps) == 2
@@ -784,13 +784,13 @@ def test_run_plan_complete_state_flow_created_stays_created(
     plan_runner = PlanRunner(step_runner=runner)
     
     # 初始状态为 CREATED
-    assert fresh_context.status == TaskStatus.CREATED
+    assert fresh_context.status == InternalStatus.CREATED
     
     # 执行计划（不改变状态，因为不是 PLANNED）
     plan_runner.run_plan(single_step_plan, fresh_context)
     
     # 状态应保持为 CREATED
-    assert fresh_context.status == TaskStatus.CREATED
+    assert fresh_context.status == InternalStatus.CREATED
     # 但步骤应该已执行
     assert "S1" in fresh_context.step_results
     assert fresh_context.plan is single_step_plan
@@ -964,7 +964,7 @@ def test_plan_runner_blocks_when_task_input_safety_blocks(
 
     assert excinfo.value.failure_type == FailureType.SAFETY_BLOCK
     # 输入阻断后最终应进入 FAILED
-    assert planned_context.status == TaskStatus.FAILED
+    assert planned_context.status == InternalStatus.FAILED
     assert planned_context.step_results == {}
     assert planned_context.safety_events[-1].action == "block"
 
@@ -1000,4 +1000,4 @@ def test_plan_runner_blocks_on_final_safety(
     # 步骤已执行，但最终安全阻断
     assert "S1" in planned_context.step_results
     assert planned_context.safety_events[-1].action == "block"
-    assert planned_context.status == TaskStatus.FAILED
+    assert planned_context.status == InternalStatus.FAILED

--- a/tests/unit/test_safety_agent.py
+++ b/tests/unit/test_safety_agent.py
@@ -15,7 +15,7 @@ from src.models.contracts import (
 
 from src.agents.safety import SafetyAgent
 from src.workflow.context import WorkflowContext
-from src.models.db import TaskStatus
+from src.models.db import InternalStatus
 
 
 @pytest.fixture
@@ -52,7 +52,7 @@ def dummy_context(dummy_task: ProteinDesignTask) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.CREATED,
+            status=InternalStatus.CREATED,
     )
 
 

--- a/tests/unit/test_status_transition.py
+++ b/tests/unit/test_status_transition.py
@@ -2,17 +2,23 @@
 import pytest
 
 from src.models.contracts import now_iso
-from src.models.db import TaskRecord, TaskStatus
+from src.models.db import (
+    ExternalStatus,
+    InternalStatus,
+    TaskRecord,
+    to_external_status,
+)
 from src.workflow.context import WorkflowContext
 from src.workflow.status import transition_task_status
 
 
 @pytest.mark.unit
 class TestTaskStatusTransition:
-    def _make_record(self, task_id: str, status: TaskStatus) -> TaskRecord:
+    def _make_record(self, task_id: str, status: InternalStatus) -> TaskRecord:
         return TaskRecord(
             id=task_id,
-            status=status,
+            status=to_external_status(status),
+            internal_status=status,
             created_at=now_iso(),
             updated_at=now_iso(),
             goal="test",
@@ -24,16 +30,17 @@ class TestTaskStatusTransition:
         )
 
     def test_transition_updates_context_and_record(self, sample_task):
-        record = self._make_record(sample_task.task_id, TaskStatus.CREATED)
-        context = WorkflowContext(task=sample_task, status=TaskStatus.CREATED)
+        record = self._make_record(sample_task.task_id, InternalStatus.CREATED)
+        context = WorkflowContext(task=sample_task, status=InternalStatus.CREATED)
         events: list[dict] = []
 
         transition_task_status(
-            context, record, TaskStatus.PLANNING, logger=events.append
+            context, record, InternalStatus.PLANNING, logger=events.append
         )
 
-        assert context.status == TaskStatus.PLANNING
-        assert record.status == TaskStatus.PLANNING
+        assert context.status == InternalStatus.PLANNING
+        assert record.status == ExternalStatus.PLANNING
+        assert record.internal_status == InternalStatus.PLANNING
         assert events == [
             {
                 "event": "TASK_STATUS_CHANGED",
@@ -41,45 +48,49 @@ class TestTaskStatusTransition:
                 "from_status": "CREATED",
                 "to_status": "PLANNING",
                 "state": "PLANNING",
+                "external_status": "PLANNING",
                 "reason": None,
             }
         ]
 
     def test_transition_rejects_invalid_jump(self, sample_task):
-        record = self._make_record(sample_task.task_id, TaskStatus.CREATED)
-        context = WorkflowContext(task=sample_task, status=TaskStatus.CREATED)
+        record = self._make_record(sample_task.task_id, InternalStatus.CREATED)
+        context = WorkflowContext(task=sample_task, status=InternalStatus.CREATED)
 
         with pytest.raises(ValueError):
-            transition_task_status(context, record, TaskStatus.RUNNING)
+            transition_task_status(context, record, InternalStatus.RUNNING)
 
     def test_transition_rejects_status_mismatch(self, sample_task):
-        record = self._make_record(sample_task.task_id, TaskStatus.PLANNED)
-        context = WorkflowContext(task=sample_task, status=TaskStatus.CREATED)
+        record = self._make_record(sample_task.task_id, InternalStatus.PLANNED)
+        context = WorkflowContext(task=sample_task, status=InternalStatus.CREATED)
 
         with pytest.raises(ValueError):
-            transition_task_status(context, record, TaskStatus.PLANNING)
+            transition_task_status(context, record, InternalStatus.PLANNING)
 
     @pytest.mark.parametrize(
         "from_status,to_status",
         [
-            (TaskStatus.CREATED, TaskStatus.PLANNING),
-            (TaskStatus.PLANNING, TaskStatus.PLANNED),
-            (TaskStatus.PLANNING, TaskStatus.FAILED),
-            (TaskStatus.PLANNED, TaskStatus.RUNNING),
-            (TaskStatus.RUNNING, TaskStatus.WAITING_PATCH),
-            (TaskStatus.RUNNING, TaskStatus.WAITING_REPLAN),
-            (TaskStatus.RUNNING, TaskStatus.SUMMARIZING),
-            (TaskStatus.WAITING_PATCH, TaskStatus.PATCHING),
-            (TaskStatus.PATCHING, TaskStatus.RUNNING),
-            (TaskStatus.PATCHING, TaskStatus.WAITING_REPLAN),
-            (TaskStatus.WAITING_REPLAN, TaskStatus.REPLANNING),
-            (TaskStatus.REPLANNING, TaskStatus.RUNNING),
-            (TaskStatus.REPLANNING, TaskStatus.FAILED),
-            (TaskStatus.SUMMARIZING, TaskStatus.DONE),
+            (InternalStatus.CREATED, InternalStatus.PLANNING),
+            (InternalStatus.PLANNING, InternalStatus.PLANNED),
+            (InternalStatus.PLANNING, InternalStatus.WAITING_PLAN_CONFIRM),
+            (InternalStatus.WAITING_PLAN_CONFIRM, InternalStatus.PLANNED),
+            (InternalStatus.WAITING_PLAN_CONFIRM, InternalStatus.PLANNING),
+            (InternalStatus.PLANNING, InternalStatus.FAILED),
+            (InternalStatus.PLANNED, InternalStatus.RUNNING),
+            (InternalStatus.RUNNING, InternalStatus.WAITING_PATCH),
+            (InternalStatus.RUNNING, InternalStatus.WAITING_REPLAN),
+            (InternalStatus.RUNNING, InternalStatus.SUMMARIZING),
+            (InternalStatus.WAITING_PATCH, InternalStatus.PATCHING),
+            (InternalStatus.PATCHING, InternalStatus.RUNNING),
+            (InternalStatus.PATCHING, InternalStatus.WAITING_REPLAN),
+            (InternalStatus.WAITING_REPLAN, InternalStatus.REPLANNING),
+            (InternalStatus.REPLANNING, InternalStatus.RUNNING),
+            (InternalStatus.REPLANNING, InternalStatus.FAILED),
+            (InternalStatus.SUMMARIZING, InternalStatus.DONE),
         ],
     )
     def test_transition_allows_expected_pairs(
-        self, sample_task, from_status: TaskStatus, to_status: TaskStatus
+        self, sample_task, from_status: InternalStatus, to_status: InternalStatus
     ):
         record = self._make_record(sample_task.task_id, from_status)
         context = WorkflowContext(task=sample_task, status=from_status)
@@ -87,35 +98,48 @@ class TestTaskStatusTransition:
         transition_task_status(context, record, to_status)
 
         assert context.status == to_status
-        assert record.status == to_status
+        assert record.status == to_external_status(to_status)
+        assert record.internal_status == to_status
 
     @pytest.mark.parametrize(
         "start,sequence",
         [
             (
-                TaskStatus.PLANNED,
-                [TaskStatus.RUNNING, TaskStatus.SUMMARIZING, TaskStatus.DONE],
+                InternalStatus.PLANNED,
+                [
+                    InternalStatus.RUNNING,
+                    InternalStatus.SUMMARIZING,
+                    InternalStatus.DONE,
+                ],
             ),
             (
-                TaskStatus.RUNNING,
-                [TaskStatus.WAITING_PATCH, TaskStatus.PATCHING, TaskStatus.RUNNING],
+                InternalStatus.RUNNING,
+                [
+                    InternalStatus.WAITING_PATCH,
+                    InternalStatus.PATCHING,
+                    InternalStatus.RUNNING,
+                ],
             ),
             (
-                TaskStatus.RUNNING,
-                [TaskStatus.WAITING_REPLAN, TaskStatus.REPLANNING, TaskStatus.RUNNING],
+                InternalStatus.RUNNING,
+                [
+                    InternalStatus.WAITING_REPLAN,
+                    InternalStatus.REPLANNING,
+                    InternalStatus.RUNNING,
+                ],
             ),
             (
-                TaskStatus.REPLANNING,
-                [TaskStatus.FAILED],
+                InternalStatus.REPLANNING,
+                [InternalStatus.FAILED],
             ),
             (
-                TaskStatus.RUNNING,
-                [TaskStatus.WAITING_REPLAN, TaskStatus.REPLANNING],
+                InternalStatus.RUNNING,
+                [InternalStatus.WAITING_REPLAN, InternalStatus.REPLANNING],
             ),
         ],
     )
     def test_transition_allows_expected_sequences(
-        self, sample_task, start: TaskStatus, sequence: list[TaskStatus]
+        self, sample_task, start: InternalStatus, sequence: list[InternalStatus]
     ):
         record = self._make_record(sample_task.task_id, start)
         context = WorkflowContext(task=sample_task, status=start)
@@ -124,4 +148,5 @@ class TestTaskStatusTransition:
             transition_task_status(context, record, target)
 
         assert context.status == sequence[-1]
-        assert record.status == sequence[-1]
+        assert record.status == to_external_status(sequence[-1])
+        assert record.internal_status == sequence[-1]

--- a/tests/unit/test_step_runner.py
+++ b/tests/unit/test_step_runner.py
@@ -16,7 +16,7 @@ from src.workflow.step_runner import StepRunner
 from src.workflow.errors import FailureType, StepRunError
 from src.models.contracts import ProteinDesignTask, PlanStep, StepResult
 from src.workflow.context import WorkflowContext
-from src.models.db import TaskStatus
+from src.models.db import InternalStatus
 from src.workflow.step_runner import StepRetryPolicy
 
 
@@ -122,7 +122,7 @@ def empty_context(dummy_task) -> WorkflowContext:
         step_results={},
         safety_events=[],
         design_result=None,
-        status=TaskStatus.CREATED,
+        status=InternalStatus.CREATED,
     )
 
 def test_run_step_returns_steppresult_instance(empty_context):


### PR DESCRIPTION
## What

实现 Issue #9: 任务状态机重构，拆分 ExternalStatus / InternalStatus，并将执行链路统一迁移到 InternalStatus 驱动，同时持久化 external/internal 两态以保证对外一致性与内部可控性。

## Why

- 解决 对外展示状态 与 内部执行状态 混用导致的隐式跳转与不可审计问题
- 为后续 HITL 与决策提交提供稳定的状态契约
- 对齐系统设计中 FSM 的显式转移与终态保护要求

## Changes

### 1) 状态机拆分与映射(src/models/db.py)

- 新增 `ExternalStatus` / `InternalStatus`
- 新增 `to_external_status`
- 新增 `TERMINAL_EXTERNAL_STATUSES` / `TERMINAL_INTERNAL_STATUSES`
- `TaskRecord` 增加 `internal_status`
- `derive_task_status` 现在返回 `InternalStatus`

## 2) 状态转移统一入口与落库一致（src/workflow/status.py）
- 状态转移统一入口改为 `InternalStatus`
- 转移时同时写入 external/internal
- 合法转移表包含 `WAITING_PLAN_CONFIRM`
- 禁止隐式跳转，终态保护包含 `CANCELLED`
- 日志事件增加 `external_status`

### 3) 执行链路迁移到 InternalStatus
- `src/workflow/context.py`
- `src/workflow/workflow.py`
- `src/workflow/plan_runner.py`
- `src/workflow/patch_runner.py`

## Tests
- 更新所有使用 TaskStatus 的测试为 External/Internal 双态
- 新增 internal -> external 映射断言
- 状态转移测试改为 InternalStatus，并校验 ExternalStatus 的写入一致性

Closes #9 

