### PR TITLE
feat(api): enforce decision idempotency and audit trail

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from src.models.contracts import ProteinDesignTask, Decision, DecisionChoice
+from src.models.contracts import ProteinDesignTask, Decision, DecisionChoice, PendingActionStatus
 from src.models.db import TaskRecord
 from src.models.validation import DecisionValidationError, validate_decision_for_pending_action
 from src.workflow.workflow import run_task_sync
@@ -15,6 +15,7 @@ from src.workflow.decision_apply import (
     apply_patch_confirm_decision,
     apply_replan_confirm_decision,
     DecisionApplyError,
+    DecisionConflictError,
 )
 from src.models.contracts import PendingActionType, now_iso
 from src.workflow.context import WorkflowContext
@@ -98,6 +99,19 @@ async def submit_decision(pending_action_id: str, req: DecisionSubmitRequest):
 
     pending_action = record.pending_action
 
+    # 显式检查 PendingAction 状态
+    if pending_action is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"pending_action {pending_action_id} not found in task record"
+        )
+
+    if pending_action.status != PendingActionStatus.PENDING:
+        raise HTTPException(
+            status_code=409,
+            detail=f"PendingAction {pending_action_id} is not in PENDING status (current: {pending_action.status.value})"
+        )
+
     # 构造 Decision 对象
     try:
         decision = Decision(
@@ -149,12 +163,12 @@ async def submit_decision(pending_action_id: str, req: DecisionSubmitRequest):
                 status_code=400,
                 detail=f"Unsupported action type: {pending_action.action_type.value}"
             )
+    except DecisionConflictError as e:
+        # 决策冲突：已决策或状态不匹配
+        raise HTTPException(status_code=409, detail=str(e))
     except DecisionApplyError as e:
-        # 决策冲突或应用失败
-        error_msg = str(e)
-        if "conflict" in error_msg.lower() or "already" in error_msg.lower():
-            raise HTTPException(status_code=409, detail=error_msg)
-        raise HTTPException(status_code=500, detail=error_msg)
+        # 其他决策应用失败
+        raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to apply decision: {str(e)}")
 

--- a/src/models/db.py
+++ b/src/models/db.py
@@ -12,6 +12,7 @@ from .contracts import (
     StepResult,
     DesignResult,
     SafetyResult,
+    Decision,
     now_iso,
 )
 
@@ -124,6 +125,9 @@ class TaskRecord(BaseModel):
 
     # 若处于 WAITING_*，记录当前待决策对象
     pending_action: Optional[PendingAction] = None
+
+    # 决策记录（用于审计和回放）
+    decisions: List[Decision] = Field(default_factory=list)
 
     # 安全事件汇总
     safety_events: List[SafetyResult] = Field(default_factory=list)

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -119,6 +119,10 @@ def apply_plan_confirm_decision(
     action.decided_at = now_iso()
     _sync_pending_action(context, record, action)
 
+    # 持久化 Decision 到 TaskRecord
+    if record is not None:
+        record.decisions.append(decision)
+
     # Emit structured EventLog events
     _emit_decision_applied_event(context, action, decision, prev_status)
     _emit_waiting_exit_event(
@@ -187,6 +191,10 @@ def apply_patch_confirm_decision(
         action.decided_at = now_iso()
         _sync_pending_action(context, record, action)
 
+        # 持久化 Decision 到 TaskRecord
+        if record is not None:
+            record.decisions.append(decision)
+
         # Emit WAITING_EXIT for the cancelled patch confirm
         _emit_waiting_exit_event(
             context,
@@ -243,6 +251,10 @@ def apply_patch_confirm_decision(
 
     action.decided_at = now_iso()
     _sync_pending_action(context, record, action)
+
+    # 持久化 Decision 到 TaskRecord
+    if record is not None:
+        record.decisions.append(decision)
 
     # Emit structured EventLog events
     _emit_decision_applied_event(context, action, decision, prev_status)
@@ -322,6 +334,10 @@ def apply_replan_confirm_decision(
 
     action.decided_at = now_iso()
     _sync_pending_action(context, record, action)
+
+    # 持久化 Decision 到 TaskRecord
+    if record is not None:
+        record.decisions.append(decision)
 
     # Emit structured EventLog events
     _emit_decision_applied_event(context, action, decision, prev_status)

--- a/tests/unit/test_decision_apply.py
+++ b/tests/unit/test_decision_apply.py
@@ -434,3 +434,66 @@ def test_status_mismatch_rejected(sample_task, sample_plan):
 
     with pytest.raises(DecisionConflictError):
         apply_plan_confirm_decision(context, record, decision)
+
+
+@pytest.mark.unit
+def test_missing_pending_action_rejected(sample_task):
+    """测试 PendingAction 缺失场景"""
+    decision = Decision(
+        decision_id="dec_missing_pa",
+        task_id=sample_task.task_id,
+        pending_action_id="pa_missing",
+        choice=DecisionChoice.ACCEPT,
+        selected_candidate_id="plan_a",
+        decided_by="user_1",
+    )
+    context = WorkflowContext(
+        task=sample_task,
+        status=InternalStatus.WAITING_PLAN_CONFIRM,
+        pending_action=None,
+    )
+    record = _make_record(sample_task.task_id, InternalStatus.WAITING_PLAN_CONFIRM)
+    record.pending_action = None
+
+    with pytest.raises(DecisionApplyError, match="PendingAction is required"):
+        apply_plan_confirm_decision(context, record, decision)
+
+
+@pytest.mark.unit
+def test_decision_persisted_to_record(sample_task, sample_plan):
+    """测试决策持久化到 TaskRecord.decisions"""
+    pending_action = PendingAction(
+        pending_action_id="pa_persist",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(candidate_id="plan_a", payload=sample_plan)
+        ],
+        explanation="test",
+    )
+    decision = Decision(
+        decision_id="dec_persist",
+        task_id=sample_task.task_id,
+        pending_action_id=pending_action.pending_action_id,
+        choice=DecisionChoice.ACCEPT,
+        selected_candidate_id="plan_a",
+        decided_by="user_1",
+    )
+    context = WorkflowContext(
+        task=sample_task,
+        plan=None,
+        status=InternalStatus.WAITING_PLAN_CONFIRM,
+        pending_action=pending_action,
+    )
+    record = _make_record(sample_task.task_id, InternalStatus.WAITING_PLAN_CONFIRM)
+    record.pending_action = pending_action
+
+    # 验证初始状态
+    assert len(record.decisions) == 0
+
+    apply_plan_confirm_decision(context, record, decision)
+
+    # 验证决策已持久化
+    assert len(record.decisions) == 1
+    assert record.decisions[0].decision_id == "dec_persist"
+    assert record.decisions[0].choice == DecisionChoice.ACCEPT


### PR DESCRIPTION
## Summary

实现 issue #78, 强化决策 API 的幂等性保证和审计追踪能力。

## Background

在之前的实现中，决策冲突导致以来字符串匹配(`if "conflict" in error_msg.lower()`), 且决策记录未持久化到数据库，导致:

- 409 响应不稳定，依赖异常消息格式
- 决策记录仅在内存流程中使用，无法审计和回放
- PendingAction 状态检查不够显式

## Changes

### API 层强化(`src/api/main.py`)

显式 PendingAction 状态检查

```python
# 在 submit_decision 中添加前置检查
if pending_action is None:
  raise HTTPException(status_code=404, ...)

if pending_action.status != PendingActionStatus.PENDING:
  raise HTTPException(status_code=409, detail=f"PendingActin {pending_action_id} is not in PENDING status")
```

结构化异常处理

```python
  # 从字符串匹配改为结构化异常
except DecisionConflictError as e:
  raise HTTPException(status_code=409, detail=str(e))
except DecisionApplyError as e:
  raise HTTPException(status_code=500, detail=str(e))

```

### Decision 持久化(`src/models/db.py`)

在 `TaskRecord` 添加决策记录字段:

```python
# 决策记录(用于审计和回放)
decision: List[Decision] = Field(default_factory=list)
```

向后兼容,使用 `default_factory=list`确保已有记录可正常加载.

### 决策写入逻辑(`src/workflow/decision_apply.py`)

在所有 apply 函数的关键位置添加决策持久化:

- `apply_plan_confirm_decision`: 主流程+CANCEL分支
- `apply_patch_confirm_decision`: ACCEPT/CANCEL + REPLAN 特殊分支
- `apply_replan_confirm_decision`: 所有决策分支

```python
# 在决策应用后立即持久化
if record is not None:
  record.decisions.append(decision)
```

### 单元测试补充(`tests/unit/test_decision_apply.py`)

新增2个测试用例:

- `test_missing_pending_action_rejectes`
  - 验证 PendingActin 为 None 时抛出 `DecisionApplyError`
- `test_decision_persisted_to_record`
  - 验证决策应用成功后写入 `TaskRecord.decisions`
  - 检查 decision_id 和 choice 正确持久化

## 架构影响

- 向后兼容: `TaskRecord.decisions` 使用 `default_factory`, 已有记录无需迁移
- 最小化改动: 仅修改决策相关路径,不影响其他 FSM 状态
- 审计能力: Decision 记录现可用于回访和审计分析

## 后续建议

1. 考虑在 API 响应中暴露 `TaskRecord.decisions` 供前端展示决策历史
1. 可为 `decisions` 字段添加数据库索引
1. 考虑添加决策记录的最大条数限制
