### PR TITLE
feat(model): 增加最小 TaskSnapshot 结构与验证

### DIFF
--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, List, Optional, Literal
+from typing import Any, Dict, List, Optional, Literal
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
@@ -260,15 +261,86 @@ class Decision(BaseModel):
         return self
 
 
+class ArtifactRef(BaseModel):
+    """Reference to a persisted artifact."""
+
+    uri: str
+    metadata: Dict = Field(default_factory=dict)
+
+
 class TaskSnapshot(BaseModel):
     """任务在某一时间点的最小可恢复上下文"""
 
     snapshot_id: str
     task_id: str
     state: str
-    plan_version: Optional[str] = None
+    plan_version: Optional[int] = None
+    step_index: int = 0
+    artifacts: Dict[str, Any] = Field(default_factory=dict)
     current_step_index: int = 0
     completed_step_ids: List[str] = Field(default_factory=list)
-    artifacts: Dict[str, str] = Field(default_factory=dict)
     pending_action_id: Optional[str] = None
     created_at: str = Field(default_factory=now_iso)
+
+    @field_validator("state")
+    @classmethod
+    def _validate_state(cls, value: str) -> str:
+        from src.models.db import ExternalStatus
+
+        allowed_states = {status.value for status in ExternalStatus}
+        if value not in allowed_states:
+            raise ValueError(f"state must be one of {sorted(allowed_states)}")
+        return value
+
+    @field_validator("plan_version")
+    @classmethod
+    def _validate_plan_version(cls, value: Optional[int]) -> Optional[int]:
+        if value is None:
+            return value
+        if value < 0:
+            raise ValueError("plan_version must be >= 0")
+        return value
+
+    @field_validator("step_index")
+    @classmethod
+    def _validate_step_index(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("step_index must be >= 0")
+        return value
+
+    @field_validator("current_step_index")
+    @classmethod
+    def _validate_current_step_index(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("current_step_index must be >= 0")
+        return value
+
+    @field_validator("artifacts")
+    @classmethod
+    def _validate_artifacts(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError("artifacts must be a mapping")
+        for key, artifact in value.items():
+            if not isinstance(key, str):
+                raise ValueError("artifacts keys must be strings")
+            if isinstance(artifact, ArtifactRef):
+                continue
+            try:
+                json.dumps(artifact, ensure_ascii=True)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "artifacts must be JSON-serializable or ArtifactRef"
+                ) from exc
+        return value
+
+    @model_validator(mode="after")
+    def _sync_step_index(self):
+        step_set = "step_index" in self.model_fields_set
+        current_set = "current_step_index" in self.model_fields_set
+        if step_set and not current_set:
+            self.current_step_index = self.step_index
+        elif current_set and not step_set:
+            self.step_index = self.current_step_index
+        elif self.step_index != self.current_step_index:
+            raise ValueError("step_index must match current_step_index")
+        return self

--- a/src/workflow/snapshots.py
+++ b/src/workflow/snapshots.py
@@ -29,6 +29,7 @@ def build_task_snapshot(
         task_id=context.task.task_id,
         state=external_state.value,
         plan_version=_extract_plan_version(context),
+        step_index=len(step_ids),
         current_step_index=len(step_ids),
         completed_step_ids=step_ids,
         artifacts={},
@@ -37,7 +38,7 @@ def build_task_snapshot(
     )
 
 
-def _extract_plan_version(context: WorkflowContext) -> Optional[str]:
+def _extract_plan_version(context: WorkflowContext) -> Optional[int]:
     plan = context.plan
     if plan is None:
         return None
@@ -45,5 +46,8 @@ def _extract_plan_version(context: WorkflowContext) -> Optional[str]:
         value = plan.metadata.get("plan_version")
         if value is None:
             return None
-        return str(value)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
     return None

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.models.contracts import ArtifactRef, TaskSnapshot, now_iso
+from src.models.db import ExternalStatus
+
+
+@pytest.mark.unit
+def test_task_snapshot_can_construct():
+    snapshot = TaskSnapshot(
+        snapshot_id="snapshot_001",
+        task_id="task_001",
+        state=ExternalStatus.CREATED.value,
+        plan_version=1,
+        step_index=0,
+        artifacts={
+            "log_path": "data/logs/task_001.jsonl",
+            "report_ref": ArtifactRef(uri="output/report.json"),
+        },
+        created_at=now_iso(),
+    )
+
+    assert snapshot.step_index == 0
+    assert snapshot.current_step_index == 0
+    assert snapshot.plan_version == 1
+
+
+@pytest.mark.unit
+def test_task_snapshot_round_trip():
+    snapshot = TaskSnapshot(
+        snapshot_id="snapshot_002",
+        task_id="task_002",
+        state=ExternalStatus.RUNNING.value,
+        plan_version=2,
+        step_index=3,
+        artifacts={
+            "metrics": {"runtime_ms": 12, "tool": "dummy"},
+            "artifact_path": "output/artifacts/a.json",
+        },
+        created_at=now_iso(),
+    )
+
+    payload = snapshot.model_dump()
+    restored = TaskSnapshot.model_validate(payload)
+
+    assert restored.model_dump() == payload
+
+
+@pytest.mark.unit
+def test_task_snapshot_rejects_negative_plan_version():
+    with pytest.raises(ValueError):
+        TaskSnapshot(
+            snapshot_id="snapshot_003",
+            task_id="task_003",
+            state=ExternalStatus.CREATED.value,
+            plan_version=-1,
+            step_index=0,
+            artifacts={},
+            created_at=now_iso(),
+        )
+
+
+@pytest.mark.unit
+def test_task_snapshot_rejects_negative_step_index():
+    with pytest.raises(ValueError):
+        TaskSnapshot(
+            snapshot_id="snapshot_004",
+            task_id="task_004",
+            state=ExternalStatus.CREATED.value,
+            plan_version=0,
+            step_index=-2,
+            artifacts={},
+            created_at=now_iso(),
+        )


### PR DESCRIPTION
## Summary

引入可手动构造的最小 TaskSnapshot，并补齐字段校验与序列化保障，为后续恢复机制做准备。

## Background

当前快照结构字段与校验不完整，缺少最小恢复所需的 plan_version / step_index / artifacts 约束，且缺少对应单测。

## Changes

- 在 TaskSnapshot 中新增 step_index、ArtifactRef 与校验逻辑，保证状态、版本与工件合法。
- 兼容旧字段 current_step_index，并确保与 step_index 同步。
- build_task_snapshot 写入新的 step_index 并将 plan_version 解析为非负整数。
- 新增单测覆盖手动构造、序列化往返与负值拒绝。

## Impact / Risk

- 影响：快照校验更严格，非法数据将更早被拒绝。
- 风险：若上游使用了不符合约束的字段值，会触发校验错误；已有单测覆盖基础场景。

## Related

- Closes #13
