### PR TITLE
实现远程模型服务 Provider 配置系统(NVIDIA NIM)

### DIFF
--- a/configs/model_providers.json
+++ b/configs/model_providers.json
@@ -1,0 +1,18 @@
+{
+  "providers": {
+    "nvidia_nim": {
+      "provider_type": "nvidia_nim",
+      "description": "NVIDIA NIM Biology Models",
+      "base_url": "https://integrate.api.nvidia.com/v1",
+      "api_key_env": "NIM_API_KEY",
+      "timeout": 60,
+      "max_retries": 3,
+      "extra": {
+        "supported_models": [
+          "nvidia/esmfold",
+          "nvidia/esm2nv"
+        ]
+      }
+    }
+  }
+}

--- a/src/engines/provider_config.py
+++ b/src/engines/provider_config.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+DEFAULT_PROVIDER_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "configs" / "model_providers.json"
+)
+
+
+@dataclass
+class ProviderConfig:
+    provider_type: str
+    description: str = ""
+    base_url: str = ""
+    api_key_env: str = ""
+    timeout: float = 60.0
+    max_retries: int = 3
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def get_api_key(self) -> str:
+        """Fetch API key from the configured environment variable."""
+        if not self.api_key_env:
+            return ""
+        return os.getenv(self.api_key_env, "")
+
+
+def _default_provider_configs() -> Dict[str, ProviderConfig]:
+    return {
+        "nvidia_nim": ProviderConfig(
+            provider_type="nvidia_nim",
+            description="NVIDIA NIM Biology Models",
+            base_url="https://integrate.api.nvidia.com/v1",
+            api_key_env="NIM_API_KEY",
+            timeout=60.0,
+            max_retries=3,
+            extra={
+                "supported_models": [
+                    "nvidia/esmfold",
+                    "nvidia/esm2nv",
+                ]
+            },
+        )
+    }
+
+
+def load_provider_config(
+    path: Path | None = None,
+) -> Dict[str, ProviderConfig]:
+    """Load provider config from JSON; fallback to defaults if missing."""
+    config_path = path or DEFAULT_PROVIDER_CONFIG_PATH
+    if not config_path.exists():
+        return _default_provider_configs()
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    providers = data.get("providers", {})
+    if not isinstance(providers, dict):
+        raise ValueError("Provider config 'providers' must be a dict")
+
+    configs: Dict[str, ProviderConfig] = {}
+    for name, payload in providers.items():
+        if not isinstance(payload, dict):
+            raise ValueError(f"Provider config for '{name}' must be a dict")
+
+        extra = payload.get("extra", {})
+        if extra is None:
+            extra = {}
+        if not isinstance(extra, dict):
+            raise ValueError(f"Provider config extra for '{name}' must be a dict")
+
+        timeout = payload.get("timeout", 60.0)
+        if timeout is None:
+            timeout = 60.0
+
+        max_retries = payload.get("max_retries", 3)
+        if max_retries is None:
+            max_retries = 3
+
+        configs[name] = ProviderConfig(
+            provider_type=payload.get("provider_type", name),
+            description=payload.get("description", ""),
+            base_url=payload.get("base_url", ""),
+            api_key_env=payload.get("api_key_env", ""),
+            timeout=float(timeout),
+            max_retries=int(max_retries),
+            extra=extra,
+        )
+
+    return configs
+
+
+def get_provider_config(provider: str) -> ProviderConfig:
+    """Get config for a single provider by name."""
+    configs = load_provider_config()
+    try:
+        return configs[provider]
+    except KeyError as exc:
+        raise KeyError(f"Provider config not found: {provider}") from exc

--- a/tests/unit/test_provider_config.py
+++ b/tests/unit/test_provider_config.py
@@ -1,0 +1,85 @@
+import json
+
+import pytest
+
+from src.engines import provider_config
+from src.engines.provider_config import ProviderConfig, load_provider_config
+
+
+def test_load_provider_config_from_file(tmp_path):
+    data = {
+        "providers": {
+            "custom": {
+                "provider_type": "custom",
+                "description": "Custom provider",
+                "base_url": "https://example.com/api",
+                "api_key_env": "CUSTOM_API_KEY",
+                "timeout": 12,
+                "max_retries": 5,
+                "extra": {"region": "us-west"},
+            }
+        }
+    }
+    path = tmp_path / "providers.json"
+    path.write_text(json.dumps(data))
+
+    configs = load_provider_config(path)
+
+    config = configs["custom"]
+    assert config.provider_type == "custom"
+    assert config.description == "Custom provider"
+    assert config.base_url == "https://example.com/api"
+    assert config.api_key_env == "CUSTOM_API_KEY"
+    assert config.timeout == 12.0
+    assert config.max_retries == 5
+    assert config.extra["region"] == "us-west"
+
+
+def test_load_provider_config_fallback_default(tmp_path):
+    missing_path = tmp_path / "missing.json"
+    configs = load_provider_config(missing_path)
+
+    assert "nvidia_nim" in configs
+    config = configs["nvidia_nim"]
+    assert config.base_url == "https://integrate.api.nvidia.com/v1"
+    assert config.api_key_env == "NIM_API_KEY"
+    assert "supported_models" in config.extra
+
+
+def test_provider_config_get_api_key(monkeypatch):
+    config = ProviderConfig(
+        provider_type="nvidia_nim",
+        api_key_env="TEST_API_KEY",
+    )
+    monkeypatch.setenv("TEST_API_KEY", "secret")
+
+    assert config.get_api_key() == "secret"
+
+
+def test_get_provider_config_uses_default_path(tmp_path, monkeypatch):
+    data = {
+        "providers": {
+            "example": {
+                "provider_type": "example",
+                "base_url": "https://example.com",
+            }
+        }
+    }
+    path = tmp_path / "providers.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(provider_config, "DEFAULT_PROVIDER_CONFIG_PATH", path)
+
+    config = provider_config.get_provider_config("example")
+
+    assert config.provider_type == "example"
+    assert config.base_url == "https://example.com"
+
+
+def test_get_provider_config_missing_provider(tmp_path, monkeypatch):
+    data = {"providers": {}}
+    path = tmp_path / "providers.json"
+    path.write_text(json.dumps(data))
+    monkeypatch.setattr(provider_config, "DEFAULT_PROVIDER_CONFIG_PATH", path)
+
+    with pytest.raises(KeyError):
+        provider_config.get_provider_config("missing")


### PR DESCRIPTION
## 关联 Issue

Fixes #108

## 背景

为支持 NVIDIA NIM 作为 remote_model_service 后端, 需要集中式配置系统,支持从 JSON 加载并通过环境变量管理 API key, 且在配置文件缺失时可以回退默认配置.

## 主要变更

- 新增 `ProviderConfig` 数据类与加载逻辑: 支持从配置文件读取, 默认回退, API Key环境变量解析
- 新增 `configs/model_providers.json`: 提供 `nvidia_nim` 默认配置(base_url, timeout, max_retries, supported_models)
- 增加单元测试覆盖: 配置加载, 缺省回退, API key解析与缺失 provider 的错误处理
- 默认 API Key 环境变量名调整为 `NIM_API_KEY`(匹配本地环境)

## 影响范围

- 新增 `src/engines/provider_config.py`
- 新增 `configs/model_providers.json`
- 新增 `tests/unit/test_provider_config.py`

## 备注

- API Key 通过 `api_key_env` 指定的环境变量读取, 不在代码或配置中硬编码.
