### PR TITLE
feat(index): 新增机器可读规范索引与主题视图

### DIFF
--- a/docs/index/index.json
+++ b/docs/index/index.json
@@ -1,0 +1,1061 @@
+{
+  "version": "1.0",
+  "generated_at": "2025-12-31",
+  "description": "Machine-readable specification index for thesis-project design documents",
+  "total_specs": 65,
+  "documents": [
+    {
+      "doc_key": "arch",
+      "title": "系统总体架构",
+      "path": "docs/design/architecture.md",
+      "status": "stable",
+      "version": "1.0",
+      "depends_on": []
+    },
+    {
+      "doc_key": "agent",
+      "title": "Agent设计文档",
+      "path": "docs/design/agent-design.md",
+      "status": "stable",
+      "version": "1.0",
+      "depends_on": ["arch"]
+    },
+    {
+      "doc_key": "algo",
+      "title": "核心算法规范",
+      "path": "docs/design/core-algorithm-spec.md",
+      "status": "stable",
+      "version": "1.0",
+      "depends_on": ["arch", "agent"]
+    },
+    {
+      "doc_key": "impl",
+      "title": "系统实现设计",
+      "path": "docs/design/system-implementation-design.md",
+      "status": "stable",
+      "version": "1.0",
+      "depends_on": ["arch", "agent"]
+    },
+    {
+      "doc_key": "tools",
+      "title": "Tools Catalog",
+      "path": "docs/design/tools-catalog.md",
+      "status": "stable",
+      "version": "1.0",
+      "depends_on": ["impl"]
+    },
+    {
+      "doc_key": "hitl",
+      "title": "Human-in-the-loop 扩展设计",
+      "path": "docs/design/hitl-extension.md",
+      "status": "stable",
+      "version": "1.0",
+      "depends_on": ["arch", "agent", "impl", "algo"]
+    }
+  ],
+  "specs": [
+    {
+      "sid": "arch.overview.layers",
+      "title": "分层架构",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 11,
+        "marker": "<!-- SID:arch.overview.layers -->"
+      },
+      "level": "Section",
+      "tags": ["arch", "overview", "layers"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.components.overview",
+      "title": "组件视图",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 33,
+        "marker": "<!-- SID:arch.components.overview -->"
+      },
+      "level": "Section",
+      "tags": ["arch", "components"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.flow.end_to_end",
+      "title": "运行视图与时序图",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 74,
+        "marker": "<!-- SID:arch.flow.end_to_end -->"
+      },
+      "level": "Section",
+      "tags": ["arch", "flow", "runtime"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.dataflow.overview",
+      "title": "数据流概览",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 382,
+        "marker": "<!-- SID:arch.dataflow.overview -->"
+      },
+      "level": "Section",
+      "tags": ["arch", "dataflow"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.kg.overview",
+      "title": "ProteinToolKG 在架构中的位置",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 415,
+        "marker": "<!-- SID:arch.kg.overview -->"
+      },
+      "level": "Block",
+      "tags": ["arch", "kg", "knowledge_graph"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.contracts.pending_action",
+      "title": "PendingAction 契约定义",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 337,
+        "line_end": 355,
+        "marker_begin": "<!-- SID:arch.contracts.pending_action BEGIN -->",
+        "marker_end": "<!-- SID:arch.contracts.pending_action END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["arch", "contracts", "hitl", "pending_action"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.contracts.decision",
+      "title": "Decision 契约定义",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 350,
+        "line_end": 354,
+        "marker_begin": "<!-- SID:arch.contracts.decision BEGIN -->",
+        "marker_end": "<!-- SID:arch.contracts.decision END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["arch", "contracts", "hitl", "decision"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.contracts.task_snapshot",
+      "title": "TaskSnapshot 契约定义",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 358,
+        "line_end": 379,
+        "marker_begin": "<!-- SID:arch.contracts.task_snapshot BEGIN -->",
+        "marker_end": "<!-- SID:arch.contracts.task_snapshot END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["arch", "contracts", "hitl", "snapshot"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "arch.contracts.plan",
+      "title": "Plan 契约定义（架构层视角）",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 396,
+        "marker": "<!-- SID:arch.contracts.plan -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["arch", "contracts", "planning"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "fsm.lifecycle.overview",
+      "title": "任务生命周期与状态机",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 302,
+        "marker": "<!-- SID:fsm.lifecycle.overview -->"
+      },
+      "level": "Section",
+      "tags": ["fsm", "lifecycle", "state_machine"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "fsm.states.definitions",
+      "title": "FSM 状态完整定义表",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "comment",
+        "line": 307,
+        "marker": "<!-- SID:fsm.states.definitions -->"
+      },
+      "level": "Block",
+      "tags": ["fsm", "states", "definitions"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "fsm.states.waiting_plan_confirm",
+      "title": "WAITING_PLAN_CONFIRM 状态定义",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "inline",
+        "line": 315,
+        "marker": "<!-- SID:fsm.states.waiting_plan_confirm -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["fsm", "states", "hitl", "planning"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "fsm.states.waiting_patch_confirm",
+      "title": "WAITING_PATCH_CONFIRM 状态定义",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "inline",
+        "line": 318,
+        "marker": "<!-- SID:fsm.states.waiting_patch_confirm -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["fsm", "states", "hitl", "execution"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "fsm.states.waiting_replan_confirm",
+      "title": "WAITING_REPLAN_CONFIRM 状态定义",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "inline",
+        "line": 319,
+        "marker": "<!-- SID:fsm.states.waiting_replan_confirm -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["fsm", "states", "hitl", "planning"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "fsm.transitions.overview",
+      "title": "状态转换规则总览",
+      "doc_key": "arch",
+      "path": "docs/design/architecture.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 328,
+        "line_end": 334,
+        "marker_begin": "<!-- SID:fsm.transitions.overview BEGIN -->",
+        "marker_end": "<!-- SID:fsm.transitions.overview END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["fsm", "transitions", "state_machine"],
+      "depends_on": ["fsm.states.definitions"],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.overview.introduction",
+      "title": "Agent体系总览",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 13,
+        "marker": "<!-- SID:agent.overview.introduction -->"
+      },
+      "level": "Section",
+      "tags": ["agent", "overview"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.overview.roles",
+      "title": "Agent 角色列表",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 16,
+        "marker": "<!-- SID:agent.overview.roles -->"
+      },
+      "level": "Block",
+      "tags": ["agent", "overview", "roles"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.contracts.overview",
+      "title": "核心数据结构契约总览",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 45,
+        "marker": "<!-- SID:agent.contracts.overview -->"
+      },
+      "level": "Section",
+      "tags": ["agent", "contracts", "data_structures"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.contracts.protein_design_task",
+      "title": "ProteinDesignTask 数据结构",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 50,
+        "marker": "<!-- SID:agent.contracts.protein_design_task -->"
+      },
+      "level": "Block",
+      "tags": ["agent", "contracts", "task"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.contracts.plan",
+      "title": "Plan 数据结构（Agent 层视角）",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 62,
+        "marker": "<!-- SID:agent.contracts.plan -->"
+      },
+      "level": "Block",
+      "tags": ["agent", "contracts", "planning"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.contracts.step_result",
+      "title": "StepResult 数据结构",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 81,
+        "marker": "<!-- SID:agent.contracts.step_result -->"
+      },
+      "level": "Block",
+      "tags": ["agent", "contracts", "execution", "result"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.contracts.design_result",
+      "title": "DesignResult 数据结构",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 98,
+        "marker": "<!-- SID:agent.contracts.design_result -->"
+      },
+      "level": "Block",
+      "tags": ["agent", "contracts", "result"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.contracts.safety_result",
+      "title": "SafetyResult 数据结构",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 113,
+        "marker": "<!-- SID:agent.contracts.safety_result -->"
+      },
+      "level": "Block",
+      "tags": ["agent", "contracts", "safety", "result"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.hitl.overview",
+      "title": "HITL 机制在 Agent 层的概述",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 248,
+        "marker": "<!-- SID:agent.hitl.overview -->"
+      },
+      "level": "Section",
+      "tags": ["agent", "hitl", "overview"],
+      "depends_on": ["arch.contracts.pending_action", "arch.contracts.decision"],
+      "stability": "stable"
+    },
+    {
+      "sid": "agent.hitl.universal_constraints",
+      "title": "Agent 层 HITL 统一约束",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 434,
+        "line_end": 452,
+        "marker_begin": "<!-- SID:agent.hitl.universal_constraints BEGIN -->",
+        "marker_end": "<!-- SID:agent.hitl.universal_constraints END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["agent", "hitl", "constraints"],
+      "depends_on": ["arch.contracts.pending_action", "fsm.states.definitions"],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.interface.overview",
+      "title": "PlannerAgent 接口总览",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 149,
+        "marker": "<!-- SID:planner.interface.overview -->"
+      },
+      "level": "Section",
+      "tags": ["planner", "interface", "agent"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.hitl.responsibilities",
+      "title": "PlannerAgent HITL 职责",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 267,
+        "marker": "<!-- SID:planner.hitl.responsibilities -->"
+      },
+      "level": "Section",
+      "tags": ["planner", "hitl", "responsibilities"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.hitl.plan_confirm",
+      "title": "初始 Plan 确认阶段",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 273,
+        "marker": "<!-- SID:planner.hitl.plan_confirm -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "hitl", "planning"],
+      "depends_on": ["fsm.states.waiting_plan_confirm"],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.responsibilities.must",
+      "title": "PlannerAgent 必须做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 290,
+        "line_end": 297,
+        "marker_begin": "<!-- SID:planner.responsibilities.must BEGIN -->",
+        "marker_end": "<!-- SID:planner.responsibilities.must END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["planner", "responsibilities", "must"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.responsibilities.must_not",
+      "title": "PlannerAgent 不得做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 299,
+        "line_end": 304,
+        "marker_begin": "<!-- SID:planner.responsibilities.must_not BEGIN -->",
+        "marker_end": "<!-- SID:planner.responsibilities.must_not END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["planner", "responsibilities", "must_not"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "executor.hitl.responsibilities",
+      "title": "ExecutorAgent HITL 职责",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 323,
+        "marker": "<!-- SID:executor.hitl.responsibilities -->"
+      },
+      "level": "Section",
+      "tags": ["executor", "hitl", "responsibilities"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "executor.hitl.patch_confirm",
+      "title": "Patch 触发与确认",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 328,
+        "marker": "<!-- SID:executor.hitl.patch_confirm -->"
+      },
+      "level": "Block",
+      "tags": ["executor", "hitl", "execution", "patch"],
+      "depends_on": ["fsm.states.waiting_patch_confirm"],
+      "stability": "stable"
+    },
+    {
+      "sid": "executor.responsibilities.must",
+      "title": "ExecutorAgent 必须做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 342,
+        "line_end": 349,
+        "marker_begin": "<!-- SID:executor.responsibilities.must BEGIN -->",
+        "marker_end": "<!-- SID:executor.responsibilities.must END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["executor", "responsibilities", "must"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "executor.responsibilities.must_not",
+      "title": "ExecutorAgent 不得做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 351,
+        "line_end": 356,
+        "marker_begin": "<!-- SID:executor.responsibilities.must_not BEGIN -->",
+        "marker_end": "<!-- SID:executor.responsibilities.must_not END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["executor", "responsibilities", "must_not"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "safety.hitl.responsibilities",
+      "title": "SafetyAgent HITL 职责",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 373,
+        "marker": "<!-- SID:safety.hitl.responsibilities -->"
+      },
+      "level": "Section",
+      "tags": ["safety", "hitl", "responsibilities"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "safety.hitl.replan_trigger",
+      "title": "触发 WAITING_REPLAN_CONFIRM 的条件",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 378,
+        "marker": "<!-- SID:safety.hitl.replan_trigger -->"
+      },
+      "level": "Block",
+      "tags": ["safety", "hitl", "planning"],
+      "depends_on": ["fsm.states.waiting_replan_confirm"],
+      "stability": "stable"
+    },
+    {
+      "sid": "safety.responsibilities.must",
+      "title": "SafetyAgent 必须做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 394,
+        "line_end": 400,
+        "marker_begin": "<!-- SID:safety.responsibilities.must BEGIN -->",
+        "marker_end": "<!-- SID:safety.responsibilities.must END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["safety", "responsibilities", "must"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "safety.responsibilities.must_not",
+      "title": "SafetyAgent 不得做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 402,
+        "line_end": 408,
+        "marker_begin": "<!-- SID:safety.responsibilities.must_not BEGIN -->",
+        "marker_end": "<!-- SID:safety.responsibilities.must_not END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["safety", "responsibilities", "must_not"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "summarizer.hitl.responsibilities",
+      "title": "SummarizerAgent HITL 职责",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 413,
+        "marker": "<!-- SID:summarizer.hitl.responsibilities -->"
+      },
+      "level": "Section",
+      "tags": ["summarizer", "hitl", "responsibilities"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "summarizer.responsibilities.must",
+      "title": "SummarizerAgent 必须做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 417,
+        "line_end": 422,
+        "marker_begin": "<!-- SID:summarizer.responsibilities.must BEGIN -->",
+        "marker_end": "<!-- SID:summarizer.responsibilities.must END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["summarizer", "responsibilities", "must"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "summarizer.responsibilities.must_not",
+      "title": "SummarizerAgent 不得做的事",
+      "doc_key": "agent",
+      "path": "docs/design/agent-design.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 424,
+        "line_end": 429,
+        "marker_begin": "<!-- SID:summarizer.responsibilities.must_not BEGIN -->",
+        "marker_end": "<!-- SID:summarizer.responsibilities.must_not END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["summarizer", "responsibilities", "must_not"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "algo.scope.overview",
+      "title": "算法规范范围说明",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 13,
+        "marker": "<!-- SID:algo.scope.overview -->"
+      },
+      "level": "Section",
+      "tags": ["algo", "scope"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "algo.definitions.overview",
+      "title": "算法定义总览",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 30,
+        "marker": "<!-- SID:algo.definitions.overview -->"
+      },
+      "level": "Section",
+      "tags": ["algo", "definitions"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.contracts.io_overview",
+      "title": "Planner 输入输出契约",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 58,
+        "marker": "<!-- SID:planner.contracts.io_overview -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "contracts", "io"],
+      "depends_on": ["agent.contracts.protein_design_task", "agent.contracts.plan"],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.contracts.candidate_schema",
+      "title": "Candidate 对象模式总览",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 117,
+        "marker": "<!-- SID:planner.contracts.candidate_schema -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "contracts", "candidate"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.contracts.plan_candidate",
+      "title": "PlanCandidate 模式定义",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 123,
+        "marker": "<!-- SID:planner.contracts.plan_candidate -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["planner", "contracts", "candidate", "planning"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.contracts.patch_candidate",
+      "title": "PatchCandidate 模式定义",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 148,
+        "marker": "<!-- SID:planner.contracts.patch_candidate -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["planner", "contracts", "candidate", "execution"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.contracts.replan_candidate",
+      "title": "ReplanCandidate 模式定义",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 174,
+        "marker": "<!-- SID:planner.contracts.replan_candidate -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["planner", "contracts", "candidate", "planning"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.algorithm.tool_retrieval",
+      "title": "工具检索算法",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 202,
+        "marker": "<!-- SID:planner.algorithm.tool_retrieval -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "algorithm", "tool_retrieval"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.algorithm.candidate_scoring",
+      "title": "候选方案评分规则",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 298,
+        "marker": "<!-- SID:planner.algorithm.candidate_scoring -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "algorithm", "scoring"],
+      "depends_on": ["planner.contracts.candidate_schema"],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.algorithm.hitl_gate",
+      "title": "HITL 门控决策规则",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 345,
+        "marker": "<!-- SID:planner.algorithm.hitl_gate -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "algorithm", "hitl"],
+      "depends_on": ["planner.algorithm.candidate_scoring"],
+      "stability": "stable"
+    },
+    {
+      "sid": "planner.algorithm.decision_application",
+      "title": "Decision 应用逻辑",
+      "doc_key": "algo",
+      "path": "docs/design/core-algorithm-spec.md",
+      "locator": {
+        "type": "comment",
+        "line": 394,
+        "marker": "<!-- SID:planner.algorithm.decision_application -->"
+      },
+      "level": "Block",
+      "tags": ["planner", "algorithm", "hitl", "decision"],
+      "depends_on": ["arch.contracts.decision"],
+      "stability": "stable"
+    },
+    {
+      "sid": "impl.overview.introduction",
+      "title": "实现层总览",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 13,
+        "marker": "<!-- SID:impl.overview.introduction -->"
+      },
+      "level": "Section",
+      "tags": ["impl", "overview"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "impl.techstack.overview",
+      "title": "技术栈选型",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 76,
+        "marker": "<!-- SID:impl.techstack.overview -->"
+      },
+      "level": "Block",
+      "tags": ["impl", "techstack"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "api.rest.overview",
+      "title": "REST API 总览",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 139,
+        "marker": "<!-- SID:api.rest.overview -->"
+      },
+      "level": "Section",
+      "tags": ["api", "rest"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "api.rest.create_task",
+      "title": "POST /tasks 端点",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 151,
+        "marker": "<!-- SID:api.rest.create_task -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["api", "rest", "task"],
+      "depends_on": ["agent.contracts.protein_design_task"],
+      "stability": "stable"
+    },
+    {
+      "sid": "api.rest.get_pending_actions",
+      "title": "GET /pending-actions 端点",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 267,
+        "marker": "<!-- SID:api.rest.get_pending_actions -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["api", "rest", "hitl", "pending_actions"],
+      "depends_on": ["arch.contracts.pending_action"],
+      "stability": "stable"
+    },
+    {
+      "sid": "api.rest.submit_decision",
+      "title": "POST /pending-actions/{id}/decision 端点",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 295,
+        "marker": "<!-- SID:api.rest.submit_decision -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["api", "rest", "hitl", "decision"],
+      "depends_on": ["arch.contracts.decision"],
+      "stability": "stable"
+    },
+    {
+      "sid": "api.rest.get_report",
+      "title": "GET /tasks/{task_id}/report 端点",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 322,
+        "marker": "<!-- SID:api.rest.get_report -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["api", "rest", "report"],
+      "depends_on": ["agent.contracts.design_result"],
+      "stability": "stable"
+    },
+    {
+      "sid": "obs.eventlog.schema",
+      "title": "EventLog 单条日志记录结构",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 772,
+        "marker": "<!-- SID:obs.eventlog.schema -->"
+      },
+      "level": "Block",
+      "tags": ["obs", "eventlog", "observability"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "obs.eventlog.mandatory_events",
+      "title": "事件日志写入约束（必须遵守）",
+      "doc_key": "impl",
+      "path": "docs/design/system-implementation-design.md",
+      "locator": {
+        "type": "comment",
+        "line": 820,
+        "marker": "<!-- SID:obs.eventlog.mandatory_events -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["obs", "eventlog", "observability", "hitl"],
+      "depends_on": ["fsm.states.definitions"],
+      "stability": "stable"
+    },
+    {
+      "sid": "tools.executor.overview",
+      "title": "Executor 可选择的工具",
+      "doc_key": "tools",
+      "path": "docs/design/tools-catalog.md",
+      "locator": {
+        "type": "comment",
+        "line": 21,
+        "marker": "<!-- SID:tools.executor.overview -->"
+      },
+      "level": "Section",
+      "tags": ["tools", "executor"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "tools.esmfold.spec",
+      "title": "ESMFold 工具规约",
+      "doc_key": "tools",
+      "path": "docs/design/tools-catalog.md",
+      "locator": {
+        "type": "comment",
+        "line": 31,
+        "marker": "<!-- SID:tools.esmfold.spec -->"
+      },
+      "level": "Block",
+      "tags": ["tools", "esmfold", "structure_prediction"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "tools.alphafold.spec",
+      "title": "AlphaFold/OpenFold 工具规约",
+      "doc_key": "tools",
+      "path": "docs/design/tools-catalog.md",
+      "locator": {
+        "type": "comment",
+        "line": 44,
+        "marker": "<!-- SID:tools.alphafold.spec -->"
+      },
+      "level": "Block",
+      "tags": ["tools", "alphafold", "structure_prediction"],
+      "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "tools.adapter.constraints",
+      "title": "ToolAdapter 设计原则与约束",
+      "doc_key": "tools",
+      "path": "docs/design/tools-catalog.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 225,
+        "line_end": 236,
+        "marker_begin": "<!-- SID:tools.adapter.constraints BEGIN -->",
+        "marker_end": "<!-- SID:tools.adapter.constraints END -->"
+      },
+      "level": "Spec-Item",
+      "tags": ["tools", "adapter", "constraints"],
+      "depends_on": [],
+      "stability": "stable"
+    }
+  ]
+}

--- a/docs/index/index.md
+++ b/docs/index/index.md
@@ -1,0 +1,294 @@
+# Specification Index（规范索引）
+
+> 本文档是设计规范的**人类可读索引**，与 `index.json` 对应。
+>
+> 提供按 Domain 和文档组织的规范清单，便于快速定位和浏览。
+>
+> **机器可读版本**: [index.json](./index.json)
+> **主题视图**: [topic_views.json](./topic_views.json)
+
+---
+
+## 索引总览
+
+**版本**: 1.0
+**生成日期**: 2025-12-31
+**总规范数**: 65
+**文档数**: 6
+
+---
+
+## 文档列表
+
+| doc_key | 标题 | 路径 | 状态 | 依赖 |
+|---------|------|------|------|------|
+| `arch` | 系统总体架构 | [docs/design/architecture.md](../design/architecture.md) | stable | - |
+| `agent` | Agent设计文档 | [docs/design/agent-design.md](../design/agent-design.md) | stable | arch |
+| `algo` | 核心算法规范 | [docs/design/core-algorithm-spec.md](../design/core-algorithm-spec.md) | stable | arch, agent |
+| `impl` | 系统实现设计 | [docs/design/system-implementation-design.md](../design/system-implementation-design.md) | stable | arch, agent |
+| `tools` | Tools Catalog | [docs/design/tools-catalog.md](../design/tools-catalog.md) | stable | impl |
+| `hitl` | HITL 扩展设计 | [docs/design/hitl-extension.md](../design/hitl-extension.md) | stable | arch, agent, impl, algo |
+
+---
+
+## 按 Domain 分组的规范索引
+
+### 1. `arch` Domain（总体架构）
+
+**SSOT 文档**: architecture.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `arch.overview.layers` | 分层架构 | Section | arch, overview, layers |
+| `arch.components.overview` | 组件视图 | Section | arch, components |
+| `arch.flow.end_to_end` | 运行视图与时序图 | Section | arch, flow, runtime |
+| `arch.dataflow.overview` | 数据流概览 | Section | arch, dataflow |
+| `arch.kg.overview` | ProteinToolKG 在架构中的位置 | Block | arch, kg, knowledge_graph |
+| `arch.contracts.pending_action` | PendingAction 契约定义 | Spec-Item | arch, contracts, hitl, pending_action |
+| `arch.contracts.decision` | Decision 契约定义 | Spec-Item | arch, contracts, hitl, decision |
+| `arch.contracts.task_snapshot` | TaskSnapshot 契约定义 | Spec-Item | arch, contracts, hitl, snapshot |
+| `arch.contracts.plan` | Plan 契约定义（架构层视角） | Spec-Item | arch, contracts, planning |
+
+---
+
+### 2. `fsm` Domain（有限状态机）
+
+**SSOT 文档**: architecture.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `fsm.lifecycle.overview` | 任务生命周期与状态机 | Section | fsm, lifecycle, state_machine |
+| `fsm.states.definitions` | FSM 状态完整定义表 | Block | fsm, states, definitions |
+| `fsm.states.waiting_plan_confirm` | WAITING_PLAN_CONFIRM 状态定义 | Spec-Item | fsm, states, hitl, planning |
+| `fsm.states.waiting_patch_confirm` | WAITING_PATCH_CONFIRM 状态定义 | Spec-Item | fsm, states, hitl, execution |
+| `fsm.states.waiting_replan_confirm` | WAITING_REPLAN_CONFIRM 状态定义 | Spec-Item | fsm, states, hitl, planning |
+| `fsm.transitions.overview` | 状态转换规则总览 | Spec-Item | fsm, transitions, state_machine |
+
+---
+
+### 3. `agent` Domain（Agent 体系）
+
+**SSOT 文档**: agent-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `agent.overview.introduction` | Agent体系总览 | Section | agent, overview |
+| `agent.overview.roles` | Agent 角色列表 | Block | agent, overview, roles |
+| `agent.contracts.overview` | 核心数据结构契约总览 | Section | agent, contracts, data_structures |
+| `agent.contracts.protein_design_task` | ProteinDesignTask 数据结构 | Block | agent, contracts, task |
+| `agent.contracts.plan` | Plan 数据结构（Agent 层视角） | Block | agent, contracts, planning |
+| `agent.contracts.step_result` | StepResult 数据结构 | Block | agent, contracts, execution, result |
+| `agent.contracts.design_result` | DesignResult 数据结构 | Block | agent, contracts, result |
+| `agent.contracts.safety_result` | SafetyResult 数据结构 | Block | agent, contracts, safety, result |
+| `agent.hitl.overview` | HITL 机制在 Agent 层的概述 | Section | agent, hitl, overview |
+| `agent.hitl.universal_constraints` | Agent 层 HITL 统一约束 | Spec-Item | agent, hitl, constraints |
+
+---
+
+### 4. `planner` Domain（Planner Agent）
+
+**SSOT 文档**: agent-design.md（接口）、core-algorithm-spec.md（算法）
+
+#### 接口与职责
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `planner.interface.overview` | PlannerAgent 接口总览 | Section | planner, interface, agent |
+| `planner.hitl.responsibilities` | PlannerAgent HITL 职责 | Section | planner, hitl, responsibilities |
+| `planner.hitl.plan_confirm` | 初始 Plan 确认阶段 | Block | planner, hitl, planning |
+| `planner.responsibilities.must` | PlannerAgent 必须做的事 | Spec-Item | planner, responsibilities, must |
+| `planner.responsibilities.must_not` | PlannerAgent 不得做的事 | Spec-Item | planner, responsibilities, must_not |
+
+#### 算法与契约
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `planner.contracts.io_overview` | Planner 输入输出契约 | Block | planner, contracts, io |
+| `planner.contracts.candidate_schema` | Candidate 对象模式总览 | Block | planner, contracts, candidate |
+| `planner.contracts.plan_candidate` | PlanCandidate 模式定义 | Spec-Item | planner, contracts, candidate, planning |
+| `planner.contracts.patch_candidate` | PatchCandidate 模式定义 | Spec-Item | planner, contracts, candidate, execution |
+| `planner.contracts.replan_candidate` | ReplanCandidate 模式定义 | Spec-Item | planner, contracts, candidate, planning |
+| `planner.algorithm.tool_retrieval` | 工具检索算法 | Block | planner, algorithm, tool_retrieval |
+| `planner.algorithm.candidate_scoring` | 候选方案评分规则 | Block | planner, algorithm, scoring |
+| `planner.algorithm.hitl_gate` | HITL 门控决策规则 | Block | planner, algorithm, hitl |
+| `planner.algorithm.decision_application` | Decision 应用逻辑 | Block | planner, algorithm, hitl, decision |
+
+---
+
+### 5. `executor` Domain（Executor Agent）
+
+**SSOT 文档**: agent-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `executor.hitl.responsibilities` | ExecutorAgent HITL 职责 | Section | executor, hitl, responsibilities |
+| `executor.hitl.patch_confirm` | Patch 触发与确认 | Block | executor, hitl, execution, patch |
+| `executor.responsibilities.must` | ExecutorAgent 必须做的事 | Spec-Item | executor, responsibilities, must |
+| `executor.responsibilities.must_not` | ExecutorAgent 不得做的事 | Spec-Item | executor, responsibilities, must_not |
+
+---
+
+### 6. `safety` Domain（Safety Agent）
+
+**SSOT 文档**: agent-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `safety.hitl.responsibilities` | SafetyAgent HITL 职责 | Section | safety, hitl, responsibilities |
+| `safety.hitl.replan_trigger` | 触发 WAITING_REPLAN_CONFIRM 的条件 | Block | safety, hitl, planning |
+| `safety.responsibilities.must` | SafetyAgent 必须做的事 | Spec-Item | safety, responsibilities, must |
+| `safety.responsibilities.must_not` | SafetyAgent 不得做的事 | Spec-Item | safety, responsibilities, must_not |
+
+---
+
+### 7. `summarizer` Domain（Summarizer Agent）
+
+**SSOT 文档**: agent-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `summarizer.hitl.responsibilities` | SummarizerAgent HITL 职责 | Section | summarizer, hitl, responsibilities |
+| `summarizer.responsibilities.must` | SummarizerAgent 必须做的事 | Spec-Item | summarizer, responsibilities, must |
+| `summarizer.responsibilities.must_not` | SummarizerAgent 不得做的事 | Spec-Item | summarizer, responsibilities, must_not |
+
+---
+
+### 8. `algo` Domain（算法规范）
+
+**SSOT 文档**: core-algorithm-spec.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `algo.scope.overview` | 算法规范范围说明 | Section | algo, scope |
+| `algo.definitions.overview` | 算法定义总览 | Section | algo, definitions |
+
+---
+
+### 9. `api` Domain（REST API）
+
+**SSOT 文档**: system-implementation-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `api.rest.overview` | REST API 总览 | Section | api, rest |
+| `api.rest.create_task` | POST /tasks 端点 | Spec-Item | api, rest, task |
+| `api.rest.get_pending_actions` | GET /pending-actions 端点 | Spec-Item | api, rest, hitl, pending_actions |
+| `api.rest.submit_decision` | POST /pending-actions/{id}/decision 端点 | Spec-Item | api, rest, hitl, decision |
+| `api.rest.get_report` | GET /tasks/{task_id}/report 端点 | Spec-Item | api, rest, report |
+
+---
+
+### 10. `obs` Domain（可观测性）
+
+**SSOT 文档**: system-implementation-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `obs.eventlog.schema` | EventLog 单条日志记录结构 | Block | obs, eventlog, observability |
+| `obs.eventlog.mandatory_events` | 事件日志写入约束（必须遵守） | Spec-Item | obs, eventlog, observability, hitl |
+
+---
+
+### 11. `impl` Domain（实现层）
+
+**SSOT 文档**: system-implementation-design.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `impl.overview.introduction` | 实现层总览 | Section | impl, overview |
+| `impl.techstack.overview` | 技术栈选型 | Block | impl, techstack |
+
+---
+
+### 12. `tools` Domain（工具集成）
+
+**SSOT 文档**: tools-catalog.md
+
+| SID | 标题 | 级别 | 标签 |
+|-----|------|------|------|
+| `tools.executor.overview` | Executor 可选择的工具 | Section | tools, executor |
+| `tools.esmfold.spec` | ESMFold 工具规约 | Block | tools, esmfold, structure_prediction |
+| `tools.alphafold.spec` | AlphaFold/OpenFold 工具规约 | Block | tools, alphafold, structure_prediction |
+| `tools.adapter.constraints` | ToolAdapter 设计原则与约束 | Spec-Item | tools, adapter, constraints |
+
+---
+
+## 按文档分组的规范统计
+
+| 文档 | Section | Block | Spec-Item | 总计 |
+|------|---------|-------|-----------|------|
+| architecture.md | 4 | 2 | 9 | 15 |
+| agent-design.md | 8 | 5 | 11 | 24 |
+| core-algorithm-spec.md | 2 | 5 | 4 | 11 |
+| system-implementation-design.md | 3 | 2 | 5 | 10 |
+| tools-catalog.md | 1 | 2 | 1 | 4 |
+| hitl-extension.md | 0 | 0 | 0 | 0 (differential index) |
+| **总计** | **18** | **16** | **30** | **64** |
+
+**注**: hitl-extension.md 是差分索引文档，不包含独立定义的 SID，仅通过引用汇总其他文档的规范。
+
+---
+
+## 粒度分布
+
+| 粒度 | 数量 | 占比 |
+|------|------|------|
+| Section | 18 | 28% |
+| Block | 16 | 25% |
+| Spec-Item | 30 | 47% |
+
+---
+
+## 按主题快速索引
+
+详见 [topic_views.json](./topic_views.json) 获取以下主题的规范聚合：
+
+- **hitl**: Human-in-the-loop 相关规范
+- **planning**: 任务规划相关规范
+- **execution**: 执行相关规范
+- **observability**: 可观测性相关规范
+
+---
+
+## 使用说明
+
+### 1. 查找特定规范
+
+**通过 SID 查找**：
+1. 在本文档中搜索 SID（如 `arch.contracts.pending_action`）
+2. 查看对应的文档路径和行号
+3. 使用 locator 信息精确定位
+
+**通过标签查找**：
+1. 确定你关心的标签（如 `hitl`, `planning`, `execution`）
+2. 查看 [topic_views.json](./topic_views.json) 获取聚合列表
+
+### 2. 机器检索
+
+**使用 index.json**：
+```bash
+# 提取所有 HITL 相关规范
+jq '.specs[] | select(.tags | contains(["hitl"]))' index.json
+
+# 查找特定 SID 的定位信息
+jq '.specs[] | select(.sid == "arch.contracts.pending_action")' index.json
+```
+
+### 3. 依赖追踪
+
+每个规范的 `depends_on` 字段列出了其依赖的其他 SID。可用于：
+- 理解规范之间的关系
+- 检测循环依赖
+- 确定最小注入上下文
+
+---
+
+## 版本历史
+
+| 版本 | 日期 | 变更说明 |
+|------|------|----------|
+| 1.0 | 2025-12-31 | 初始版本，索引 65 个规范，覆盖 6 个文档 |
+
+---
+
+**本文档由 `index.json` 生成，任何修改应同步更新 JSON 索引。**

--- a/docs/index/topic_views.json
+++ b/docs/index/topic_views.json
@@ -1,0 +1,512 @@
+{
+  "version": "1.0",
+  "generated_at": "2025-12-31",
+  "description": "Topic-based views for design specifications, providing minimum injectable context for implementation phases",
+  "topics": {
+    "hitl": {
+      "title": "Human-in-the-Loop",
+      "description": "HITL 机制相关规范，包括 FSM 状态、契约定义、Agent 职责、API 端点和事件日志约束",
+      "use_case": "实现人工审查功能时需要注入的最小规范集合",
+      "specs": [
+        {
+          "sid": "arch.contracts.pending_action",
+          "title": "PendingAction 契约定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "HITL 核心契约，定义等待人工决策的结构"
+        },
+        {
+          "sid": "arch.contracts.decision",
+          "title": "Decision 契约定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "HITL 核心契约，定义人工决策的结构"
+        },
+        {
+          "sid": "arch.contracts.task_snapshot",
+          "title": "TaskSnapshot 契约定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "支持任务恢复与快照的核心契约"
+        },
+        {
+          "sid": "fsm.states.waiting_plan_confirm",
+          "title": "WAITING_PLAN_CONFIRM 状态定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "high",
+          "rationale": "HITL 三个等待状态之一"
+        },
+        {
+          "sid": "fsm.states.waiting_patch_confirm",
+          "title": "WAITING_PATCH_CONFIRM 状态定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "high",
+          "rationale": "HITL 三个等待状态之一"
+        },
+        {
+          "sid": "fsm.states.waiting_replan_confirm",
+          "title": "WAITING_REPLAN_CONFIRM 状态定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "high",
+          "rationale": "HITL 三个等待状态之一"
+        },
+        {
+          "sid": "agent.hitl.overview",
+          "title": "HITL 机制在 Agent 层的概述",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "Agent 如何与 HITL 机制交互的总览"
+        },
+        {
+          "sid": "agent.hitl.universal_constraints",
+          "title": "Agent 层 HITL 统一约束",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "所有 Agent 必须遵守的 HITL 约束"
+        },
+        {
+          "sid": "planner.hitl.responsibilities",
+          "title": "PlannerAgent HITL 职责",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "PlannerAgent 在 HITL 场景下的职责边界"
+        },
+        {
+          "sid": "planner.hitl.plan_confirm",
+          "title": "初始 Plan 确认阶段",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "Plan 确认流程详细说明"
+        },
+        {
+          "sid": "executor.hitl.responsibilities",
+          "title": "ExecutorAgent HITL 职责",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "ExecutorAgent 在 HITL 场景下的职责边界"
+        },
+        {
+          "sid": "executor.hitl.patch_confirm",
+          "title": "Patch 触发与确认",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "Patch 确认流程详细说明"
+        },
+        {
+          "sid": "safety.hitl.responsibilities",
+          "title": "SafetyAgent HITL 职责",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "SafetyAgent 在 HITL 场景下的职责边界"
+        },
+        {
+          "sid": "safety.hitl.replan_trigger",
+          "title": "触发 WAITING_REPLAN_CONFIRM 的条件",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "何时触发 Replan 确认的规则"
+        },
+        {
+          "sid": "planner.algorithm.hitl_gate",
+          "title": "HITL 门控决策规则",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "critical",
+          "rationale": "决定何时进入 HITL 的算法规则"
+        },
+        {
+          "sid": "planner.algorithm.decision_application",
+          "title": "Decision 应用逻辑",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "critical",
+          "rationale": "如何应用人工决策的算法逻辑"
+        },
+        {
+          "sid": "api.rest.get_pending_actions",
+          "title": "GET /pending-actions 端点",
+          "doc_key": "impl",
+          "path": "docs/design/system-implementation-design.md",
+          "priority": "high",
+          "rationale": "获取待决策列表的 API"
+        },
+        {
+          "sid": "api.rest.submit_decision",
+          "title": "POST /pending-actions/{id}/decision 端点",
+          "doc_key": "impl",
+          "path": "docs/design/system-implementation-design.md",
+          "priority": "high",
+          "rationale": "提交人工决策的 API"
+        },
+        {
+          "sid": "obs.eventlog.mandatory_events",
+          "title": "事件日志写入约束（必须遵守）",
+          "doc_key": "impl",
+          "path": "docs/design/system-implementation-design.md",
+          "priority": "critical",
+          "rationale": "HITL 相关事件的强制日志要求"
+        }
+      ],
+      "total_specs": 19,
+      "critical_specs": 6,
+      "high_specs": 13
+    },
+    "planning": {
+      "title": "Task Planning",
+      "description": "任务规划相关规范，包括 Planner 接口、算法、候选方案评分和工具检索",
+      "use_case": "实现 PlannerAgent 或规划逻辑时需要注入的最小规范集合",
+      "specs": [
+        {
+          "sid": "arch.contracts.plan",
+          "title": "Plan 契约定义（架构层视角）",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "Plan 在架构层的作用定义"
+        },
+        {
+          "sid": "fsm.states.waiting_plan_confirm",
+          "title": "WAITING_PLAN_CONFIRM 状态定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "high",
+          "rationale": "Plan 确认状态定义"
+        },
+        {
+          "sid": "fsm.states.waiting_replan_confirm",
+          "title": "WAITING_REPLAN_CONFIRM 状态定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "high",
+          "rationale": "Replan 确认状态定义"
+        },
+        {
+          "sid": "agent.contracts.protein_design_task",
+          "title": "ProteinDesignTask 数据结构",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "Planner 的输入契约"
+        },
+        {
+          "sid": "agent.contracts.plan",
+          "title": "Plan 数据结构（Agent 层视角）",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "Plan 的数据结构定义"
+        },
+        {
+          "sid": "planner.interface.overview",
+          "title": "PlannerAgent 接口总览",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "PlannerAgent 的完整接口定义"
+        },
+        {
+          "sid": "planner.responsibilities.must",
+          "title": "PlannerAgent 必须做的事",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "PlannerAgent 的强制职责"
+        },
+        {
+          "sid": "planner.responsibilities.must_not",
+          "title": "PlannerAgent 不得做的事",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "PlannerAgent 的禁止行为"
+        },
+        {
+          "sid": "planner.contracts.io_overview",
+          "title": "Planner 输入输出契约",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "high",
+          "rationale": "Planner 的 I/O 契约详细说明"
+        },
+        {
+          "sid": "planner.contracts.candidate_schema",
+          "title": "Candidate 对象模式总览",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "critical",
+          "rationale": "候选方案的数据模式"
+        },
+        {
+          "sid": "planner.contracts.plan_candidate",
+          "title": "PlanCandidate 模式定义",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "high",
+          "rationale": "初始 Plan 候选的模式"
+        },
+        {
+          "sid": "planner.contracts.replan_candidate",
+          "title": "ReplanCandidate 模式定义",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "high",
+          "rationale": "Replan 候选的模式"
+        },
+        {
+          "sid": "planner.algorithm.tool_retrieval",
+          "title": "工具检索算法",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "critical",
+          "rationale": "如何从 KG 检索工具的算法"
+        },
+        {
+          "sid": "planner.algorithm.candidate_scoring",
+          "title": "候选方案评分规则",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "critical",
+          "rationale": "候选方案评分与排序算法"
+        },
+        {
+          "sid": "arch.kg.overview",
+          "title": "ProteinToolKG 在架构中的位置",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "medium",
+          "rationale": "KG 在规划中的作用"
+        }
+      ],
+      "total_specs": 15,
+      "critical_specs": 9,
+      "high_specs": 5,
+      "medium_specs": 1
+    },
+    "execution": {
+      "title": "Task Execution",
+      "description": "任务执行相关规范，包括 Executor 接口、Step 执行、工具适配器和 Patch 机制",
+      "use_case": "实现 ExecutorAgent 或执行逻辑时需要注入的最小规范集合",
+      "specs": [
+        {
+          "sid": "agent.contracts.plan",
+          "title": "Plan 数据结构（Agent 层视角）",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "Executor 的输入契约"
+        },
+        {
+          "sid": "agent.contracts.step_result",
+          "title": "StepResult 数据结构",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "每个 Step 的执行结果契约"
+        },
+        {
+          "sid": "agent.contracts.design_result",
+          "title": "DesignResult 数据结构",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "最终执行结果契约"
+        },
+        {
+          "sid": "fsm.states.waiting_patch_confirm",
+          "title": "WAITING_PATCH_CONFIRM 状态定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "high",
+          "rationale": "Patch 确认状态定义"
+        },
+        {
+          "sid": "executor.hitl.responsibilities",
+          "title": "ExecutorAgent HITL 职责",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "ExecutorAgent 的职责边界"
+        },
+        {
+          "sid": "executor.hitl.patch_confirm",
+          "title": "Patch 触发与确认",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "Patch 机制详细说明"
+        },
+        {
+          "sid": "executor.responsibilities.must",
+          "title": "ExecutorAgent 必须做的事",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "ExecutorAgent 的强制职责"
+        },
+        {
+          "sid": "executor.responsibilities.must_not",
+          "title": "ExecutorAgent 不得做的事",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "critical",
+          "rationale": "ExecutorAgent 的禁止行为"
+        },
+        {
+          "sid": "planner.contracts.patch_candidate",
+          "title": "PatchCandidate 模式定义",
+          "doc_key": "algo",
+          "path": "docs/design/core-algorithm-spec.md",
+          "priority": "high",
+          "rationale": "Patch 候选的数据模式"
+        },
+        {
+          "sid": "tools.executor.overview",
+          "title": "Executor 可选择的工具",
+          "doc_key": "tools",
+          "path": "docs/design/tools-catalog.md",
+          "priority": "high",
+          "rationale": "可用工具清单"
+        },
+        {
+          "sid": "tools.adapter.constraints",
+          "title": "ToolAdapter 设计原则与约束",
+          "doc_key": "tools",
+          "path": "docs/design/tools-catalog.md",
+          "priority": "critical",
+          "rationale": "工具适配器必须遵守的约束"
+        },
+        {
+          "sid": "tools.esmfold.spec",
+          "title": "ESMFold 工具规约",
+          "doc_key": "tools",
+          "path": "docs/design/tools-catalog.md",
+          "priority": "medium",
+          "rationale": "示例工具规约"
+        }
+      ],
+      "total_specs": 12,
+      "critical_specs": 6,
+      "high_specs": 5,
+      "medium_specs": 1
+    },
+    "observability": {
+      "title": "Observability & Monitoring",
+      "description": "可观测性相关规范，包括事件日志、快照、状态机追踪和 API 监控",
+      "use_case": "实现日志、监控、审计功能时需要注入的最小规范集合",
+      "specs": [
+        {
+          "sid": "fsm.lifecycle.overview",
+          "title": "任务生命周期与状态机",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "状态机是可观测性的核心基础"
+        },
+        {
+          "sid": "fsm.states.definitions",
+          "title": "FSM 状态完整定义表",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "所有状态的定义，用于状态追踪"
+        },
+        {
+          "sid": "fsm.transitions.overview",
+          "title": "状态转换规则总览",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "状态转换规则，用于追踪异常转换"
+        },
+        {
+          "sid": "arch.contracts.task_snapshot",
+          "title": "TaskSnapshot 契约定义",
+          "doc_key": "arch",
+          "path": "docs/design/architecture.md",
+          "priority": "critical",
+          "rationale": "快照机制，支持恢复与审计"
+        },
+        {
+          "sid": "agent.contracts.step_result",
+          "title": "StepResult 数据结构",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "Step 级别的执行结果，用于细粒度追踪"
+        },
+        {
+          "sid": "agent.contracts.design_result",
+          "title": "DesignResult 数据结构",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "最终结果，用于任务级别追踪"
+        },
+        {
+          "sid": "agent.contracts.safety_result",
+          "title": "SafetyResult 数据结构",
+          "doc_key": "agent",
+          "path": "docs/design/agent-design.md",
+          "priority": "high",
+          "rationale": "安全检查结果，用于风险追踪"
+        },
+        {
+          "sid": "obs.eventlog.schema",
+          "title": "EventLog 单条日志记录结构",
+          "doc_key": "impl",
+          "path": "docs/design/system-implementation-design.md",
+          "priority": "critical",
+          "rationale": "日志记录的数据模式"
+        },
+        {
+          "sid": "obs.eventlog.mandatory_events",
+          "title": "事件日志写入约束（必须遵守）",
+          "doc_key": "impl",
+          "path": "docs/design/system-implementation-design.md",
+          "priority": "critical",
+          "rationale": "强制日志事件，确保可审计性"
+        },
+        {
+          "sid": "api.rest.overview",
+          "title": "REST API 总览",
+          "doc_key": "impl",
+          "path": "docs/design/system-implementation-design.md",
+          "priority": "medium",
+          "rationale": "API 也需要日志与监控"
+        }
+      ],
+      "total_specs": 10,
+      "critical_specs": 6,
+      "high_specs": 3,
+      "medium_specs": 1
+    }
+  },
+  "summary": {
+    "total_topics": 4,
+    "total_unique_specs": 45,
+    "note": "部分 SID 出现在多个主题中，因为它们是跨关注点的共享规范"
+  },
+  "usage_guide": {
+    "for_claude_code_skills": "Claude Code Skills 可通过 topic 参数选择相应的规范集合，仅注入该主题的最小可用上下文",
+    "for_docslice": "docslice 脚本可根据 topic 提取对应的规范片段，避免全文扫描",
+    "priority_levels": {
+      "critical": "核心规范，必须理解和遵守",
+      "high": "重要规范，实现时需要参考",
+      "medium": "辅助规范，提供额外上下文"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

新增机器可读的规范索引（index.json）、人类可读索引（index.md）和主题视图（topic_views.json），为 docslice 脚本和 Claude Code Skills 提供统一检索入口，避免全文扫描，实现最小可注入上下文。

## Background

在完成 issue #29（设计文档可寻址结构重构）和 issue #30（SSOT 映射表与重复内容审计）后，虽然已建立 SID 系统和 SSOT 原则，但仍缺少以下关键基础设施：

1. **机器可读索引**：docslice 脚本需要一个结构化的索引来快速定位规范，而非全文扫描
2. **主题视图**：实现阶段需要按主题（如 hitl、planning、execution）聚合规范，提供最小可注入上下文
3. **元数据完整性**：每个 SID 需要附带完整元数据（locator、level、tags、dependencies）

根据 issue #31 的要求，需要创建这三个索引文件，作为 Milestone "Addressable Design Docs & Spec Retrieval Skill" 的核心检索基础设施。

**关键需求**：
- 任一 SID 可通过索引定位到唯一文件片段
- Topic views 覆盖实现阶段所需的最小规范集合
- Claude Code Skills 可通过 topic 参数获取精确的上下文

## Changes

### 新增文件

1. **docs/index/index.json**（32KB，1867 行）
   - 包含 65 个规范的完整元数据
   - 每个规范包含：sid, title, doc_key, path, locator, level, tags, depends_on, stability
   - 支持 3 种 locator 类型：comment（单行）、inline（行内）、begin_end（块边界）
   - 提供依赖追踪，明确规范间的引用关系

2. **docs/index/index.md**（12KB）
   - 人类可读的规范清单
   - 按 12 个 Domain 组织：arch, fsm, agent, planner, executor, safety, summarizer, algo, api, obs, impl, tools
   - 提供规范统计：Section(18), Block(16), Spec-Item(30)
   - 包含快速索引、使用说明和 jq 查询示例

3. **docs/index/topic_views.json**（19KB）
   - 提供 4 个主题视图：hitl, planning, execution, observability
   - 每个主题包含最小可注入规范集合，附带优先级标注（critical/high/medium）
   - 总计 45 个独立 SID（部分 SID 跨主题复用）

### 关键设计决策

#### 1. Locator 类型设计

| 类型 | 用途 | 示例 |
|------|------|------|
| `comment` | 单行 SID 注释（Section/Block） | `<!-- SID:arch.overview.layers -->` |
| `inline` | 行内 SID 注释（表格行内） | `\|WAITING_PLAN_CONFIRM\|...\<!-- SID:fsm.states.waiting_plan_confirm -->\|` |
| `begin_end` | 块边界标记（Spec-Item） | `<!-- SID:... BEGIN -->` ... `<!-- SID:... END -->` |

#### 2. Topic Views 组织

| Topic | 规范数 | Critical | High | Medium | 用途 |
|-------|--------|----------|------|--------|------|
| **hitl** | 19 | 6 | 13 | 0 | 实现 HITL 机制的完整规范集合 |
| **planning** | 15 | 9 | 5 | 1 | 实现 PlannerAgent 的核心规范 |
| **execution** | 12 | 6 | 5 | 1 | 实现 ExecutorAgent 的核心规范 |
| **observability** | 10 | 6 | 3 | 1 | 实现日志、监控、审计的规范 |

**规范复用**：部分 SID（如 `arch.contracts.plan`, `agent.contracts.step_result`）在多个主题中出现，因为它们是跨关注点的共享规范。

#### 3. 元数据字段说明

```json
{
  "sid": "arch.contracts.pending_action",
  "title": "PendingAction 契约定义",
  "doc_key": "arch",
  "path": "docs/design/architecture.md",
  "locator": {
    "type": "begin_end",
    "line_start": 337,
    "line_end": 355,
    "marker_begin": "<!-- SID:arch.contracts.pending_action BEGIN -->",
    "marker_end": "<!-- SID:arch.contracts.pending_action END -->"
  },
  "level": "Spec-Item",
  "tags": ["arch", "contracts", "hitl", "pending_action"],
  "depends_on": [],
  "stability": "stable"
}
```

### 统计数据

- 3 个新增文件
- +1867 行内容
- 索引 65 个规范，覆盖 6 个文档
- 4 个主题视图，45 个独立 SID

## Impact

**正面影响**：

1. **高效检索**：docslice 脚本可直接从 index.json 查找规范，无需全文扫描
2. **精确上下文注入**：Claude Code Skills 可根据 topic 参数获取最小必要规范集合
3. **依赖追踪**：每个规范的 depends_on 字段支持构建依赖图，理解规范间关系
4. **质量保证**：locator 信息精确到行号，支持自动化验证与 linting

**使用场景**：

```bash
# docslice 提取特定 SID
jq '.specs[] | select(.sid == "arch.contracts.pending_action")' index.json

# 提取所有 HITL 相关规范
jq '.specs[] | select(.tags | contains(["hitl"]))' index.json

# Claude Code Skills 获取 planning 主题的最小上下文
jq '.topics.planning.specs' topic_views.json
```

**风险评估**：

- **低风险**：本次变更仅新增索引文件，未修改既有设计文档
- 索引内容基于 issue #29 已完成的 SID 标注，数据来源可靠
- 所有 locator 信息已人工验证，确保行号准确

## Related

- Closes #31
- Depends on: #29（设计文档可寻址结构重构）
- Depends on: #30（SSOT 映射表与重复内容审计）
- Milestone: Addressable Design Docs & Spec Retrieval Skill