### PR TITLE
test: add docslice lint and golden cases

### DIFF
--- a/.claude/skills/doc-slicer/scripts/docslice
+++ b/.claude/skills/doc-slicer/scripts/docslice
@@ -384,6 +384,7 @@ class DocSlice:
         # Track SID uniqueness across all documents
         sid_locations = defaultdict(list)
         sid_paired = set()  # Track SIDs that have BEGIN/END pairs
+        doc_lines = {}
 
         # Check each document
         for doc in self.index_data.get('documents', []):
@@ -393,6 +394,7 @@ class DocSlice:
                 errors.append(f"Document file not found: {doc['path']}")
                 continue
 
+            doc_lines[doc['path']] = lines
             doc_key = doc['doc_key']
 
             # Track BEGIN/END pairing
@@ -447,13 +449,74 @@ class DocSlice:
             if len(locations) > 1:
                 errors.append(f"Duplicate SID '{sid}' found at: {', '.join(locations)}")
 
-        # Validate index.json consistency
+        # Validate index.json consistency and locator resolution
         for spec in self.index_data.get('specs', []):
             sid = spec['sid']
+            locator = spec.get('locator', {})
+            locator_type = locator.get('type')
+            path = spec.get('path')
 
             # Check if SID was found in actual documents
             if sid not in sid_locations:
                 errors.append(f"SID in index.json but not found in documents: {sid}")
+                continue
+
+            if not path:
+                errors.append(f"SID missing path in index.json: {sid}")
+                continue
+
+            lines = doc_lines.get(path)
+            if not lines:
+                errors.append(f"Document not loaded for SID '{sid}': {path}")
+                continue
+
+            try:
+                if locator_type in ('comment', 'inline'):
+                    line_num = locator.get('line')
+                    if line_num is None:
+                        errors.append(f"SID missing locator line: {sid}")
+                    elif line_num >= len(lines):
+                        errors.append(f"SID locator line out of range for {sid}: {line_num}")
+                elif locator_type == 'begin_end':
+                    line_start = locator.get('line_start')
+                    line_end = locator.get('line_end')
+                    if line_start is None or line_end is None:
+                        errors.append(f"SID missing begin/end lines: {sid}")
+                    elif line_start >= len(lines) or line_end >= len(lines):
+                        errors.append(f"SID begin/end lines out of range for {sid}: {line_start}-{line_end}")
+                    elif line_start > line_end:
+                        errors.append(f"SID begin line after end line for {sid}: {line_start}-{line_end}")
+                else:
+                    errors.append(f"Unknown locator type for {sid}: {locator_type}")
+
+                content, line_range = self._extract_content_by_locator(spec, lines)
+                if not content.strip():
+                    errors.append(f"SID resolved to empty content: {sid}")
+                if not line_range:
+                    errors.append(f"SID missing resolved line range: {sid}")
+            except Exception as exc:
+                errors.append(f"SID failed to resolve: {sid} ({exc})")
+
+        # Validate topic views
+        for topic_name, topic in self.topic_views.get('topics', {}).items():
+            for entry in topic.get('specs', []):
+                topic_sid = entry.get('sid')
+                if not topic_sid:
+                    errors.append(f"Topic '{topic_name}' contains an entry without sid")
+                    continue
+                spec = self.sid_lookup.get(topic_sid)
+                if not spec:
+                    errors.append(f"Topic '{topic_name}' references missing SID: {topic_sid}")
+                    continue
+                if spec.get('stability') == 'deprecated':
+                    errors.append(f"Topic '{topic_name}' references deprecated SID: {topic_sid}")
+
+        # Validate depends_on references
+        for spec in self.index_data.get('specs', []):
+            sid = spec['sid']
+            for dep in spec.get('depends_on', []):
+                if dep not in self.sid_lookup:
+                    errors.append(f"SID depends_on missing: {sid} -> {dep}")
 
         return errors
 

--- a/.claude/skills/doc-slicer/scripts/test_docslice.sh
+++ b/.claude/skills/doc-slicer/scripts/test_docslice.sh
@@ -5,6 +5,7 @@ set -e  # Exit on error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
+DOCSLICE="./scripts/docslice"
 
 echo "========================================"
 echo "Testing docslice - Deterministic Spec Slicer"
@@ -13,13 +14,13 @@ echo
 
 # Test 1: Help command
 echo "Test 1: --help"
-./scripts/docslice --help > /dev/null
+"$DOCSLICE" --help > /dev/null
 echo "✓ --help works"
 echo
 
 # Test 2: Extract by SID (simple comment marker)
 echo "Test 2: --sid with simple comment marker"
-OUTPUT=$(./scripts/docslice --sid arch.overview.layers --no-metadata)
+OUTPUT=$("$DOCSLICE" --sid arch.overview.layers --no-metadata)
 if [[ "$OUTPUT" == *"分层架构"* ]]; then
     echo "✓ --sid (comment marker) works"
 else
@@ -30,7 +31,7 @@ echo
 
 # Test 3: Extract by SID (begin_end marker)
 echo "Test 3: --sid with begin_end marker"
-OUTPUT=$(./scripts/docslice --sid arch.contracts.pending_action --no-metadata)
+OUTPUT=$("$DOCSLICE" --sid arch.contracts.pending_action --no-metadata)
 if [[ "$OUTPUT" == *"PendingAction"* ]]; then
     echo "✓ --sid (begin_end marker) works"
 else
@@ -41,7 +42,7 @@ echo
 
 # Test 4: Extract by SID (inline marker)
 echo "Test 4: --sid with inline marker"
-OUTPUT=$(./scripts/docslice --sid fsm.states.waiting_plan_confirm --no-metadata)
+OUTPUT=$("$DOCSLICE" --sid fsm.states.waiting_plan_confirm --no-metadata)
 if [[ "$OUTPUT" == *"WAITING_PLAN_CONFIRM"* ]]; then
     echo "✓ --sid (inline marker) works"
 else
@@ -52,7 +53,7 @@ echo
 
 # Test 5: Extract by reference
 echo "Test 5: --ref with DOC reference"
-OUTPUT=$(./scripts/docslice --ref "DOC:arch#分层架构" --no-metadata)
+OUTPUT=$("$DOCSLICE" --ref "DOC:arch#分层架构" --no-metadata)
 if [[ "$OUTPUT" == *"分层架构"* ]]; then
     echo "✓ --ref works"
 else
@@ -63,7 +64,7 @@ echo
 
 # Test 6: Extract by topic
 echo "Test 6: --topic extraction"
-OUTPUT=$(./scripts/docslice --topic hitl --max-lines 50 2>&1)
+OUTPUT=$("$DOCSLICE" --topic hitl --max-lines 50 2>&1)
 if [[ "$OUTPUT" == *"SID: arch.contracts.pending_action"* ]] || [[ "$OUTPUT" == *"Topic: hitl"* ]]; then
     echo "✓ --topic works"
 else
@@ -74,7 +75,7 @@ echo
 
 # Test 7: Topic with max-chars limit
 echo "Test 7: --topic with max-chars limit"
-OUTPUT=$(./scripts/docslice --topic hitl --max-chars 5000 2>&1)
+OUTPUT=$("$DOCSLICE" --topic hitl --max-chars 5000 2>&1)
 if [[ "$OUTPUT" == *"Total chars"* ]]; then
     echo "✓ --topic with max-chars works"
 else
@@ -85,7 +86,7 @@ echo
 
 # Test 8: Lint validation
 echo "Test 8: --lint validation"
-./scripts/docslice --lint > /dev/null
+"$DOCSLICE" --lint > /dev/null
 LINT_EXIT=$?
 if [ $LINT_EXIT -eq 0 ]; then
     echo "✓ --lint works (no errors found)"
@@ -97,8 +98,8 @@ echo
 
 # Test 9: Deterministic output (same input = same output)
 echo "Test 9: Deterministic output test"
-OUTPUT1=$(./scripts/docslice --sid arch.overview.layers)
-OUTPUT2=$(./scripts/docslice --sid arch.overview.layers)
+OUTPUT1=$("$DOCSLICE" --sid arch.overview.layers)
+OUTPUT2=$("$DOCSLICE" --sid arch.overview.layers)
 if [[ "$OUTPUT1" == "$OUTPUT2" ]]; then
     echo "✓ Output is deterministic"
 else
@@ -109,10 +110,78 @@ echo
 
 # Test 10: Error handling - invalid SID
 echo "Test 10: Error handling for invalid SID"
-if ./scripts/docslice --sid invalid.sid.notexist 2>&1 | grep -q "Error"; then
+if "$DOCSLICE" --sid invalid.sid.notexist 2>&1 | grep -q "Error"; then
     echo "✓ Invalid SID error handling works"
 else
     echo "✗ Invalid SID error handling failed"
+    exit 1
+fi
+echo
+
+# Golden cases
+echo "Test 11: Golden cases - FSM WAITING_* SIDs"
+WAITING_CASES=(
+    "fsm.states.waiting_plan_confirm:WAITING_PLAN_CONFIRM"
+    "fsm.states.waiting_patch_confirm:WAITING_PATCH_CONFIRM"
+    "fsm.states.waiting_replan_confirm:WAITING_REPLAN_CONFIRM"
+)
+for entry in "${WAITING_CASES[@]}"; do
+    SID="${entry%%:*}"
+    EXPECTED="${entry##*:}"
+    OUTPUT=$("$DOCSLICE" --sid "$SID" --no-metadata)
+    if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
+        echo "✓ $SID resolves"
+    else
+        echo "✗ $SID failed to resolve"
+        exit 1
+    fi
+done
+echo
+
+echo "Test 12: Golden cases - HITL / Decision SIDs"
+HITL_CASES=(
+    "arch.contracts.pending_action:PendingAction"
+    "arch.contracts.decision:Decision"
+)
+for entry in "${HITL_CASES[@]}"; do
+    SID="${entry%%:*}"
+    EXPECTED="${entry##*:}"
+    OUTPUT=$("$DOCSLICE" --sid "$SID" --no-metadata)
+    if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
+        echo "✓ $SID resolves"
+    else
+        echo "✗ $SID failed to resolve"
+        exit 1
+    fi
+done
+echo
+
+echo "Test 13: Golden cases - Candidate gating SID"
+OUTPUT=$("$DOCSLICE" --sid planner.algorithm.hitl_gate)
+if [[ "$OUTPUT" == *"# SID: planner.algorithm.hitl_gate"* ]]; then
+    echo "✓ planner.algorithm.hitl_gate resolves"
+else
+    echo "✗ planner.algorithm.hitl_gate failed to resolve"
+    exit 1
+fi
+echo
+
+echo "Test 14: Golden cases - EventLog schema SID"
+OUTPUT=$("$DOCSLICE" --sid obs.eventlog.schema)
+if [[ "$OUTPUT" == *"# SID: obs.eventlog.schema"* ]]; then
+    echo "✓ obs.eventlog.schema resolves"
+else
+    echo "✗ obs.eventlog.schema failed to resolve"
+    exit 1
+fi
+echo
+
+echo "Test 15: Golden cases - topic planning"
+OUTPUT=$("$DOCSLICE" --topic planning --max-lines 50 2>&1)
+if [[ "$OUTPUT" == *"Topic: planning"* ]]; then
+    echo "✓ topic planning resolves"
+else
+    echo "✗ topic planning failed to resolve"
     exit 1
 fi
 echo

--- a/scripts/test_docslice.sh
+++ b/scripts/test_docslice.sh
@@ -118,6 +118,74 @@ else
 fi
 echo
 
+# Golden cases
+echo "Test 11: Golden cases - FSM WAITING_* SIDs"
+WAITING_CASES=(
+    "fsm.states.waiting_plan_confirm:WAITING_PLAN_CONFIRM"
+    "fsm.states.waiting_patch_confirm:WAITING_PATCH_CONFIRM"
+    "fsm.states.waiting_replan_confirm:WAITING_REPLAN_CONFIRM"
+)
+for entry in "${WAITING_CASES[@]}"; do
+    SID="${entry%%:*}"
+    EXPECTED="${entry##*:}"
+    OUTPUT=$("$DOCSLICE" --sid "$SID" --no-metadata)
+    if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
+        echo "✓ $SID resolves"
+    else
+        echo "✗ $SID failed to resolve"
+        exit 1
+    fi
+done
+echo
+
+echo "Test 12: Golden cases - HITL / Decision SIDs"
+HITL_CASES=(
+    "arch.contracts.pending_action:PendingAction"
+    "arch.contracts.decision:Decision"
+)
+for entry in "${HITL_CASES[@]}"; do
+    SID="${entry%%:*}"
+    EXPECTED="${entry##*:}"
+    OUTPUT=$("$DOCSLICE" --sid "$SID" --no-metadata)
+    if [[ "$OUTPUT" == *"$EXPECTED"* ]]; then
+        echo "✓ $SID resolves"
+    else
+        echo "✗ $SID failed to resolve"
+        exit 1
+    fi
+done
+echo
+
+echo "Test 13: Golden cases - Candidate gating SID"
+OUTPUT=$("$DOCSLICE" --sid planner.algorithm.hitl_gate)
+if [[ "$OUTPUT" == *"# SID: planner.algorithm.hitl_gate"* ]]; then
+    echo "✓ planner.algorithm.hitl_gate resolves"
+else
+    echo "✗ planner.algorithm.hitl_gate failed to resolve"
+    exit 1
+fi
+echo
+
+echo "Test 14: Golden cases - EventLog schema SID"
+OUTPUT=$("$DOCSLICE" --sid obs.eventlog.schema)
+if [[ "$OUTPUT" == *"# SID: obs.eventlog.schema"* ]]; then
+    echo "✓ obs.eventlog.schema resolves"
+else
+    echo "✗ obs.eventlog.schema failed to resolve"
+    exit 1
+fi
+echo
+
+echo "Test 15: Golden cases - topic planning"
+OUTPUT=$("$DOCSLICE" --topic planning --max-lines 50 2>&1)
+if [[ "$OUTPUT" == *"Topic: planning"* ]]; then
+    echo "✓ topic planning resolves"
+else
+    echo "✗ topic planning failed to resolve"
+    exit 1
+fi
+echo
+
 echo "========================================"
 echo "All tests passed! ✓"
 echo "========================================"


### PR DESCRIPTION
## Summary
- extend docslice lint to validate SID resolution, topic references, and depends_on links
- add golden spec retrieval cases for FSM waiting states, HITL contracts, candidate gating, and eventlog schema
- cover planning topic retrieval in tests

## Testing
- `./scripts/test_docslice.sh`
