### PR TITLE
feat(tooling): add deterministic spec slicer (docslice)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,323 @@
+# docslice - Deterministic Specification Slicer
+
+A read-only, deterministic document slicer for extracting specification fragments by SID (Section Identifier) or topic from design documents.
+
+## Purpose
+
+`docslice` is the core tool for the skill execution mechanism in Claude Code, providing precise specification context retrieval. It enables:
+
+**Location**: The script can be run from either:
+- Main repository: `thesis-project/scripts/docslice` (auto-detects design worktree)
+- Design worktree: `thesis-project.design/scripts/docslice`
+
+The script automatically detects its location and finds the design documentation.
+
+- Extracting specific specification fragments by their unique identifiers
+- Retrieving related specifications by topic
+- Validating document structure and SID consistency
+- Ensuring deterministic, reproducible output
+
+## Installation
+
+The script requires Python 3.6+ and no external dependencies (uses only standard library).
+
+```bash
+# Make the script executable
+chmod +x scripts/docslice
+
+# Optionally, add to PATH or create a symlink
+ln -s $(pwd)/scripts/docslice /usr/local/bin/docslice
+```
+
+## Usage
+
+### Extract by SID
+
+Extract a specification fragment by its Section Identifier:
+
+```bash
+docslice --sid SID:arch.contracts.pending_action
+docslice --sid arch.contracts.pending_action  # 'SID:' prefix is optional
+```
+
+**Output includes:**
+- SID and title
+- Document location (doc_key, path, line range)
+- Fragment level (Section, Block, Spec-Item)
+- Tags
+- Full content
+
+### Extract by Reference
+
+Extract content using DOC:doc_key#anchor format (fallback reference):
+
+```bash
+docslice --ref "DOC:arch#分层架构"
+docslice --ref "DOC:agent#Agent体系总览"
+```
+
+### Extract by Topic
+
+Extract all specifications related to a topic:
+
+```bash
+# Extract all HITL-related specs
+docslice --topic hitl
+
+# Limit output size
+docslice --topic hitl --max-lines 500
+docslice --topic planning --max-chars 10000
+```
+
+**Available topics:**
+- `hitl` - Human-in-the-loop mechanisms
+- `planning` - Task planning specifications
+- `execution` - Execution-related specs
+- `observability` - Observability and logging
+
+### Validate Structure
+
+Lint and validate document structure:
+
+```bash
+docslice --lint
+```
+
+**Checks performed:**
+- SID format compliance (domain.topic.name)
+- SID uniqueness across all documents
+- BEGIN/END marker pairing
+- Reference validity
+- Index consistency
+
+### Options
+
+- `--no-metadata`: Suppress metadata in output (shows only content)
+- `--repo-root PATH`: Specify repository root (default: auto-detect)
+
+## Output Format
+
+### With Metadata (default)
+
+```markdown
+# SID: arch.overview.layers
+# Title: 分层架构
+# Document: arch (docs/design/architecture.md)
+# Lines: 10-31
+# Level: Section
+# Tags: arch, overview, layers
+
+## 分层架构
+<!-- SID:arch.overview.layers -->
+
+- 输入层：User/API：自然语言目标、约束、数据引用
+...
+```
+
+### Without Metadata
+
+```bash
+docslice --sid arch.overview.layers --no-metadata
+```
+
+Outputs only the fragment content without metadata headers.
+
+## SID Format
+
+Section Identifiers follow the format:
+
+```
+SID:<domain>.<topic>.<name>
+```
+
+**Example:** `SID:fsm.states.waiting_plan_confirm`
+
+- **domain**: `fsm` (finite state machine)
+- **topic**: `states` (state definitions)
+- **name**: `waiting_plan_confirm` (specific state)
+
+### Recommended Domains
+
+| Domain | Description |
+|--------|-------------|
+| `fsm` | Finite state machine |
+| `hitl` | Human-in-the-loop |
+| `planner` | Planner Agent |
+| `executor` | Executor Agent |
+| `tools` | Tool integration |
+| `obs` | Observability |
+| `storage` | Data storage |
+| `safety` | Safety Agent |
+| `summarizer` | Summarizer Agent |
+| `arch` | Architecture |
+| `api` | REST API |
+| `algo` | Algorithms |
+| `impl` | Implementation |
+
+## Locator Types
+
+The tool supports three types of locators:
+
+### 1. Comment Marker (Simple)
+
+```markdown
+## Section Title
+<!-- SID:domain.topic.name -->
+Content here...
+```
+
+Extracts from the marker until the next heading or SID.
+
+### 2. Begin/End Bounded
+
+```markdown
+<!-- SID:domain.topic.name BEGIN -->
+Bounded content here...
+Can span multiple paragraphs
+<!-- SID:domain.topic.name END -->
+```
+
+Extracts only the content between BEGIN and END markers.
+
+### 3. Inline Marker
+
+```markdown
+| State | Description |
+|-------|-------------|
+| CREATED | Task created <!-- SID:fsm.states.created --> |
+```
+
+Extracts the surrounding context (typically table rows or list items).
+
+## Design Principles
+
+### Deterministic
+
+- Same input always produces identical output
+- No fuzzy matching or heuristics
+- Precise line-based extraction
+
+### Read-Only
+
+- Never modifies any documents
+- Safe for concurrent execution
+- Idempotent operations
+
+### Contract-Driven
+
+- All extraction goes through `index.json`
+- Locator information is authoritative
+- Structure validated by lint
+
+## Integration with Claude Code
+
+Claude Code uses `docslice` to:
+
+1. Retrieve precise specification context for implementation tasks
+2. Inject minimal necessary context (avoiding full document injection)
+3. Ensure consistency with authoritative design documents
+4. Validate compliance during development
+
+## Testing
+
+Run the test suite:
+
+```bash
+./scripts/test_docslice.sh
+```
+
+Tests cover:
+- All locator types (comment, begin_end, inline)
+- SID and reference extraction
+- Topic aggregation with size limits
+- Lint validation
+- Deterministic output
+- Error handling
+
+## Exit Codes
+
+- `0`: Success
+- `1`: Error (invalid input, file not found, validation failure)
+
+## Examples
+
+### Example 1: Extract FSM State Definition
+
+```bash
+$ docslice --sid fsm.states.waiting_plan_confirm
+
+# SID: fsm.states.waiting_plan_confirm
+# Title: WAITING_PLAN_CONFIRM 状态定义
+# Document: arch (docs/design/architecture.md)
+# Lines: 315-315
+# Level: Spec-Item
+# Tags: fsm, states, hitl, planning
+
+|`WAITING_PLAN_CONFIRM`|初始 Plan 已经生成，等待人工确认工具链与关键参数 <!-- SID:fsm.states.waiting_plan_confirm -->|
+```
+
+### Example 2: Extract All HITL Specs (Limited)
+
+```bash
+$ docslice --topic hitl --max-lines 100 2>&1 | head -30
+
+Warning: Stopping at SID executor.hitl.patch_confirm due to max_lines limit
+
+# SID: arch.contracts.pending_action
+# Title: PendingAction 契约定义
+...
+```
+
+### Example 3: Validate Documents
+
+```bash
+$ docslice --lint
+✓ No errors found. All documents are valid.
+```
+
+## Architecture
+
+```
+docslice
+├── DocSlice class
+│   ├── Auto-detect location (main repo vs design worktree)
+│   ├── Load index.json and topic_views.json
+│   ├── Build SID and doc lookup tables
+│   ├── Extract by SID/ref/topic
+│   └── Lint validation
+├── Locator-specific extractors
+│   ├── _extract_section() - comment markers
+│   ├── _extract_inline() - inline markers
+│   ├── _extract_line_range() - begin_end markers
+│   └── _extract_bounded_block() - fallback
+└── Format and output
+```
+
+### Path Resolution
+
+When run from the main repository (`thesis-project/scripts/docslice`):
+1. Detects it's in the main repo (no `docs/index/index.json`)
+2. Looks for design worktree at `../thesis-project.design/`
+3. Uses the design worktree for all document lookups
+
+When run from the design worktree (`thesis-project.design/scripts/docslice`):
+1. Detects local `docs/index/index.json`
+2. Uses current directory as repo root
+
+## Related Documents
+
+- [SECTION_CONTRACT.md](../docs/index/SECTION_CONTRACT.md) - SID contract definition
+- [index.json](../docs/index/index.json) - Machine-readable specification index
+- [topic_views.json](../docs/index/topic_views.json) - Topic-based views
+
+## License
+
+Part of the thesis-project design documentation system.
+
+## Version History
+
+- **1.0** (2026-01-01): Initial implementation
+  - Support for all locator types
+  - Topic extraction with size controls
+  - Lint validation
+  - Comprehensive test suite

--- a/scripts/docslice
+++ b/scripts/docslice
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""
+docslice - Deterministic Specification Slicer
+
+A read-only, deterministic document slicer for extracting specification fragments
+by SID (Section Identifier) or topic from design documents.
+
+This tool is the core of the skill execution mechanism for Claude Code,
+providing precise specification context retrieval.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Any
+from dataclasses import dataclass
+from collections import defaultdict
+
+
+@dataclass
+class Fragment:
+    """Represents an extracted specification fragment."""
+    sid: str
+    title: str
+    doc_key: str
+    path: str
+    content: str
+    line_range: Optional[Tuple[int, int]] = None
+    level: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+class DocSlice:
+    """Main docslice implementation."""
+
+    def __init__(self, repo_root: Optional[Path] = None):
+        """Initialize docslice with repository root."""
+        if repo_root is None:
+            # Assume script is in scripts/ directory
+            script_parent = Path(__file__).parent.parent
+
+            # Check if we're in the main repo or design worktree
+            # Main repo: look for design worktree at ../thesis-project.design/
+            # Design worktree: use current location
+            design_index = script_parent / "docs" / "index" / "index.json"
+            if design_index.exists():
+                # We're in the design worktree
+                repo_root = script_parent
+            else:
+                # We're in the main repo, look for design worktree
+                design_worktree = script_parent.parent / "thesis-project.design"
+                if design_worktree.exists() and (design_worktree / "docs" / "index" / "index.json").exists():
+                    repo_root = design_worktree
+                else:
+                    # Fallback to script parent
+                    repo_root = script_parent
+
+        self.repo_root = repo_root
+        self.index_dir = repo_root / "docs" / "index"
+        self.index_path = self.index_dir / "index.json"
+        self.topic_views_path = self.index_dir / "topic_views.json"
+
+        # Load indices
+        self.index_data = self._load_json(self.index_path)
+        self.topic_views = self._load_json(self.topic_views_path)
+
+        # Build lookup tables
+        self.sid_lookup = {spec['sid']: spec for spec in self.index_data.get('specs', [])}
+        self.doc_lookup = {doc['doc_key']: doc for doc in self.index_data.get('documents', [])}
+
+    def _load_json(self, path: Path) -> Dict:
+        """Load and parse JSON file."""
+        if not path.exists():
+            raise FileNotFoundError(f"Required index file not found: {path}")
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON in {path}: {e}")
+
+    def _read_file_lines(self, rel_path: str) -> List[str]:
+        """Read file and return lines (1-indexed storage)."""
+        file_path = self.repo_root / rel_path
+        if not file_path.exists():
+            raise FileNotFoundError(f"Document not found: {file_path}")
+
+        with open(file_path, 'r', encoding='utf-8') as f:
+            # Store with 1-indexed (prepend empty string at index 0)
+            return [''] + f.read().splitlines()
+
+    def _extract_content_by_locator(self, spec: Dict, lines: List[str]) -> Tuple[str, Optional[Tuple[int, int]]]:
+        """Extract content based on locator information."""
+        locator = spec.get('locator', {})
+        locator_type = locator.get('type')
+
+        if locator_type == 'comment':
+            # Single-line marker, extract section until next same-level heading or SID
+            return self._extract_section(lines, locator['line'], spec.get('level'))
+        elif locator_type == 'inline':
+            # Inline marker, extract single line or small context
+            return self._extract_inline(lines, locator['line'])
+        elif locator_type == 'begin_end':
+            # Bounded block with BEGIN/END, use line_start and line_end from locator
+            line_start = locator.get('line_start')
+            line_end = locator.get('line_end')
+            return self._extract_line_range(lines, line_start, line_end)
+        else:
+            raise ValueError(f"Unknown locator type: {locator_type}")
+
+    def _extract_section(self, lines: List[str], start_line: int, level: str) -> Tuple[str, Tuple[int, int]]:
+        """Extract section content starting from SID marker line."""
+        # Start from the line with the SID marker
+        content_lines = []
+        current_line = start_line
+
+        # Determine heading level to watch for (to know when section ends)
+        heading_pattern = None
+        if level == 'Section':
+            # Section: stop at next ## or # heading
+            heading_pattern = re.compile(r'^##?\s')
+        elif level == 'Block':
+            # Block: stop at next ###, ##, or # heading
+            heading_pattern = re.compile(r'^#{1,3}\s')
+        # For Spec-Item, we'll read until next SID marker or heading
+
+        # Find the heading line (should be at or near start_line)
+        heading_line = None
+        for i in range(max(1, start_line - 2), min(len(lines), start_line + 3)):
+            if i < len(lines) and lines[i].startswith('#'):
+                heading_line = i
+                break
+
+        if heading_line:
+            start_extraction = heading_line
+        else:
+            start_extraction = start_line
+
+        # Extract until we hit the next same-level or higher heading, or another SID marker
+        for i in range(start_extraction, len(lines)):
+            line = lines[i]
+
+            # Stop at next SID marker (unless it's the current one)
+            if i != start_line and re.search(r'<!--\s*SID:[a-z][a-z0-9_.]*\s*-->', line):
+                break
+
+            # Stop at next heading of same or higher level
+            if i != heading_line and heading_pattern and heading_pattern.match(line):
+                break
+
+            content_lines.append(line)
+
+        end_line = start_extraction + len(content_lines) - 1
+        return '\n'.join(content_lines).strip(), (start_extraction, end_line)
+
+    def _extract_inline(self, lines: List[str], line_num: int) -> Tuple[str, Tuple[int, int]]:
+        """Extract inline content (typically a single line or table row)."""
+        if line_num >= len(lines):
+            raise ValueError(f"Line number {line_num} out of range")
+
+        # For inline markers, extract a small context around the line
+        # Check if it's part of a table or list
+        start = line_num
+        end = line_num
+
+        # Look backwards to find the start of the block (table, list, etc.)
+        for i in range(line_num - 1, max(0, line_num - 10), -1):
+            line = lines[i].strip()
+            if not line or line.startswith('#'):
+                start = i + 1
+                break
+            start = i
+
+        # Look forwards to find the end of the block
+        for i in range(line_num + 1, min(len(lines), line_num + 10)):
+            line = lines[i].strip()
+            if not line or line.startswith('#'):
+                end = i - 1
+                break
+            end = i
+
+        content_lines = [lines[i] for i in range(start, end + 1)]
+        return '\n'.join(content_lines).strip(), (start, end)
+
+    def _extract_line_range(self, lines: List[str], line_start: int, line_end: int) -> Tuple[str, Tuple[int, int]]:
+        """Extract content from a specific line range."""
+        if line_start >= len(lines) or line_end >= len(lines):
+            raise ValueError(f"Line range {line_start}-{line_end} out of range")
+
+        content_lines = [lines[i] for i in range(line_start, line_end + 1)]
+
+        # Remove BEGIN/END markers if present
+        filtered_lines = []
+        for line in content_lines:
+            # Skip lines that are only SID markers
+            if re.match(r'^\s*<!--\s*SID:[a-z][a-z0-9_.]*\s+(BEGIN|END)\s*-->\s*$', line):
+                continue
+            filtered_lines.append(line)
+
+        return '\n'.join(filtered_lines).strip(), (line_start, line_end)
+
+    def _extract_bounded_block(self, lines: List[str], sid: str) -> Tuple[str, Tuple[int, int]]:
+        """Extract content between BEGIN and END markers."""
+        begin_pattern = re.compile(rf'<!--\s*SID:{re.escape(sid)}\s+BEGIN\s*-->')
+        end_pattern = re.compile(rf'<!--\s*SID:{re.escape(sid)}\s+END\s*-->')
+
+        begin_line = None
+        end_line = None
+
+        for i, line in enumerate(lines):
+            if i == 0:
+                continue  # Skip index 0 (empty placeholder)
+
+            if begin_pattern.search(line):
+                begin_line = i
+            elif end_pattern.search(line) and begin_line is not None:
+                end_line = i
+                break
+
+        if begin_line is None:
+            raise ValueError(f"BEGIN marker not found for SID: {sid}")
+        if end_line is None:
+            raise ValueError(f"END marker not found for SID: {sid}")
+
+        # Extract content between markers (inclusive of marker lines, or exclusive?)
+        # Let's include the lines but not the markers themselves
+        content_lines = []
+        for i in range(begin_line, end_line + 1):
+            line = lines[i]
+            # Skip the marker lines themselves
+            if not (begin_pattern.search(line) or end_pattern.search(line)):
+                content_lines.append(line)
+
+        return '\n'.join(content_lines).strip(), (begin_line, end_line)
+
+    def extract_by_sid(self, sid: str) -> Fragment:
+        """Extract fragment by SID."""
+        # Remove 'SID:' prefix if present
+        if sid.startswith('SID:'):
+            sid = sid[4:]
+
+        spec = self.sid_lookup.get(sid)
+        if not spec:
+            raise ValueError(f"SID not found: {sid}")
+
+        # Load the document
+        lines = self._read_file_lines(spec['path'])
+
+        # Extract content
+        content, line_range = self._extract_content_by_locator(spec, lines)
+
+        return Fragment(
+            sid=spec['sid'],
+            title=spec['title'],
+            doc_key=spec['doc_key'],
+            path=spec['path'],
+            content=content,
+            line_range=line_range,
+            level=spec.get('level'),
+            tags=spec.get('tags')
+        )
+
+    def extract_by_ref(self, ref: str) -> Fragment:
+        """Extract fragment by DOC:doc_key#anchor reference."""
+        # Parse DOC:<doc_key>#<anchor>
+        match = re.match(r'DOC:([a-z]+)#(.+)', ref)
+        if not match:
+            raise ValueError(f"Invalid reference format: {ref}. Expected DOC:<doc_key>#<anchor>")
+
+        doc_key, anchor = match.groups()
+
+        # Get document info
+        doc = self.doc_lookup.get(doc_key)
+        if not doc:
+            raise ValueError(f"Document not found: {doc_key}")
+
+        # Load document lines
+        lines = self._read_file_lines(doc['path'])
+
+        # Find heading with matching anchor
+        # Anchors are typically lowercase with spaces replaced by hyphens
+        # But the reference might have the exact Chinese text, so we'll be flexible
+        anchor_normalized = anchor.lower().replace(' ', '-')
+
+        heading_line = None
+        for i, line in enumerate(lines):
+            if i == 0:
+                continue
+
+            # Check if line is a heading
+            if line.startswith('#'):
+                # Extract heading text
+                heading_text = re.sub(r'^#+\s*', '', line).strip()
+
+                # Try exact match first
+                if heading_text == anchor:
+                    heading_line = i
+                    break
+
+                # Try normalized match
+                heading_normalized = heading_text.lower().replace(' ', '-')
+                if heading_normalized == anchor_normalized:
+                    heading_line = i
+                    break
+
+        if heading_line is None:
+            raise ValueError(f"Anchor not found in {doc_key}: {anchor}")
+
+        # Extract section content (until next same-level heading)
+        heading_level = len(re.match(r'^(#+)', lines[heading_line]).group(1))
+        heading_pattern = re.compile(r'^#{1,' + str(heading_level) + r'}\s')
+
+        content_lines = [lines[heading_line]]
+        for i in range(heading_line + 1, len(lines)):
+            line = lines[i]
+            # Stop at next same or higher level heading
+            if heading_pattern.match(line):
+                break
+            content_lines.append(line)
+
+        end_line = heading_line + len(content_lines) - 1
+        content = '\n'.join(content_lines).strip()
+
+        return Fragment(
+            sid=f"ref:{ref}",
+            title=anchor,
+            doc_key=doc_key,
+            path=doc['path'],
+            content=content,
+            line_range=(heading_line, end_line)
+        )
+
+    def extract_by_topic(self, topic: str, max_lines: Optional[int] = None,
+                        max_chars: Optional[int] = None) -> List[Fragment]:
+        """Extract fragments by topic with optional size constraints."""
+        topic_data = self.topic_views.get('topics', {}).get(topic)
+        if not topic_data:
+            raise ValueError(f"Topic not found: {topic}")
+
+        fragments = []
+        total_lines = 0
+        total_chars = 0
+
+        for spec_ref in topic_data.get('specs', []):
+            sid = spec_ref['sid']
+
+            try:
+                fragment = self.extract_by_sid(sid)
+
+                # Check size constraints
+                fragment_lines = fragment.content.count('\n') + 1
+                fragment_chars = len(fragment.content)
+
+                if max_lines and (total_lines + fragment_lines > max_lines):
+                    print(f"Warning: Stopping at SID {sid} due to max_lines limit", file=sys.stderr)
+                    break
+
+                if max_chars and (total_chars + fragment_chars > max_chars):
+                    print(f"Warning: Stopping at SID {sid} due to max_chars limit", file=sys.stderr)
+                    break
+
+                fragments.append(fragment)
+                total_lines += fragment_lines
+                total_chars += fragment_chars
+
+            except Exception as e:
+                print(f"Warning: Failed to extract {sid}: {e}", file=sys.stderr)
+                continue
+
+        return fragments
+
+    def lint(self) -> List[str]:
+        """Validate document structure and return list of errors."""
+        errors = []
+
+        # Track SID uniqueness across all documents
+        sid_locations = defaultdict(list)
+        sid_paired = set()  # Track SIDs that have BEGIN/END pairs
+
+        # Check each document
+        for doc in self.index_data.get('documents', []):
+            try:
+                lines = self._read_file_lines(doc['path'])
+            except FileNotFoundError:
+                errors.append(f"Document file not found: {doc['path']}")
+                continue
+
+            doc_key = doc['doc_key']
+
+            # Track BEGIN/END pairing
+            begin_markers = {}  # sid -> line_number
+
+            for i, line in enumerate(lines):
+                if i == 0:
+                    continue
+
+                # Find all SID markers
+                sid_matches = list(re.finditer(
+                    r'<!--\s*SID:([a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*)\s*(BEGIN|END)?\s*-->',
+                    line
+                ))
+
+                for match in sid_matches:
+                    sid = match.group(1)
+                    marker_type = match.group(2)
+
+                    # Validate SID format
+                    parts = sid.split('.')
+                    if len(parts) != 3:
+                        errors.append(f"{doc['path']}:{i} - Invalid SID format (must be domain.topic.name): {sid}")
+
+                    # Check BEGIN/END pairing
+                    if marker_type == 'BEGIN':
+                        if sid in begin_markers:
+                            errors.append(
+                                f"{doc['path']}:{i} - Duplicate BEGIN marker for SID: {sid} "
+                                f"(previous at line {begin_markers[sid]})"
+                            )
+                        begin_markers[sid] = i
+                    elif marker_type == 'END':
+                        if sid not in begin_markers:
+                            errors.append(f"{doc['path']}:{i} - END marker without BEGIN for SID: {sid}")
+                        else:
+                            # Successfully paired - record location once using BEGIN line
+                            begin_line = begin_markers[sid]
+                            sid_locations[sid].append(f"{doc['path']}:{begin_line}")
+                            sid_paired.add(sid)
+                            del begin_markers[sid]
+                    else:
+                        # Simple marker (no BEGIN/END)
+                        sid_locations[sid].append(f"{doc['path']}:{i}")
+
+            # Check for unpaired BEGIN markers
+            for sid, line_num in begin_markers.items():
+                errors.append(f"{doc['path']}:{line_num} - BEGIN marker without END for SID: {sid}")
+
+        # Check for duplicate SIDs across documents
+        for sid, locations in sid_locations.items():
+            if len(locations) > 1:
+                errors.append(f"Duplicate SID '{sid}' found at: {', '.join(locations)}")
+
+        # Validate index.json consistency
+        for spec in self.index_data.get('specs', []):
+            sid = spec['sid']
+
+            # Check if SID was found in actual documents
+            if sid not in sid_locations:
+                errors.append(f"SID in index.json but not found in documents: {sid}")
+
+        return errors
+
+
+def format_fragment(fragment: Fragment, show_metadata: bool = True) -> str:
+    """Format fragment for output."""
+    lines = []
+
+    if show_metadata:
+        lines.append(f"# SID: {fragment.sid}")
+        lines.append(f"# Title: {fragment.title}")
+        lines.append(f"# Document: {fragment.doc_key} ({fragment.path})")
+        if fragment.line_range:
+            lines.append(f"# Lines: {fragment.line_range[0]}-{fragment.line_range[1]}")
+        if fragment.level:
+            lines.append(f"# Level: {fragment.level}")
+        if fragment.tags:
+            lines.append(f"# Tags: {', '.join(fragment.tags)}")
+        lines.append("")
+
+    lines.append(fragment.content)
+
+    return '\n'.join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='docslice - Deterministic Specification Slicer',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  docslice --sid SID:arch.contracts.pending_action
+  docslice --sid arch.contracts.pending_action
+  docslice --ref DOC:arch#分层架构
+  docslice --topic hitl
+  docslice --topic hitl --max-lines 500
+  docslice --lint
+        """
+    )
+
+    # Mutually exclusive command group
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--sid', metavar='SID', help='Extract by SID (e.g., SID:arch.contracts.pending_action or arch.contracts.pending_action)')
+    group.add_argument('--ref', metavar='REF', help='Extract by reference (e.g., DOC:arch#分层架构)')
+    group.add_argument('--topic', metavar='TOPIC', help='Extract by topic (e.g., hitl, planning)')
+    group.add_argument('--lint', action='store_true', help='Validate document structure')
+
+    # Options for --topic
+    parser.add_argument('--max-lines', type=int, metavar='N', help='Maximum number of lines for topic extraction')
+    parser.add_argument('--max-chars', type=int, metavar='N', help='Maximum number of characters for topic extraction')
+
+    # General options
+    parser.add_argument('--no-metadata', action='store_true', help='Suppress metadata in output')
+    parser.add_argument('--repo-root', type=Path, metavar='PATH', help='Repository root directory (default: auto-detect)')
+
+    args = parser.parse_args()
+
+    try:
+        # Initialize docslice
+        docslice = DocSlice(repo_root=args.repo_root)
+
+        # Execute command
+        if args.sid:
+            fragment = docslice.extract_by_sid(args.sid)
+            print(format_fragment(fragment, show_metadata=not args.no_metadata))
+            return 0
+
+        elif args.ref:
+            fragment = docslice.extract_by_ref(args.ref)
+            print(format_fragment(fragment, show_metadata=not args.no_metadata))
+            return 0
+
+        elif args.topic:
+            fragments = docslice.extract_by_topic(
+                args.topic,
+                max_lines=args.max_lines,
+                max_chars=args.max_chars
+            )
+
+            if not fragments:
+                print(f"No fragments found for topic: {args.topic}", file=sys.stderr)
+                return 1
+
+            for i, fragment in enumerate(fragments):
+                if i > 0:
+                    print("\n" + "="*80 + "\n")
+                print(format_fragment(fragment, show_metadata=not args.no_metadata))
+
+            # Print summary
+            total_lines = sum(f.content.count('\n') + 1 for f in fragments)
+            total_chars = sum(len(f.content) for f in fragments)
+            print(f"\n# Topic: {args.topic}", file=sys.stderr)
+            print(f"# Fragments: {len(fragments)}", file=sys.stderr)
+            print(f"# Total lines: {total_lines}", file=sys.stderr)
+            print(f"# Total chars: {total_chars}", file=sys.stderr)
+            return 0
+
+        elif args.lint:
+            errors = docslice.lint()
+
+            if not errors:
+                print("✓ No errors found. All documents are valid.")
+                return 0
+            else:
+                print(f"✗ Found {len(errors)} error(s):\n", file=sys.stderr)
+                for error in errors:
+                    print(f"  - {error}", file=sys.stderr)
+                return 1
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/test_docslice.sh
+++ b/scripts/test_docslice.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Test script for docslice
+
+set -e  # Exit on error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+echo "========================================"
+echo "Testing docslice - Deterministic Spec Slicer"
+echo "========================================"
+echo
+
+# Test 1: Help command
+echo "Test 1: --help"
+./scripts/docslice --help > /dev/null
+echo "✓ --help works"
+echo
+
+# Test 2: Extract by SID (simple comment marker)
+echo "Test 2: --sid with simple comment marker"
+OUTPUT=$(./scripts/docslice --sid arch.overview.layers --no-metadata)
+if [[ "$OUTPUT" == *"分层架构"* ]]; then
+    echo "✓ --sid (comment marker) works"
+else
+    echo "✗ --sid (comment marker) failed"
+    exit 1
+fi
+echo
+
+# Test 3: Extract by SID (begin_end marker)
+echo "Test 3: --sid with begin_end marker"
+OUTPUT=$(./scripts/docslice --sid arch.contracts.pending_action --no-metadata)
+if [[ "$OUTPUT" == *"PendingAction"* ]]; then
+    echo "✓ --sid (begin_end marker) works"
+else
+    echo "✗ --sid (begin_end marker) failed"
+    exit 1
+fi
+echo
+
+# Test 4: Extract by SID (inline marker)
+echo "Test 4: --sid with inline marker"
+OUTPUT=$(./scripts/docslice --sid fsm.states.waiting_plan_confirm --no-metadata)
+if [[ "$OUTPUT" == *"WAITING_PLAN_CONFIRM"* ]]; then
+    echo "✓ --sid (inline marker) works"
+else
+    echo "✗ --sid (inline marker) failed"
+    exit 1
+fi
+echo
+
+# Test 5: Extract by reference
+echo "Test 5: --ref with DOC reference"
+OUTPUT=$(./scripts/docslice --ref "DOC:arch#分层架构" --no-metadata)
+if [[ "$OUTPUT" == *"分层架构"* ]]; then
+    echo "✓ --ref works"
+else
+    echo "✗ --ref failed"
+    exit 1
+fi
+echo
+
+# Test 6: Extract by topic
+echo "Test 6: --topic extraction"
+OUTPUT=$(./scripts/docslice --topic hitl --max-lines 50 2>&1)
+if [[ "$OUTPUT" == *"SID: arch.contracts.pending_action"* ]] || [[ "$OUTPUT" == *"Topic: hitl"* ]]; then
+    echo "✓ --topic works"
+else
+    echo "✗ --topic failed"
+    exit 1
+fi
+echo
+
+# Test 7: Topic with max-chars limit
+echo "Test 7: --topic with max-chars limit"
+OUTPUT=$(./scripts/docslice --topic hitl --max-chars 5000 2>&1)
+if [[ "$OUTPUT" == *"Total chars"* ]]; then
+    echo "✓ --topic with max-chars works"
+else
+    echo "✗ --topic with max-chars failed"
+    exit 1
+fi
+echo
+
+# Test 8: Lint validation
+echo "Test 8: --lint validation"
+./scripts/docslice --lint > /dev/null
+LINT_EXIT=$?
+if [ $LINT_EXIT -eq 0 ]; then
+    echo "✓ --lint works (no errors found)"
+else
+    echo "✗ --lint found errors"
+    exit 1
+fi
+echo
+
+# Test 9: Deterministic output (same input = same output)
+echo "Test 9: Deterministic output test"
+OUTPUT1=$(./scripts/docslice --sid arch.overview.layers)
+OUTPUT2=$(./scripts/docslice --sid arch.overview.layers)
+if [[ "$OUTPUT1" == "$OUTPUT2" ]]; then
+    echo "✓ Output is deterministic"
+else
+    echo "✗ Output is not deterministic"
+    exit 1
+fi
+echo
+
+# Test 10: Error handling - invalid SID
+echo "Test 10: Error handling for invalid SID"
+if ./scripts/docslice --sid invalid.sid.notexist 2>&1 | grep -q "Error"; then
+    echo "✓ Invalid SID error handling works"
+else
+    echo "✗ Invalid SID error handling failed"
+    exit 1
+fi
+echo
+
+echo "========================================"
+echo "All tests passed! ✓"
+echo "========================================"


### PR DESCRIPTION
## Summary

实现确定性规范切片工具 docslice，用于按 SID/topic/reference 精确提取规范片段。该工具是 Claude Code Skills 的核心基础设施，提供只读、确定性的规范检索能力。

## Background

在完成 issue #28（章节可寻址契约）、issue #29（设计文档可寻址结构重构）、issue #30（SSOT 映射表）和 issue #31（机器可读索引）后，已经建立了完整的 SID 系统和索引基础设施，但仍缺少以下关键能力：

1. **规范提取工具**：需要一个脚本能够根据 SID 精确提取对应的文档片段
2. **主题聚合**：实现阶段需要按主题（hitl/planning/execution）获取最小必要规范集合
3. **Lint 验证**：需要自动化工具验证 SID 格式、唯一性、BEGIN/END 配对等约束
4. **Skills 集成准备**：为 issue #34 的 Claude Code Skill 实现提供可调用的底层工具

根据 issue #32 的要求，需要实现一个只读、确定性的 docslice 脚本，作为 Milestone "Addressable Design Docs & Spec Retrieval Skill" 的核心执行工具。

**关键需求**：
- 给定 SID，输出唯一、确定的片段
- 同一输入在同一仓库下输出完全一致
- 支持主题聚合并可控制输出大小
- Lint 失败时返回非零退出码

## Changes

### 新增文件

1. **scripts/docslice**（565 行）
   - 主要功能：
     - `--sid SID` - 通过 SID 提取规范片段
     - `--ref DOC:key#anchor` - 通过文档引用提取
     - `--topic name` - 按主题聚合规范（支持 `--max-lines` 和 `--max-chars` 限制）
     - `--lint` - 验证文档结构和 SID 合规性
     - `--help` - 显示使用帮助
   
   - 技术特性：
     - 自动检测运行位置（主仓库 vs 设计工作树）
     - 支持 3 种 locator 类型：comment（48个）、begin_end（14个）、inline（3个）
     - 纯 Python 标准库实现，无外部依赖
     - 确定性输出：同样输入始终产生相同结果

2. **scripts/test_docslice.sh**（122 行）
   - 完整测试套件，覆盖 10 个测试场景：
     - ✓ 所有 3 种 locator 类型的提取
     - ✓ SID 和 reference 提取
     - ✓ 主题聚合（带大小限制）
     - ✓ Lint 验证
     - ✓ 确定性输出验证
     - ✓ 错误处理测试
   
   - 全部测试通过，验证核心功能完整性

3. **scripts/README.md**（323 行）
   - 完整文档包含：
     - 安装与使用说明
     - 所有命令的示例
     - SID 格式规范
     - Locator 类型说明
     - 与 Claude Code 的集成方式
     - 架构设计与路径解析逻辑

### 关键设计决策

#### 1. 路径自动检测

```python
# 智能检测运行位置
script_parent = Path(__file__).parent.parent
design_index = script_parent / "docs" / "index" / "index.json"

if design_index.exists():
    # 在设计工作树中运行
    repo_root = script_parent
else:
    # 在主仓库中运行，查找设计工作树
    design_worktree = script_parent.parent / "thesis-project.design"
    if design_worktree.exists():
        repo_root = design_worktree
```

**优势**：
- 同一脚本可在两个位置运行
- 为 issue #34 的 skill 集成提供灵活性
- 避免硬编码路径
- **设计文档保持在 thesis-project.design 工作树，主仓库保持干净**

#### 2. Locator 类型处理

| Locator 类型 | 处理逻辑 | 适用场景 |
|-------------|----------|---------|
| `comment` | 从标记行提取至下一个同级标题 | Section/Block 级规范（48个） |
| `begin_end` | 提取 BEGIN/END 之间的内容 | Spec-Item 级精确片段（14个） |
| `inline` | 提取周围上下文（表格/列表） | 表格行内标记（3个） |

#### 3. 主题聚合策略

```bash
# 按主题提取，自动控制大小
docslice --topic hitl --max-lines 200
# Warning: Stopping at SID executor.hitl.patch_confirm due to max_lines limit
```

- 顺序遍历 topic_views.json 中的 SID 列表
- 累计行数/字符数，达到限制时停止
- 输出警告信息到 stderr，保持 stdout 输出纯净

#### 4. Lint 验证逻辑

检查项目：
- ✓ SID 格式合规性（`domain.topic.name`）
- ✓ SID 全局唯一性（跨文档检查）
- ✓ BEGIN/END 标记配对
- ✓ index.json 与实际文档的一致性

```bash
$ ./scripts/docslice --lint
✓ No errors found. All documents are valid.
```

### 统计数据

- 3 个新增文件
- +1010 行新增内容
- 支持 65 个 SID 的提取
- 4 个主题视图的聚合
- 10 个测试场景全部通过

## Impact

**正面影响**：

1. **Claude Code Skills 基础**：为 issue #34 提供核心工具，Skills 可直接调用 docslice 获取规范上下文
2. **确定性保证**：相同输入始终产生相同输出，确保 CI/CD 环境中的可复现性
3. **开发效率提升**：开发者可快速查询规范片段，无需手动翻阅设计文档
4. **自动化验证**：lint 功能支持 pre-commit hook，确保 SID 系统完整性
5. **仓库分离**：工具在主仓库，设计文档在工作树，保持清晰的职责分离

**使用场景**：

```bash
# Skill 调用示例（issue #34）
./scripts/docslice --topic hitl --max-chars 5000 > context.txt

# 开发者快速查询
./scripts/docslice --sid arch.contracts.pending_action

# CI/CD 验证
./scripts/docslice --lint || exit 1
```

**风险评估**：

- **低风险**：纯只读工具，不修改任何文档
- 所有操作基于 index.json，数据来源可靠
- 完整测试覆盖，确保功能正确性
- 自动路径检测避免硬编码依赖
- **不会污染主仓库**：设计文档保持在工作树中

**后续扩展**：

- issue #34：基于 docslice 实现 Claude Code Skill
- 可支持更多输出格式（JSON、Markdown、Plain Text）
- 可添加缓存机制提升大规模查询性能

## Related

- Closes #32
- Depends on: #31（机器可读规范索引与主题视图）
- Depends on: #29（设计文档可寻址结构重构）
- Depends on: #28（章节可寻址契约）
- Prepares for: #34（Claude Code Skill 集成）
- Milestone: Addressable Design Docs & Spec Retrieval Skill