### PR TITLE
issue-50-docslice-begin-end-fallback

### DIFF
--- a/.claude/skills/doc-slicer/scripts/docslice
+++ b/.claude/skills/doc-slicer/scripts/docslice
@@ -110,9 +110,13 @@ class DocSlice:
             return self._extract_inline(lines, locator['line'])
         elif locator_type == 'begin_end':
             # Bounded block with BEGIN/END, use line_start and line_end from locator
-            line_start = locator.get('line_start')
-            line_end = locator.get('line_end')
-            return self._extract_line_range(lines, line_start, line_end)
+            content, line_range, used_fallback, reason = self._extract_begin_end_with_fallback(spec, lines)
+            if used_fallback:
+                print(
+                    f"Warning: Falling back to marker scan for SID {spec['sid']} ({reason})",
+                    file=sys.stderr
+                )
+            return content, line_range
         else:
             raise ValueError(f"Unknown locator type: {locator_type}")
 
@@ -215,6 +219,38 @@ class DocSlice:
             filtered_lines.append(line)
 
         return '\n'.join(filtered_lines).strip(), (line_start, line_end)
+
+    def _extract_begin_end_with_fallback(
+        self,
+        spec: Dict,
+        lines: List[str]
+    ) -> Tuple[str, Tuple[int, int], bool, str]:
+        """Extract begin/end block with fallback to marker scan."""
+        sid = spec['sid']
+        locator = spec.get('locator', {})
+        line_start = locator.get('line_start')
+        line_end = locator.get('line_end')
+
+        begin_pattern = re.compile(rf'<!--\s*SID:{re.escape(sid)}\s+BEGIN\s*-->')
+        end_pattern = re.compile(rf'<!--\s*SID:{re.escape(sid)}\s+END\s*-->')
+
+        fallback_reason = ""
+        if line_start is None or line_end is None:
+            fallback_reason = "missing line range"
+        elif line_start < 1 or line_end < 1 or line_start >= len(lines) or line_end >= len(lines):
+            fallback_reason = "line range out of bounds"
+        elif line_start > line_end:
+            fallback_reason = "line range reversed"
+        elif not begin_pattern.search(lines[line_start]) or not end_pattern.search(lines[line_end]):
+            fallback_reason = "marker not at expected lines"
+        else:
+            content, line_range = self._extract_line_range(lines, line_start, line_end)
+            if content.strip():
+                return content, line_range, False, ""
+            fallback_reason = "empty content"
+
+        content, line_range = self._extract_bounded_block(lines, sid)
+        return content, line_range, True, fallback_reason
 
     def _extract_bounded_block(self, lines: List[str], sid: str) -> Tuple[str, Tuple[int, int]]:
         """Extract content between BEGIN and END markers."""
@@ -491,10 +527,19 @@ class DocSlice:
                     line_end = locator.get('line_end')
                     if line_start is None or line_end is None:
                         errors.append(f"SID missing begin/end lines: {sid}")
-                    elif line_start >= len(lines) or line_end >= len(lines):
-                        errors.append(f"SID begin/end lines out of range for {sid}: {line_start}-{line_end}")
-                    elif line_start > line_end:
-                        errors.append(f"SID begin line after end line for {sid}: {line_start}-{line_end}")
+                        continue
+
+                    content, line_range, used_fallback, reason = self._extract_begin_end_with_fallback(spec, lines)
+                    if used_fallback:
+                        print(
+                            f"Warning: Falling back to marker scan for SID {sid} ({reason})",
+                            file=sys.stderr
+                        )
+                    if not content.strip():
+                        errors.append(f"SID resolved to empty content: {sid}")
+                    if not line_range:
+                        errors.append(f"SID missing resolved line range: {sid}")
+                    continue
                 else:
                     errors.append(f"Unknown locator type for {sid}: {locator_type}")
 

--- a/.claude/skills/doc-slicer/scripts/test_docslice.sh
+++ b/.claude/skills/doc-slicer/scripts/test_docslice.sh
@@ -103,6 +103,58 @@ else
 fi
 echo
 
+# Test 2d: begin_end fallback when line range is stale
+echo "Test 2d: --sid begin_end fallback to marker scan"
+TMP_ROOT_FALLBACK="$(mktemp -d)"
+mkdir -p "$TMP_ROOT_FALLBACK/docs/design" "$TMP_ROOT_FALLBACK/docs/index"
+cat > "$TMP_ROOT_FALLBACK/docs/design/sample.md" <<'EOF'
+# Sample Doc
+
+<!-- SID:sample.block.a BEGIN -->
+Block content line
+<!-- SID:sample.block.a END -->
+EOF
+cat > "$TMP_ROOT_FALLBACK/docs/index/index.json" <<'EOF'
+{
+  "documents": [
+    {
+      "doc_key": "sample",
+      "title": "Sample Doc",
+      "path": "docs/design/sample.md",
+      "status": "stable",
+      "depends_on": []
+    }
+  ],
+  "specs": [
+    {
+      "sid": "sample.block.a",
+      "title": "Sample Block",
+      "doc_key": "sample",
+      "path": "docs/design/sample.md",
+      "locator": {
+        "type": "begin_end",
+        "line_start": 50,
+        "line_end": 60
+      },
+      "level": "Spec-Item",
+      "tags": []
+    }
+  ]
+}
+EOF
+cat > "$TMP_ROOT_FALLBACK/docs/index/topic_views.json" <<'EOF'
+{ "topics": {} }
+EOF
+OUTPUT=$("$DOCSLICE" --sid sample.block.a --no-metadata --repo-root "$TMP_ROOT_FALLBACK" 2>&1)
+rm -rf "$TMP_ROOT_FALLBACK"
+if [[ "$OUTPUT" == *"Warning: Falling back to marker scan for SID sample.block.a"* ]] && [[ "$OUTPUT" == *"Block content line"* ]]; then
+    echo "✓ begin_end fallback works"
+else
+    echo "✗ begin_end fallback failed"
+    exit 1
+fi
+echo
+
 # Test 3: Extract by SID (begin_end marker)
 echo "Test 3: --sid with begin_end marker"
 OUTPUT=$("$DOCSLICE" --sid arch.contracts.pending_action --no-metadata)


### PR DESCRIPTION
## Summary

为 docslice 的 begin_end 定位增加 marker 扫描的 fallback，避免索引行号漂
移导致抽取失败。

## Background

begin_end 目前强依赖 line_start/line_end，文档插行或删行后需要频繁同步索
引。该问题会造成隐性错误和维护成本上升，需要提供更稳健的回退机制。

## Changes

- 保留 line_start/line_end 作为 fast path。
- 当行号越界、内容为空或 marker 不在预期行时，自动回退到 BEGIN/END 扫描。
- fallback 成功时输出 warning（stderr）。
- 增加回归测试覆盖行号失效的场景。

## Impact

- 文档结构变化后仍能返回正确片段，降低索引维护成本。
- 现有输出格式与 topic_views 使用方式不变。
- lint 仍可正常工作，不因回退机制失败。

## Related

- Closes #50

