### PR TITLE
实现KG对远程NIM ESMFold 的补齐与后端检索支持, 并更新 schema 以兼容结构化execution

### DIFF
--- a/src/kg/kg_client.py
+++ b/src/kg/kg_client.py
@@ -53,6 +53,35 @@ def find_tools_by_capability(
     return filtered
 
 
+def find_tools_by_backend(
+    backend: str,
+    provider: str | None = None,
+    *,
+    path: Path | None = None,
+) -> List[dict]:
+    """Find tools by execution backend and optional provider."""
+    tools = get_tool_nodes(path)
+    matched: List[dict] = []
+
+    for tool in tools:
+        execution = tool.get("execution")
+        if isinstance(execution, str):
+            if provider is not None:
+                continue
+            if execution == backend:
+                matched.append(tool)
+            continue
+
+        if isinstance(execution, dict):
+            if execution.get("backend") != backend:
+                continue
+            if provider is not None and execution.get("provider") != provider:
+                continue
+            matched.append(tool)
+
+    return matched
+
+
 def find_compatible_next(tool: dict, *, path: Path | None = None) -> List[dict]:
     outputs = set(tool.get("io", {}).get("outputs", {}).keys())
     if not outputs:

--- a/src/kg/protein_tool_kg.json
+++ b/src/kg/protein_tool_kg.json
@@ -123,6 +123,49 @@
       "version": "1.0.0"
     },
     {
+      "id": "nim_esmfold",
+      "tool_id": "nim_esmfold",
+      "name": "NIM ESMFold",
+      "domain": "protein/structure",
+      "description": "Remote ESMFold via NVIDIA NIM.",
+      "capabilities": ["structure_prediction"],
+      "io": {
+        "io_type_id": "sequence_to_structure",
+        "inputs": {
+          "sequence": "str"
+        },
+        "outputs": {
+          "pdb_path": "path",
+          "plddt": "float",
+          "pdb_string": "str"
+        },
+        "input_types": ["sequence"],
+        "output_types": ["structure_pdb", "plddt"],
+        "combinable": true
+      },
+      "constraints": {
+        "preconditions": ["sequence_provided"],
+        "resource_assumptions": ["network_available", "nim_api_key_configured"],
+        "model_assumptions": ["single_chain_only"],
+        "limits": {
+          "max_length": 400
+        }
+      },
+      "execution": {
+        "backend": "remote_model_service",
+        "provider": "nvidia_nim",
+        "model_id": "nvidia/esmfold",
+        "sync_mode": true
+      },
+      "cost_score": 0.3,
+      "safety_level": 1,
+      "compat": {
+        "from": ["protein_mpnn.sequence"]
+      },
+      "preferred_next": ["biopython_qc"],
+      "version": "1.0.0"
+    },
+    {
       "id": "protein_mpnn",
       "tool_id": "protein_mpnn",
       "name": "ProteinMPNN",
@@ -160,7 +203,7 @@
         "from": ["esmfold.pdb_path", "alphafold.pdb_path"]
       },
       "failure_modes": ["invalid_backbone", "missing_backbone"],
-      "preferred_next": ["esmfold", "alphafold"],
+      "preferred_next": ["esmfold", "nim_esmfold", "alphafold"],
       "version": "1.0.0"
     },
     {

--- a/src/kg/protein_tool_kg/schema.json
+++ b/src/kg/protein_tool_kg/schema.json
@@ -84,8 +84,15 @@
         "io": {"$ref": "#/$defs/tool_io"},
         "constraints": {"$ref": "#/$defs/tool_constraints"},
         "execution": {
-          "type": "string",
-          "enum": ["nextflow", "python", "external_api"],
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["nextflow", "python", "external_api"]
+            },
+            {
+              "$ref": "#/$defs/execution_config"
+            }
+          ],
           "description": "Execution mode used by Executor."
         },
         "cost_score": {
@@ -162,6 +169,29 @@
         "combinable": {
           "type": "boolean",
           "description": "Whether outputs can be composed with other tools."
+        }
+      },
+      "additionalProperties": false
+    },
+    "execution_config": {
+      "type": "object",
+      "required": ["backend"],
+      "properties": {
+        "backend": {
+          "type": "string",
+          "description": "Execution backend identifier (e.g. remote_model_service)."
+        },
+        "provider": {
+          "type": "string",
+          "description": "Optional provider name for the backend."
+        },
+        "model_id": {
+          "type": "string",
+          "description": "Optional model identifier for remote backends."
+        },
+        "sync_mode": {
+          "type": "boolean",
+          "description": "Whether the execution is synchronous."
         }
       },
       "additionalProperties": false

--- a/tests/unit/test_kg_client_backend.py
+++ b/tests/unit/test_kg_client_backend.py
@@ -1,0 +1,37 @@
+from src.kg.kg_client import (
+    find_tools_by_backend,
+    find_tools_by_capability,
+    load_tool_kg,
+)
+
+
+def test_find_tools_by_capability_includes_nim_esmfold() -> None:
+    tools = find_tools_by_capability("structure_prediction")
+    tool_ids = {tool["id"] for tool in tools}
+
+    assert "esmfold" in tool_ids
+    assert "nim_esmfold" in tool_ids
+
+
+def test_find_tools_by_backend_remote_model_service() -> None:
+    tools = find_tools_by_backend("remote_model_service", "nvidia_nim")
+    tool_ids = {tool["id"] for tool in tools}
+
+    assert tool_ids == {"nim_esmfold"}
+
+
+def test_find_tools_by_backend_nextflow() -> None:
+    tools = find_tools_by_backend("nextflow")
+    tool_ids = {tool["id"] for tool in tools}
+
+    assert "esmfold" in tool_ids
+
+
+def test_mpnn_to_nim_esmfold_chain_is_compatible() -> None:
+    kg = load_tool_kg()
+    tools = {tool["id"]: tool for tool in kg["tools"]}
+
+    mpnn_outputs = set(tools["protein_mpnn"]["io"]["outputs"].keys())
+    nim_inputs = set(tools["nim_esmfold"]["io"]["inputs"].keys())
+
+    assert nim_inputs.issubset(mpnn_outputs)


### PR DESCRIPTION
## 变更内容

- 新增 `nim_esmfold` 工具定义(remote_model_service执行后端)
- `execution` 字段 schema 扩展为支持结构化对象
- 新增 `find_tools_by_backend()` 查询接口
- `protein_mpnn`的 `preferred_next` 增加 `nim_esmfold`
- 新增单元测试覆盖后端检索与链路兼容性

## 变更代码示例

### KG中的结构化 execution (`src/kg/protein_tool_kg.json`)

```python
{
  "id": "nim_esmfold",
  "execution": {
    "backend":
    "remote_model_service",
    "provider": "nvidia_nim",
    "model_id": "nvidia/esmfold",
    "sync_mode": true
  }
}
```

### 后端检索接口用法 (`src/kg/kg_client.py`)

```python
from src.kg.kg_client import find_tools_by_backend

tools = find_tools_by_backend("remote_model_service", "nvidia_nim")
tool_ids = {tool["id"] for tool in tools}

# {"nim_esmfold"}
```

## 测试

- `pytest tests/unit/test_kg_client_backend.py`

## 影响文件

- `src/kg/protein_tool_kg.json`
- `src/kg/protein_tool_kg/schema.json`
- `src/kg/kg_client.py`
- `tests/unit/test_kg_client_backend.py`
