### PR TITLE
feat(infra): 在 WAITING 状态和决策点强制日志记录

### DIFF
--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.models.event_log import EventLog
 
 # 事件日志默认目录，按 task_id 写入 jsonl 文件
 DEFAULT_LOG_DIR = Path("data/logs")
@@ -18,5 +21,24 @@ def append_event(
     log_dir.mkdir(parents=True, exist_ok=True)
     path = log_dir / f"{task_id}.jsonl"
     payload = json.dumps(dict(event), ensure_ascii=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(payload + "\n")
+
+
+def write_event_log(
+    event_log: EventLog,
+    *,
+    log_dir: Path = DEFAULT_LOG_DIR,
+) -> None:
+    """将 EventLog 对象持久化到 jsonl 文件中
+
+    Args:
+        event_log: EventLog 实例
+        log_dir: 日志目录路径
+    """
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / f"{event_log.task_id}.jsonl"
+    # 使用 model_dump() 转换为字典，保留所有字段
+    payload = json.dumps(event_log.model_dump(), ensure_ascii=True)
     with path.open("a", encoding="utf-8") as handle:
         handle.write(payload + "\n")

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Optional
 
+from src.infra.event_log_factory import make_waiting_exit, make_decision_applied
 from src.models.contracts import (
     Decision,
     DecisionChoice,
@@ -20,7 +21,8 @@ from src.models.validation import (
     validate_decision_for_pending_action,
 )
 from src.models.db import ExternalStatus, InternalStatus, TaskRecord, to_external_status
-from src.storage.log_store import append_event
+from src.models.event_log import ActorType
+from src.storage.log_store import append_event, write_event_log
 from src.workflow.context import WorkflowContext
 from src.workflow.patch import apply_patch
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
@@ -74,6 +76,9 @@ def apply_plan_confirm_decision(
     _ensure_action_type(action, PendingActionType.PLAN_CONFIRM)
     _validate_decision_and_state(context, record, action, decision)
 
+    # Record the WAITING_* status before transition
+    prev_status = to_external_status(context.status)
+
     logger = event_logger or _default_event_logger
     logger(_decision_event("DECISION_SUBMITTED", context, action, decision))
 
@@ -113,6 +118,16 @@ def apply_plan_confirm_decision(
 
     action.decided_at = now_iso()
     _sync_pending_action(context, record, action)
+
+    # Emit structured EventLog events
+    _emit_decision_applied_event(context, action, decision, prev_status)
+    _emit_waiting_exit_event(
+        context,
+        action,
+        prev_status,
+        waiting_state=InternalStatus.WAITING_PLAN_CONFIRM.value,
+    )
+
     logger(_decision_event("DECISION_APPLIED", context, action, decision))
     _write_snapshot(context, action, snapshot_writer)
 
@@ -138,6 +153,9 @@ def apply_patch_confirm_decision(
     action = _resolve_pending_action(context, record, pending_action)
     _ensure_action_type(action, PendingActionType.PATCH_CONFIRM)
     _validate_decision_and_state(context, record, action, decision)
+
+    # Record the WAITING_* status before transition
+    prev_status = to_external_status(context.status)
 
     logger = event_logger or _default_event_logger
     logger(_decision_event("DECISION_SUBMITTED", context, action, decision))
@@ -168,6 +186,14 @@ def apply_patch_confirm_decision(
         action.status = PendingActionStatus.CANCELLED
         action.decided_at = now_iso()
         _sync_pending_action(context, record, action)
+
+        # Emit WAITING_EXIT for the cancelled patch confirm
+        _emit_waiting_exit_event(
+            context,
+            action,
+            prev_status,
+            waiting_state=InternalStatus.WAITING_PATCH.value,
+        )
 
         replan_action_id = f"{action.pending_action_id}_replan"
         replan_action = build_pending_action(
@@ -217,6 +243,16 @@ def apply_patch_confirm_decision(
 
     action.decided_at = now_iso()
     _sync_pending_action(context, record, action)
+
+    # Emit structured EventLog events
+    _emit_decision_applied_event(context, action, decision, prev_status)
+    _emit_waiting_exit_event(
+        context,
+        action,
+        prev_status,
+        waiting_state=InternalStatus.WAITING_PATCH.value,
+    )
+
     logger(_decision_event("DECISION_APPLIED", context, action, decision))
     _write_snapshot(context, action, snapshot_writer)
 
@@ -243,6 +279,9 @@ def apply_replan_confirm_decision(
     action = _resolve_pending_action(context, record, pending_action)
     _ensure_action_type(action, PendingActionType.REPLAN_CONFIRM)
     _validate_decision_and_state(context, record, action, decision)
+
+    # Record the WAITING_* status before transition
+    prev_status = to_external_status(context.status)
 
     logger = event_logger or _default_event_logger
     logger(_decision_event("DECISION_SUBMITTED", context, action, decision))
@@ -283,6 +322,16 @@ def apply_replan_confirm_decision(
 
     action.decided_at = now_iso()
     _sync_pending_action(context, record, action)
+
+    # Emit structured EventLog events
+    _emit_decision_applied_event(context, action, decision, prev_status)
+    _emit_waiting_exit_event(
+        context,
+        action,
+        prev_status,
+        waiting_state=InternalStatus.WAITING_REPLAN.value,
+    )
+
     logger(_decision_event("DECISION_APPLIED", context, action, decision))
     _write_snapshot(context, action, snapshot_writer)
 
@@ -470,3 +519,66 @@ def _default_event_logger(event: dict) -> None:
     if not task_id:
         return
     append_event(task_id, event)
+
+
+def _emit_decision_applied_event(
+    context: WorkflowContext,
+    action: PendingAction,
+    decision: Decision,
+    prev_status: ExternalStatus,
+) -> None:
+    """Emit DECISION_APPLIED EventLog.
+
+    Args:
+        context: Workflow context.
+        action: The resolved PendingAction.
+        decision: The decision being applied.
+        prev_status: Previous external status (must be WAITING_*).
+    """
+    current_status = to_external_status(context.status)
+    decision_event = make_decision_applied(
+        task_id=context.task.task_id,
+        decision_id=decision.decision_id,
+        pending_action_id=action.pending_action_id,
+        prev_status=prev_status,
+        new_status=current_status,
+        choice=decision.choice.value,
+        actor_type=ActorType.HUMAN,
+        internal_status=context.status,
+        data={
+            "selected_candidate_id": decision.selected_candidate_id,
+            "action_type": action.action_type.value,
+        },
+    )
+    write_event_log(decision_event)
+
+
+def _emit_waiting_exit_event(
+    context: WorkflowContext,
+    action: PendingAction,
+    prev_status: ExternalStatus,
+    waiting_state: str,
+) -> None:
+    """Emit WAITING_EXIT EventLog.
+
+    Args:
+        context: Workflow context.
+        action: The resolved PendingAction.
+        prev_status: Previous external status (must be WAITING_*).
+        waiting_state: The waiting state description.
+    """
+    current_status = to_external_status(context.status)
+    exit_event = make_waiting_exit(
+        task_id=context.task.task_id,
+        prev_status=prev_status,
+        new_status=current_status,
+        waiting_state=waiting_state,
+        actor_type=ActorType.HUMAN,
+        internal_status=context.status,
+        pending_action_id=action.pending_action_id,
+        data={
+            "action_type": action.action_type.value,
+            "action_status": action.status.value,
+        },
+    )
+    write_event_log(exit_event)

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Callable, Iterable, Optional
 from uuid import uuid4
 
+from src.infra.event_log_factory import make_waiting_enter
 from src.models.contracts import (
     PendingAction,
     PendingActionCandidate,
@@ -16,7 +17,8 @@ from src.models.contracts import (
     now_iso,
 )
 from src.models.db import ExternalStatus, InternalStatus, TaskRecord, to_external_status
-from src.storage.log_store import append_event
+from src.models.event_log import ActorType
+from src.storage.log_store import append_event, write_event_log
 from src.workflow.context import WorkflowContext
 from src.workflow.snapshots import (
     SnapshotWriter,
@@ -99,10 +101,16 @@ def enter_waiting_state(
         ValueError: 当 PendingAction 与目标 WAITING_* 状态不匹配。
     """
     _validate_waiting_transition(context, pending_action, to_status, record)
+
+    # 记录进入 WAITING_* 状态前的状态
+    prev_status = to_external_status(context.status)
+    new_status = _to_external_waiting_status(to_status)
+
     context.pending_action = pending_action
     if record is not None:
         record.pending_action = pending_action
 
+    # 写入旧格式事件日志以保持兼容性
     log_handler = event_logger or _default_event_logger
     log_handler(
         {
@@ -115,9 +123,26 @@ def enter_waiting_state(
         }
     )
 
+    # 写入结构化 WAITING_ENTER EventLog
+    waiting_enter_event = make_waiting_enter(
+        task_id=context.task.task_id,
+        pending_action_id=pending_action.pending_action_id,
+        prev_status=prev_status,
+        new_status=new_status,
+        waiting_state=to_status.value,
+        actor_type=ActorType.SYSTEM,
+        internal_status=to_status,
+        data={
+            "action_type": pending_action.action_type.value,
+            "reason": reason or "entering_waiting_state",
+            "candidate_count": len(pending_action.candidates),
+        },
+    )
+    write_event_log(waiting_enter_event)
+
     snapshot = build_task_snapshot(
         context,
-        state_override=_to_external_waiting_status(to_status),
+        state_override=new_status,
         pending_action_id=pending_action.pending_action_id,
     )
     (snapshot_writer or default_snapshot_writer)(snapshot)

--- a/tests/integration/test_event_log_integration.py
+++ b/tests/integration/test_event_log_integration.py
@@ -1,0 +1,287 @@
+"""Integration tests for EventLog integration in workflow.
+
+This module verifies that WAITING_ENTER, WAITING_EXIT, and DECISION_APPLIED
+events are properly logged during state transitions and decision application.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from src.models.contracts import (
+    Decision,
+    DecisionChoice,
+    PendingActionStatus,
+    PendingActionType,
+    ProteinDesignTask,
+)
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.models.event_log import EventType
+from src.workflow.context import WorkflowContext
+from src.workflow.decision_apply import apply_plan_confirm_decision
+from src.workflow.pending_action import build_pending_action, enter_waiting_state
+from src.storage.log_store import DEFAULT_LOG_DIR
+
+
+@pytest.fixture
+def cleanup_logs():
+    """Cleanup test logs after test."""
+    yield
+    # Clean up test log files
+    if DEFAULT_LOG_DIR.exists():
+        for log_file in DEFAULT_LOG_DIR.glob("test_*.jsonl"):
+            log_file.unlink()
+
+
+def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
+    """Test that enter_waiting_state emits WAITING_ENTER EventLog."""
+    task = ProteinDesignTask(
+        task_id="test_enter_waiting_001",
+        goal="test enter waiting state logging",
+        constraints={},
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        status=InternalStatus.PLANNING,
+        plan=None,
+        step_results={},
+        design_result=None,
+        safety_events=[],
+        pending_action=None,
+    )
+    record = TaskRecord(
+        id=task.task_id,
+        goal=task.goal,
+        status=ExternalStatus.PLANNING,
+        internal_status=InternalStatus.PLANNING,
+        plan=None,
+        pending_action=None,
+        design_result=None,
+    )
+
+    # Build and enter WAITING_PLAN_CONFIRM state
+    pending_action = build_pending_action(
+        task_id=task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[],
+        explanation="test waiting enter",
+    )
+    enter_waiting_state(
+        context,
+        record,
+        pending_action,
+        InternalStatus.WAITING_PLAN_CONFIRM,
+        reason="test_enter_waiting",
+    )
+
+    # Read the log file
+    log_file = DEFAULT_LOG_DIR / f"{task.task_id}.jsonl"
+    assert log_file.exists(), "Log file should be created"
+
+    # Parse all log entries
+    log_entries = []
+    with log_file.open("r") as f:
+        for line in f:
+            log_entries.append(json.loads(line))
+
+    # Find WAITING_ENTER event
+    waiting_enter_events = [
+        e for e in log_entries if e.get("event_type") == EventType.WAITING_ENTER.value
+    ]
+    assert len(waiting_enter_events) == 1, "Should have exactly one WAITING_ENTER event"
+
+    event = waiting_enter_events[0]
+    assert event["task_id"] == task.task_id
+    assert event["pending_action_id"] == pending_action.pending_action_id
+    assert event["prev_status"] == ExternalStatus.PLANNING.value
+    assert event["new_status"] == ExternalStatus.WAITING_PLAN_CONFIRM.value
+    assert event["internal_status"] == InternalStatus.WAITING_PLAN_CONFIRM.value
+    assert event["data"]["waiting_state"] == InternalStatus.WAITING_PLAN_CONFIRM.value
+    assert event["actor_type"] == "system"
+
+
+def test_decision_apply_emits_waiting_exit_and_decision_applied(cleanup_logs):
+    """Test that applying a decision emits both WAITING_EXIT and DECISION_APPLIED events."""
+    task = ProteinDesignTask(
+        task_id="test_decision_apply_002",
+        goal="test decision apply logging",
+        constraints={},
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        status=InternalStatus.WAITING_PLAN_CONFIRM,
+        plan=None,
+        step_results={},
+        design_result=None,
+        safety_events=[],
+        pending_action=None,
+    )
+    record = TaskRecord(
+        id=task.task_id,
+        goal=task.goal,
+        status=ExternalStatus.WAITING_PLAN_CONFIRM,
+        internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+        plan=None,
+        pending_action=None,
+        design_result=None,
+    )
+
+    # Build pending action with a candidate plan
+    from src.models.contracts import Plan, PlanStep, PendingActionCandidate
+
+    candidate_plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="dummy_tool",
+                inputs={"sequence": "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR"},
+                metadata={},
+            )
+        ],
+        constraints={},
+        metadata={},
+    )
+    pending_action = build_pending_action(
+        task_id=task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="candidate_1",
+                payload=candidate_plan,
+                summary="test plan",
+                score_breakdown={},
+            )
+        ],
+        default_suggestion="candidate_1",
+        explanation="test decision apply",
+    )
+    context.pending_action = pending_action
+    record.pending_action = pending_action
+
+    # Apply decision to accept the plan
+    decision = Decision(
+        decision_id="decision_001",
+        task_id=task.task_id,
+        pending_action_id=pending_action.pending_action_id,
+        choice=DecisionChoice.ACCEPT,
+        selected_candidate_id="candidate_1",
+        decided_by="test_user",
+    )
+
+    apply_plan_confirm_decision(context, record, decision)
+
+    # Read the log file
+    log_file = DEFAULT_LOG_DIR / f"{task.task_id}.jsonl"
+    assert log_file.exists(), "Log file should be created"
+
+    # Parse all log entries
+    log_entries = []
+    with log_file.open("r") as f:
+        for line in f:
+            log_entries.append(json.loads(line))
+
+    # Find DECISION_APPLIED event
+    decision_applied_events = [
+        e
+        for e in log_entries
+        if e.get("event_type") == EventType.DECISION_APPLIED.value
+    ]
+    assert (
+        len(decision_applied_events) == 1
+    ), "Should have exactly one DECISION_APPLIED event"
+
+    decision_event = decision_applied_events[0]
+    assert decision_event["task_id"] == task.task_id
+    assert decision_event["decision_id"] == decision.decision_id
+    assert decision_event["pending_action_id"] == pending_action.pending_action_id
+    assert decision_event["prev_status"] == ExternalStatus.WAITING_PLAN_CONFIRM.value
+    assert decision_event["new_status"] == ExternalStatus.PLANNED.value
+    assert decision_event["data"]["choice"] == DecisionChoice.ACCEPT.value
+    assert decision_event["actor_type"] == "human"
+
+    # Find WAITING_EXIT event
+    waiting_exit_events = [
+        e for e in log_entries if e.get("event_type") == EventType.WAITING_EXIT.value
+    ]
+    assert len(waiting_exit_events) == 1, "Should have exactly one WAITING_EXIT event"
+
+    exit_event = waiting_exit_events[0]
+    assert exit_event["task_id"] == task.task_id
+    assert exit_event["pending_action_id"] == pending_action.pending_action_id
+    assert exit_event["prev_status"] == ExternalStatus.WAITING_PLAN_CONFIRM.value
+    assert exit_event["new_status"] == ExternalStatus.PLANNED.value
+    assert (
+        exit_event["data"]["waiting_state"] == InternalStatus.WAITING_PLAN_CONFIRM.value
+    )
+    assert exit_event["data"]["action_status"] == PendingActionStatus.DECIDED.value
+
+
+def test_fsm_reconstruction_from_logs(cleanup_logs):
+    """Test that logs can reconstruct FSM state transitions."""
+    task = ProteinDesignTask(
+        task_id="test_fsm_reconstruction_003",
+        goal="test FSM reconstruction from logs",
+        constraints={},
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        status=InternalStatus.PLANNING,
+        plan=None,
+        step_results={},
+        design_result=None,
+        safety_events=[],
+        pending_action=None,
+    )
+
+    # Build and enter WAITING_PLAN_CONFIRM
+    pending_action = build_pending_action(
+        task_id=task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[],
+        explanation="test FSM reconstruction",
+    )
+    enter_waiting_state(
+        context,
+        None,
+        pending_action,
+        InternalStatus.WAITING_PLAN_CONFIRM,
+        reason="entering_waiting_for_plan",
+    )
+
+    # Read the log file and verify we can reconstruct the state machine
+    log_file = DEFAULT_LOG_DIR / f"{task.task_id}.jsonl"
+    log_entries = []
+    with log_file.open("r") as f:
+        for line in f:
+            log_entries.append(json.loads(line))
+
+    # Extract state transitions from logs
+    state_transitions = []
+    for entry in log_entries:
+        if entry.get("event") == "TASK_STATUS_CHANGED":
+            state_transitions.append(
+                (entry["from_status"], entry["to_status"], entry.get("reason"))
+            )
+        elif entry.get("event_type") == EventType.WAITING_ENTER.value:
+            state_transitions.append(
+                (
+                    entry["prev_status"],
+                    entry["new_status"],
+                    "WAITING_ENTER",
+                )
+            )
+
+    # Verify we can see the state transition sequence
+    assert len(state_transitions) >= 1, "Should have at least one state transition"
+
+    # Verify WAITING_ENTER is present in the log
+    waiting_transitions = [
+        t for t in state_transitions if t[2] == "WAITING_ENTER"
+    ]
+    assert len(waiting_transitions) == 1, "Should have exactly one WAITING_ENTER transition"
+    assert waiting_transitions[0][0] == ExternalStatus.PLANNING.value
+    assert waiting_transitions[0][1] == ExternalStatus.WAITING_PLAN_CONFIRM.value


### PR DESCRIPTION
## Summary

实现完整的 EventLog 集成，确保所有 WAITING_* 状态转换和人工决策点都有结构化日志记录，满足 issue #15 的要求。

## Background

根据架构设计文档（SID:arch.contracts.task_snapshot, SID:obs.eventlog.mandatory_events），系统要求：
- 保证关键状态变更前后均有日志记录
- 无日志的状态变更会被视为 bug
- 日志顺序可反推 FSM

虽然 EventLog 基础设施（WAITING_ENTER、WAITING_EXIT、DECISION_APPLIED）已定义，但实际工作流代码中并未使用。本 PR 将这些 EventLog 集成到状态转换和决策应用流程中。

## Changes

### 1. 日志持久化 (src/storage/log_store.py)
- 新增 `write_event_log()` 函数
- 支持将 EventLog 对象持久化到 `data/logs/{task_id}.jsonl`
- 使用 `model_dump()` 保留所有字段

### 2. WAITING_ENTER 日志集成 (src/workflow/pending_action.py)
- 在 `enter_waiting_state()` 中调用 `make_waiting_enter()` 创建事件
- 记录进入 WAITING_* 状态前后的状态
- 关联 PendingAction ID
- 包含等待状态、动作类型、候选数量等元数据

### 3. WAITING_EXIT 和 DECISION_APPLIED 日志集成 (src/workflow/decision_apply.py)
- 在所有三个决策应用函数中集成日志发射：
  - `apply_plan_confirm_decision()`
  - `apply_patch_confirm_decision()`
  - `apply_replan_confirm_decision()`
- 每次决策应用发射两个事件：
  - `DECISION_APPLIED`: 记录人工决策内容
  - `WAITING_EXIT`: 记录离开等待状态
- 新增辅助函数 `_emit_decision_applied_event()` 和 `_emit_waiting_exit_event()`

### 4. 集成测试 (tests/integration/test_event_log_integration.py)
- `test_enter_waiting_state_emits_waiting_enter_event`: 验证 WAITING_ENTER 事件发射
- `test_decision_apply_emits_waiting_exit_and_decision_applied`: 验证决策应用时的双事件发射
- `test_fsm_reconstruction_from_logs`: 验证日志可重建 FSM 状态转换序列

## Impact / Risks

### 正面影响
- ✅ 完整的审计追踪：所有 HITL 决策点都有完整日志
- ✅ FSM 可重建：通过日志可完整重建任务生命周期
- ✅ 符合架构设计：实现了架构文档中定义的可观测性要求
- ✅ 测试覆盖：新增 3 项集成测试，所有 210 项测试通过

### 风险
- 🔵 低风险：仅新增日志记录，不修改业务逻辑
- 🔵 向后兼容：保留原有 `TASK_STATUS_CHANGED` 等旧格式日志
- 🔵 性能影响：每次状态转换额外写入 1-2 条日志，影响可忽略

## Related

- Closes #15
- 相关设计文档：
  - SID:arch.contracts.task_snapshot (状态变更即写入日志事件)
  - SID:obs.eventlog.mandatory_events (EventLog 写入约束)
  - SID:fsm.states.definitions (FSM 状态定义)