### PR TITLE
Refine docslice heading resolution strategy

### DIFF
--- a/.claude/skills/doc-slicer/scripts/docslice
+++ b/.claude/skills/doc-slicer/scripts/docslice
@@ -132,12 +132,17 @@ class DocSlice:
             heading_pattern = re.compile(r'^#{1,3}\s')
         # For Spec-Item, we'll read until next SID marker
 
-        # Find the heading line (should be at or near start_line)
+        # Find the heading line, preferring the closest heading above the SID marker.
         heading_line = None
-        for i in range(max(1, start_line - 2), min(len(lines), start_line + 3)):
-            if i < len(lines) and lines[i].startswith('#'):
+        for i in range(start_line, 0, -1):
+            if lines[i].startswith('#'):
                 heading_line = i
                 break
+        if heading_line is None:
+            for i in range(start_line + 1, len(lines)):
+                if lines[i].startswith('#'):
+                    heading_line = i
+                    break
 
         if heading_line:
             start_extraction = heading_line

--- a/.claude/skills/doc-slicer/scripts/test_docslice.sh
+++ b/.claude/skills/doc-slicer/scripts/test_docslice.sh
@@ -40,6 +40,69 @@ else
 fi
 echo
 
+# Test 2c: Heading resolution prefers nearest upward heading
+echo "Test 2c: --sid resolves heading by nearest upward heading"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+mkdir -p "$TMP_ROOT/docs/design" "$TMP_ROOT/docs/index"
+cat > "$TMP_ROOT/docs/design/sample.md" <<'EOF'
+# Sample Doc
+
+Intro paragraph.
+
+## Section A
+
+Some explanation before SID.
+
+<!-- SID:sample.section.a -->
+Paragraph after SID.
+
+### Subheading A1
+Details under A1.
+
+## Section B
+Section B content.
+EOF
+SID_LINE=$(nl -ba "$TMP_ROOT/docs/design/sample.md" | awk '/SID:sample.section.a/ {print $1}')
+cat > "$TMP_ROOT/docs/index/index.json" <<EOF
+{
+  "documents": [
+    {
+      "doc_key": "sample",
+      "title": "Sample Doc",
+      "path": "docs/design/sample.md",
+      "status": "stable",
+      "depends_on": []
+    }
+  ],
+  "specs": [
+    {
+      "sid": "sample.section.a",
+      "title": "Section A",
+      "doc_key": "sample",
+      "path": "docs/design/sample.md",
+      "locator": {
+        "type": "comment",
+        "line": ${SID_LINE}
+      },
+      "level": "Section",
+      "tags": []
+    }
+  ]
+}
+EOF
+cat > "$TMP_ROOT/docs/index/topic_views.json" <<'EOF'
+{ "topics": {} }
+EOF
+OUTPUT=$("$DOCSLICE" --sid sample.section.a --no-metadata --repo-root "$TMP_ROOT")
+if [[ "$OUTPUT" == "## Section A"* ]]; then
+    echo "✓ heading resolved to nearest upward heading"
+else
+    echo "✗ heading resolution did not prefer upward heading"
+    exit 1
+fi
+echo
+
 # Test 3: Extract by SID (begin_end marker)
 echo "Test 3: --sid with begin_end marker"
 OUTPUT=$("$DOCSLICE" --sid arch.contracts.pending_action --no-metadata)


### PR DESCRIPTION
## Summary\n\n调整 docslice 的标题定位策略，优先向上查找最近标题，避免抽取范围漂移。\n\n## Background\n\n当 SID 附近同时存在上下标题时，当前实现可能选中向后的标题，导致提取区间偏移。随着说明段插入增多，该问题更易触发。\n\n## Changes\n\n- heading_line 改为优先向上扫描最近标题，向下扫描作为 fallback。\n- 新增回归测试，覆盖 SID 位于上下标题之间的场景。\n\n## Impact\n\n- Section/Block 抽取边界更稳定，与文档编辑顺序变化解耦。\n- 不改变输出格式，兼容现有 index/topic 结构。\n\n## Related\n\n- Closes #49