### PR TITLE
feat(api): 添加决策提交端点以驱动 FSM

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from src.models.contracts import ProteinDesignTask
+from src.models.contracts import ProteinDesignTask, Decision, DecisionChoice
 from src.models.db import TaskRecord
+from src.models.validation import DecisionValidationError, validate_decision_for_pending_action
 from src.workflow.workflow import run_task_sync
+from src.workflow.decision_apply import (
+    apply_plan_confirm_decision,
+    apply_patch_confirm_decision,
+    apply_replan_confirm_decision,
+    DecisionApplyError,
+)
+from src.models.contracts import PendingActionType, now_iso
+from src.workflow.context import WorkflowContext
 
 app = FastAPI(title="Protein Design Agent System (Mini Demo)", version="0.3.1")
 
@@ -20,6 +29,14 @@ class TaskCreateRequest(BaseModel):
     goal: str = Field(..., description="蛋白质设计任务目标(自然语言)")
     constraints: Dict[str, Any] = Field(default_factory=dict, description="结构化约束")
     metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class DecisionSubmitRequest(BaseModel):
+    """提交人工决策的请求体"""
+    choice: DecisionChoice = Field(..., description="决策选择")
+    selected_candidate_id: Optional[str] = Field(None, description="当choice为accept时必填")
+    decided_by: str = Field(..., description="决策者标识")
+    comment: Optional[str] = Field(None, description="可选的决策备注")
 
 
 @app.post("/tasks", response_model=TaskRecord)
@@ -45,4 +62,101 @@ async def get_task(task_id: str):
     record = TASK_STORE.get(task_id)
     if record is None:
         raise HTTPException(status_code=404, detail="task not found")
+    return record
+
+
+@app.post("/pending-actions/{pending_action_id}/decision", response_model=TaskRecord)
+async def submit_decision(pending_action_id: str, req: DecisionSubmitRequest):
+    """提交人工决策以驱动 FSM 前进
+
+    Args:
+        pending_action_id: 待决策的 PendingAction ID
+        req: 决策请求体
+
+    Returns:
+        更新后的 TaskRecord
+
+    Raises:
+        HTTPException: 404 当 PendingAction 未找到
+        HTTPException: 400 当决策验证失败
+        HTTPException: 409 当决策冲突(已决策或状态不匹配)
+        HTTPException: 500 当应用决策失败
+    """
+    # 查找包含该 pending_action 的任务
+    record = None
+    for task_record in TASK_STORE.values():
+        if (task_record.pending_action
+            and task_record.pending_action.pending_action_id == pending_action_id):
+            record = task_record
+            break
+
+    if record is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"pending_action {pending_action_id} not found"
+        )
+
+    pending_action = record.pending_action
+
+    # 构造 Decision 对象
+    try:
+        decision = Decision(
+            decision_id=f"decision_{uuid4().hex[:8]}",
+            task_id=record.id,
+            pending_action_id=pending_action_id,
+            choice=req.choice,
+            selected_candidate_id=req.selected_candidate_id,
+            decided_by=req.decided_by,
+            comment=req.comment,
+            decided_at=now_iso(),
+        )
+    except Exception as e:
+        # Pydantic 验证错误
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # 验证决策
+    try:
+        validate_decision_for_pending_action(pending_action, decision)
+    except DecisionValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    # 构造 WorkflowContext
+    context = WorkflowContext(
+        task=ProteinDesignTask(
+            task_id=record.id,
+            goal=record.goal,
+            constraints=record.constraints or {},
+            metadata=record.metadata or {},
+        ),
+        status=record.internal_status,
+        plan=record.plan,
+        step_results={},
+        design_result=record.design_result,
+        safety_events=[],
+        pending_action=pending_action,
+    )
+
+    # 根据 action_type 路由到对应的 apply 函数
+    try:
+        if pending_action.action_type == PendingActionType.PLAN_CONFIRM:
+            apply_plan_confirm_decision(context, record, decision)
+        elif pending_action.action_type == PendingActionType.PATCH_CONFIRM:
+            apply_patch_confirm_decision(context, record, decision)
+        elif pending_action.action_type == PendingActionType.REPLAN_CONFIRM:
+            apply_replan_confirm_decision(context, record, decision)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported action type: {pending_action.action_type.value}"
+            )
+    except DecisionApplyError as e:
+        # 决策冲突或应用失败
+        error_msg = str(e)
+        if "conflict" in error_msg.lower() or "already" in error_msg.lower():
+            raise HTTPException(status_code=409, detail=error_msg)
+        raise HTTPException(status_code=500, detail=error_msg)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to apply decision: {str(e)}")
+
+    # 返回更新后的 TaskRecord
     return record

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -4,8 +4,10 @@ import httpx
 
 from src.api.main import app, TASK_STORE
 from src.models.contracts import (
+    DecisionChoice,
     PendingAction,
     PendingActionCandidate,
+    PendingActionStatus,
     PendingActionType,
     Plan,
     PlanPatch,
@@ -289,3 +291,207 @@ class TestAPIEndpoints:
         assert data["status"] == external_status.value
         # pending_action 应该是 None 或不存在
         assert data.get("pending_action") is None
+
+    async def test_submit_decision_accept_plan(self, client: httpx.AsyncClient):
+        """测试提交 ACCEPT 决策以接受计划"""
+        task_id = "task_decision_accept_plan"
+        pending_action_id = "pa_accept_plan"
+
+        # 创建一个 WAITING_PLAN_CONFIRM 状态的任务
+        plan = Plan(
+            task_id=task_id,
+            steps=[PlanStep(id="S1", tool="tool_a", inputs={}, metadata={})],
+            constraints={},
+            metadata={},
+        )
+        pending_action = PendingAction(
+            pending_action_id=pending_action_id,
+            task_id=task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            status=PendingActionStatus.PENDING,
+            candidates=[
+                PendingActionCandidate(candidate_id="plan_1", payload=plan)
+            ],
+            explanation="please confirm plan",
+        )
+        record = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.WAITING_PLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+            goal="test decision accept",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=pending_action,
+        )
+        TASK_STORE[task_id] = record
+
+        # 提交决策
+        response = await client.post(
+            f"/pending-actions/{pending_action_id}/decision",
+            json={
+                "choice": "accept",
+                "selected_candidate_id": "plan_1",
+                "decided_by": "test_user",
+                "comment": "looks good",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == task_id
+        assert data["status"] == ExternalStatus.PLANNED.value
+        assert data["plan"] is not None
+        assert data["pending_action"] is None or data["pending_action"]["status"] == PendingActionStatus.DECIDED.value
+
+    async def test_submit_decision_not_found(self, client: httpx.AsyncClient):
+        """测试提交决策时 PendingAction 不存在"""
+        response = await client.post(
+            "/pending-actions/nonexistent_pa/decision",
+            json={
+                "choice": "accept",
+                "selected_candidate_id": "plan_1",
+                "decided_by": "test_user",
+            },
+        )
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    async def test_submit_decision_validation_error(self, client: httpx.AsyncClient):
+        """测试提交决策时验证失败（accept 缺少 candidate_id）"""
+        task_id = "task_decision_validation_error"
+        pending_action_id = "pa_validation_error"
+
+        pending_action = PendingAction(
+            pending_action_id=pending_action_id,
+            task_id=task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            status=PendingActionStatus.PENDING,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="plan_1",
+                    payload=Plan(task_id=task_id, steps=[], constraints={}, metadata={}),
+                )
+            ],
+            explanation="test",
+        )
+        record = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.WAITING_PLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+            goal="test validation error",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=pending_action,
+        )
+        TASK_STORE[task_id] = record
+
+        # 提交 accept 决策但不提供 selected_candidate_id
+        response = await client.post(
+            f"/pending-actions/{pending_action_id}/decision",
+            json={
+                "choice": "accept",
+                "decided_by": "test_user",
+            },
+        )
+
+        # Pydantic 验证错误会被捕获并返回 400
+        assert response.status_code == 400
+
+    async def test_submit_decision_replan_choice(self, client: httpx.AsyncClient):
+        """测试提交 REPLAN 决策"""
+        task_id = "task_decision_replan"
+        pending_action_id = "pa_replan"
+
+        pending_action = PendingAction(
+            pending_action_id=pending_action_id,
+            task_id=task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            status=PendingActionStatus.PENDING,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="plan_1",
+                    payload=Plan(task_id=task_id, steps=[], constraints={}, metadata={}),
+                )
+            ],
+            explanation="test replan",
+        )
+        record = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.WAITING_PLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+            goal="test replan decision",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=pending_action,
+        )
+        TASK_STORE[task_id] = record
+
+        # 提交 replan 决策
+        response = await client.post(
+            f"/pending-actions/{pending_action_id}/decision",
+            json={
+                "choice": "replan",
+                "decided_by": "test_user",
+                "comment": "need better plan",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == task_id
+        # REPLAN 会触发重新规划，状态应该变为 PLANNING
+        assert data["status"] == ExternalStatus.PLANNING.value
+
+    async def test_submit_decision_cancel_choice(self, client: httpx.AsyncClient):
+        """测试提交 CANCEL 决策"""
+        task_id = "task_decision_cancel"
+        pending_action_id = "pa_cancel"
+
+        pending_action = PendingAction(
+            pending_action_id=pending_action_id,
+            task_id=task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            status=PendingActionStatus.PENDING,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="plan_1",
+                    payload=Plan(task_id=task_id, steps=[], constraints={}, metadata={}),
+                )
+            ],
+            explanation="test cancel",
+        )
+        record = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.WAITING_PLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+            goal="test cancel decision",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=pending_action,
+        )
+        TASK_STORE[task_id] = record
+
+        # 提交 cancel 决策
+        response = await client.post(
+            f"/pending-actions/{pending_action_id}/decision",
+            json={
+                "choice": "cancel",
+                "decided_by": "test_user",
+                "comment": "task cancelled by user",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == task_id
+        # CANCEL 应该将任务状态设置为 CANCELLED
+        assert data["status"] == ExternalStatus.CANCELLED.value


### PR DESCRIPTION
## 概述
实现 issue #17: 提供提交人工决策的 API 并驱动 FSM 前进

## 变更内容

### API 端点
- **POST /pending-actions/{id}/decision**: 提交人工决策端点
  - 接受 `DecisionSubmitRequest` 请求体
  - 返回更新后的 `TaskRecord`
  - HTTP 状态码:
    - 200: 决策成功应用
    - 400: 决策验证失败
    - 404: PendingAction 不存在
    - 409: 决策冲突(已决策或状态不匹配)
    - 500: 应用决策失败

### 核心实现

#### 1. 请求模型 (`DecisionSubmitRequest`)
```python
class DecisionSubmitRequest(BaseModel):
    choice: DecisionChoice          # accept/replan/continue/cancel
    selected_candidate_id: Optional[str]  # accept 时必填
    decided_by: str                 # 决策者标识
    comment: Optional[str]          # 可选备注
```

#### 2. 决策处理流程
1. **查找任务**: 根据 `pending_action_id` 在 TASK_STORE 中查找对应任务
2. **构造决策**: 创建 `Decision` 对象(包含 Pydantic 验证)
3. **验证决策**: 调用 `validate_decision_for_pending_action` 进行业务验证
4. **应用决策**: 根据 `action_type` 路由到对应的 apply 函数:
   - `PLAN_CONFIRM` → `apply_plan_confirm_decision`
   - `PATCH_CONFIRM` → `apply_patch_confirm_decision`
   - `REPLAN_CONFIRM` → `apply_replan_confirm_decision`
5. **返回结果**: 返回更新后的 `TaskRecord`

#### 3. EventLog 集成
- 通过 issue #15 的实现，决策应用时自动记录:
  - `DECISION_APPLIED`: 决策应用事件
  - `WAITING_EXIT`: 退出等待状态事件

### 测试覆盖

新增 5 个测试用例:

1. **test_submit_decision_accept_plan**: 测试 ACCEPT 决策接受计划
   - 验证状态从 `WAITING_PLAN_CONFIRM` → `PLANNED`
   - 验证 plan 被正确设置

2. **test_submit_decision_not_found**: 测试 PendingAction 不存在
   - 返回 404 状态码

3. **test_submit_decision_validation_error**: 测试验证失败
   - ACCEPT 缺少 `selected_candidate_id`
   - 返回 400 状态码

4. **test_submit_decision_replan_choice**: 测试 REPLAN 决策
   - 验证状态从 `WAITING_PLAN_CONFIRM` → `PLANNING`

5. **test_submit_decision_cancel_choice**: 测试 CANCEL 决策
   - 验证状态从 `WAITING_PLAN_CONFIRM` → `CANCELLED`

## 验收标准

✅ **decision 被校验**
- Pydantic 模型验证 (accept 需要 selected_candidate_id)
- 自定义业务验证 (choice 合法性、候选存在性)

✅ **FSM 正确推进**
- 通过 `apply_*_decision` 函数驱动状态转移
- 支持所有决策类型: ACCEPT, REPLAN, CONTINUE, CANCEL

✅ **有 EventLog**
- 通过 issue #15 集成的 EventLog 基础设施
- 自动记录 `DECISION_APPLIED` 和 `WAITING_EXIT` 事件

## 测试结果

```
pytest tests/api/test_api_endpoints.py -v
===================== 22 passed =====================

pytest
===================== 222 passed ====================
```

所有测试通过，包括新增的 5 个 API 端点测试。

## 相关 Issue

Closes #17

## Checklist

- [x] 代码实现完成
- [x] 测试覆盖充分
- [x] 所有测试通过
- [x] EventLog 集成正常
- [x] FSM 状态转移正确