### PR TITLE
feat(register): 新增ProteinMPNN注册节点

### DIFF
--- a/src/kg/protein_tool_kg.json
+++ b/src/kg/protein_tool_kg.json
@@ -7,6 +7,12 @@
       "name": "Structure Prediction",
       "domain": "protein/structure",
       "description": "Predict 3D protein structures from sequence inputs."
+    },
+    {
+      "capability_id": "sequence_design",
+      "name": "Sequence Design",
+      "domain": "protein/design",
+      "description": "Design amino acid sequences from a structural backbone or template."
     }
   ],
   "io_types": [
@@ -16,6 +22,13 @@
       "output_types": ["structure_pdb", "plddt"],
       "combinable": true,
       "description": "Single sequence to structure prediction outputs."
+    },
+    {
+      "io_type_id": "structure_to_sequence",
+      "input_types": ["structure_pdb"],
+      "output_types": ["sequence"],
+      "combinable": true,
+      "description": "Design sequences from structural backbone inputs."
     },
     {
       "io_type_id": "sequence_msa_to_structure",
@@ -39,6 +52,19 @@
         "max_length": 2000
       },
       "description": "ESMFold runtime requirements and limits."
+    },
+    {
+      "constraint_id": "protein_mpnn_runtime",
+      "preconditions": ["structure_template_provided"],
+      "resource_assumptions": [
+        "gpu_available",
+        "python_environment_ready"
+      ],
+      "model_assumptions": ["backbone_required"],
+      "limits": {
+        "max_length": 2000
+      },
+      "description": "ProteinMPNN runtime requirements for backbone-guided design."
     },
     {
       "constraint_id": "alphafold_runtime",
@@ -94,6 +120,47 @@
       },
       "failure_modes": ["timeout", "nan_output"],
       "preferred_next": ["biopython_qc"],
+      "version": "1.0.0"
+    },
+    {
+      "id": "protein_mpnn",
+      "tool_id": "protein_mpnn",
+      "name": "ProteinMPNN",
+      "domain": "protein/design",
+      "description": "Sequence design from backbone coordinates.",
+      "capabilities": ["sequence_design"],
+      "io": {
+        "io_type_id": "structure_to_sequence",
+        "inputs": {
+          "pdb_path": "path"
+        },
+        "outputs": {
+          "sequence": "str",
+          "sequence_score": "float"
+        },
+        "input_types": ["structure_pdb"],
+        "output_types": ["sequence"],
+        "combinable": true
+      },
+      "constraints": {
+        "preconditions": ["structure_template_provided"],
+        "resource_assumptions": [
+          "gpu_available",
+          "python_environment_ready"
+        ],
+        "model_assumptions": ["backbone_required"],
+        "limits": {
+          "max_length": 2000
+        }
+      },
+      "execution": "python",
+      "cost_score": 0.4,
+      "safety_level": 1,
+      "compat": {
+        "from": ["esmfold.pdb_path", "alphafold.pdb_path"]
+      },
+      "failure_modes": ["invalid_backbone", "missing_backbone"],
+      "preferred_next": ["esmfold", "alphafold"],
       "version": "1.0.0"
     },
     {

--- a/tests/unit/test_protein_tool_kg.py
+++ b/tests/unit/test_protein_tool_kg.py
@@ -1,0 +1,25 @@
+from src.kg.kg_client import load_tool_kg
+
+
+def test_kg_includes_protein_mpnn_and_design_capability() -> None:
+    kg = load_tool_kg()
+    tool_ids = {tool["id"] for tool in kg["tools"]}
+    capability_ids = {cap["capability_id"] for cap in kg["capabilities"]}
+    io_type_ids = {io_type["io_type_id"] for io_type in kg["io_types"]}
+
+    assert "protein_mpnn" in tool_ids
+    assert "sequence_design" in capability_ids
+    assert "structure_to_sequence" in io_type_ids
+
+
+def test_design_to_prediction_chain_is_compatible() -> None:
+    kg = load_tool_kg()
+    tools = {tool["id"]: tool for tool in kg["tools"]}
+
+    mpnn = tools["protein_mpnn"]
+    esmfold = tools["esmfold"]
+
+    mpnn_outputs = set(mpnn["io"]["outputs"].keys())
+    esmfold_inputs = set(esmfold["io"]["inputs"].keys())
+
+    assert esmfold_inputs.issubset(mpnn_outputs)


### PR DESCRIPTION
## 背景

#92 要求在ProteinToolKG中注册ProteinMPNN(设计工具), 明确 design vs prediction 能力区分, 并保证 Planner 可规划 design->predict 顺序; 不要求Executor 可运行, 也不修改 Planner 算法.

## 变更概述

- 在KG实例中新增设计能力与ProteinMPNN工具节点, 补足 design->predict链路
- 增加最小单元测试, 锁定 KG 中ProteinMPNN/设计能力/IO类型及链路兼容性

## 主要变更

1. 新增/扩展KG数据

- `src/kg/protein_tool_kg.json`
  - 新增 `sequence_design` capability
  - 新增 `structure_to_sequence` io_type
  - 新增 `protein_mpnn_runtim` constraint
  - 新增 `protein_mpnn` tool 节点, 输入 `pdb_path` 输出 `sequence`
  - `protein_mpnn` 兼容上游结构预测工具输出, 并偏好后续走 esmfold/alphafold

2. 测试

- `tests/unit/test_protein_tool_kg.py`

## 风险/注意

- 仅数据变更+最小测试
- KG 版本仍为1.0.0

## 关联

Closes #92
