### PR TITLE
Fix docslice section/block extraction rules

### DIFF
--- a/.claude/skills/doc-slicer/scripts/docslice
+++ b/.claude/skills/doc-slicer/scripts/docslice
@@ -125,12 +125,12 @@ class DocSlice:
         # Determine heading level to watch for (to know when section ends)
         heading_pattern = None
         if level == 'Section':
-            # Section: stop at next ## or # heading
+            # Section: stop at next same or higher heading level
             heading_pattern = re.compile(r'^##?\s')
         elif level == 'Block':
-            # Block: stop at next ###, ##, or # heading
+            # Block: stop at next same or higher heading level
             heading_pattern = re.compile(r'^#{1,3}\s')
-        # For Spec-Item, we'll read until next SID marker or heading
+        # For Spec-Item, we'll read until next SID marker
 
         # Find the heading line (should be at or near start_line)
         heading_line = None
@@ -141,16 +141,20 @@ class DocSlice:
 
         if heading_line:
             start_extraction = heading_line
+            if level in ('Section', 'Block'):
+                heading_level = len(re.match(r'^(#+)', lines[heading_line]).group(1))
+                heading_pattern = re.compile(r'^#{1,' + str(heading_level) + r'}\s')
         else:
             start_extraction = start_line
 
-        # Extract until we hit the next same-level or higher heading, or another SID marker
+        # Extract until heading boundary; Spec-Item also stops at next SID marker
         for i in range(start_extraction, len(lines)):
             line = lines[i]
 
-            # Stop at next SID marker (unless it's the current one)
-            if i != start_line and re.search(r'<!--\s*SID:[a-z][a-z0-9_.]*\s*-->', line):
-                break
+            # Spec-Item: stop at next SID marker (unless it's the current one)
+            if level == 'Spec-Item':
+                if i != start_line and re.search(r'<!--\s*SID:[a-z][a-z0-9_.]*\s*-->', line):
+                    break
 
             # Stop at next heading of same or higher level
             if i != heading_line and heading_pattern and heading_pattern.match(line):

--- a/.claude/skills/doc-slicer/scripts/test_docslice.sh
+++ b/.claude/skills/doc-slicer/scripts/test_docslice.sh
@@ -29,6 +29,17 @@ else
 fi
 echo
 
+# Test 2b: Section extraction includes nested SIDs
+echo "Test 2b: --sid section includes nested SIDs"
+OUTPUT=$("$DOCSLICE" --sid agent.contracts.overview --no-metadata)
+if [[ "$OUTPUT" == *"SID:agent.contracts.protein_design_task"* ]]; then
+    echo "✓ section extraction includes nested SIDs"
+else
+    echo "✗ section extraction missing nested SIDs"
+    exit 1
+fi
+echo
+
 # Test 3: Extract by SID (begin_end marker)
 echo "Test 3: --sid with begin_end marker"
 OUTPUT=$("$DOCSLICE" --sid arch.contracts.pending_action --no-metadata)


### PR DESCRIPTION
## Summary

修复 docslice 在 Section/Block 抽取时遇到子 SID 提前终止的问题，保证片段完整性。

## Background

随着文档中 SID 细分增多，Section/Block 内部包含多个子 SID 会导致抽取结果被截断，影响语义完整性与后续引用。

## Changes

- Section/Block 抽取仅依据同级/更高标题边界终止，不再被内部 SID 截断。
-  基于实际标题级别动态计算边界，避免顶层标题过早停止。
- 增加回归用例，验证 Section 内嵌套 SID 的完整抽取。\n\n## Impact\n\n- 输出片段更完整，topic_view 聚合内容不减少。
- 行为与 SECTION_CONTRACT 约定一致，兼容现有 SID 与索引。

 ## Related

- Closes #48