### PR TITLE
feat(executor): 记录输入产物并支持NIM回退执行

### DIFF
--- a/src/agents/summarizer.py
+++ b/src/agents/summarizer.py
@@ -26,13 +26,25 @@ class SummarizerAgent:
 
         # 简单策略：从 step_results 中提取信息
         seq_len = None
+        final_sequence = None
         structure_pdb_path = None
         structure_scores = {}  # 与结构相关的评分指标
+        execution_steps: list[dict] = []
 
-        for r in context.step_results.values():
+        if context.plan is not None:
+            ordered_step_ids = [step.id for step in context.plan.steps]
+        else:
+            ordered_step_ids = list(context.step_results.keys())
+
+        for step_id in ordered_step_ids:
+            r = context.step_results.get(step_id)
+            if r is None:
+                continue
             # 提取序列长度
             if "sequence_length" in r.outputs:
                 seq_len = r.outputs["sequence_length"]
+            if "sequence" in r.outputs:
+                final_sequence = r.outputs["sequence"]
 
             # 提取结构预测结果（通用方式，不限于特定工具）
             # 只要 outputs 包含 pdb_path，就认为是结构预测工具的输出
@@ -54,7 +66,20 @@ class SummarizerAgent:
                     if "confidence" in metrics:
                         structure_scores["confidence"] = metrics["confidence"]
 
+            execution_steps.append(
+                {
+                    "step_id": r.step_id,
+                    "tool": r.tool,
+                    "exec_type": r.metrics.get("exec_type"),
+                    "provider": r.metrics.get("provider"),
+                    "model_id": r.metrics.get("model_id"),
+                    "backend": r.metrics.get("backend"),
+                }
+            )
+
         scores = {}
+        if seq_len is None and final_sequence is not None:
+            seq_len = len(final_sequence)
         if seq_len is not None:
             scores["sequence_length"] = seq_len
         # 合并结构预测的分数
@@ -71,9 +96,15 @@ class SummarizerAgent:
             task_id,
         )
 
+        if final_sequence is None:
+            final_sequence = context.task.constraints.get("sequence")
+
+        plan_metadata = context.plan.metadata if context.plan else {}
+        plan_version = plan_metadata.get("plan_version") or plan_metadata.get("version")
+
         design = DesignResult(
             task_id=task_id,
-            sequence=context.task.constraints.get("sequence"),
+            sequence=final_sequence,
             structure_pdb_path=structure_pdb_path,  # ESMFold 生成的 PDB 文件
             scores=scores,
             risk_flags=[],
@@ -84,6 +115,9 @@ class SummarizerAgent:
                 "artifacts": visualization_artifacts,
                 "summary_report_path": str(summary_report_path),
                 "report_source": report_source,
+                "plan_metadata": plan_metadata,
+                "plan_version": plan_version,
+                "execution_steps": execution_steps,
             },
         )
         

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -86,7 +86,9 @@ class StepResult(BaseModel):
     error_message: Optional[str] = None
     # 可选错误细节，用于附加上下文（例如 trace_id / 原始异常消息等）
     error_details: Dict = Field(default_factory=dict)
+    inputs: Dict = Field(default_factory=dict)
     outputs: Dict = Field(default_factory=dict)
+    artifacts: Dict = Field(default_factory=dict)
     metrics: Dict = Field(default_factory=dict)
     risk_flags: List[RiskFlag] = Field(default_factory=list)
     logs_path: Optional[str] = None

--- a/src/workflow/step_runner.py
+++ b/src/workflow/step_runner.py
@@ -10,7 +10,7 @@ step_runner.py
 - 根据统一数据契约生成 StepResult, 并写入：
     - task_id / step_id / tool
     - status
-    - outputs / metrics
+    - inputs / outputs / artifacts / metrics
     - risk_flags
     - logs_path
     - timestamp
@@ -23,7 +23,9 @@ from time import perf_counter, sleep
 from typing import Any, Callable, Dict
 
 from src.models.contracts import PlanStep, StepResult
+from src.adapters.base_tool_adapter import BaseToolAdapter
 from src.adapters.registry import get_adapter
+from src.kg.kg_client import ToolKGError, load_tool_kg
 from src.workflow.context import WorkflowContext
 from src.agents.safety import SafetyAgent
 from src.workflow.errors import (
@@ -98,7 +100,7 @@ class StepRunner:
         - 返回一个StepResult实例，并满足:
             - task_id == context.task.task_id
             - step_id == step.id
-            - tool == step.tool
+            - tool == step.tool（若发生 fallback 则记录实际执行的 tool）
             - status == "success"（若输入解析失败则返回 failed）
             - metrics:
                 - 至少包含：
@@ -188,7 +190,9 @@ class StepRunner:
                     phase="safety_precheck",
                     timestamp=now_iso,
                 ),
+                inputs={},
                 outputs={},
+                artifacts={},
                 metrics={
                     "exec_type": "safety_precheck",
                     "duration_ms": duration_ms,
@@ -200,7 +204,7 @@ class StepRunner:
         
         # 获取适配器
         try:
-            adapter = get_adapter(step.tool)
+            adapter, resolved_tool_id, adapter_meta = self._resolve_adapter(step)
         except KeyError as exc:
             duration_ms = int((perf_counter() - t0) * 1000)
             now_iso = datetime.now(timezone.utc).isoformat()
@@ -218,7 +222,9 @@ class StepRunner:
                     exception_type=type(exc).__name__,
                     exception_message=str(exc),
                 ),
+                inputs={},
                 outputs={},
+                artifacts={},
                 metrics={
                     "exec_type": "adapter_lookup",
                     "duration_ms": duration_ms,
@@ -237,7 +243,7 @@ class StepRunner:
             return StepResult(
                 task_id=context.task.task_id,
                 step_id=step.id,
-                tool=step.tool,
+                tool=resolved_tool_id,
                 status="failed",
                 failure_type=FailureType.NON_RETRYABLE,
                 error_message=str(exc),
@@ -248,7 +254,9 @@ class StepRunner:
                     exception_type=type(exc).__name__,
                     exception_message=str(exc),
                 ),
+                inputs={},
                 outputs={},
+                artifacts={},
                 metrics={
                     "exec_type": "input_resolution",
                     "duration_ms": duration_ms,
@@ -263,6 +271,16 @@ class StepRunner:
             outputs_payload, adapter_metrics = adapter.run_local(resolved_inputs)
             self._validate_outputs(step, outputs_payload)
         except StepRunError as exc:
+            fallback_result = self._try_fallback_after_error(
+                step=step,
+                context=context,
+                resolved_inputs=resolved_inputs,
+                error=exc,
+                requested_tool=resolved_tool_id,
+                start_time=t0,
+            )
+            if fallback_result is not None:
+                return fallback_result
             duration_ms = int((perf_counter() - t0) * 1000)
             now_iso = datetime.now(timezone.utc).isoformat()
             # 工具失败（可重试/不可重试由 failure_type 决定）
@@ -271,7 +289,7 @@ class StepRunner:
             return StepResult(
                 task_id=context.task.task_id,
                 step_id=step.id,
-                tool=step.tool,
+                tool=resolved_tool_id,
                 status="failed",
                 failure_type=exc.failure_type,
                 error_message=str(exc),
@@ -282,10 +300,13 @@ class StepRunner:
                     exception_type=type(exc).__name__,
                     exception_message=str(exc),
                 ),
+                inputs=resolved_inputs,
                 outputs={},
+                artifacts={},
                 metrics={
                     "exec_type": "tool_execution",
                     "duration_ms": duration_ms,
+                    **adapter_meta,
                 },
                 risk_flags=[],
                 logs_path=None,
@@ -297,7 +318,7 @@ class StepRunner:
             return StepResult(
                 task_id=context.task.task_id,
                 step_id=step.id,
-                tool=step.tool,
+                tool=resolved_tool_id,
                 status="failed",
                 failure_type=FailureType.TOOL_ERROR,
                 error_message=f"Unexpected tool exception: {exc}",
@@ -308,92 +329,28 @@ class StepRunner:
                     exception_type=type(exc).__name__,
                     exception_message=str(exc),
                 ),
+                inputs=resolved_inputs,
                 outputs={},
+                artifacts={},
                 metrics={
                     "exec_type": "tool_execution",
                     "duration_ms": duration_ms,
+                    **adapter_meta,
                 },
                 risk_flags=[],
                 logs_path=None,
                 timestamp=now_iso,
             )
-
-        # 计算执行时间
-        duration_ms = int((perf_counter() - t0) * 1000)
-
-        # 生成 ISO 8601 时间戳
-        now_iso = datetime.now(timezone.utc).isoformat()
-
-        metrics_payload = dict(adapter_metrics or {})
-        metrics_payload.setdefault("exec_type", "adapter_local")
-        metrics_payload.setdefault("duration_ms", duration_ms)
-
-        # A4: 安全检查 - 步骤执行后
-        # 先构造一个临时的 StepResult 用于安全检查
-        temp_result = StepResult(
-            task_id=context.task.task_id,
-            step_id=step.id,
-            tool=step.tool,
-            status="success",
-            failure_type=None,
-            error_message=None,
-            error_details={},
-            outputs=outputs_payload,
-            metrics=metrics_payload,
-            risk_flags=[],
-            logs_path=None,
-            timestamp=now_iso,
+        return self._build_success_result(
+            step=step,
+            context=context,
+            tool_id=resolved_tool_id,
+            resolved_inputs=resolved_inputs,
+            outputs_payload=outputs_payload,
+            adapter_metrics=adapter_metrics,
+            start_time=t0,
+            metrics_extra=adapter_meta,
         )
-        
-        post_safety_result = self._safety_agent.check_post_step(
-            step, temp_result, context
-        )
-        self._add_safety_event(context, post_safety_result)
-        if post_safety_result.action == "block":
-            duration_ms = int((perf_counter() - t0) * 1000)
-            now_iso = datetime.now(timezone.utc).isoformat()
-            return StepResult(
-                task_id=context.task.task_id,
-                step_id=step.id,
-                tool=step.tool,
-                status="failed",
-                failure_type=FailureType.SAFETY_BLOCK,
-                error_message=f"SafetyAgent blocked step {step.id} after execution",
-                error_details=build_error_meta(
-                    failure_code=FailureCode.SAFETY_POST_BLOCK,
-                    phase="safety_postcheck",
-                    timestamp=now_iso,
-                ),
-                outputs=temp_result.outputs,
-                metrics={
-                    "exec_type": "safety_postcheck",
-                    "duration_ms": duration_ms,
-                },
-                risk_flags=post_safety_result.risk_flags,
-                logs_path=None,
-                timestamp=now_iso,
-            )
-        
-        # 从 post_safety_result 中提取 risk_flags
-        risk_flags = post_safety_result.risk_flags
-
-        # 构造最终的 StepResult，包含安全检查结果
-        result = StepResult(
-            task_id=context.task.task_id,
-            step_id=step.id,
-            tool=step.tool,
-            status="success",
-            failure_type=None,
-            error_message=None,
-            error_details={},
-            outputs=outputs_payload,
-            metrics=metrics_payload,
-            risk_flags=risk_flags,
-            logs_path=None,
-            timestamp=now_iso,
-        )
-
-        return result
 
     def _normalize_failure_type(self, failure_type: Any) -> FailureType | None:
         """容忍 str/枚举/None 的混合输入，统一为 FailureType"""
@@ -512,3 +469,304 @@ class StepRunner:
         if py_type is None:
             return True  # 未知类型名时不强校验，保持宽松
         return isinstance(value, py_type)
+
+    def _resolve_adapter(
+        self, step: PlanStep
+    ) -> tuple[BaseToolAdapter, str, dict]:
+        """解析适配器，必要时回退到本地工具"""
+        try:
+            adapter = get_adapter(step.tool)
+            return adapter, step.tool, {}
+        except KeyError:
+            fallback_tool = self._select_fallback_tool(step)
+            if not fallback_tool:
+                raise
+            adapter = get_adapter(fallback_tool)
+            return (
+                adapter,
+                fallback_tool,
+                {
+                    "requested_tool": step.tool,
+                    "fallback_from": step.tool,
+                    "fallback_reason": "adapter_missing",
+                },
+            )
+
+    def _try_fallback_after_error(
+        self,
+        *,
+        step: PlanStep,
+        context: WorkflowContext,
+        resolved_inputs: Dict[str, Any],
+        error: StepRunError,
+        requested_tool: str,
+        start_time: float,
+    ) -> StepResult | None:
+        if not self._should_fallback_from_error(step, error):
+            return None
+
+        fallback_tool = self._select_fallback_tool(step)
+        if not fallback_tool or fallback_tool == requested_tool:
+            return None
+
+        try:
+            adapter = get_adapter(fallback_tool)
+        except KeyError:
+            return None
+
+        try:
+            outputs_payload, adapter_metrics = adapter.run_local(resolved_inputs)
+            self._validate_outputs(step, outputs_payload)
+        except StepRunError as exc:
+            duration_ms = int((perf_counter() - start_time) * 1000)
+            now_iso = datetime.now(timezone.utc).isoformat()
+            error_code = getattr(exc, "code", None)
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=fallback_tool,
+                status="failed",
+                failure_type=exc.failure_type,
+                error_message=str(exc),
+                error_details=build_error_meta(
+                    failure_code=error_code or FailureCode.TOOL_EXECUTION_ERROR,
+                    phase="tool_execution",
+                    timestamp=now_iso,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                ),
+                inputs=resolved_inputs,
+                outputs={},
+                artifacts={},
+                metrics={
+                    "exec_type": "tool_execution",
+                    "duration_ms": duration_ms,
+                    "fallback_from": requested_tool,
+                    "fallback_reason": "nim_unavailable",
+                    "requested_tool": step.tool,
+                },
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso,
+            )
+        except Exception as exc:
+            duration_ms = int((perf_counter() - start_time) * 1000)
+            now_iso = datetime.now(timezone.utc).isoformat()
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=fallback_tool,
+                status="failed",
+                failure_type=FailureType.TOOL_ERROR,
+                error_message=f"Unexpected tool exception: {exc}",
+                error_details=build_error_meta(
+                    failure_code=FailureCode.TOOL_UNEXPECTED_ERROR,
+                    phase="tool_execution",
+                    timestamp=now_iso,
+                    exception_type=type(exc).__name__,
+                    exception_message=str(exc),
+                ),
+                inputs=resolved_inputs,
+                outputs={},
+                artifacts={},
+                metrics={
+                    "exec_type": "tool_execution",
+                    "duration_ms": duration_ms,
+                    "fallback_from": requested_tool,
+                    "fallback_reason": "nim_unavailable",
+                    "requested_tool": step.tool,
+                },
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso,
+            )
+
+        return self._build_success_result(
+            step=step,
+            context=context,
+            tool_id=fallback_tool,
+            resolved_inputs=resolved_inputs,
+            outputs_payload=outputs_payload,
+            adapter_metrics=adapter_metrics,
+            start_time=start_time,
+            metrics_extra={
+                "fallback_from": requested_tool,
+                "fallback_reason": "nim_unavailable",
+                "requested_tool": step.tool,
+            },
+        )
+
+    def _should_fallback_from_error(self, step: PlanStep, error: StepRunError) -> bool:
+        tool_entry = self._lookup_tool_entry(step.tool)
+        if not tool_entry or not _is_remote_execution(tool_entry.get("execution")):
+            return False
+        code = getattr(error, "code", None)
+        return code in {
+            FailureCode.NIM_AUTH_FAILED.value,
+            FailureCode.NIM_API_KEY_MISSING.value,
+            FailureCode.NIM_NETWORK_ERROR.value,
+            FailureCode.NIM_TIMEOUT.value,
+        }
+
+    def _select_fallback_tool(self, step: PlanStep) -> str | None:
+        tool_entry = self._lookup_tool_entry(step.tool)
+        if not tool_entry:
+            return None
+        if not _is_remote_execution(tool_entry.get("execution")):
+            return None
+        capabilities = tool_entry.get("capabilities", [])
+        if not isinstance(capabilities, list) or not capabilities:
+            return None
+        required_inputs = set(step.inputs.keys())
+        candidates: list[str] = []
+        for tool in self._iter_tools():
+            tool_id = tool.get("id")
+            if not tool_id or tool_id == step.tool:
+                continue
+            if _is_remote_execution(tool.get("execution")):
+                continue
+            tool_caps = tool.get("capabilities", [])
+            if not isinstance(tool_caps, list) or not tool_caps:
+                continue
+            if not set(tool_caps).intersection(capabilities):
+                continue
+            io_inputs = tool.get("io", {}).get("inputs", {})
+            if isinstance(io_inputs, dict):
+                if not set(io_inputs.keys()).issubset(required_inputs):
+                    continue
+            try:
+                get_adapter(tool_id)
+            except KeyError:
+                continue
+            candidates.append(tool_id)
+        if not candidates:
+            return None
+        if "esmfold" in candidates:
+            return "esmfold"
+        return sorted(candidates)[0]
+
+    def _lookup_tool_entry(self, tool_id: str) -> Dict[str, Any] | None:
+        for tool in self._iter_tools():
+            if tool.get("id") == tool_id:
+                return tool
+        return None
+
+    def _iter_tools(self) -> list[dict]:
+        try:
+            kg = load_tool_kg()
+        except ToolKGError:
+            return []
+        tools = kg.get("tools", [])
+        if isinstance(tools, list):
+            return tools
+        return []
+
+    def _extract_artifacts(self, outputs: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(outputs, dict):
+            return {}
+        artifacts: Dict[str, Any] = {}
+        if "artifacts" in outputs:
+            artifacts_value = outputs.get("artifacts")
+            if isinstance(artifacts_value, dict):
+                artifacts.update(artifacts_value)
+            else:
+                artifacts["artifacts"] = artifacts_value
+        if "pdb_path" in outputs and "pdb_path" not in artifacts:
+            artifacts["pdb_path"] = outputs.get("pdb_path")
+        return artifacts
+
+    def _build_success_result(
+        self,
+        *,
+        step: PlanStep,
+        context: WorkflowContext,
+        tool_id: str,
+        resolved_inputs: Dict[str, Any],
+        outputs_payload: Dict[str, Any],
+        adapter_metrics: Dict[str, Any] | None,
+        start_time: float,
+        metrics_extra: Dict[str, Any] | None = None,
+    ) -> StepResult:
+        duration_ms = int((perf_counter() - start_time) * 1000)
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        metrics_payload = dict(adapter_metrics or {})
+        metrics_payload.setdefault("exec_type", "adapter_local")
+        metrics_payload.setdefault("duration_ms", duration_ms)
+        if metrics_extra:
+            metrics_payload.update(metrics_extra)
+
+        artifacts_payload = self._extract_artifacts(outputs_payload)
+
+        temp_result = StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=tool_id,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            inputs=resolved_inputs,
+            outputs=outputs_payload,
+            artifacts=artifacts_payload,
+            metrics=metrics_payload,
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso,
+        )
+
+        post_safety_result = self._safety_agent.check_post_step(
+            step, temp_result, context
+        )
+        self._add_safety_event(context, post_safety_result)
+        if post_safety_result.action == "block":
+            duration_ms = int((perf_counter() - start_time) * 1000)
+            now_iso = datetime.now(timezone.utc).isoformat()
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=tool_id,
+                status="failed",
+                failure_type=FailureType.SAFETY_BLOCK,
+                error_message=f"SafetyAgent blocked step {step.id} after execution",
+                error_details=build_error_meta(
+                    failure_code=FailureCode.SAFETY_POST_BLOCK,
+                    phase="safety_postcheck",
+                    timestamp=now_iso,
+                ),
+                inputs=resolved_inputs,
+                outputs=temp_result.outputs,
+                artifacts=artifacts_payload,
+                metrics={
+                    "exec_type": "safety_postcheck",
+                    "duration_ms": duration_ms,
+                },
+                risk_flags=post_safety_result.risk_flags,
+                logs_path=None,
+                timestamp=now_iso,
+            )
+
+        risk_flags = post_safety_result.risk_flags
+
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=tool_id,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            inputs=resolved_inputs,
+            outputs=outputs_payload,
+            artifacts=artifacts_payload,
+            metrics=metrics_payload,
+            risk_flags=risk_flags,
+            logs_path=None,
+            timestamp=now_iso,
+        )
+
+
+def _is_remote_execution(execution: Any) -> bool:
+    if isinstance(execution, dict):
+        return execution.get("backend") == "remote_model_service"
+    return False

--- a/tests/unit/test_step_runner.py
+++ b/tests/unit/test_step_runner.py
@@ -181,6 +181,8 @@ def test_run_step_basic_fields_and_outputs_contract(empty_context, monkeypatch):
     assert result.task_id == empty_context.task.task_id
     assert result.tool == step.tool
     assert result.status == "success"
+    assert result.inputs["x"] == 1
+    assert result.inputs["y"] == "text"
 
     # outputs 约定
     assert "dummy_output" in result.outputs
@@ -279,6 +281,56 @@ def test_run_step_uses_adapter_path(empty_context):
     assert adapter.received_inputs == {"value": 42}
     assert result.outputs["dummy_output"] == "ok"
     assert result.metrics.get("exec_type") == "adapter_local"
+
+
+def test_run_step_fallbacks_to_local_tool_when_nim_missing(empty_context, monkeypatch):
+    """当 NIM 工具不可用时，StepRunner 应回退到本地工具"""
+    from src.workflow import step_runner as step_runner_module
+
+    class LocalESMFoldAdapter(BaseToolAdapter):
+        tool_id = "esmfold"
+        adapter_id = "esmfold_local"
+
+        def resolve_inputs(self, step: PlanStep, context: WorkflowContext) -> dict:
+            return _resolve_inputs(step, context)
+
+        def run_local(self, inputs: dict) -> tuple[dict, dict]:
+            return {"pdb_path": "/tmp/fallback.pdb"}, {"exec_type": "nextflow"}
+
+    register_adapter(LocalESMFoldAdapter())
+
+    mock_kg = {
+        "tools": [
+            {
+                "id": "nim_esmfold",
+                "capabilities": ["structure_prediction"],
+                "execution": {"backend": "remote_model_service"},
+                "io": {"inputs": {"sequence": "str"}, "outputs": {"pdb_path": "path"}},
+            },
+            {
+                "id": "esmfold",
+                "capabilities": ["structure_prediction"],
+                "execution": "nextflow",
+                "io": {"inputs": {"sequence": "str"}, "outputs": {"pdb_path": "path"}},
+            },
+        ]
+    }
+
+    monkeypatch.setattr(step_runner_module, "load_tool_kg", lambda: mock_kg)
+
+    step = PlanStep(
+        id="S1",
+        tool="nim_esmfold",
+        inputs={"sequence": "ACDEFG"},
+        metadata={},
+    )
+
+    runner = StepRunner()
+    result = runner.run_step(step, empty_context)
+
+    assert result.status == "success"
+    assert result.tool == "esmfold"
+    assert result.metrics.get("fallback_from") == "nim_esmfold"
 
 
 def test_run_step_missing_adapter_returns_failed_result(empty_context):

--- a/tests/unit/test_summarizer_agent.py
+++ b/tests/unit/test_summarizer_agent.py
@@ -212,6 +212,45 @@ class TestSummarizerAgent:
         assert "plddt_mean" not in result.scores
         assert "confidence" not in result.scores
 
+    def test_summarizer_records_execution_providers(
+        self, sample_workflow_context: WorkflowContext, tmp_path: Path
+    ):
+        """测试汇总器记录执行后端与 provider 信息"""
+        from src.models.contracts import now_iso
+
+        summarizer = SummarizerAgent()
+        context = sample_workflow_context
+
+        step_result = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="nim_esmfold",
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={"pdb_path": "/path/to/task123.pdb"},
+            metrics={
+                "exec_type": "nvidia_nim",
+                "provider": "nvidia_nim",
+                "model_id": "nvidia/esmfold",
+            },
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+        context.step_results["S1"] = step_result
+
+        report_dir = tmp_path / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+
+        result = summarizer.summarize(context)
+
+        execution_steps = result.metadata.get("execution_steps", [])
+        assert execution_steps
+        assert execution_steps[0]["tool"] == "nim_esmfold"
+        assert execution_steps[0]["provider"] == "nvidia_nim"
+
     def test_summarizer_combines_multiple_step_results(
         self, sample_workflow_context: WorkflowContext, sample_step_result: StepResult, tmp_path: Path
     ):


### PR DESCRIPTION
## 总结

Closes #104

完成多步串联与artifacts传递: StepRunner记录解析输入与产物, 支持NIM不可用时回退本地执行; Summarizer汇总执行后端与 provider信息

## 背景

Issue #104 需要在 Executor 侧完善顺序执行与数据依赖解析, 并统一 StepResult 输出(inputs/outputs/artifacts/metrics), 同时支持 remote_model_service(NIM) 与本地 Nextfllow 的自动回退

## 变更文件

- `src/models/contracts.py`
- `src/workflow/step_runner.py`
- `src/agents/summarizer.py`
- `tests/unit/test_step_runner.py`
- `tests/unit/test_summarizer_agent.py`

## 具体变更内容及示例代码

- `StepResult`新增 `inputs`, `artifacts `字段, 记录解析后的实际输入与产物路径
- `StepRunner`:
  - 执行前解析输入并写入 `StepResult.inputs`
  - 从输出中提取`artifacts`(含 `pdb_path`)
  - 当NIM不可用或确实适配器时自动回退到本地工具
- `Summarizer`:
  - 优先从步骤输出提取最终序列
  - 在 `DesignResult.metadata.execution_steps` 中记录 `exec_type/provider/model_id`

### 示例代码

```python
# StepRunner 返回的 StepResult 包含inputs与artifacts
resutl = runner.run_step(step, context)
print(result.inputs) # 实际解析输入
print(result.artifacts) # 产物路径
print(result.metrics) # exec_type/provider/model_id等
```

```python
# Summarizer 产物中含执行元信息
design = SummarizerAgent().summarize(context)
print(design.metadata["execution_steps"])
```

## 影响

- 执行链路数据依赖更透明: 可追溯每步真实输入与产物
- NIM 不可用时自动回退到本地 Nextflow, 避免流程中断
- 对现有模型为向后兼容

## 未来计划

- 在集成测试中覆盖 NIM->本地回退的完整流程
- 扩展对更对远程后端的回退策略与指标汇总
- 进一步丰富artifacts 结构(例如按step分类或统一引用格式)
