### PR TITLE
refactor(design): 更新设计文档以添加nvidia的适配

### DIFF
--- a/docs/design/tools-catalog.md
+++ b/docs/design/tools-catalog.md
@@ -33,14 +33,25 @@ depends_on: [impl]
 - 类型：蛋白质结构预测
 - 输入：单条氨基酸序列(FASTA / string)
 - 输出：PDB 文件、置信度(pLDDT)
-- 执行方式：nextflow（v0.x 唯一方式，blocking）
-  - 仅通过 Nextflow 调度容器，不提供 docker run/compose 路径
-- 运行假设：
+- 执行方式：支持两种路径（按优先级）
+  1. **NVIDIA NIM 远程调用**（推荐，Week 5 优先）
+     - 通过 `nim_esmfold` 工具调用 NVIDIA NIM Biology API
+     - 无需本地 GPU，简化部署
+     - 依赖 `NIM_API_KEY` / `NVIDIA_API_KEY` 环境变量
+  2. **本地 Nextflow**（备选）
+     - 仅通过 Nextflow 调度容器，不提供 docker run/compose 路径
+     - 需要本地 GPU
+- 运行假设（本地 Nextflow 路径）：
   - Nextflow 已安装，可通过 `nextflow --info` 验证
   - profile: `docker` / `podman`（Fedora 开发环境默认 podman）
   - 容器引擎：Docker 或 Podman
   - GPU 必须存在（系统不负责 GPU 管理）
-- 模块位置：`nf/modules/esmfold.nf`
+- 运行假设（NIM 路径）：
+  - 网络可用
+  - API Key 已配置（`NVIDIA_API_KEY` 环境变量）
+- 模块位置：
+  - NIM 路径：`src/engines/nim_client.py`、`src/adapters/nim_adapter.py`
+  - Nextflow 路径：`nf/modules/esmfold.nf`
 - 产物目录约定：`output/pdb/`、`output/metrics/`、`output/artifacts/`（文件名包含 `task_id`）
 - 非目标：
   - batch / 多序列
@@ -49,8 +60,48 @@ depends_on: [impl]
 - 备注:
   - 轻量，无需 MSA
   - 适合作为第一个真实结构工具
-  - 同类结构预测工具在 v0.x 统一通过 Nextflow 接入
-- 控制流与执行边界：见 `docs/design/system-implementation-design.md` 的“Nextflow 接入边界与控制流约束”
+  - NIM 路径优先用于开发与演示，Nextflow 路径用于本地高性能计算
+- 控制流与执行边界：见 `docs/design/system-implementation-design.md` 的"Nextflow 接入边界与控制流约束"
+
+#### NIM ESMFold
+<!-- SID:tools.nim_esmfold.spec -->
+
+- 类型：蛋白质结构预测（远程）
+- 输入：`{"sequence": str}` 单条氨基酸序列
+- 输出：
+  - `pdb_path`: PDB 文件路径
+  - `plddt`: 置信度分数（float）
+  - `pdb_string`: PDB 内容字符串
+- 执行方式：`remote_model_service`（通过 NVIDIA NIM API）
+- 执行配置：
+  ```json
+  {
+    "backend": "remote_model_service",
+    "provider": "nvidia_nim",
+    "model_id": "nvidia/esmfold",
+    "sync_mode": true
+  }
+  ```
+- 运行约束：
+  - 前置条件：`sequence_provided`
+  - 资源假设：`network_available`、`nim_api_key_configured`
+  - 限制：`max_length: 400`（序列最大长度）
+- 成本评分：`0.3`（相对较低，适合快速迭代）
+- 安全级别：`1`（无特殊风险）
+- 失败码映射（见 `src/workflow/errors.py`）：
+  | FailureCode | FailureType | 触发场景 | 恢复动作 |
+  |-------------|-------------|----------|----------|
+  | NIM_AUTH_FAILED | NON_RETRYABLE | API key 无效/过期 | HITL（凭证问题） |
+  | NIM_QUOTA_EXCEEDED | RETRYABLE | API 配额/速率限制 | 带退避重试，然后 patch 到替代工具 |
+  | NIM_MODEL_NOT_FOUND | NON_RETRYABLE | 请求的模型不可用 | Patch 到替代工具 |
+  | NIM_INVALID_INPUT | NON_RETRYABLE | 输入验证失败 | Patch step 输入 |
+  | NIM_MODEL_ERROR | RETRYABLE | 模型内部错误 | 重试，然后 replan |
+- 模块位置：`src/engines/nim_client.py`、`src/adapters/nim_adapter.py`
+- 配置文件：`configs/model_providers.json`
+- 备注：
+  - 当 `NVIDIA_API_KEY` 存在时自动注册到 adapter registry
+  - 与本地 `esmfold` 工具能力兼容，可作为替代选项
+  - Planner 可根据 KG 选择 `protein_mpnn → esmfold` 或 `protein_mpnn → nim_esmfold`
 
 #### AlphaFold / OpenFold
 <!-- SID:tools.alphafold.spec -->
@@ -246,5 +297,11 @@ depends_on: [impl]
   - 不应影响系统整体架构
   - 同类工具可并存，供后续选择
 - 结构预测类工具：
-  - v0.x 统一通过 Nextflow 容器方式接入
+  - 支持多种执行后端：`nextflow`（本地）、`remote_model_service`（远程 API）
+  - 同一能力可由多个工具提供（如 `esmfold` 和 `nim_esmfold` 均提供 `structure_prediction`）
+  - Planner 通过 ProteinToolKG 选择合适的工具路径
+- 远程模型服务（`remote_model_service`）：
+  - 通过 Provider 配置系统管理 API 凭证与端点（见 `configs/model_providers.json`）
+  - 失败码需映射到统一的 `FailureCode` 体系
+  - 支持自动回退到本地工具（如 NIM 不可用时回退到 Nextflow）
 <!-- SID:tools.adapter.constraints END -->

--- a/docs/impl/implementation_index.md
+++ b/docs/impl/implementation_index.md
@@ -89,8 +89,11 @@ src/
 | Adapter 注册表 | `src/adapters/registry.py` | 工具适配器注册与查找 | `register_adapter` |
 | 内置注册 | `src/adapters/builtins.py` | 默认适配器注册入口 | `ensure_builtin_adapters` |
 | 工具适配器 | `src/adapters/*.py` | ProteinMPNN/ESMFold/RDKit 等 | `run_local`/`run_remote` |
+| NIM 适配器 | `src/adapters/nim_adapter.py` | NVIDIA NIM ESMFold 适配器 | `NIMESMFoldAdapter` |
 | Nextflow 后端 | `src/engines/nextflow_adapter.py` | 单步执行后端封装 | Nextflow 进程调度 |
 | 远程模型调用 | `src/engines/remote_model_service.py` | 远程 submit/poll/download | `RemoteModelInvocationService` |
+| NIM 客户端 | `src/engines/nim_client.py` | NVIDIA NIM API 客户端 | `NvidiaNIMClient`、`call_sync` |
+| Provider 配置 | `src/engines/provider_config.py` | 远程模型提供商配置管理 | `ProviderConfig`、`load_provider_config` |
 | 可视化工具 | `src/tools/visualization/` | 可视化适配与流程 | `adapter.py`、`pipeline.py` |
 
 ### 4.5 LLM Provider 层
@@ -137,13 +140,18 @@ src/
 | 远程工具调用 | `src/engines/remote_model_service.py` | submit → poll → download |
 | 快照恢复 | `src/workflow/recovery.py` | `restore_context_from_snapshot` |
 
-## 6. 近期新增模块索引（Issue #75 - #77）
+## 6. 近期新增模块索引（Issue #75 - #77, #101 - #108）
 
 | Issue | 模块/功能 | 入口/路径 | 关联实现文档 |
 | --- | --- | --- | --- |
 | #75 | LLM Provider 插件化 | `src/llm/`、`src/agents/planner.py` | `docs/impl/issue_75_implementation_summary.md`、`docs/impl/llm_provider_guide.md` |
 | #76 | 远程模型调用 | `src/engines/remote_model_service.py`、`src/adapters/remote_esmfold_adapter.py` | `docs/impl/remote_model_invocation.md` |
 | #77 | 快照恢复 | `src/workflow/recovery.py`、`src/storage/snapshot_store.py` | `docs/impl/snapshot-recovery.md` |
+| #101 | ESMFold 可用性（NIM 路径） | `src/engines/nim_client.py`、`src/adapters/nim_adapter.py` | `docs/impl/remote_model_invocation.md` |
+| #102 | KG 工具定义扩展 | `src/kg/protein_tool_kg.json`、`src/kg/kg_client.py` | `docs/design/tools-catalog.md` |
+| #105 | NIM 失败码分类 | `src/workflow/errors.py` | `docs/impl/remote_model_invocation.md` |
+| #107 | ProteinMPNN 适配器 | `src/adapters/protein_mpnn_adapter.py` | - |
+| #108 | Provider 配置系统 | `src/engines/provider_config.py`、`configs/model_providers.json` | `docs/impl/remote_model_invocation.md` |
 
 ## 7. 增量维护清单
 
@@ -164,3 +172,4 @@ src/
 | 日期 | 变更 |
 | --- | --- |
 | 2026-01-11 | 初始版本，建立代码结构快览与模块/流程索引 |
+| 2026-01-25 | 新增 Issue #101-#108 模块索引（NIM 集成、Provider 配置、失败码分类） |

--- a/docs/impl/remote_model_invocation.md
+++ b/docs/impl/remote_model_invocation.md
@@ -5,6 +5,8 @@
 
 为了支持远程 ESMFold 服务调用，系统新增了通用的 `RemoteModelInvocationService` 抽象层。该层提供统一的 submit/poll/download 接口，默认实现 REST 客户端，并保留 SSH/SDK 扩展点。
 
+**Week 5 扩展**：新增 NVIDIA NIM 作为首选远程调用后端，通过 `NvidiaNIMClient` 和 `NIMESMFoldAdapter` 实现。
+
 ## 架构设计
 
 ### 核心组件
@@ -25,14 +27,32 @@
      - `GET /job/{job_id}` - 查询作业状态
      - `GET /results/{job_id}` - 获取作业结果
 
-3. **BaseToolAdapter 扩展** (`src/adapters/base_tool_adapter.py`)
+3. **NvidiaNIMClient** (`src/engines/nim_client.py`) - Week 5 新增
+   - NVIDIA NIM Biology API 客户端
+   - 支持 `call_sync()` 同步调用 NIM 端点
+   - 从 `ProviderConfig` 读取配置（API key、base URL、超时等）
+   - HTTP 错误映射到 `FailureCode`（见 Issue #105）
+
+4. **ProviderConfig** (`src/engines/provider_config.py`) - Week 5 新增
+   - 远程模型服务提供商配置数据类
+   - 从 `configs/model_providers.json` 加载配置
+   - 支持环境变量解析 API Key
+   - 配置文件不存在时回退到内置默认值
+
+5. **BaseToolAdapter 扩展** (`src/adapters/base_tool_adapter.py`)
    - 新增 `run_remote()` 方法（可选实现）
    - 保持向后兼容性（`run_local()` 保持不变）
 
-4. **RemoteESMFoldAdapter** (`src/adapters/remote_esmfold_adapter.py`)
+6. **RemoteESMFoldAdapter** (`src/adapters/remote_esmfold_adapter.py`)
    - ESMFold 远程适配器示例实现
    - 将 `run_local()` 委托给 `run_remote()`
    - 与现有 StepRunner 无缝集成
+
+7. **NIMESMFoldAdapter** (`src/adapters/nim_adapter.py`) - Week 5 新增
+   - 继承 `BaseToolAdapter`
+   - 输入转换：`{"sequence": "..."}` → NIM 格式
+   - 输出转换：NIM 响应 → `{"pdb_path": ..., "plddt": ..., "pdb_string": ...}`
+   - 当 `NVIDIA_API_KEY` 环境变量存在时自动注册
 
 ## 工作流程
 
@@ -217,6 +237,24 @@ outputs = {
 
 所有错误通过 `StepRunError` 异常抛出，与现有的失败处理流程（retry/patch/replan）无缝集成。
 
+### NVIDIA NIM 特定失败码
+<!-- SID:impl.remote_model_invocation.nim_failure_codes -->
+
+NIM 客户端定义了专用的失败码（在 `src/workflow/errors.py`）：
+
+| FailureCode | FailureType | HTTP 状态码 | 触发场景 | 恢复动作 |
+|-------------|-------------|-------------|----------|----------|
+| `NIM_AUTH_FAILED` | NON_RETRYABLE | 401, 403 | API key 无效/过期 | HITL（凭证问题） |
+| `NIM_QUOTA_EXCEEDED` | RETRYABLE | 429 | API 配额/速率限制 | 带退避重试，然后 patch 到替代工具 |
+| `NIM_MODEL_NOT_FOUND` | NON_RETRYABLE | 404 | 请求的模型不可用 | Patch 到替代工具 |
+| `NIM_INVALID_INPUT` | NON_RETRYABLE | 400, 422 | 输入验证失败（如序列过长） | Patch step 输入 |
+| `NIM_MODEL_ERROR` | RETRYABLE | 500+ | 模型内部错误 | 重试，然后 replan |
+
+这些失败码与通用失败处理流程集成：
+- `RETRYABLE` 类型会触发自动重试（带指数退避）
+- 重试耗尽后，可 patch 到替代工具（如 `esmfold` 本地路径）
+- `NON_RETRYABLE` 类型直接触发 HITL 或 patch 流程
+
 ## 扩展点
 
 ### 实现自定义远程服务
@@ -285,3 +323,201 @@ pytest tests/unit/test_remote_esmfold_adapter.py -v
 - ✅ REST 实现可正常 submit/poll/download
 - ✅ 具备可测试的 mock 入口
 - ✅ 所有单元测试通过（251/252 通过，1个失败与本功能无关）
+
+---
+
+## NVIDIA NIM 集成（Week 5 扩展）
+<!-- SID:impl.remote_model_invocation.nvidia_nim -->
+
+### 概述
+
+NVIDIA NIM（NVIDIA Inference Microservices）提供托管的生物信息学模型 API，包括 ESMFold。系统通过 `NvidiaNIMClient` 和 `NIMESMFoldAdapter` 实现 NIM 集成。
+
+### 架构
+
+```
+┌─────────────┐
+│  StepRunner │
+└──────┬──────┘
+       │
+       │ run_local(inputs)
+       ▼
+┌──────────────────┐
+│ NIMESMFoldAdapter│
+└────────┬─────────┘
+         │
+         │ call_sync(inputs)
+         ▼
+┌────────────────────┐     ┌─────────────────┐
+│  NvidiaNIMClient   │────►│  ProviderConfig │
+└─────────┬──────────┘     └─────────────────┘
+          │                        ▲
+          │ HTTP POST              │ load from
+          ▼                        │
+┌─────────────────────────┐  ┌─────────────────────────┐
+│ NVIDIA NIM API          │  │ configs/model_providers │
+│ integrate.api.nvidia.com│  │ .json                   │
+└─────────────────────────┘  └─────────────────────────┘
+```
+
+### Provider 配置系统
+<!-- SID:impl.remote_model_invocation.provider_config -->
+
+#### ProviderConfig 数据类
+
+```python
+@dataclass
+class ProviderConfig:
+    provider_type: str           # e.g. "nvidia_nim"
+    description: str = ""
+    base_url: str = ""
+    api_key_env: str = ""        # 环境变量名，如 "NVIDIA_API_KEY"
+    timeout: float = 60.0
+    max_retries: int = 3
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def get_api_key(self) -> str:
+        """从环境变量获取 API Key"""
+```
+
+#### 配置文件格式
+
+`configs/model_providers.json`:
+
+```json
+{
+  "providers": {
+    "nvidia_nim": {
+      "provider_type": "nvidia_nim",
+      "description": "NVIDIA NIM Biology Models",
+      "base_url": "https://integrate.api.nvidia.com/v1",
+      "api_key_env": "NVIDIA_API_KEY",
+      "timeout": 60,
+      "max_retries": 3,
+      "extra": {
+        "supported_models": ["nvidia/esmfold", "nvidia/esm2nv"]
+      }
+    }
+  }
+}
+```
+
+#### 配置加载
+
+```python
+from src.engines.provider_config import load_provider_config, get_provider_config
+
+# 加载所有配置
+configs = load_provider_config()
+
+# 获取特定提供商配置
+nim_config = get_provider_config("nvidia_nim")
+api_key = nim_config.get_api_key()  # 从 NVIDIA_API_KEY 环境变量获取
+```
+
+### NIM Client 使用示例
+
+```python
+from src.engines.nim_client import NvidiaNIMClient
+
+# 创建客户端（自动加载配置）
+client = NvidiaNIMClient()
+
+# 同步调用 ESMFold
+result = client.call_sync(
+    model_id="nvidia/esmfold",
+    inputs={"sequence": "MKFLKFSLLTAVLLSVVFAFSSCGDDDDTGYLPPSQAIQDLLKRMKV"}
+)
+
+# 结果包含
+# - pdb_string: PDB 结构内容
+# - plddt: 置信度分数
+```
+
+### NIM ESMFold Adapter 使用
+
+```python
+from src.adapters.nim_adapter import NIMESMFoldAdapter
+from pathlib import Path
+
+# 创建适配器
+adapter = NIMESMFoldAdapter(output_dir=Path("output/nim"))
+
+# 执行预测
+outputs, metrics = adapter.run_local({
+    "sequence": "MKFLKFSLLTAVLLSVVFAFSSCGDDDDTGYLPPSQAIQDLLKRMKV",
+    "task_id": "task_001",
+    "step_id": "S1",
+})
+
+# outputs 包含：
+# - pdb_path: 保存的 PDB 文件路径
+# - plddt: 置信度分数
+# - pdb_string: PDB 内容字符串
+
+# metrics 包含：
+# - provider: "nvidia_nim"
+# - model_id: "nvidia/esmfold"
+# - exec_type: "remote"
+# - duration_ms: 执行时间
+```
+
+### 自动注册
+
+在 `src/adapters/builtins.py` 中，当检测到 `NVIDIA_API_KEY` 环境变量时，会自动注册 `NIMESMFoldAdapter`：
+
+```python
+def ensure_builtin_adapters():
+    # ... 其他注册 ...
+
+    # NIM ESMFold（当 API key 存在时）
+    if os.getenv("NVIDIA_API_KEY"):
+        from src.adapters.nim_adapter import NIMESMFoldAdapter
+        register_adapter("nim_esmfold", NIMESMFoldAdapter)
+```
+
+### 相关文件
+
+- `src/engines/nim_client.py` - NIM API 客户端
+- `src/engines/provider_config.py` - Provider 配置系统
+- `src/adapters/nim_adapter.py` - NIM ESMFold 适配器
+- `configs/model_providers.json` - 提供商配置文件
+- `tests/unit/test_nim_client.py` - NIM 客户端测试
+- `tests/unit/test_nim_adapter.py` - NIM 适配器测试
+
+### 与 KG 集成
+
+ProteinToolKG 中新增 `nim_esmfold` 工具定义：
+
+```json
+{
+  "id": "nim_esmfold",
+  "name": "NIM ESMFold",
+  "capabilities": ["structure_prediction"],
+  "io": {
+    "inputs": {"sequence": "str"},
+    "outputs": {"pdb_path": "path", "plddt": "float", "pdb_string": "str"}
+  },
+  "constraints": {
+    "preconditions": ["sequence_provided"],
+    "resource_assumptions": ["network_available", "nim_api_key_configured"],
+    "limits": {"max_length": 400}
+  },
+  "execution": {
+    "backend": "remote_model_service",
+    "provider": "nvidia_nim",
+    "model_id": "nvidia/esmfold",
+    "sync_mode": true
+  },
+  "cost_score": 0.3,
+  "safety_level": 1
+}
+```
+
+Planner 可通过 KG 选择工具路径：
+- `protein_mpnn` → `esmfold`（本地 Nextflow）
+- `protein_mpnn` → `nim_esmfold`（NIM 远程）
+
+查询接口：
+- `find_tools_by_capability("structure_prediction")` → 返回 `esmfold` 和 `nim_esmfold`
+- `find_tools_by_backend("remote_model_service", "nvidia_nim")` → 返回 `nim_esmfold`

--- a/docs/index/index.json
+++ b/docs/index/index.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-11",
+  "generated_at": "2026-01-25",
   "description": "Machine-readable specification index for thesis-project design documents",
-  "total_specs": 77,
+  "total_specs": 82,
   "documents": [
     {
       "doc_key": "arch",
@@ -1139,8 +1139,8 @@
       "path": "docs/design/tools-catalog.md",
       "locator": {
         "type": "begin_end",
-        "line_start": 237,
-        "line_end": 250,
+        "line_start": 288,
+        "line_end": 307,
         "marker_begin": "<!-- SID:tools.adapter.constraints BEGIN -->",
         "marker_end": "<!-- SID:tools.adapter.constraints END -->"
       },
@@ -1282,6 +1282,66 @@
       "level": "Section",
       "tags": ["impl", "remote_model_invocation", "rest_api"],
       "depends_on": [],
+      "stability": "stable"
+    },
+    {
+      "sid": "tools.nim_esmfold.spec",
+      "title": "NIM ESMFold 工具规约",
+      "doc_key": "tools",
+      "path": "docs/design/tools-catalog.md",
+      "locator": {
+        "type": "comment",
+        "line": 67,
+        "marker": "<!-- SID:tools.nim_esmfold.spec -->"
+      },
+      "level": "Block",
+      "tags": ["tools", "nim_esmfold", "structure_prediction", "nvidia_nim"],
+      "depends_on": ["tools.esmfold.spec"],
+      "stability": "stable"
+    },
+    {
+      "sid": "impl.remote_model_invocation.nim_failure_codes",
+      "title": "NVIDIA NIM 失败码定义",
+      "doc_key": "impl_remote_model_invocation",
+      "path": "docs/impl/remote_model_invocation.md",
+      "locator": {
+        "type": "comment",
+        "line": 241,
+        "marker": "<!-- SID:impl.remote_model_invocation.nim_failure_codes -->"
+      },
+      "level": "Block",
+      "tags": ["impl", "remote_model_invocation", "nvidia_nim", "failure_codes"],
+      "depends_on": ["impl.remote_model_invocation.overview"],
+      "stability": "stable"
+    },
+    {
+      "sid": "impl.remote_model_invocation.nvidia_nim",
+      "title": "NVIDIA NIM 集成",
+      "doc_key": "impl_remote_model_invocation",
+      "path": "docs/impl/remote_model_invocation.md",
+      "locator": {
+        "type": "comment",
+        "line": 330,
+        "marker": "<!-- SID:impl.remote_model_invocation.nvidia_nim -->"
+      },
+      "level": "Section",
+      "tags": ["impl", "remote_model_invocation", "nvidia_nim"],
+      "depends_on": ["impl.remote_model_invocation.overview"],
+      "stability": "stable"
+    },
+    {
+      "sid": "impl.remote_model_invocation.provider_config",
+      "title": "Provider 配置系统",
+      "doc_key": "impl_remote_model_invocation",
+      "path": "docs/impl/remote_model_invocation.md",
+      "locator": {
+        "type": "comment",
+        "line": 364,
+        "marker": "<!-- SID:impl.remote_model_invocation.provider_config -->"
+      },
+      "level": "Block",
+      "tags": ["impl", "remote_model_invocation", "provider_config", "nvidia_nim"],
+      "depends_on": ["impl.remote_model_invocation.nvidia_nim"],
       "stability": "stable"
     }
   ]


### PR DESCRIPTION
## 目的

issue#101 ~ issue#108 引入了除本地, nextflow, 远程服务器之外的第四种调用大模型的方式: 通过 NVIDIA NIM, 并将其作为首选项. 因此需要更新设计文档

## 变更文件

1. `docs.design/tools-catalog.md`
  - **更新 ESMFold 规约**(`tools.esmfold.spec`)
    - 添加了两种执行路径: NVIDIA NIM(推荐)和本地 Nextflow(备选)
    - 更新了运行假设和模块位置
  - **新增 NIM ESMFold 规约**(`tools.nim_esmfold.spec`)
    - 定义输入/输出格式
    - 添加执行配置(`remote_model_service`后端)
    - 定义运行约束(max_length: 400)
    - 列出了 NIM 失败码映射表
  - **更新设计原则**
    - 移除 "v0.x 统一通过 Nextflow 接入" 的限制
    - 添加多执行后端执行说明
    - 添加 Provider 配置系统说明
2. `docs/impl/remote_model_invocation.md`
  - **更新概述, 添加Week5扩展说明**
  - **扩展核心组件列表**
    - 新增 `NvidiaNIMClient`
    - 新增 `ProviderConfig`
    - 新增 `NIMESMFoldAdapter`
  - **新增 NIM 失败码章节**(`impl.remote_model_invocation.nim_failure_codes`)
  - **新增 NVIDIA VIM 集成章节**(`impl.remote_model_invocation.nvidia_nim`)
    - 架构图
    - Provider 配置系统详细说明
    - NIM Client 和 Adapter 使用示例
    - 与KG集成说明
3. `docs/impl/implementation_index.md`
  - **更新工具适配与执行后端索引表**
    - 新增 NIM 适配器, NIM 客户端, Provider配置模块
  - **扩展近期新增模块索引**
    - 添加 Issue #101 (ESMFold NIM 路径)
    - 添加 Issue #102 (KG工具定义扩展)
    - 添加 Issue #105 (NIM失败码分类)
    - 添加 Issue #107 (ProteinMPNN适配器)
    - 添加 Issue #108 (Provider 配置系统)
4. `docs/index/index.json`
  - 更新 `generated_at` 为 2025-01-25
  - 更新 `total_specs` 从 77 增加到 82
  - 新增5个 SID 条目
    - `tools.nim_esmfold.spec`
    - `impl.remote_model_invocation.nim_failure_codes`
    - `impl.remote_model_invocation.nvidia_nim`
    - `impl.remote_model_invocation.provider_config`
