### PR TITLE
docs(tools): 明确 ESMFold v0.x Nextflow-only 运行假设与输出目录约定（fix #61）

### DIFF
--- a/docs/design/system-implementation-design.md
+++ b/docs/design/system-implementation-design.md
@@ -135,17 +135,19 @@ project-root/
       protein_mpnn.nf
       esmfold.nf
       rdkit_props.nf
-    output/
-      pdb/
-      metrics/
-      artifacts/
-      reports/
-    data/
-      inputs/
-      logs/
+  data/
+    inputs/
+    logs/
+  output/
+    pdb/
+    metrics/
+    artifacts/
+    reports/
 ```
 
 ---
+
+产物目录统一放在 `output/` 下，按类型分子目录（`pdb/`、`metrics/`、`artifacts/`、`reports/`），文件名需包含 `task_id` 便于检索与追踪。
 
 ### ToolAdapter 分层实现与 tools/ 模块
 

--- a/docs/design/tools-catalog.md
+++ b/docs/design/tools-catalog.md
@@ -31,14 +31,25 @@ depends_on: [impl]
 <!-- SID:tools.esmfold.spec -->
 
 - 类型：蛋白质结构预测
-- 输入：氨基酸序列(FASTA / string)
-- 输出: PDB 文件、置信度(pLDDT)
-- 接入方式：
-  - python(本地模型)
-  - nextflow(容器化，推荐)
+- 输入：单条氨基酸序列(FASTA / string)
+- 输出：PDB 文件、置信度(pLDDT)
+- 执行方式：nextflow（v0.x 唯一方式，blocking）
+  - 仅通过 Nextflow 调度容器，不提供 docker run/compose 路径
+- 运行假设：
+  - Nextflow 已安装，可通过 `nextflow --info` 验证
+  - profile: `docker` / `podman`（Fedora 开发环境默认 podman）
+  - 容器引擎：Docker 或 Podman
+  - GPU 必须存在（系统不负责 GPU 管理）
+- 模块位置：`nf/modules/esmfold.nf`
+- 产物目录约定：`output/pdb/`、`output/metrics/`、`output/artifacts/`（文件名包含 `task_id`）
+- 非目标：
+  - batch / 多序列
+  - GPU 管理
+  - 并发/并行
 - 备注:
   - 轻量，无需 MSA
   - 适合作为第一个真实结构工具
+  - 同类结构预测工具在 v0.x 统一通过 Nextflow 接入
 
 #### AlphaFold / OpenFold
 <!-- SID:tools.alphafold.spec -->
@@ -233,4 +244,6 @@ depends_on: [impl]
 - 工具替换：
   - 不应影响系统整体架构
   - 同类工具可并存，供后续选择
+- 结构预测类工具：
+  - v0.x 统一通过 Nextflow 容器方式接入
 <!-- SID:tools.adapter.constraints END -->

--- a/plan/index(12.26-1.13).md
+++ b/plan/index(12.26-1.13).md
@@ -32,8 +32,8 @@
 
 | Issue ID | 日期 | 模块 | Issue 标题 | 关键工作内容 | 产出/验收标准 |
 |--------|------|------|-----------|-------------|--------------|
-| #11 | 12.31 | Tool | ESMFold 接入方案确认 | 本地 / 容器 / Nextflow 决策 | 接入路径确定 |
-| #12 | 01.01 | Tool | ESMFoldAdapter 实现 | run() + 输出标准化 | StepResult 正确 |
+| #11 | 12.31 | Tool | ESMFold 接入方法与运行假设确认 | 本地 / 容器 / Nextflow 决策 | 接入路径确定 |
+| #12 | 01.01 | Tool | ESMFoldAdapter 最小实现 | run() + 输出标准化 | StepResult 正确 |
 | #13 | 01.02 | Executor | StepRunner 真实执行 | 执行时间/失败捕获 | artifacts 生成 |
 | #14 | 01.03 | Executor | 真实失败场景测试 | 非法输入 / 超时 | WAITING_* 触发 |
 | #15 | 01.03 | Planner | Patch / Replan 触发验证 | 规则版 Patch / Replan | 人工确认生效 |


### PR DESCRIPTION
## 重要说明（必读）

本 PR 未在本机真实启动或运行 ESMFold。所有文档调整均基于“宿主机已可通过 podman
成功启动 ESMFold、Nextflow 已安装、GPU 已就绪”的前提假设进行整理与明确化。

———

## 变更摘要

本 PR 仅更新设计文档，明确 ESMFold 在 v0.x 阶段的唯一执行方式为
Nextflow（blocking），补充运行假设、非目标能力，并统一输出目录约定以对齐架构层
资源层说明。

### 详细变更

1. ESMFold 规约更新（SID:tools.esmfold.spec）

- 明确 v0.x 仅允许 Nextflow 执行（blocking），不提供 docker run/compose 路径
- 输入限制为单序列
- 运行假设补充：
    - nextflow --info 可用
    - profile: docker / podman（Fedora 默认 podman）
    - 容器引擎：Docker 或 Podman
    - GPU 必须存在（系统不负责 GPU 管理）
- 补充模块位置与产物目录约定：nf/modules/esmfold.nf、output/
  {pdb,metrics,artifacts}
- 明确非目标能力：无 batch / 无 GPU 管理 / 无并发
- 标注同类结构预测工具 v0.x 统一通过 Nextflow 接入
- 文件：/home/yurikon/文档/thesis/thesis-project.design/docs/design/tools-
  catalog.md

2. 工具接入原则补充

- 在 tools.adapter.constraints 中追加：结构预测类工具 v0.x 统一 Nextflow 接入
- 文件：/home/yurikon/文档/thesis/thesis-project.design/docs/design/tools-
  catalog.md

3. 输出目录与资源层对齐

- 顶层目录建议中将 output/ 调整到 repo 根目录（对齐架构“资源层含 output/”）
- 增加“产物目录统一规则：output/ 下按类型分目录，文件名包含 task_id”
- 文件：/home/yurikon/文档/thesis/thesis-project.design/docs/design/system-
  implementation-design.md

———

## 测试

- 未运行测试（文档变更）

风险与影响

- 仅文档变更，不影响运行时行为
- 后续若实际运行约束与假设不符，需要调整文档描述

## 关联 Issue
  Closes #61

## 备注

- 本 PR 不包含 ESMFold 实际运行验证
