### PR TITLE
feat(executor): 统一失败归一化与标准化失败码

### DIFF
--- a/src/adapters/remote_esmfold_adapter.py
+++ b/src/adapters/remote_esmfold_adapter.py
@@ -23,7 +23,7 @@ from src.engines.remote_model_service import (
 )
 from src.models.contracts import PlanStep, TaskSnapshot, now_iso
 from src.workflow.context import WorkflowContext
-from src.workflow.errors import FailureType, StepRunError
+from src.workflow.errors import FailureType, FailureCode, StepRunError
 from src.workflow.recovery import RemoteJobContext
 
 __all__ = ["RemoteESMFoldAdapter"]
@@ -190,7 +190,7 @@ class RemoteESMFoldAdapter(BaseToolAdapter):
                 raise StepRunError(
                     failure_type=FailureType.NON_RETRYABLE,
                     message="Missing required input 'sequence'",
-                    code="ESMFOLD_MISSING_SEQUENCE",
+                    code=FailureCode.INPUT_RESOLUTION_FAILED.value,
                 )
 
             # 准备远程服务输入
@@ -236,7 +236,7 @@ class RemoteESMFoldAdapter(BaseToolAdapter):
                     raise StepRunError(
                         failure_type=FailureType.NON_RETRYABLE,
                         message=f"Job {job_id} status is unknown",
-                        code="REMOTE_JOB_UNKNOWN",
+                        code=FailureCode.REMOTE_JOB_UNKNOWN.value,
                     )
 
                 time.sleep(poll_interval)
@@ -245,7 +245,7 @@ class RemoteESMFoldAdapter(BaseToolAdapter):
                 raise StepRunError(
                     failure_type=FailureType.RETRYABLE,
                     message=f"Job {job_id} polling timeout",
-                    code="REMOTE_POLL_TIMEOUT",
+                    code=FailureCode.REMOTE_POLL_TIMEOUT.value,
                 )
 
         if final_status == JobStatus.FAILED:
@@ -253,7 +253,7 @@ class RemoteESMFoldAdapter(BaseToolAdapter):
             raise StepRunError(
                 failure_type=FailureType.TOOL_ERROR,
                 message=f"Remote job {job_id} failed",
-                code="REMOTE_JOB_FAILED",
+                code=FailureCode.REMOTE_JOB_FAILED.value,
             )
 
         # 下载结果

--- a/src/engines/remote_model_service.py
+++ b/src/engines/remote_model_service.py
@@ -23,7 +23,7 @@ from typing import Any, Dict
 
 import httpx
 
-from src.workflow.errors import FailureType, StepRunError
+from src.workflow.errors import FailureType, FailureCode, StepRunError
 
 __all__ = [
     "JobStatus",
@@ -177,30 +177,41 @@ class RESTModelInvocationService(RemoteModelInvocationService):
                 raise StepRunError(
                     failure_type=FailureType.TOOL_ERROR,
                     message="Remote service response missing 'job_id'",
-                    code="REMOTE_INVALID_RESPONSE",
+                    code=FailureCode.REMOTE_SUBMIT_INVALID_RESPONSE.value,
                 )
 
             return data["job_id"]
 
         except httpx.HTTPStatusError as exc:
+            # 根据 HTTP 状态码选择失败码
+            if exc.response.status_code >= 500:
+                failure_code = FailureCode.REMOTE_SUBMIT_HTTP_5XX
+            else:
+                failure_code = FailureCode.REMOTE_SUBMIT_HTTP_4XX
             raise StepRunError(
                 failure_type=FailureType.RETRYABLE
                 if exc.response.status_code >= 500
                 else FailureType.NON_RETRYABLE,
                 message=f"Failed to submit job: HTTP {exc.response.status_code}",
-                code=f"REMOTE_SUBMIT_HTTP_{exc.response.status_code}",
+                code=failure_code.value,
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise StepRunError(
+                failure_type=FailureType.RETRYABLE,
+                message=f"Timeout during job submission: {exc}",
+                code=FailureCode.REMOTE_SUBMIT_TIMEOUT.value,
             ) from exc
         except httpx.RequestError as exc:
             raise StepRunError(
                 failure_type=FailureType.RETRYABLE,
                 message=f"Network error during job submission: {exc}",
-                code="REMOTE_SUBMIT_NETWORK_ERROR",
+                code=FailureCode.REMOTE_SUBMIT_NETWORK_ERROR.value,
             ) from exc
         except Exception as exc:
             raise StepRunError(
                 failure_type=FailureType.TOOL_ERROR,
                 message=f"Unexpected error during job submission: {exc}",
-                code="REMOTE_SUBMIT_UNEXPECTED_ERROR",
+                code=FailureCode.REMOTE_SUBMIT_UNEXPECTED_ERROR.value,
             ) from exc
 
     def poll_status(
@@ -231,24 +242,35 @@ class RESTModelInvocationService(RemoteModelInvocationService):
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
                 return JobStatus.UNKNOWN
+            # 根据 HTTP 状态码选择失败码
+            if exc.response.status_code >= 500:
+                failure_code = FailureCode.REMOTE_POLL_HTTP_5XX
+            else:
+                failure_code = FailureCode.REMOTE_POLL_HTTP_4XX
             raise StepRunError(
                 failure_type=FailureType.RETRYABLE
                 if exc.response.status_code >= 500
                 else FailureType.NON_RETRYABLE,
                 message=f"Failed to poll job status: HTTP {exc.response.status_code}",
-                code=f"REMOTE_POLL_HTTP_{exc.response.status_code}",
+                code=failure_code.value,
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise StepRunError(
+                failure_type=FailureType.RETRYABLE,
+                message=f"Timeout during status polling: {exc}",
+                code=FailureCode.REMOTE_POLL_TIMEOUT.value,
             ) from exc
         except httpx.RequestError as exc:
             raise StepRunError(
                 failure_type=FailureType.RETRYABLE,
                 message=f"Network error during status polling: {exc}",
-                code="REMOTE_POLL_NETWORK_ERROR",
+                code=FailureCode.REMOTE_POLL_NETWORK_ERROR.value,
             ) from exc
         except Exception as exc:
             raise StepRunError(
                 failure_type=FailureType.TOOL_ERROR,
                 message=f"Unexpected error during status polling: {exc}",
-                code="REMOTE_POLL_UNEXPECTED_ERROR",
+                code=FailureCode.REMOTE_POLL_UNEXPECTED_ERROR.value,
             ) from exc
 
     def download_results(
@@ -313,24 +335,35 @@ class RESTModelInvocationService(RemoteModelInvocationService):
             return outputs
 
         except httpx.HTTPStatusError as exc:
+            # 根据 HTTP 状态码选择失败码
+            if exc.response.status_code >= 500:
+                failure_code = FailureCode.REMOTE_DOWNLOAD_HTTP_5XX
+            else:
+                failure_code = FailureCode.REMOTE_DOWNLOAD_HTTP_4XX
             raise StepRunError(
                 failure_type=FailureType.RETRYABLE
                 if exc.response.status_code >= 500
                 else FailureType.NON_RETRYABLE,
                 message=f"Failed to download results: HTTP {exc.response.status_code}",
-                code=f"REMOTE_DOWNLOAD_HTTP_{exc.response.status_code}",
+                code=failure_code.value,
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise StepRunError(
+                failure_type=FailureType.RETRYABLE,
+                message=f"Timeout during result download: {exc}",
+                code=FailureCode.REMOTE_DOWNLOAD_TIMEOUT.value,
             ) from exc
         except httpx.RequestError as exc:
             raise StepRunError(
                 failure_type=FailureType.RETRYABLE,
                 message=f"Network error during result download: {exc}",
-                code="REMOTE_DOWNLOAD_NETWORK_ERROR",
+                code=FailureCode.REMOTE_DOWNLOAD_NETWORK_ERROR.value,
             ) from exc
         except Exception as exc:
             raise StepRunError(
                 failure_type=FailureType.TOOL_ERROR,
                 message=f"Unexpected error during result download: {exc}",
-                code="REMOTE_DOWNLOAD_UNEXPECTED_ERROR",
+                code=FailureCode.REMOTE_DOWNLOAD_UNEXPECTED_ERROR.value,
             ) from exc
 
     def _download_file(
@@ -379,7 +412,7 @@ class RESTModelInvocationService(RemoteModelInvocationService):
                 raise StepRunError(
                     failure_type=FailureType.NON_RETRYABLE,
                     message=f"Job {job_id} status is unknown",
-                    code="REMOTE_JOB_UNKNOWN",
+                    code=FailureCode.REMOTE_JOB_UNKNOWN.value,
                 )
 
             time.sleep(self.poll_interval)
@@ -388,5 +421,5 @@ class RESTModelInvocationService(RemoteModelInvocationService):
         raise StepRunError(
             failure_type=FailureType.RETRYABLE,
             message=f"Job {job_id} polling timeout after {self.max_poll_attempts} attempts",
-            code="REMOTE_POLL_TIMEOUT",
+            code=FailureCode.REMOTE_POLL_TIMEOUT.value,
         )

--- a/src/workflow/errors.py
+++ b/src/workflow/errors.py
@@ -6,19 +6,25 @@
 - 不可重试任务
 - 工具异常
 - 安全阻断
+
+同时定义标准化的失败码（FailureCode）和错误元数据（ErrorMeta）结构，
+用于统一本地执行和远程调用的失败归因与审计追踪。
 """
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Dict, Optional, TypedDict
 
 __all__ = [
     "FailureType",
+    "FailureCode",
+    "ErrorMeta",
     "RunnerError",
     "StepRunError",
     "PlanRunError",
     "classify_exception",
     "is_retryable_failure",
+    "build_error_meta",
 ]
 
 
@@ -29,6 +35,95 @@ class FailureType(str, Enum):
     NON_RETRYABLE = "non_retryable"
     TOOL_ERROR = "tool_error"
     SAFETY_BLOCK = "safety_block"
+
+
+class FailureCode(str, Enum):
+    """标准化失败码枚举
+
+    用于统一本地执行和远程调用的失败归因。
+    每个失败码对应一种具体的失败原因，便于：
+    - 审计追踪
+    - 失败统计分析
+    - Patch/Replan 策略决策
+    """
+
+    # 安全检查相关失败
+    SAFETY_PRE_BLOCK = "SAFETY_PRE_BLOCK"  # 步骤执行前安全阻断
+    SAFETY_POST_BLOCK = "SAFETY_POST_BLOCK"  # 步骤执行后安全阻断
+    SAFETY_TASK_INPUT_BLOCK = "SAFETY_TASK_INPUT_BLOCK"  # 任务输入安全阻断
+    SAFETY_FINAL_BLOCK = "SAFETY_FINAL_BLOCK"  # 最终结果安全阻断
+
+    # 适配器查找失败
+    ADAPTER_NOT_FOUND = "ADAPTER_NOT_FOUND"  # 找不到工具适配器
+
+    # 输入解析失败
+    INPUT_RESOLUTION_FAILED = "INPUT_RESOLUTION_FAILED"  # 输入解析失败
+    INPUT_REFERENCE_NOT_FOUND = "INPUT_REFERENCE_NOT_FOUND"  # 引用的步骤结果不存在
+    INPUT_FIELD_NOT_FOUND = "INPUT_FIELD_NOT_FOUND"  # 引用的字段不存在
+
+    # 输出验证失败
+    OUTPUT_NOT_DICT = "OUTPUT_NOT_DICT"  # 输出不是字典
+    OUTPUT_MISSING = "OUTPUT_MISSING"  # 缺少必需输出字段
+    OUTPUT_TYPE_MISMATCH = "OUTPUT_TYPE_MISMATCH"  # 输出类型不匹配
+
+    # 工具执行失败
+    TOOL_EXECUTION_ERROR = "TOOL_EXECUTION_ERROR"  # 工具执行异常
+    TOOL_UNEXPECTED_ERROR = "TOOL_UNEXPECTED_ERROR"  # 工具未预期异常
+
+    # 远程调用失败 - 提交阶段
+    REMOTE_SUBMIT_NETWORK_ERROR = "REMOTE_SUBMIT_NETWORK_ERROR"  # 提交作业时网络错误
+    REMOTE_SUBMIT_TIMEOUT = "REMOTE_SUBMIT_TIMEOUT"  # 提交作业超时
+    REMOTE_SUBMIT_HTTP_4XX = "REMOTE_SUBMIT_HTTP_4XX"  # 提交作业 HTTP 4xx 错误
+    REMOTE_SUBMIT_HTTP_5XX = "REMOTE_SUBMIT_HTTP_5XX"  # 提交作业 HTTP 5xx 错误
+    REMOTE_SUBMIT_INVALID_RESPONSE = "REMOTE_SUBMIT_INVALID_RESPONSE"  # 提交响应格式无效
+    REMOTE_SUBMIT_UNEXPECTED_ERROR = "REMOTE_SUBMIT_UNEXPECTED_ERROR"  # 提交作业未预期异常
+
+    # 远程调用失败 - 轮询阶段
+    REMOTE_POLL_NETWORK_ERROR = "REMOTE_POLL_NETWORK_ERROR"  # 轮询状态时网络错误
+    REMOTE_POLL_TIMEOUT = "REMOTE_POLL_TIMEOUT"  # 轮询超时
+    REMOTE_POLL_HTTP_4XX = "REMOTE_POLL_HTTP_4XX"  # 轮询状态 HTTP 4xx 错误
+    REMOTE_POLL_HTTP_5XX = "REMOTE_POLL_HTTP_5XX"  # 轮询状态 HTTP 5xx 错误
+    REMOTE_POLL_UNEXPECTED_ERROR = "REMOTE_POLL_UNEXPECTED_ERROR"  # 轮询状态未预期异常
+    REMOTE_JOB_UNKNOWN = "REMOTE_JOB_UNKNOWN"  # 远程作业状态未知
+    REMOTE_JOB_FAILED = "REMOTE_JOB_FAILED"  # 远程作业执行失败
+
+    # 远程调用失败 - 结果下载阶段
+    REMOTE_DOWNLOAD_NETWORK_ERROR = "REMOTE_DOWNLOAD_NETWORK_ERROR"  # 下载结果时网络错误
+    REMOTE_DOWNLOAD_TIMEOUT = "REMOTE_DOWNLOAD_TIMEOUT"  # 下载结果超时
+    REMOTE_DOWNLOAD_HTTP_4XX = "REMOTE_DOWNLOAD_HTTP_4XX"  # 下载结果 HTTP 4xx 错误
+    REMOTE_DOWNLOAD_HTTP_5XX = "REMOTE_DOWNLOAD_HTTP_5XX"  # 下载结果 HTTP 5xx 错误
+    REMOTE_DOWNLOAD_UNEXPECTED_ERROR = "REMOTE_DOWNLOAD_UNEXPECTED_ERROR"  # 下载结果未预期异常
+
+    # 通用失败码
+    UNKNOWN_ERROR = "UNKNOWN_ERROR"  # 未知错误
+
+
+class ErrorMeta(TypedDict, total=False):
+    """标准化错误元数据结构
+
+    用于在 StepResult.error_details 中存储统一的失败信息。
+    所有字段都是可选的，但建议尽可能填充以便追踪和调试。
+    """
+
+    failure_code: str  # 标准失败码（FailureCode 枚举值）
+    phase: str  # 失败阶段（如 "adapter_lookup", "input_resolution", "tool_execution", "safety_precheck" 等）
+    timestamp: str  # 失败时间戳（ISO 8601 格式）
+
+    # 远程调用相关信息
+    remote_job_id: Optional[str]  # 远程作业 ID
+    remote_endpoint: Optional[str]  # 远程服务端点
+    http_status_code: Optional[int]  # HTTP 状态码
+
+    # 上下文信息
+    retry_count: Optional[int]  # 重试次数
+    max_retries: Optional[int]  # 最大重试次数
+
+    # 原始异常信息
+    exception_type: Optional[str]  # 异常类型
+    exception_message: Optional[str]  # 异常消息
+
+    # 附加上下文（可扩展）
+    context: Optional[Dict[str, Any]]  # 额外上下文信息
 
 
 class RunnerError(RuntimeError):
@@ -99,8 +194,82 @@ def classify_exception(exc: Exception) -> FailureType:
 
 
 def is_retryable_failure(failure_type: FailureType) -> bool:
-    """静态判定某失败分类是否“理论上可重试”
+    """静态判定某失败分类是否"理论上可重试"
 
     不包含重试次数、FSM 状态或 patch/replan 决策，仅用于粗粒度决策。
     """
     return failure_type == FailureType.RETRYABLE
+
+
+def build_error_meta(
+    failure_code: str | FailureCode,
+    phase: str,
+    *,
+    timestamp: Optional[str] = None,
+    remote_job_id: Optional[str] = None,
+    remote_endpoint: Optional[str] = None,
+    http_status_code: Optional[int] = None,
+    retry_count: Optional[int] = None,
+    max_retries: Optional[int] = None,
+    exception_type: Optional[str] = None,
+    exception_message: Optional[str] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> ErrorMeta:
+    """构建标准化的错误元数据
+
+    统一构建 StepResult.error_details 的辅助函数，确保失败信息结构一致。
+
+    Args:
+        failure_code: 标准失败码（FailureCode 枚举值或字符串）
+        phase: 失败阶段
+        timestamp: 失败时间戳（ISO 8601 格式），如果未提供则使用当前时间
+        remote_job_id: 远程作业 ID（远程调用失败时）
+        remote_endpoint: 远程服务端点（远程调用失败时）
+        http_status_code: HTTP 状态码（远程调用失败时）
+        retry_count: 重试次数
+        max_retries: 最大重试次数
+        exception_type: 原始异常类型
+        exception_message: 原始异常消息
+        context: 额外上下文信息
+
+    Returns:
+        ErrorMeta: 标准化的错误元数据字典
+    """
+    from datetime import datetime, timezone
+
+    # 规范化 failure_code
+    if isinstance(failure_code, FailureCode):
+        failure_code_str = failure_code.value
+    else:
+        failure_code_str = str(failure_code)
+
+    # 如果未提供 timestamp，使用当前时间
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+    # 构建基础元数据
+    meta: ErrorMeta = {
+        "failure_code": failure_code_str,
+        "phase": phase,
+        "timestamp": timestamp,
+    }
+
+    # 添加可选字段（仅添加非 None 的字段）
+    if remote_job_id is not None:
+        meta["remote_job_id"] = remote_job_id
+    if remote_endpoint is not None:
+        meta["remote_endpoint"] = remote_endpoint
+    if http_status_code is not None:
+        meta["http_status_code"] = http_status_code
+    if retry_count is not None:
+        meta["retry_count"] = retry_count
+    if max_retries is not None:
+        meta["max_retries"] = max_retries
+    if exception_type is not None:
+        meta["exception_type"] = exception_type
+    if exception_message is not None:
+        meta["exception_message"] = exception_message
+    if context is not None:
+        meta["context"] = context
+
+    return meta

--- a/src/workflow/step_runner.py
+++ b/src/workflow/step_runner.py
@@ -28,8 +28,10 @@ from src.workflow.context import WorkflowContext
 from src.agents.safety import SafetyAgent
 from src.workflow.errors import (
     FailureType,
+    FailureCode,
     StepRunError,
     is_retryable_failure,
+    build_error_meta,
 )
 
 __all__ = ["StepRunner", "StepRetryPolicy"]
@@ -181,7 +183,11 @@ class StepRunner:
                 status="failed",
                 failure_type=FailureType.SAFETY_BLOCK,
                 error_message=f"SafetyAgent blocked step {step.id} before execution",
-                error_details={"code": "SAFETY_PRE_BLOCK", "phase": "safety_precheck"},
+                error_details=build_error_meta(
+                    failure_code=FailureCode.SAFETY_PRE_BLOCK,
+                    phase="safety_precheck",
+                    timestamp=now_iso,
+                ),
                 outputs={},
                 metrics={
                     "exec_type": "safety_precheck",
@@ -205,7 +211,13 @@ class StepRunner:
                 status="failed",
                 failure_type=FailureType.NON_RETRYABLE,
                 error_message=str(exc),
-                error_details={"phase": "adapter_lookup"},
+                error_details=build_error_meta(
+                    failure_code=FailureCode.ADAPTER_NOT_FOUND,
+                    phase="adapter_lookup",
+                    timestamp=now_iso,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                ),
                 outputs={},
                 metrics={
                     "exec_type": "adapter_lookup",
@@ -229,7 +241,13 @@ class StepRunner:
                 status="failed",
                 failure_type=FailureType.NON_RETRYABLE,
                 error_message=str(exc),
-                error_details={"phase": "input_resolution"},
+                error_details=build_error_meta(
+                    failure_code=FailureCode.INPUT_RESOLUTION_FAILED,
+                    phase="input_resolution",
+                    timestamp=now_iso,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                ),
                 outputs={},
                 metrics={
                     "exec_type": "input_resolution",
@@ -248,6 +266,8 @@ class StepRunner:
             duration_ms = int((perf_counter() - t0) * 1000)
             now_iso = datetime.now(timezone.utc).isoformat()
             # 工具失败（可重试/不可重试由 failure_type 决定）
+            # StepRunError 已经包含 code，直接使用或构建标准化元数据
+            error_code = getattr(exc, "code", None)
             return StepResult(
                 task_id=context.task.task_id,
                 step_id=step.id,
@@ -255,7 +275,13 @@ class StepRunner:
                 status="failed",
                 failure_type=exc.failure_type,
                 error_message=str(exc),
-                error_details={"code": getattr(exc, "code", None), "phase": "tool_execution"},
+                error_details=build_error_meta(
+                    failure_code=error_code or FailureCode.TOOL_EXECUTION_ERROR,
+                    phase="tool_execution",
+                    timestamp=now_iso,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                ),
                 outputs={},
                 metrics={
                     "exec_type": "tool_execution",
@@ -275,7 +301,13 @@ class StepRunner:
                 status="failed",
                 failure_type=FailureType.TOOL_ERROR,
                 error_message=f"Unexpected tool exception: {exc}",
-                error_details={"phase": "tool_execution"},
+                error_details=build_error_meta(
+                    failure_code=FailureCode.TOOL_UNEXPECTED_ERROR,
+                    phase="tool_execution",
+                    timestamp=now_iso,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                ),
                 outputs={},
                 metrics={
                     "exec_type": "tool_execution",
@@ -327,7 +359,11 @@ class StepRunner:
                 status="failed",
                 failure_type=FailureType.SAFETY_BLOCK,
                 error_message=f"SafetyAgent blocked step {step.id} after execution",
-                error_details={"code": "SAFETY_POST_BLOCK", "phase": "safety_postcheck"},
+                error_details=build_error_meta(
+                    failure_code=FailureCode.SAFETY_POST_BLOCK,
+                    phase="safety_postcheck",
+                    timestamp=now_iso,
+                ),
                 outputs=temp_result.outputs,
                 metrics={
                     "exec_type": "safety_postcheck",
@@ -441,7 +477,7 @@ class StepRunner:
             raise StepRunError(
                 failure_type=FailureType.NON_RETRYABLE,
                 message="Tool outputs is not a dict",
-                code="OUTPUT_NOT_DICT",
+                code=FailureCode.OUTPUT_NOT_DICT.value,
             )
 
         required = step.metadata.get("required_outputs", []) if step.metadata else []
@@ -450,7 +486,7 @@ class StepRunner:
                 raise StepRunError(
                     failure_type=FailureType.NON_RETRYABLE,
                     message=f"Missing required output field '{key}'",
-                    code="OUTPUT_MISSING",
+                    code=FailureCode.OUTPUT_MISSING.value,
                 )
 
         type_hints: Dict[str, str] = step.metadata.get("output_types", {}) if step.metadata else {}
@@ -459,7 +495,7 @@ class StepRunner:
                 raise StepRunError(
                     failure_type=FailureType.NON_RETRYABLE,
                     message=f"Output field '{key}' type mismatch, expected {expected}",
-                    code="OUTPUT_TYPE_MISMATCH",
+                    code=FailureCode.OUTPUT_TYPE_MISMATCH.value,
                 )
 
     def _type_matches(self, value: Any, type_name: str) -> bool:

--- a/tests/unit/test_error_normalization.py
+++ b/tests/unit/test_error_normalization.py
@@ -1,0 +1,233 @@
+"""
+测试失败归一化与标准化失败码
+
+验证：
+- FailureCode 枚举的定义
+- ErrorMeta 结构的构建
+- build_error_meta 辅助函数
+- StepResult 中 error_details 的标准化格式
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.workflow.errors import (
+    FailureType,
+    FailureCode,
+    ErrorMeta,
+    build_error_meta,
+    StepRunError,
+)
+
+
+def test_failure_code_enum_values() -> None:
+    """测试 FailureCode 枚举包含所有必需的失败码"""
+    # 安全检查相关
+    assert FailureCode.SAFETY_PRE_BLOCK.value == "SAFETY_PRE_BLOCK"
+    assert FailureCode.SAFETY_POST_BLOCK.value == "SAFETY_POST_BLOCK"
+    assert FailureCode.SAFETY_TASK_INPUT_BLOCK.value == "SAFETY_TASK_INPUT_BLOCK"
+    assert FailureCode.SAFETY_FINAL_BLOCK.value == "SAFETY_FINAL_BLOCK"
+
+    # 适配器查找失败
+    assert FailureCode.ADAPTER_NOT_FOUND.value == "ADAPTER_NOT_FOUND"
+
+    # 输入解析失败
+    assert FailureCode.INPUT_RESOLUTION_FAILED.value == "INPUT_RESOLUTION_FAILED"
+    assert FailureCode.INPUT_REFERENCE_NOT_FOUND.value == "INPUT_REFERENCE_NOT_FOUND"
+    assert FailureCode.INPUT_FIELD_NOT_FOUND.value == "INPUT_FIELD_NOT_FOUND"
+
+    # 输出验证失败
+    assert FailureCode.OUTPUT_NOT_DICT.value == "OUTPUT_NOT_DICT"
+    assert FailureCode.OUTPUT_MISSING.value == "OUTPUT_MISSING"
+    assert FailureCode.OUTPUT_TYPE_MISMATCH.value == "OUTPUT_TYPE_MISMATCH"
+
+    # 工具执行失败
+    assert FailureCode.TOOL_EXECUTION_ERROR.value == "TOOL_EXECUTION_ERROR"
+    assert FailureCode.TOOL_UNEXPECTED_ERROR.value == "TOOL_UNEXPECTED_ERROR"
+
+    # 远程调用失败 - 提交阶段
+    assert FailureCode.REMOTE_SUBMIT_NETWORK_ERROR.value == "REMOTE_SUBMIT_NETWORK_ERROR"
+    assert FailureCode.REMOTE_SUBMIT_TIMEOUT.value == "REMOTE_SUBMIT_TIMEOUT"
+    assert FailureCode.REMOTE_SUBMIT_HTTP_4XX.value == "REMOTE_SUBMIT_HTTP_4XX"
+    assert FailureCode.REMOTE_SUBMIT_HTTP_5XX.value == "REMOTE_SUBMIT_HTTP_5XX"
+
+    # 远程调用失败 - 轮询阶段
+    assert FailureCode.REMOTE_POLL_NETWORK_ERROR.value == "REMOTE_POLL_NETWORK_ERROR"
+    assert FailureCode.REMOTE_POLL_TIMEOUT.value == "REMOTE_POLL_TIMEOUT"
+    assert FailureCode.REMOTE_POLL_HTTP_4XX.value == "REMOTE_POLL_HTTP_4XX"
+    assert FailureCode.REMOTE_POLL_HTTP_5XX.value == "REMOTE_POLL_HTTP_5XX"
+    assert FailureCode.REMOTE_JOB_UNKNOWN.value == "REMOTE_JOB_UNKNOWN"
+    assert FailureCode.REMOTE_JOB_FAILED.value == "REMOTE_JOB_FAILED"
+
+    # 远程调用失败 - 结果下载阶段
+    assert FailureCode.REMOTE_DOWNLOAD_NETWORK_ERROR.value == "REMOTE_DOWNLOAD_NETWORK_ERROR"
+    assert FailureCode.REMOTE_DOWNLOAD_TIMEOUT.value == "REMOTE_DOWNLOAD_TIMEOUT"
+    assert FailureCode.REMOTE_DOWNLOAD_HTTP_4XX.value == "REMOTE_DOWNLOAD_HTTP_4XX"
+    assert FailureCode.REMOTE_DOWNLOAD_HTTP_5XX.value == "REMOTE_DOWNLOAD_HTTP_5XX"
+
+
+def test_build_error_meta_basic() -> None:
+    """测试 build_error_meta 基础功能"""
+    meta = build_error_meta(
+        failure_code=FailureCode.TOOL_EXECUTION_ERROR,
+        phase="tool_execution",
+    )
+
+    assert meta["failure_code"] == "TOOL_EXECUTION_ERROR"
+    assert meta["phase"] == "tool_execution"
+    assert "timestamp" in meta
+
+
+def test_build_error_meta_with_remote_info() -> None:
+    """测试 build_error_meta 包含远程调用信息"""
+    meta = build_error_meta(
+        failure_code=FailureCode.REMOTE_SUBMIT_HTTP_5XX,
+        phase="remote_submit",
+        remote_job_id="job123",
+        remote_endpoint="https://api.example.com",
+        http_status_code=500,
+    )
+
+    assert meta["failure_code"] == "REMOTE_SUBMIT_HTTP_5XX"
+    assert meta["phase"] == "remote_submit"
+    assert meta["remote_job_id"] == "job123"
+    assert meta["remote_endpoint"] == "https://api.example.com"
+    assert meta["http_status_code"] == 500
+
+
+def test_build_error_meta_with_retry_info() -> None:
+    """测试 build_error_meta 包含重试信息"""
+    meta = build_error_meta(
+        failure_code=FailureCode.TOOL_EXECUTION_ERROR,
+        phase="tool_execution",
+        retry_count=2,
+        max_retries=3,
+    )
+
+    assert meta["retry_count"] == 2
+    assert meta["max_retries"] == 3
+
+
+def test_build_error_meta_with_exception_info() -> None:
+    """测试 build_error_meta 包含异常信息"""
+    meta = build_error_meta(
+        failure_code=FailureCode.TOOL_UNEXPECTED_ERROR,
+        phase="tool_execution",
+        exception_type="ValueError",
+        exception_message="Invalid input",
+    )
+
+    assert meta["exception_type"] == "ValueError"
+    assert meta["exception_message"] == "Invalid input"
+
+
+def test_build_error_meta_with_context() -> None:
+    """测试 build_error_meta 包含额外上下文"""
+    meta = build_error_meta(
+        failure_code=FailureCode.INPUT_RESOLUTION_FAILED,
+        phase="input_resolution",
+        context={"step_id": "S1", "field": "sequence"},
+    )
+
+    assert "context" in meta
+    assert meta["context"]["step_id"] == "S1"
+    assert meta["context"]["field"] == "sequence"
+
+
+def test_build_error_meta_accepts_string_code() -> None:
+    """测试 build_error_meta 接受字符串失败码"""
+    meta = build_error_meta(
+        failure_code="CUSTOM_ERROR",
+        phase="custom_phase",
+    )
+
+    assert meta["failure_code"] == "CUSTOM_ERROR"
+    assert meta["phase"] == "custom_phase"
+
+
+def test_step_run_error_with_standard_code() -> None:
+    """测试 StepRunError 使用标准化失败码"""
+    error = StepRunError(
+        failure_type=FailureType.RETRYABLE,
+        message="Network error during job submission",
+        code=FailureCode.REMOTE_SUBMIT_NETWORK_ERROR.value,
+    )
+
+    assert error.failure_type == FailureType.RETRYABLE
+    assert error.code == "REMOTE_SUBMIT_NETWORK_ERROR"
+    assert "Network error" in str(error)
+
+
+def test_error_meta_structure_is_dict_compatible() -> None:
+    """测试 ErrorMeta 结构与 Dict 兼容"""
+    meta = build_error_meta(
+        failure_code=FailureCode.TOOL_EXECUTION_ERROR,
+        phase="tool_execution",
+    )
+
+    # ErrorMeta 应该是一个普通的字典
+    assert isinstance(meta, dict)
+    assert "failure_code" in meta
+    assert "phase" in meta
+    assert "timestamp" in meta
+
+
+def test_build_error_meta_custom_timestamp() -> None:
+    """测试 build_error_meta 使用自定义时间戳"""
+    custom_timestamp = "2024-01-01T00:00:00+00:00"
+    meta = build_error_meta(
+        failure_code=FailureCode.TOOL_EXECUTION_ERROR,
+        phase="tool_execution",
+        timestamp=custom_timestamp,
+    )
+
+    assert meta["timestamp"] == custom_timestamp
+
+
+def test_build_error_meta_omits_none_fields() -> None:
+    """测试 build_error_meta 不包含 None 值字段"""
+    meta = build_error_meta(
+        failure_code=FailureCode.TOOL_EXECUTION_ERROR,
+        phase="tool_execution",
+        remote_job_id=None,  # 应该被省略
+        retry_count=None,  # 应该被省略
+    )
+
+    assert "remote_job_id" not in meta
+    assert "retry_count" not in meta
+    assert "failure_code" in meta
+    assert "phase" in meta
+
+
+def test_error_meta_comprehensive_example() -> None:
+    """测试 ErrorMeta 完整示例（模拟远程作业超时失败）"""
+    meta = build_error_meta(
+        failure_code=FailureCode.REMOTE_POLL_TIMEOUT,
+        phase="remote_poll",
+        timestamp="2024-01-01T12:00:00+00:00",
+        remote_job_id="job_abc123",
+        remote_endpoint="https://esmfold.example.com",
+        retry_count=3,
+        max_retries=3,
+        exception_type="TimeoutError",
+        exception_message="Job polling timeout after 60 attempts",
+        context={
+            "poll_attempts": 60,
+            "poll_interval_ms": 5000,
+            "last_known_status": "running",
+        },
+    )
+
+    # 验证所有字段都正确填充
+    assert meta["failure_code"] == "REMOTE_POLL_TIMEOUT"
+    assert meta["phase"] == "remote_poll"
+    assert meta["timestamp"] == "2024-01-01T12:00:00+00:00"
+    assert meta["remote_job_id"] == "job_abc123"
+    assert meta["remote_endpoint"] == "https://esmfold.example.com"
+    assert meta["retry_count"] == 3
+    assert meta["max_retries"] == 3
+    assert meta["exception_type"] == "TimeoutError"
+    assert meta["exception_message"] == "Job polling timeout after 60 attempts"
+    assert meta["context"]["poll_attempts"] == 60
+    assert meta["context"]["poll_interval_ms"] == 5000
+    assert meta["context"]["last_known_status"] == "running"

--- a/tests/unit/test_remote_model_service.py
+++ b/tests/unit/test_remote_model_service.py
@@ -93,7 +93,7 @@ def test_submit_job_http_error(service: RESTModelInvocationService) -> None:
             )
 
     assert exc_info.value.failure_type == FailureType.RETRYABLE
-    assert "500" in exc_info.value.code
+    assert exc_info.value.code == "REMOTE_SUBMIT_HTTP_5XX"
 
 
 def test_submit_job_network_error(service: RESTModelInvocationService) -> None:


### PR DESCRIPTION
实现 issue#79 中的失败归一化需求：

## 新增功能
- 定义 FailureCode 枚举，包含所有标准化失败码
  - 安全检查失败（SAFETY_PRE_BLOCK, SAFETY_POST_BLOCK 等）
  - 适配器查找失败（ADAPTER_NOT_FOUND）
  - 输入解析失败（INPUT_RESOLUTION_FAILED 等）
  - 输出验证失败（OUTPUT_NOT_DICT, OUTPUT_MISSING 等）
  - 工具执行失败（TOOL_EXECUTION_ERROR, TOOL_UNEXPECTED_ERROR）
  - 远程调用失败（REMOTE_SUBMIT_*, REMOTE_POLL_*, REMOTE_DOWNLOAD_*）

- 定义 ErrorMeta TypedDict 结构，统一错误元数据格式
  - 包含 failure_code, phase, timestamp 等基础字段
  - 支持远程调用信息（remote_job_id, remote_endpoint, http_status_code）
  - 支持重试信息（retry_count, max_retries）
  - 支持异常信息（exception_type, exception_message）
  - 支持额外上下文（context）

- 新增 build_error_meta 辅助函数，用于构建标准化的 error_details

## 代码改进
- 更新 StepRunner 所有失败路径使用标准化失败信息
  - 安全检查阻断使用 FailureCode.SAFETY_PRE_BLOCK / SAFETY_POST_BLOCK
  - 适配器查找失败使用 FailureCode.ADAPTER_NOT_FOUND
  - 输入解析失败使用 FailureCode.INPUT_RESOLUTION_FAILED
  - 工具执行失败使用 FailureCode.TOOL_EXECUTION_ERROR / TOOL_UNEXPECTED_ERROR
  - 输出验证失败使用 FailureCode.OUTPUT_NOT_DICT / OUTPUT_MISSING / OUTPUT_TYPE_MISMATCH

- 更新 RemoteModelInvocationService 所有失败路径使用标准化失败码
  - 提交阶段：REMOTE_SUBMIT_HTTP_4XX / 5XX, REMOTE_SUBMIT_NETWORK_ERROR, REMOTE_SUBMIT_TIMEOUT
  - 轮询阶段：REMOTE_POLL_HTTP_4XX / 5XX, REMOTE_POLL_NETWORK_ERROR, REMOTE_POLL_TIMEOUT, REMOTE_JOB_UNKNOWN
  - 下载阶段：REMOTE_DOWNLOAD_HTTP_4XX / 5XX, REMOTE_DOWNLOAD_NETWORK_ERROR, REMOTE_DOWNLOAD_TIMEOUT
  - 作业失败：REMOTE_JOB_FAILED

- 更新 RemoteESMFoldAdapter 使用标准化失败码

## 测试覆盖
- 新增 test_error_normalization.py 测试文件
  - 验证 FailureCode 枚举定义
  - 验证 build_error_meta 功能
  - 验证 ErrorMeta 结构与 Dict 兼容性
  - 验证完整失败信息示例（远程作业超时等场景）
- 更新 test_remote_model_service.py 适配新的失败码格式
- 所有现有测试通过（48 passed）

## 验收标准
- ✅ 失败可追踪、可复现（标准化的 failure_code + error_meta）
- ✅ 本地执行和远程调用走同一失败治理链路
- ✅ 测试覆盖完整（单元测试 + 集成测试）

相关 issue: #79

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
