### PR TITLE
refactor(design): 重构设计文档以支持可寻址结构

### DIFF
--- a/docs/design/agent-design.md
+++ b/docs/design/agent-design.md
@@ -1,10 +1,19 @@
+---
+doc_key: agent
+version: 1.0
+status: stable
+depends_on: [arch]
+---
+
 # Agent设计文档
 
 本文档用于定义系统中四类核心Agent(Planner/Executor/Safety/Summarizer)的职责边界、输入输出契约、交互方式以及在整体工作流中的协作关系。
 
 ## Agent体系总览
+<!-- SID:agent.overview.introduction -->
 
 ### 角色列表
+<!-- SID:agent.overview.roles -->
 
 系统中定义四类核心Agent：
 
@@ -33,10 +42,12 @@
 6. 若执行中发生错误或高风险，PlannserAgent可通过`replan`/`patch`更新计划
 
 ## 接口定义
+<!-- SID:agent.contracts.overview -->
 
 ### 核心数据结构接口
 
 #### ProteinDesignTask
+<!-- SID:agent.contracts.protein_design_task -->
 
 ```python
 @dataclass
@@ -48,6 +59,7 @@ class ProteinDesignTask:
 ```
 
 #### Plan(Planner 输出)
+<!-- SID:agent.contracts.plan -->
 
 ```python
 @dataclass
@@ -66,6 +78,7 @@ class Plan:
 ```
 
 #### StepResult(执行步骤结果)
+<!-- SID:agent.contracts.step_result -->
 
 ```python
 @dataclass
@@ -82,6 +95,7 @@ class StepResult:
 ```
 
 #### DesignResult(最终结果)
+<!-- SID:agent.contracts.design_result -->
 
 ```python
 @dataclass
@@ -96,6 +110,7 @@ class DesignResult:
 ```
 
 #### SafetyResult(安全检查结果)
+<!-- SID:agent.contracts.safety_result -->
 
 ```python
 @dataclass
@@ -131,6 +146,7 @@ class WorkfolwContext:
 ```
 
 ### PlannerAgent接口
+<!-- SID:planner.interface.overview -->
 
 #### 对外主接口
 
@@ -229,29 +245,32 @@ class PlannerAgent:
 ```
 
 ## Human-in-the-loop 扩展设计（Agent 行为层）
+<!-- SID:agent.hitl.overview -->
 
 本节在不破坏既有多 Agent 自动协作逻辑的前提下，引入 Human-in-the-loop（HITL）机制，
-明确各 Agent 在“需要人工决策”的场景下应承担的职责、触发条件与行为边界。
+明确各 Agent 在"需要人工决策"的场景下应承担的职责、触发条件与行为边界。
 
 设计原则如下：
 
 - 人类被视为一种**外部决策 Agent（External Decision Agent）**；
 - 系统内部 Agent **不直接与人类交互**；
-- 所有人工介入均通过结构化的 `PendingAction / Decision` 完成；
+- 所有人工介入均通过结构化的 `PendingAction / Decision` 完成（详见 [ref:SID:arch.contracts.pending_action]）；
 - Agent 只负责：
   - 发现问题
   - 生成候选方案
   - 提出系统建议
-  而不负责“等待”或“选择”。
+  而不负责"等待"或"选择"。
 
 ---
 
 ### 1. PlannerAgent 在 HITL 场景下的职责
+<!-- SID:planner.hitl.responsibilities -->
 
 PlannerAgent 仍然是**计划搜索与重规划的唯一负责者**，Human-in-the-loop 不改变其核心算法职责，
-仅改变“计划如何被最终确认”的路径。
+仅改变"计划如何被最终确认"的路径。
 
 #### 1.1 初始 Plan 阶段（WAITING_PLAN_CONFIRM）
+<!-- SID:planner.hitl.plan_confirm -->
 
 在以下条件之一满足时，PlannerAgent **必须创建 PendingAction(plan_confirm)**，而非直接进入执行：
 
@@ -268,10 +287,21 @@ PlannerAgent 的职责包括：
 - 给出系统默认建议（例如推荐某一 Plan）；
 - 将上述信息封装进 `PendingAction(action_type = plan_confirm)`。
 
+<!-- SID:planner.responsibilities.must BEGIN -->
+PlannerAgent **必须**：
+
+- 生成一个或多个 Plan 候选（可包含 Top-K 次优解）；
+- 为每个候选生成结构化摘要、风险等级与成本估计；
+- 给出系统默认建议；
+- 将上述信息封装进 `PendingAction`。
+<!-- SID:planner.responsibilities.must END -->
+
+<!-- SID:planner.responsibilities.must_not BEGIN -->
 PlannerAgent **不得**：
 
 - 在未收到 Decision 的情况下自行选择 Plan；
 - 直接修改 Task 状态为 `PLANNED`。
+<!-- SID:planner.responsibilities.must_not END -->
 
 ---
 
@@ -290,10 +320,12 @@ PlannerAgent **不得**：
 ---
 
 ### 2. ExecutorAgent 在 HITL 场景下的职责
+<!-- SID:executor.hitl.responsibilities -->
 
 ExecutorAgent 负责**执行控制与失败检测**，但不具备决策权。
 
 #### 2.1 Patch 触发与 WAITING_PATCH_CONFIRM
+<!-- SID:executor.hitl.patch_confirm -->
 
 当 ExecutorAgent 发现以下情况之一：
 
@@ -307,10 +339,21 @@ ExecutorAgent 应：
 3. 将任务状态推进至 `WAITING_PATCH`（实现层）；
 4. 由系统创建 `PendingAction(action_type = patch_confirm)`。
 
+<!-- SID:executor.responsibilities.must BEGIN -->
+ExecutorAgent **必须**：
+
+- 停止继续执行后续步骤；
+- 触发 PlannerAgent 生成Patch候选；
+- 将任务状态推进至 WAITING_PATCH；
+- 由系统创建 PendingAction。
+<!-- SID:executor.responsibilities.must END -->
+
+<!-- SID:executor.responsibilities.must_not BEGIN -->
 ExecutorAgent **不得**：
 
 - 自行决定应用 Patch；
 - 在 WAITING_* 状态下继续执行任何工具调用。
+<!-- SID:executor.responsibilities.must_not END -->
 
 ---
 
@@ -327,10 +370,12 @@ ExecutorAgent **不得**：
 ---
 
 ### 3. SafetyAgent 在 HITL 场景下的职责
+<!-- SID:safety.hitl.responsibilities -->
 
-SafetyAgent 是 **HITL 触发的重要信号源**，但仍保持“建议者”角色。
+SafetyAgent 是 **HITL 触发的重要信号源**，但仍保持"建议者"角色。
 
 #### 3.1 触发 WAITING_REPLAN_CONFIRM 的条件
+<!-- SID:safety.hitl.replan_trigger -->
 
 当 SafetyAgent 在任意阶段返回以下结果之一：
 
@@ -346,39 +391,55 @@ SafetyAgent 应：
   - 是否建议 Replan；
 - 触发系统进入 `WAITING_REPLAN_CONFIRM`。
 
+<!-- SID:safety.responsibilities.must BEGIN -->
+SafetyAgent **必须**：
+
+- 向系统提交风险评估结果；
+- 明确标注风险来源、风险等级、是否建议 Replan；
+- 触发系统进入 WAITING_REPLAN_CONFIRM。
+<!-- SID:safety.responsibilities.must END -->
+
+<!-- SID:safety.responsibilities.must_not BEGIN -->
 SafetyAgent **不得**：
 
 - 自行终止任务；
 - 自行决定是否 Replan；
 - 直接修改 Plan。
+<!-- SID:safety.responsibilities.must_not END -->
 
 ---
 
 ### 4. SummarizerAgent 与 HITL 的关系
+<!-- SID:summarizer.hitl.responsibilities -->
 
 SummarizerAgent 不参与任何人工决策流程。
 
-约束如下：
+<!-- SID:summarizer.responsibilities.must BEGIN -->
+SummarizerAgent **必须**：
 
-- SummarizerAgent 仅在任务进入 `SUMMARIZING` 后启动；
-- SummarizerAgent 的失败：
-  - **不得影响任务的执行结果有效性**
-  - 仅影响展示与报告生成；
-- SummarizerAgent 的输出应明确区分：
-  - 执行结果（DesignResult）
-  - 展示产物（图表、可视化、报告文本）。
+- 仅在任务进入 `SUMMARIZING` 后启动；
+- 明确区分执行结果（DesignResult）与展示产物（图表、可视化、报告文本）。
+<!-- SID:summarizer.responsibilities.must END -->
+
+<!-- SID:summarizer.responsibilities.must_not BEGIN -->
+SummarizerAgent **不得**：
+
+- 影响任务的执行结果有效性（即使Summarizer失败，执行结果仍有效）；
+- 参与任何人工决策流程。
+<!-- SID:summarizer.responsibilities.must_not END -->
 
 ---
 
 ### 5. Agent 层统一约束（必须遵守）
+<!-- SID:agent.hitl.universal_constraints BEGIN -->
 
 为确保 HITL 机制的可控性与一致性，所有 Agent 必须遵守以下规则：
 
 1. Agent **不得直接等待人工输入**；
 2. Agent **不得直接与 UI / 人类交互**；
 3. 所有人工介入点必须：
-   - 显式对应一个 `PendingAction`；
-   - 显式对应 FSM 中的 `WAITING_*` 状态；
+   - 显式对应一个 `PendingAction`（详见 [ref:SID:arch.contracts.pending_action]）；
+   - 显式对应 FSM 中的 `WAITING_*` 状态（详见 [ref:SID:fsm.states.definitions]）；
 4. Agent 的职责边界为：
    - 发现问题
    - 生成候选
@@ -388,4 +449,5 @@ SummarizerAgent 不参与任何人工决策流程。
 
 通过上述设计，Human-in-the-loop 被严格限制在少数高价值、高风险的决策节点，
 而系统在绝大多数情况下仍保持全自动执行能力。
+<!-- SID:agent.hitl.universal_constraints END -->
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,6 +1,14 @@
+---
+doc_key: arch
+version: 1.0
+status: stable
+depends_on: []
+---
+
 # 系统总体架构
 
 ## 分层架构
+<!-- SID:arch.overview.layers -->
 
 - 输入层：User/API：自然语言目标、约束、数据引用
 - 智能规划层：Planner+KG：任务解析、KG约束推理、计划JSON
@@ -22,6 +30,7 @@ A[输入层] --> B[智能规划层] --> C[执行层] --> D[安全与汇总层] -
 - 资源层：`src/kg/`, `output/`, `data`, 模型、权重等
 
 ## 组件视图
+<!-- SID:arch.components.overview -->
 
 ### Interface & Core
 
@@ -62,6 +71,7 @@ Executor/StepRunner 只依赖基础层接口，不关心具体工具实现，从
 ![系统构建图](./diagrams/component-views.svg)
 
 ## 运行视图与时序图
+<!-- SID:arch.flow.end_to_end -->
 
 端到端LLM调控闭环
 
@@ -289,10 +299,12 @@ ExecutorAgent就会启动一个小对话：
 ---   
 
 ## 任务生命周期与状态机(FSM)
+<!-- SID:fsm.lifecycle.overview -->
 
 为了支持 "人在环路"(Human-in-the-loop)、任务快照与可恢复执行，本系统将一次蛋白质设计任务抽象为一个有限自动机(Finite State Machine, FSM)。FSM 不仅表示执行进度，也编码了 "决策阶段" 与 "人工审查点"
 
 ### 状态列表
+<!-- SID:fsm.states.definitions -->
 
 在当前设计中，任务可能处于以下状态(部分为原有状态的语义精化)
 
@@ -300,22 +312,31 @@ ExecutorAgent就会启动一个小对话：
 |:---|:---|
 |`CREATED`|任务已经创建，尚未开始规划|
 |`PLANNING`|PlannerAgent 正在生成重新执行Plan|
-|`WAITING_PLAN_CONFIRM`|初始 Plan 已经生成，等待人工确认工具链与关键参数|
+|`WAITING_PLAN_CONFIRM`|初始 Plan 已经生成，等待人工确认工具链与关键参数 <!-- SID:fsm.states.waiting_plan_confirm -->|
 |`PLANNED`|Plan 已经确认(自动或人工)，可进入执行阶段|
 |`RUNNING`|ExecutorAgent 正在按照 Plan 执行步骤|
-|`WAITING_PATCH_CONFIRM`|执行中发现局部失败，系统已经生成 Patch 候选，等待人工确认是否应用|
-|`WAITING_REPLAN_CONFIRM`|执行中发现整体风险或目标转移，系统已生成 Replan 候选，等待人工确认是否应用|
+|`WAITING_PATCH_CONFIRM`|执行中发现局部失败，系统已经生成 Patch 候选，等待人工确认是否应用 <!-- SID:fsm.states.waiting_patch_confirm -->|
+|`WAITING_REPLAN_CONFIRM`|执行中发现整体风险或目标转移，系统已生成 Replan 候选，等待人工确认是否应用 <!-- SID:fsm.states.waiting_replan_confirm -->|
 |`SUMMARIZING`|执行完成: SummarizerAgent 正在生成结果汇总与报告|
 |`DONE`|任务成功完成，所有结果已经生成|
 |`FAILED`|任务失败，且无法自动或人工修复|
 |`CANCELLED`|任务被人工显式停止|
 
-其中,所有以 `WAITING_*` 命名的状态均表示:  
+其中,所有以 `WAITING_*` 命名的状态均表示:
 **系统已暂停执行，正等待人类提交决策以继续或终止任务**
 
-### 人在环路与 PendingAction 的关系
+<!-- SID:fsm.transitions.overview BEGIN -->
+**状态转换规则**:
+- `CREATED` → `PLANNING` → `WAITING_PLAN_CONFIRM` → `PLANNED` → `RUNNING`
+- `RUNNING` → `WAITING_PATCH_CONFIRM` (局部失败) 或 `WAITING_REPLAN_CONFIRM` (安全阻断)
+- `WAITING_*` → `RUNNING` (决策批准) 或 `FAILED`/`CANCELLED` (决策拒绝)
+- `RUNNING` → `SUMMARIZING` → `DONE`
+<!-- SID:fsm.transitions.overview END -->
 
-为了统一建模 "等待人工输入" 这一行为，系统在进入任意 `WAITING_*` 状态时都会生成一个结构化的 `PendingAction` 对象，例如: 
+### 人在环路与 PendingAction 的关系
+<!-- SID:arch.contracts.pending_action BEGIN -->
+
+为了统一建模 "等待人工输入" 这一行为，系统在进入任意 `WAITING_*` 状态时都会生成一个结构化的 `PendingAction` 对象，例如:
 
 - `WAITING_PLAN_CONFIRM` → `PendingAction{ action_type="plan_confirm", candidates=[Plan...], ...}`
 - `WAITING_PATCH_CONFIRM` → `PendingAction{ action_type="patch_confirm", candidate_patch=PlanPatch, ...}`
@@ -326,12 +347,15 @@ ExecutorAgent就会启动一个小对话：
 - FSM 的状态固定在对应的`WAITING_*`
 - API层可以通过 `GET /pend-actions` 或 `Get /tasks/{id}` 暴露当前待决策信息
 - 外部UI或CLI将候选方案展示给科研人员
-- 人类提交 `Decision` 后:
+- 人类提交 `Decision` 后: <!-- SID:arch.contracts.decision BEGIN -->
   - 系统能够根据 `Decision` 内容更新 Plan/PlanPatch/Replan
   - 记录事件日志
   - 触发一次状态转移
+<!-- SID:arch.contracts.decision END -->
+<!-- SID:arch.contracts.pending_action END -->
 
 ### 快照与可恢复执行的约束
+<!-- SID:arch.contracts.task_snapshot BEGIN -->
 
 为了支持长时间运行与系统重启后的可靠恢复，FSM 对持久化有明确约束:
 
@@ -352,8 +376,10 @@ ExecutorAgent就会启动一个小对话：
     - 根据 Task 当前状态和最新 `TaskSnapshot` 恢复上下文
     - 若处于 `WAITING_*`, 则继续等到 Decision, 不会自动推进
     - 若处于 `RUNNING`, 则从快照记录的步骤索引继续调度 Executor/ExecutionBackend
+<!-- SID:arch.contracts.task_snapshot END -->
 
 ## 数据流与控制流
+<!-- SID:arch.dataflow.overview -->
 
 **数据流**
 
@@ -367,6 +393,7 @@ ExecutorAgent就会启动一个小对话：
 - Workflow驱动Agent顺序；Executor负责步骤级重试/失败终止；safety贯穿检查；summarizer终结输出。
 
 ## 计划契约(Plan JSON, Planner输出)
+<!-- SID:arch.contracts.plan -->
 
 ```json
 {
@@ -385,6 +412,7 @@ ExecutorAgent就会启动一个小对话：
 - 安全级别：`S0=严格限制`/`S1=默认安全`
 
 ## ProteinToolKG概要
+<!-- SID:arch.kg.overview -->
 
 **工具节点**
 

--- a/docs/design/core-algorithm-spec.md
+++ b/docs/design/core-algorithm-spec.md
@@ -1,12 +1,20 @@
+---
+doc_key: algo
+version: 1.0
+status: stable
+depends_on: [arch, agent]
+---
+
 # core-algorithm-spec
 
-> 版本：v0.3（与 Step1/Step2 对齐）  
-> 目的：给出**可直接据此编码**的核心算法与输出契约（Plan / Patch / Replan 候选、排序、选择与固化）。  
-> 说明：本文档属于“算法与决策逻辑规范”，不包含具体 API/FSM/存储实现细节（见 system-implementation-design.md）。
+> 版本：v0.3（与 Step1/Step2 对齐）
+> 目的：给出**可直接据此编码**的核心算法与输出契约（Plan / Patch / Replan 候选、排序、选择与固化）。
+> 说明：本文档属于"算法与决策逻辑规范"，不包含具体 API/FSM/存储实现细节（见 system-implementation-design.md）。
 
 ---
 
 ## 1. 范围与非目标
+<!-- SID:algo.scope.overview -->
 
 ### 1.1 本文档覆盖的内容
 
@@ -29,6 +37,7 @@
 ---
 
 ## 2. 术语与对象定义
+<!-- SID:algo.definitions.overview -->
 
 ### 2.1 主要对象
 
@@ -40,12 +49,13 @@
 - Replan：对整体策略的重规划，可能表现为“替换 Plan 后缀”或“重新生成新的 Plan”
 
 ### 2.2 关键概念：Candidate（候选）
+<!-- SID:planner.contracts.candidate_schema BEGIN -->
 
 为了支持 Human-in-the-loop，本规范要求 Planner 在关键节点输出候选集合（Top-K）：
 
-- PlanCandidate：初始 Plan 候选
-- PatchCandidate：PlanPatch 候选
-- ReplanCandidate：Replan（Plan 后缀或整体 Plan）候选
+- PlanCandidate：初始 Plan 候选 <!-- SID:planner.contracts.plan_candidate -->
+- PatchCandidate：PlanPatch 候选 <!-- SID:planner.contracts.patch_candidate -->
+- ReplanCandidate：Replan（Plan 后缀或整体 Plan）候选 <!-- SID:planner.contracts.replan_candidate -->
 
 Candidate 必须包含：
 - candidate_id（稳定可引用）
@@ -55,10 +65,12 @@ Candidate 必须包含：
 - risk_level（低/中/高）
 - cost_estimate（低/中/高 或数值区间）
 - explanation（用于人类审查的理由，允许由 LLM 生成但必须可追溯）
+<!-- SID:planner.contracts.candidate_schema END -->
 
 ---
 
 ## 3. 输入、约束与输出契约
+<!-- SID:planner.contracts.io_overview -->
 
 ### 3.1 Planner 输入
 
@@ -129,6 +141,7 @@ Planner 的核心算法由三个模式构成：
 ---
 
 ## 5. Tool Retrieval（工具检索与约束过滤）
+<!-- SID:planner.algorithm.tool_retrieval -->
 
 ### 5.1 检索目标
 
@@ -214,6 +227,7 @@ ReplanCandidate 必须明确：
 ---
 
 ## 7. Candidate Scoring（候选打分、风险与成本估计）
+<!-- SID:planner.algorithm.candidate_scoring -->
 
 ### 7.1 多目标打分总体原则
 
@@ -258,6 +272,7 @@ cost_estimate 映射规则：
 ---
 
 ## 8. Candidate Selection（自动选择 vs HITL 输出）
+<!-- SID:planner.algorithm.hitl_gate -->
 
 ### 8.1 决策门控（何时进入 HITL）
 
@@ -283,6 +298,7 @@ Planner 在完成候选生成与排序后，需要通过“门控规则”决定
 ---
 
 ## 9. Decision 应用与方案固化（HITL 路径）
+<!-- SID:planner.algorithm.decision_application -->
 
 Planner 不直接等待 Decision，但必须定义“Decision 应用后如何固化”的纯函数逻辑（可测试）。
 

--- a/docs/design/hitl-extension.md
+++ b/docs/design/hitl-extension.md
@@ -1,8 +1,15 @@
+---
+doc_key: hitl
+version: 1.0
+status: stable
+depends_on: [arch, agent, impl, algo]
+---
+
 # 扩展设计：Human-in-the-loop 与可追溯执行（差分说明）
 
-> 本文档用于描述系统从 v0.2（全自动执行原型）到 v0.3（真实可用版本）的关键重构与扩展点。  
-> 本文档不替代 architecture.md / system-implementation-design.md / agent-design.md / core-algorithm-spec.md，  
-> 而是作为“差分索引”和“设计动机说明”。
+> 本文档用于描述系统从 v0.2（全自动执行原型）到 v0.3（真实可用版本）的关键重构与扩展点。
+> 本文档不替代 architecture.md / system-implementation-design.md / agent-design.md / core-algorithm-spec.md，
+> 而是作为"差分索引"和"设计动机说明"。
 
 ---
 
@@ -29,24 +36,22 @@
 
 ## 2. 架构层变更（architecture.md 对应）
 
-### 2.1 引入“等待人工决策”的语义状态（WAITING_*）
+### 2.1 引入"等待人工决策"的语义状态（WAITING_*）
 
-在架构层 FSM 中新增等待审查状态：
+在架构层 FSM 中新增等待审查状态，详见 [ref:SID:fsm.states.definitions]：
 
-- `WAITING_PLAN_CONFIRM`
-- `WAITING_PATCH_CONFIRM`
-- `WAITING_REPLAN_CONFIRM`
+- [ref:SID:fsm.states.waiting_plan_confirm]
+- [ref:SID:fsm.states.waiting_patch_confirm]
+- [ref:SID:fsm.states.waiting_replan_confirm]
 
 这些状态表示：系统已生成候选方案并暂停推进，等待外部 Decision 恢复执行。
 
-对应文档位置：`architecture.md` → FSM 章节。
-
 ### 2.2 PendingAction / Decision 作为一等对象（跨层统一）
 
-所有人工交互通过结构化对象实现：
+所有人工交互通过结构化对象实现，详见：
 
-- `PendingAction`：系统等待人类决策的“待办”
-- `Decision`：人类对待办的“选择”
+- `PendingAction`：[ref:SID:arch.contracts.pending_action]
+- `Decision`：[ref:SID:arch.contracts.decision]
 
 架构含义：
 
@@ -54,9 +59,9 @@
 - API / CLI / UI 的交互接口统一
 - 审计与回放边界清晰（每个 WAITING_* 都有明确的 pending_action_id）
 
-对应实现规范：`system-implementation-design.md` → contracts / API / EventLog。
-
 ### 2.3 任务快照与恢复点（TaskSnapshot / Checkpoint）
+
+TaskSnapshot 定义详见 [ref:SID:arch.contracts.task_snapshot]。
 
 在关键节点写入 TaskSnapshot：
 
@@ -72,8 +77,6 @@
 - 已完成步骤索引
 - artifacts 路径映射
 - pending_action_id（若有）
-
-对应实现规范：`system-implementation-design.md` → Snapshot 章节与约束。
 
 ---
 
@@ -96,15 +99,17 @@
 
 ### 3.2 新增接口：pending-actions 与 decision 提交
 
-新增并固化 REST API：
+新增并固化 REST API，详见 [ref:SID:api.rest.overview]：
 
-- `GET /pending-actions`：待人工决策列表
-- `POST /pending-actions/{id}/decision`：提交 Decision 并驱动状态转移
+- [ref:SID:api.rest.get_pending_actions]：待人工决策列表
+- [ref:SID:api.rest.submit_decision]：提交 Decision 并驱动状态转移
 
-并在 `GET /tasks/{id}` 返回体中：
+并在 [ref:SID:api.rest.get_task] 返回体中：
 - WAITING_* 状态必须返回 `pending_action` 摘要
 
 ### 3.3 审计与事件日志（EventLog）
+
+EventLog 定义详见 [ref:SID:obs.eventlog.schema]，硬约束详见 [ref:SID:obs.eventlog.mandatory_events]。
 
 新增 HITL 关键事件类型：
 
@@ -114,7 +119,7 @@
 - `PENDING_ACTION_CANCELLED`
 - `TASK_CANCELLED_BY_USER`
 
-并定义硬约束：
+并定义硬约束（详见 [ref:SID:obs.eventlog.mandatory_events]）：
 
 - 进入任意 WAITING_* 前必须：
   - 写 `PENDING_ACTION_CREATED`
@@ -127,33 +132,41 @@
 
 ## 4. Agent 行为层变更（agent-design.md 对应）
 
-Human-in-the-loop 不改变 Agent 核心职责，但改变“候选如何确认”的路径：
+Human-in-the-loop 不改变 Agent 核心职责，但改变"候选如何确认"的路径。
 
-- PlannerAgent：
-  - 负责生成 Plan/Patch/Replan 候选与默认建议
-  - 不负责等待与选择
-- ExecutorAgent：
-  - 负责检测失败与触发 Patch/Replan 请求
-  - WAITING_* 期间不得继续执行
-- SafetyAgent：
-  - 提供风险信号，触发 WAITING_REPLAN_CONFIRM
-  - 不直接终止任务，不直接修改 Plan
-- SummarizerAgent：
-  - 不参与决策，失败不影响执行结果有效性
+详见各 Agent 的 HITL 职责定义：
+
+- PlannerAgent：[ref:SID:planner.hitl.responsibilities]
+  - MUST: [ref:SID:planner.responsibilities.must]
+  - MUST NOT: [ref:SID:planner.responsibilities.must_not]
+- ExecutorAgent：[ref:SID:executor.hitl.responsibilities]
+  - MUST: [ref:SID:executor.responsibilities.must]
+  - MUST NOT: [ref:SID:executor.responsibilities.must_not]
+- SafetyAgent：[ref:SID:safety.hitl.responsibilities]
+  - MUST: [ref:SID:safety.responsibilities.must]
+  - MUST NOT: [ref:SID:safety.responsibilities.must_not]
+- SummarizerAgent：[ref:SID:summarizer.hitl.responsibilities]
+  - MUST: [ref:SID:summarizer.responsibilities.must]
+  - MUST NOT: [ref:SID:summarizer.responsibilities.must_not]
+
+统一约束：[ref:SID:agent.hitl.universal_constraints]
 
 ---
 
 ## 5. 核心算法层变更（core-algorithm-spec.md 对应）
 
-v0.3 引入 Candidate（Top-K）输出与门控（进入 HITL 的规则）：
+v0.3 引入 Candidate（Top-K）输出与门控（进入 HITL 的规则），详见：
 
-- PlanCandidate / PatchCandidate / ReplanCandidate
-- 多目标评分（feasibility/objective/risk/cost/overall）
-- 风险与成本阈值触发 HITL
-- Decision 应用与方案固化为纯逻辑（可单测）
+- Candidate 定义：[ref:SID:planner.contracts.candidate_schema]
+  - [ref:SID:planner.contracts.plan_candidate]
+  - [ref:SID:planner.contracts.patch_candidate]
+  - [ref:SID:planner.contracts.replan_candidate]
+- 候选评分：[ref:SID:planner.algorithm.candidate_scoring]
+- HITL 门控规则：[ref:SID:planner.algorithm.hitl_gate]
+- Decision 应用逻辑：[ref:SID:planner.algorithm.decision_application]
 
 这保证：
-- 人类看到的不只是“一个方案”，而是一组可比较的候选
+- 人类看到的不只是"一个方案"，而是一组可比较的候选
 - 系统给出默认建议与解释，降低审查成本
 - Decision 结果可追溯、可复现
 

--- a/docs/design/system-implementation-design.md
+++ b/docs/design/system-implementation-design.md
@@ -1,8 +1,18 @@
+---
+doc_key: impl
+version: 1.0
+status: stable
+depends_on: [arch, agent]
+---
+
 # 系统实现设计文档
 
 > 目标：在现有架构的算法设计基础上，明确技术选型、代码结构、组件职责、运行时流程，指导后续代码编码与集成
 
 ## 系统总体概览
+<!-- SID:impl.overview.introduction -->
+
+核心Agent与数据契约已在 [ref:SID:agent.overview.introduction] 中定义。本设计文档在此基础上，加入具体框架实现细节。
 
 系统分为五层：输入层、智能规划层、执行层、安全与汇总层、资源层
 
@@ -24,6 +34,7 @@
 ---
 
 ## 技术栈与框架选型
+<!-- SID:impl.techstack.overview -->
 
 ### 关键框架与组件
 
@@ -199,6 +210,8 @@ class DesignResult(BaseModel):
 
 #### PendingAction 与 Decision 模型
 
+核心概念定义详见 [ref:SID:arch.contracts.pending_action] 和 [ref:SID:arch.contracts.decision]。以下为 Pydantic 实现：
+
 为了统一建模“等待人工输入”这一行为，本系统在实现层引入 `PendingAction` 与 `Decision`
 两个一等数据结构，用于承载 Human-in-the-loop 的交互信息。
 
@@ -303,6 +316,8 @@ class Decision(BaseModel):
 ---
 
 #### TaskSnapshot 模型
+
+核心概念定义详见 [ref:SID:arch.contracts.task_snapshot]。以下为 Pydantic 实现：
 
 为支持任务快照与可恢复执行，本系统对每个任务在关键节点写入一份 `TaskSnapshot` 记录，用于在系统重启或显式恢复时还原上下文
 
@@ -430,8 +445,10 @@ CANCELLED
 ---
 
 #### REST API 规范
+<!-- SID:api.rest.overview -->
 
 ##### POST /tasks
+<!-- SID:api.rest.create_task -->
 
 创建一个新的蛋白质设计任务。该接口必须快速返回(不等待完整流程)
 
@@ -568,6 +585,7 @@ CANCELLED
 ---
 
 ##### GET /pending-actions
+<!-- SID:api.rest.get_pending_actions -->
 
 列出所有当前等待人工决策的 PendingAction (用于 UI 的待办列表)
 
@@ -596,6 +614,7 @@ CANCELLED
 - 返回内容为摘要，候选详情以 `GET /tasks/{task_id}` 的 `pending_action` 或数据库读取为准
 
 ##### POST /pending-actions/{pending_action_id}/decision
+<!-- SID:api.rest.submit_decision -->
 
 提交人工决策（Decision），用于解除任务在 `WAITING_*` 状态的挂起，并驱动 FSM 继续执行。
 
@@ -647,6 +666,7 @@ CANCELLED
   - 任意 `WAITING_*` + `cancel` → `CANCELLED`
 
 ##### GET /tasks/{task_id}/report
+<!-- SID:api.rest.get_report -->
 
 在任务完成后返回DesignResult
 
@@ -1445,10 +1465,12 @@ def check_final_result(design_result: DesignResult, context: WorkflowContext) ->
   - 所有详细事件(步骤执行、重试、patch、replan等)写入`data/logs/{task_id}.jsonl`
 
 ### 日志与可观测设计
+<!-- SID:obs.overview -->
 
 为支持多Agent协作任务的调试、回访与故障排查，本系统在数据库持久化之外，引入统一的日志与追踪规范。所有与任务执行相关的事件会以JSON Lines的形式写入`data/logs/{task_id}.jsonl`文件，并与状态机 / 数据库中的记录保持一致。
 
 #### 单条日志记录结构
+<!-- SID:obs.eventlog.schema -->
 
 每条日志记录为一个JSON对象，对象字段定义如下：
 
@@ -1511,6 +1533,7 @@ def check_final_result(design_result: DesignResult, context: WorkflowContext) ->
 若未来新增事件类型，应追加到该列表中，并保持语义稳定。
 
 #### 事件日志与快照写入约束（必须遵守）
+<!-- SID:obs.eventlog.mandatory_events -->
 
 本系统的“可追溯执行”依赖于 **事件日志（EventLog）** 与 **任务快照（TaskSnapshot）** 的配合。
 为确保任务可恢复、可审计、可回放，实现必须严格遵循以下约束。

--- a/docs/design/tools-catalog.md
+++ b/docs/design/tools-catalog.md
@@ -1,7 +1,14 @@
+---
+doc_key: tools
+version: 1.0
+status: stable
+depends_on: [impl]
+---
+
 # Tools Catalog(候选工具清单)
 
-> 本文档用于记录 **当前系统架构下，可接入的真实工具候选集合**  
-> 工具按照 **Executor / Visualization / Summarizer** 三类划分  
+> 本文档用于记录 **当前系统架构下，可接入的真实工具候选集合**
+> 工具按照 **Executor / Visualization / Summarizer** 三类划分
 > 不涉及任务规划逻辑，仅关注:
 >
 > -  工具真实存在，在生物信息学领域被广泛应用
@@ -11,6 +18,7 @@
 ---
 
 ## 1. Executor 可选择的工具(计算 / 评估类)
+<!-- SID:tools.executor.overview -->
 
 > Executor 负责执行实际计算任务，通常耗时较长，产出结构化 artifacts.
 > 以下工具可通过 ToolAdapter 以 `python / nextflow / external` 方式接入。
@@ -20,6 +28,7 @@
 ### 1.1 结构预测类(Structure Prediction)
 
 #### ESMFold
+<!-- SID:tools.esmfold.spec -->
 
 - 类型：蛋白质结构预测
 - 输入：氨基酸序列(FASTA / string)
@@ -32,6 +41,7 @@
   - 适合作为第一个真实结构工具
 
 #### AlphaFold / OpenFold
+<!-- SID:tools.alphafold.spec -->
 
 - 类型: 高精度结构预测
 - 输入: 序列 + MSA
@@ -192,6 +202,7 @@
 ---
 
 ## 4. 推荐的接入优先级（现实可行）
+<!-- SID:tools.integration_priority -->
 
 ### P0（近期最值得接入）
 - ESMFold（Executor）
@@ -211,6 +222,7 @@
 ---
 
 ## 5. 设计原则（约束）
+<!-- SID:tools.adapter.constraints BEGIN -->
 
 - 所有工具：
   - 不直接与人交互
@@ -221,3 +233,4 @@
 - 工具替换：
   - 不应影响系统整体架构
   - 同类工具可并存，供后续选择
+<!-- SID:tools.adapter.constraints END -->


### PR DESCRIPTION
## Summary

重构 6 个设计文档以支持 SID (Section Identifier) 可寻址结构，建立文档间的引用系统，实现单一事实来源 (SSOT) 原则。

## Background

根据 issue #29 的要求，需要对设计文档进行结构化改造，使其支持精确的章节引用与追踪。这项工作基于 issue #28 中定义的 `SECTION_CONTRACT.md` 章节可寻址契约规范。

主要动机：
- 设计文档间存在内容重复，缺乏统一的引用机制
- 无法精确定位和追踪关键规约点（如 FSM 状态、Agent 职责边界等）
- 需要建立清晰的文档依赖关系和 SSOT 原则

## Changes

### 修改的文件（6 个）

1. **docs/design/architecture.md**
   - 添加 YAML 前置元数据（doc_key: arch, version: 1.0）
   - 新增 14+ 个 SID 标记，包括 FSM 状态、PendingAction/Decision/TaskSnapshot 契约等
   - 作为 FSM 状态和核心架构契约的 SSOT

2. **docs/design/agent-design.md**
   - 添加 YAML 前置元数据（doc_key: agent, depends_on: [arch]）
   - 新增 20+ 个 SID 标记，涵盖四类 Agent 的接口定义和职责边界
   - 使用 BEGIN/END 块标记 MUST/MUST NOT 规约

3. **docs/design/core-algorithm-spec.md**
   - 添加 YAML 前置元数据（doc_key: algo, depends_on: [arch, agent]）
   - 新增 SID 标记用于 Candidate 对象模式、评分规则、HITL 门控逻辑等

4. **docs/design/tools-catalog.md**
   - 添加 YAML 前置元数据（doc_key: tools, depends_on: [impl]）
   - 为工具规约（ESMFold、Mol* 等）和 ToolAdapter 约束添加 SID

5. **docs/design/system-implementation-design.md**
   - 添加 YAML 前置元数据（doc_key: impl, depends_on: [arch, agent]）
   - 新增 SID 用于 API 端点、EventLog 模式、数据库模式等实现细节
   - 通过 `[ref:SID:...]` 引用 architecture.md 中的核心契约，避免内容重复

6. **docs/design/hitl-extension.md**
   - 添加 YAML 前置元数据（doc_key: hitl, depends_on: [arch, agent, impl, algo]）
   - **转换为差分索引文档**：将所有硬编码规约替换为对其他文档的 SID 引用
   - 保留设计动机说明，规约定义通过引用指向 SSOT 文档

### 关键变更模式

- **前置元数据**：所有文档添加 YAML front matter（doc_key, version, status, depends_on）
- **SID 标记**：使用 `<!-- SID:domain.topic.name -->` 标注关键章节
- **规约块**：使用 `<!-- SID:... BEGIN -->` ... `<!-- SID:... END -->` 标注原子规约
- **交叉引用**：使用 `[ref:SID:domain.topic.name]` 进行文档间引用

### 统计数据

- 6 个文件修改
- +224 行新增（主要是 SID 注释和前置元数据）
- -69 行删除（主要是 hitl-extension.md 中被引用替换的重复内容）

## Impact

### 影响

**正面影响**：
- 建立了清晰的文档依赖图谱（通过 depends_on 字段）
- 实现了约 60+ 个关键规约点的精确可寻址
- 消除了文档间的内容重复，建立了 SSOT 原则
- 提升了文档的可维护性和追溯能力

**风险评估**：
- **低风险**：本次变更仅添加结构化标记，未修改任何逻辑描述或功能定义
- 所有 SID 标记为 HTML 注释，不影响 Markdown 渲染
- 前置元数据使用标准 YAML 格式，兼容现有工具链

## Related

- Closes #29