### PR TITLE
feat(summarizer): 从头设计报告最小版本

### DIFF
--- a/scripts/generate_denovo_report_demo.py
+++ b/scripts/generate_denovo_report_demo.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""生成 de novo 设计报告的演示脚本
+
+生成两份报告：
+1. 成功的 de novo 设计任务
+2. 失败并进入 WAITING_* 的任务
+"""
+from pathlib import Path
+
+from src.models.contracts import (
+    ProteinDesignTask,
+    Plan,
+    PlanStep,
+    StepResult,
+    SafetyResult,
+    RiskFlag,
+    now_iso,
+)
+from src.workflow.context import WorkflowContext
+from src.agents.summarizer import (
+    generate_de_novo_report,
+    write_de_novo_reports,
+    SummarizerAgent,
+)
+
+
+def create_success_scenario():
+    """创建成功场景的报告"""
+    print("=" * 60)
+    print("生成成功场景报告")
+    print("=" * 60)
+
+    # 创建任务
+    task = ProteinDesignTask(
+        task_id="denovo_success_001",
+        goal="de_novo_design",
+        constraints={
+            "goal_type": "de_novo_design",
+            "length_range": [50, 80],
+            "description": "设计一个稳定的 alpha 螺旋蛋白",
+        },
+        metadata={
+            "created_by": "demo_script",
+            "experiment": "thesis_week5",
+        },
+    )
+
+    # 创建计划
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="protein_mpnn",
+                inputs={
+                    "goal": "de_novo_design",
+                    "length_range": [50, 80],
+                },
+                metadata={"description": "使用 ProteinMPNN 进行序列设计"},
+            ),
+            PlanStep(
+                id="S2",
+                tool="esmfold",
+                inputs={"sequence": "S1.sequence"},
+                metadata={"description": "使用 ESMFold 预测结构"},
+            ),
+        ],
+        constraints=task.constraints,
+        metadata={"plan_version": "v1"},
+        explanation="de_novo_design 任务采用序列设计→结构预测两步链路。",
+    )
+
+    # 创建上下文
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+    )
+
+    # 模拟序列设计结果
+    designed_sequence = (
+        "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLRAPGAADDKELVAQIAK"
+        "QQHNIAGQDPSSVKDHVPLMSQQEGLFDEIIQR"
+    )
+    mpnn_result = StepResult(
+        task_id=task.task_id,
+        step_id="S1",
+        tool="protein_mpnn",
+        status="success",
+        inputs={
+            "goal": "de_novo_design",
+            "length_range": [50, 80],
+        },
+        outputs={
+            "sequence": designed_sequence,
+            "sequence_score": -2.34,
+            "candidates": [
+                {"sequence": designed_sequence, "score": -2.34},
+            ],
+        },
+        metrics={
+            "exec_type": "python",
+            "duration_ms": 1523,
+            "backend": "local_gpu",
+        },
+        risk_flags=[],
+        timestamp=now_iso(),
+    )
+    context.step_results["S1"] = mpnn_result
+
+    # 模拟结构预测结果
+    esmfold_result = StepResult(
+        task_id=task.task_id,
+        step_id="S2",
+        tool="esmfold",
+        status="success",
+        inputs={"sequence": designed_sequence},
+        outputs={
+            "pdb_path": "output/pdb/denovo_success_001.pdb",
+            "metrics": {
+                "task_id": task.task_id,
+                "tool": "esmfold",
+                "plddt_mean": 0.87,
+                "confidence": "high",
+                "residue_count": len(designed_sequence),
+            },
+        },
+        metrics={
+            "exec_type": "nextflow",
+            "duration_ms": 45230,
+            "provider": "local",
+        },
+        risk_flags=[],
+        timestamp=now_iso(),
+    )
+    context.step_results["S2"] = esmfold_result
+
+    # 生成报告
+    report = generate_de_novo_report(context)
+    report_dir = Path("output/reports")
+    json_path, md_path = write_de_novo_reports(report, report_dir)
+
+    print(f"JSON 报告: {json_path}")
+    print(f"Markdown 报告: {md_path}")
+    print()
+    print("Markdown 报告内容:")
+    print("-" * 40)
+    print(md_path.read_text())
+
+    return json_path, md_path
+
+
+def create_failure_scenario():
+    """创建失败场景的报告"""
+    print("\n" + "=" * 60)
+    print("生成失败场景报告")
+    print("=" * 60)
+
+    # 创建任务
+    task = ProteinDesignTask(
+        task_id="denovo_failure_001",
+        goal="de_novo_design",
+        constraints={
+            "goal_type": "de_novo_design",
+            "length_range": [100, 150],
+            "description": "设计一个较长的膜蛋白序列",
+        },
+        metadata={
+            "created_by": "demo_script",
+            "experiment": "thesis_week5",
+        },
+    )
+
+    # 创建计划
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="protein_mpnn",
+                inputs={
+                    "goal": "de_novo_design",
+                    "length_range": [100, 150],
+                },
+                metadata={},
+            ),
+            PlanStep(
+                id="S2",
+                tool="esmfold",
+                inputs={"sequence": "S1.sequence"},
+                metadata={},
+            ),
+        ],
+        constraints=task.constraints,
+        metadata={"plan_version": "v1"},
+    )
+
+    # 创建上下文
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+    )
+
+    # S1 成功
+    partial_sequence = "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLRAPGAADDKELVAQIAK" * 2
+    mpnn_result = StepResult(
+        task_id=task.task_id,
+        step_id="S1",
+        tool="protein_mpnn",
+        status="success",
+        inputs={"goal": "de_novo_design", "length_range": [100, 150]},
+        outputs={
+            "sequence": partial_sequence,
+            "sequence_score": -1.89,
+        },
+        metrics={"exec_type": "python", "duration_ms": 2341},
+        risk_flags=[],
+        timestamp=now_iso(),
+    )
+    context.step_results["S1"] = mpnn_result
+
+    # S2 失败
+    esmfold_result = StepResult(
+        task_id=task.task_id,
+        step_id="S2",
+        tool="esmfold",
+        status="failed",
+        failure_type="tool_execution_error",
+        error_message="CUDA out of memory. Tried to allocate 2.5 GiB.",
+        error_details={
+            "cuda_error": "OutOfMemoryError",
+            "requested_memory": "2.5 GiB",
+            "available_memory": "1.2 GiB",
+        },
+        inputs={"sequence": partial_sequence},
+        outputs={},
+        metrics={"exec_type": "nextflow", "duration_ms": 12340},
+        risk_flags=[],
+        timestamp=now_iso(),
+    )
+    context.step_results["S2"] = esmfold_result
+
+    # 添加安全事件（模拟系统进入 WAITING_PATCH 状态）
+    safety_event = SafetyResult(
+        task_id=task.task_id,
+        phase="step",
+        scope="step:S2",
+        risk_flags=[
+            RiskFlag(
+                level="warn",
+                code="RESOURCE_EXHAUSTED",
+                message="GPU 内存不足，建议使用远程 NIM 服务或减少序列长度",
+                scope="step",
+                step_id="S2",
+                details={"suggestion": "use_nim_fallback"},
+            )
+        ],
+        action="warn",
+        timestamp=now_iso(),
+    )
+    context.safety_events.append(safety_event)
+
+    # 生成报告
+    report = generate_de_novo_report(context)
+    report_dir = Path("output/reports")
+    json_path, md_path = write_de_novo_reports(report, report_dir)
+
+    print(f"JSON 报告: {json_path}")
+    print(f"Markdown 报告: {md_path}")
+    print()
+    print("Markdown 报告内容:")
+    print("-" * 40)
+    print(md_path.read_text())
+
+    return json_path, md_path
+
+
+def main():
+    """主函数"""
+    print("De Novo 设计报告生成演示")
+    print("=" * 60)
+
+    # 确保输出目录存在
+    Path("output/reports").mkdir(parents=True, exist_ok=True)
+
+    # 生成两种场景的报告
+    success_json, success_md = create_success_scenario()
+    failure_json, failure_md = create_failure_scenario()
+
+    print("\n" + "=" * 60)
+    print("生成完成！")
+    print("=" * 60)
+    print(f"成功场景: {success_md}")
+    print(f"失败场景: {failure_md}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agents/summarizer.py
+++ b/src/agents/summarizer.py
@@ -1,14 +1,84 @@
 from __future__ import annotations
 from pathlib import Path
 import json
+from typing import Any, Dict, List, Optional
 
-from src.models.contracts import DesignResult, now_iso
+from pydantic import BaseModel, Field
+
+from src.models.contracts import DesignResult, now_iso, StepResult, SafetyResult
 from src.workflow.context import WorkflowContext
+
+
+# ============================================================================
+# De Novo 设计报告数据模型
+# ============================================================================
+
+
+class StepSummary(BaseModel):
+    """单个步骤的执行摘要"""
+
+    step_id: str
+    tool: str
+    status: str  # "success" | "failed" | "skipped"
+    inputs_summary: Dict[str, Any] = Field(default_factory=dict)
+    outputs_summary: Dict[str, Any] = Field(default_factory=dict)
+    error_message: Optional[str] = None
+
+
+class ToolChainInfo(BaseModel):
+    """工具链信息"""
+
+    sequence_design_tool: Optional[str] = None
+    structure_prediction_tool: Optional[str] = None
+    description: str = ""
+
+
+class SuccessReport(BaseModel):
+    """成功场景报告内容"""
+
+    final_sequence: Optional[str] = None
+    sequence_length: Optional[int] = None
+    structure_pdb_path: Optional[str] = None
+    plddt_mean: Optional[float] = None
+    confidence: Optional[str] = None
+
+
+class FailureReport(BaseModel):
+    """失败场景报告内容"""
+
+    failed_step_id: Optional[str] = None
+    failed_tool: Optional[str] = None
+    failure_type: Optional[str] = None
+    error_message: Optional[str] = None
+    safety_action: Optional[str] = None  # "allow" | "warn" | "block"
+    safety_reason: Optional[str] = None
+    suggested_next_steps: List[str] = Field(default_factory=list)
+
+
+class DeNovoReport(BaseModel):
+    """De Novo 蛋白设计任务报告"""
+
+    task_id: str
+    task_description: str
+    design_goal: str
+    created_at: str
+    status: str  # "success" | "failed" | "partial"
+
+    tool_chain: ToolChainInfo
+    step_summaries: List[StepSummary] = Field(default_factory=list)
+
+    # 成功或失败的详细信息（二选一）
+    success_report: Optional[SuccessReport] = None
+    failure_report: Optional[FailureReport] = None
+
+    # 原始数据引用
+    report_json_path: Optional[str] = None
+    report_markdown_path: Optional[str] = None
 
 
 class SummarizerAgent:
     """最小可用 SummarizerAgent: 根据已完成的步骤，生成一个简单的 DesignResult
-    
+
     当前实现：简单汇总步骤结果，生成 JSON 报告
     后续将支持更丰富的报告格式（Markdown、HTML等）
     """
@@ -84,8 +154,8 @@ class SummarizerAgent:
             scores["sequence_length"] = seq_len
         # 合并结构预测的分数
         scores.update(structure_scores)
-        
-        report_dir = Path("nf/output/reports")
+
+        report_dir = Path("output/reports")
         report_dir.mkdir(parents=True, exist_ok=True)
         summary_report_path = report_dir / f"{task_id}.json"
 
@@ -101,6 +171,19 @@ class SummarizerAgent:
 
         plan_metadata = context.plan.metadata if context.plan else {}
         plan_version = plan_metadata.get("plan_version") or plan_metadata.get("version")
+
+        # De novo 任务：生成专用报告
+        de_novo_report_paths = {}
+        if _is_de_novo_task(context.task):
+            de_novo_report = generate_de_novo_report(context)
+            json_path, md_path = write_de_novo_reports(de_novo_report, report_dir)
+            de_novo_report_paths = {
+                "de_novo_json_path": str(json_path),
+                "de_novo_markdown_path": str(md_path),
+            }
+            # 对于 de novo 任务，优先使用 Markdown 报告
+            preferred_report_path = md_path
+            report_source = "de_novo_markdown"
 
         design = DesignResult(
             task_id=task_id,
@@ -118,9 +201,10 @@ class SummarizerAgent:
                 "plan_metadata": plan_metadata,
                 "plan_version": plan_version,
                 "execution_steps": execution_steps,
+                **de_novo_report_paths,
             },
         )
-        
+
         summary_report_path.write_text(design.model_dump_json(indent=2))
         return design
 
@@ -190,7 +274,7 @@ def _write_fallback_report(
             '<html lang="en">',
             "<head>",
             '  <meta charset="utf-8" />',
-            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />",
+            '  <meta name="viewport" content="width=device-width, initial-scale=1" />',
             "  <title>Visualization Report</title>",
             "  <style>",
             "    body { font-family: Arial, sans-serif; margin: 0; background: #f6f7fb; color: #1d1f27; }",
@@ -235,7 +319,416 @@ def _build_metrics_table(metrics_json_path: str | None) -> str:
             "<table>",
             "  <tr><th>Residues</th><td>{}</td></tr>".format(residue_count),
             "  <tr><th>Chains</th><td>{}</td></tr>".format(chain_label),
-            f"  <tr><th>Metrics JSON</th><td><a href=\"{metrics_json_path}\">{metrics_json_path}</a></td></tr>",
+            f'  <tr><th>Metrics JSON</th><td><a href="{metrics_json_path}">{metrics_json_path}</a></td></tr>',
             "</table>",
         ]
     )
+
+
+# ============================================================================
+# De Novo 设计报告生成逻辑
+# ============================================================================
+
+_DE_NOVO_GOAL_TYPE = "de_novo_design"
+
+
+def _extract_goal_type(task) -> str:
+    """从任务中提取 goal_type（与 planner.py 逻辑保持一致）"""
+    for container in (task.constraints, task.metadata):
+        if isinstance(container, dict):
+            goal_block = container.get("goal")
+            if isinstance(goal_block, dict):
+                goal_type = goal_block.get("type")
+                if isinstance(goal_type, str) and goal_type:
+                    return goal_type
+            goal_type = container.get("goal_type")
+            if isinstance(goal_type, str) and goal_type:
+                return goal_type
+
+    goal_value = task.goal
+    if isinstance(goal_value, str):
+        stripped = goal_value.strip()
+        if stripped == _DE_NOVO_GOAL_TYPE:
+            return stripped
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                return ""
+            if isinstance(parsed, dict):
+                goal_type = parsed.get("type")
+                if isinstance(goal_type, str) and goal_type:
+                    return goal_type
+    return ""
+
+
+def _is_de_novo_task(task) -> bool:
+    """判断任务是否为 de novo 设计任务"""
+    return _extract_goal_type(task) == _DE_NOVO_GOAL_TYPE
+
+
+def _build_step_summary(step_result: StepResult) -> StepSummary:
+    """从 StepResult 构建步骤摘要"""
+    # 提取关键输入（过滤掉过长的内容）
+    inputs_summary = {}
+    for key, value in step_result.inputs.items():
+        if isinstance(value, str) and len(value) > 100:
+            inputs_summary[key] = f"{value[:50]}... ({len(value)} chars)"
+        else:
+            inputs_summary[key] = value
+
+    # 提取关键输出
+    outputs_summary = {}
+    for key, value in step_result.outputs.items():
+        if key == "sequence" and isinstance(value, str):
+            # 序列截断显示
+            if len(value) > 50:
+                outputs_summary[key] = f"{value[:20]}...{value[-20:]} ({len(value)} aa)"
+            else:
+                outputs_summary[key] = value
+        elif key == "metrics" and isinstance(value, dict):
+            # 提取关键指标
+            outputs_summary[key] = {
+                k: v
+                for k, v in value.items()
+                if k in ("plddt_mean", "confidence", "task_id", "tool")
+            }
+        elif key == "pdb_path":
+            outputs_summary[key] = value
+        elif isinstance(value, (str, int, float, bool)):
+            outputs_summary[key] = value
+
+    return StepSummary(
+        step_id=step_result.step_id,
+        tool=step_result.tool,
+        status=step_result.status,
+        inputs_summary=inputs_summary,
+        outputs_summary=outputs_summary,
+        error_message=step_result.error_message,
+    )
+
+
+def _build_tool_chain_info(context: WorkflowContext) -> ToolChainInfo:
+    """从上下文构建工具链信息"""
+    sequence_tool = None
+    structure_tool = None
+
+    for step_result in context.step_results.values():
+        tool = step_result.tool.lower()
+        # 识别序列设计工具
+        if any(
+            kw in tool for kw in ("mpnn", "proteinmpnn", "sequence_design", "esm_if")
+        ):
+            sequence_tool = step_result.tool
+        # 识别结构预测工具
+        elif any(kw in tool for kw in ("esmfold", "alphafold", "structure", "fold")):
+            structure_tool = step_result.tool
+
+    # 如果没有识别出来，尝试按步骤顺序推断
+    if context.plan and len(context.plan.steps) >= 2:
+        if sequence_tool is None:
+            sequence_tool = context.plan.steps[0].tool
+        if structure_tool is None:
+            structure_tool = context.plan.steps[1].tool
+
+    description = ""
+    if sequence_tool and structure_tool:
+        description = f"序列设计({sequence_tool}) → 结构预测({structure_tool})"
+    elif sequence_tool:
+        description = f"序列设计({sequence_tool})"
+    elif structure_tool:
+        description = f"结构预测({structure_tool})"
+
+    return ToolChainInfo(
+        sequence_design_tool=sequence_tool,
+        structure_prediction_tool=structure_tool,
+        description=description,
+    )
+
+
+def _build_success_report(context: WorkflowContext) -> SuccessReport:
+    """构建成功场景报告"""
+    final_sequence = None
+    sequence_length = None
+    structure_pdb_path = None
+    plddt_mean = None
+    confidence = None
+
+    for step_result in context.step_results.values():
+        outputs = step_result.outputs or {}
+
+        # 提取序列
+        if "sequence" in outputs:
+            final_sequence = outputs["sequence"]
+            sequence_length = len(final_sequence)
+
+        # 提取结构预测结果
+        if "pdb_path" in outputs:
+            structure_pdb_path = outputs["pdb_path"]
+            # 提取该步骤的指标
+            metrics = outputs.get("metrics", {})
+            if "plddt_mean" in metrics:
+                plddt_mean = metrics["plddt_mean"]
+            if "confidence" in metrics:
+                confidence = metrics["confidence"]
+
+    return SuccessReport(
+        final_sequence=final_sequence,
+        sequence_length=sequence_length,
+        structure_pdb_path=structure_pdb_path,
+        plddt_mean=plddt_mean,
+        confidence=confidence,
+    )
+
+
+def _build_failure_report(context: WorkflowContext) -> FailureReport:
+    """构建失败场景报告"""
+    failed_step_id = None
+    failed_tool = None
+    failure_type = None
+    error_message = None
+    safety_action = None
+    safety_reason = None
+    suggested_next_steps = []
+
+    # 查找失败的步骤
+    for step_result in context.step_results.values():
+        if step_result.status == "failed":
+            failed_step_id = step_result.step_id
+            failed_tool = step_result.tool
+            failure_type = step_result.failure_type
+            error_message = step_result.error_message
+            break
+
+    # 从安全事件中提取信息
+    for safety_event in context.safety_events:
+        if safety_event.action in ("warn", "block"):
+            safety_action = safety_event.action
+            # 提取安全风险原因
+            for flag in safety_event.risk_flags:
+                if flag.level in ("warn", "block"):
+                    safety_reason = flag.message
+                    break
+            break
+
+    # 生成建议的下一步
+    if failure_type == "tool_execution_error":
+        suggested_next_steps.append("检查工具配置和依赖环境")
+        suggested_next_steps.append("尝试使用备用工具执行")
+    elif failure_type == "validation_error":
+        suggested_next_steps.append("检查输入参数是否符合约束")
+        suggested_next_steps.append("调整设计目标或约束条件")
+    elif safety_action == "block":
+        suggested_next_steps.append("审查安全策略并调整输入")
+        suggested_next_steps.append("联系管理员解除安全限制")
+    else:
+        suggested_next_steps.append("查看详细日志分析失败原因")
+        suggested_next_steps.append("考虑使用 replan 功能重新规划")
+
+    return FailureReport(
+        failed_step_id=failed_step_id,
+        failed_tool=failed_tool,
+        failure_type=failure_type,
+        error_message=error_message,
+        safety_action=safety_action,
+        safety_reason=safety_reason,
+        suggested_next_steps=suggested_next_steps,
+    )
+
+
+def _determine_task_status(context: WorkflowContext) -> str:
+    """判断任务最终状态"""
+    has_failed = False
+    has_success = False
+
+    for step_result in context.step_results.values():
+        if step_result.status == "failed":
+            has_failed = True
+        elif step_result.status == "success":
+            has_success = True
+
+    # 检查安全事件是否导致阻断
+    for safety_event in context.safety_events:
+        if safety_event.action == "block":
+            return "failed"
+
+    if has_failed:
+        return "failed" if not has_success else "partial"
+    return "success"
+
+
+def generate_de_novo_report(context: WorkflowContext) -> DeNovoReport:
+    """生成 de novo 设计任务的结构化报告"""
+    task = context.task
+    status = _determine_task_status(context)
+
+    # 构建步骤摘要
+    step_summaries = []
+    if context.plan:
+        for plan_step in context.plan.steps:
+            step_result = context.step_results.get(plan_step.id)
+            if step_result:
+                step_summaries.append(_build_step_summary(step_result))
+    else:
+        for step_result in context.step_results.values():
+            step_summaries.append(_build_step_summary(step_result))
+
+    # 根据状态构建成功或失败报告
+    success_report = None
+    failure_report = None
+    if status == "success":
+        success_report = _build_success_report(context)
+    else:
+        failure_report = _build_failure_report(context)
+        # 部分成功时也包含成功部分
+        if status == "partial":
+            success_report = _build_success_report(context)
+
+    return DeNovoReport(
+        task_id=task.task_id,
+        task_description=task.goal,
+        design_goal=_extract_goal_type(task) or "de_novo_design",
+        created_at=now_iso(),
+        status=status,
+        tool_chain=_build_tool_chain_info(context),
+        step_summaries=step_summaries,
+        success_report=success_report,
+        failure_report=failure_report,
+    )
+
+
+def _render_de_novo_markdown(report: DeNovoReport) -> str:
+    """将 DeNovoReport 渲染为 Markdown 格式"""
+    lines = []
+
+    # 标题
+    lines.append(f"# De Novo 蛋白设计报告")
+    lines.append("")
+
+    # 任务概览
+    lines.append("## 任务概览")
+    lines.append("")
+    lines.append(f"- **任务 ID**: `{report.task_id}`")
+    lines.append(f"- **设计目标**: {report.task_description}")
+    lines.append(f"- **任务类型**: {report.design_goal}")
+    lines.append(f"- **生成时间**: {report.created_at}")
+    status_emoji = {"success": "✅", "failed": "❌", "partial": "⚠️"}.get(
+        report.status, "❓"
+    )
+    lines.append(f"- **执行状态**: {status_emoji} {report.status}")
+    lines.append("")
+
+    # 工具链
+    lines.append("## 工具链")
+    lines.append("")
+    if report.tool_chain.description:
+        lines.append(f"**执行链路**: {report.tool_chain.description}")
+    else:
+        lines.append("未识别到标准工具链")
+    lines.append("")
+
+    # 执行步骤
+    lines.append("## 执行步骤")
+    lines.append("")
+    for step in report.step_summaries:
+        step_emoji = {"success": "✅", "failed": "❌", "skipped": "⚠️"}.get(
+            step.status, "❓"
+        )
+        lines.append(f"### {step.step_id}: {step.tool} {step_emoji}")
+        lines.append("")
+
+        if step.inputs_summary:
+            lines.append("**输入**:")
+            for key, value in step.inputs_summary.items():
+                lines.append(f"- `{key}`: {value}")
+            lines.append("")
+
+        if step.outputs_summary:
+            lines.append("**输出**:")
+            for key, value in step.outputs_summary.items():
+                if isinstance(value, dict):
+                    lines.append(f"- `{key}`:")
+                    for k, v in value.items():
+                        lines.append(f"  - `{k}`: {v}")
+                else:
+                    lines.append(f"- `{key}`: {value}")
+            lines.append("")
+
+        if step.error_message:
+            lines.append(f"**错误**: {step.error_message}")
+            lines.append("")
+
+    # 结果
+    if report.success_report:
+        lines.append("## 设计结果")
+        lines.append("")
+        sr = report.success_report
+        if sr.final_sequence:
+            seq_display = sr.final_sequence
+            if len(seq_display) > 60:
+                seq_display = f"{seq_display[:30]}...{seq_display[-30:]}"
+            lines.append(f"- **设计序列**: `{seq_display}`")
+        if sr.sequence_length:
+            lines.append(f"- **序列长度**: {sr.sequence_length} aa")
+        if sr.structure_pdb_path:
+            lines.append(f"- **结构文件**: `{sr.structure_pdb_path}`")
+        if sr.plddt_mean is not None:
+            lines.append(f"- **pLDDT 均值**: {sr.plddt_mean:.2f}")
+        if sr.confidence:
+            lines.append(f"- **置信度等级**: {sr.confidence}")
+        lines.append("")
+
+    if report.failure_report:
+        lines.append("## 失败分析")
+        lines.append("")
+        fr = report.failure_report
+        if fr.failed_step_id:
+            lines.append(f"- **失败步骤**: {fr.failed_step_id}")
+        if fr.failed_tool:
+            lines.append(f"- **失败工具**: {fr.failed_tool}")
+        if fr.failure_type:
+            lines.append(f"- **失败类型**: {fr.failure_type}")
+        if fr.error_message:
+            lines.append(f"- **错误信息**: {fr.error_message}")
+        if fr.safety_action:
+            lines.append(f"- **安全判定**: {fr.safety_action}")
+        if fr.safety_reason:
+            lines.append(f"- **安全原因**: {fr.safety_reason}")
+        lines.append("")
+
+        if fr.suggested_next_steps:
+            lines.append("### 建议的下一步")
+            lines.append("")
+            for i, step in enumerate(fr.suggested_next_steps, 1):
+                lines.append(f"{i}. {step}")
+            lines.append("")
+
+    # 页脚
+    lines.append("---")
+    lines.append("*此报告由 SummarizerAgent 自动生成*")
+
+    return "\n".join(lines)
+
+
+def write_de_novo_reports(
+    report: DeNovoReport,
+    report_dir: Path,
+) -> tuple[Path, Path]:
+    """写入 de novo 报告文件（JSON 和 Markdown）
+
+    Returns:
+        (json_path, markdown_path): 两个报告文件的路径
+    """
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = report_dir / f"{report.task_id}_denovo.json"
+    md_path = report_dir / f"{report.task_id}_denovo.md"
+
+    # 写入 JSON
+    json_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+
+    # 写入 Markdown
+    md_content = _render_de_novo_markdown(report)
+    md_path.write_text(md_content, encoding="utf-8")
+
+    return json_path, md_path

--- a/tests/unit/test_summarizer_agent.py
+++ b/tests/unit/test_summarizer_agent.py
@@ -1,9 +1,26 @@
 """SummarizerAgent单元测试"""
+import json
 import pytest
 from pathlib import Path
-from src.agents.summarizer import SummarizerAgent
+from src.agents.summarizer import (
+    SummarizerAgent,
+    generate_de_novo_report,
+    write_de_novo_reports,
+    _is_de_novo_task,
+    _render_de_novo_markdown,
+    DeNovoReport,
+)
 from src.workflow.context import WorkflowContext
-from src.models.contracts import DesignResult, StepResult
+from src.models.contracts import (
+    DesignResult,
+    StepResult,
+    ProteinDesignTask,
+    Plan,
+    PlanStep,
+    SafetyResult,
+    RiskFlag,
+    now_iso,
+)
 
 
 @pytest.mark.unit
@@ -413,3 +430,379 @@ class TestSummarizerAgent:
         assert result.structure_pdb_path == "/path/to/alphafold_structure.pdb"
         assert result.scores["plddt_mean"] == 0.95
         assert result.scores["confidence"] == "very_high"
+
+
+@pytest.mark.unit
+class TestDeNovoReport:
+    """De Novo 设计报告测试类"""
+
+    @pytest.fixture
+    def de_novo_task(self) -> ProteinDesignTask:
+        """创建 de novo 设计任务"""
+        return ProteinDesignTask(
+            task_id="denovo_test_001",
+            goal="de_novo_design",
+            constraints={
+                "goal_type": "de_novo_design",
+                "length_range": [50, 100],
+            },
+            metadata={},
+        )
+
+    @pytest.fixture
+    def de_novo_context(self, de_novo_task: ProteinDesignTask) -> WorkflowContext:
+        """创建 de novo 设计的工作流上下文"""
+        plan = Plan(
+            task_id=de_novo_task.task_id,
+            steps=[
+                PlanStep(id="S1", tool="protein_mpnn", inputs={"goal": "de_novo_design"}),
+                PlanStep(id="S2", tool="esmfold", inputs={"sequence": "S1.sequence"}),
+            ],
+            constraints=de_novo_task.constraints,
+            metadata={},
+        )
+        return WorkflowContext(
+            task=de_novo_task,
+            plan=plan,
+            step_results={},
+            safety_events=[],
+        )
+
+    def test_is_de_novo_task_with_goal_type(self, de_novo_task: ProteinDesignTask):
+        """测试通过 goal_type 识别 de novo 任务"""
+        assert _is_de_novo_task(de_novo_task) is True
+
+    def test_is_de_novo_task_with_goal_string(self):
+        """测试通过 goal 字符串识别 de novo 任务"""
+        task = ProteinDesignTask(
+            task_id="test_001",
+            goal="de_novo_design",
+            constraints={},
+            metadata={},
+        )
+        assert _is_de_novo_task(task) is True
+
+    def test_is_de_novo_task_returns_false_for_other_tasks(self, sample_task: ProteinDesignTask):
+        """测试非 de novo 任务返回 False"""
+        assert _is_de_novo_task(sample_task) is False
+
+    def test_generate_de_novo_report_success(
+        self, de_novo_context: WorkflowContext, tmp_path: Path
+    ):
+        """测试成功场景的 de novo 报告生成"""
+        context = de_novo_context
+
+        # 添加序列设计步骤结果
+        mpnn_result = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="success",
+            inputs={"goal": "de_novo_design", "length_range": [50, 100]},
+            outputs={
+                "sequence": "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR" * 2,
+                "sequence_score": -2.5,
+            },
+            metrics={"exec_type": "python"},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+        context.step_results["S1"] = mpnn_result
+
+        # 添加结构预测步骤结果
+        esmfold_result = StepResult(
+            task_id=context.task.task_id,
+            step_id="S2",
+            tool="esmfold",
+            status="success",
+            inputs={"sequence": "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR" * 2},
+            outputs={
+                "pdb_path": "/path/to/structure.pdb",
+                "metrics": {
+                    "plddt_mean": 0.88,
+                    "confidence": "high",
+                },
+            },
+            metrics={"exec_type": "nextflow"},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+        context.step_results["S2"] = esmfold_result
+
+        report = generate_de_novo_report(context)
+
+        # 验证基本信息
+        assert report.task_id == "denovo_test_001"
+        assert report.status == "success"
+        assert report.design_goal == "de_novo_design"
+
+        # 验证工具链
+        assert report.tool_chain.sequence_design_tool == "protein_mpnn"
+        assert report.tool_chain.structure_prediction_tool == "esmfold"
+
+        # 验证步骤摘要
+        assert len(report.step_summaries) == 2
+        assert report.step_summaries[0].step_id == "S1"
+        assert report.step_summaries[1].step_id == "S2"
+
+        # 验证成功报告
+        assert report.success_report is not None
+        assert report.success_report.sequence_length == 70
+        assert report.success_report.structure_pdb_path == "/path/to/structure.pdb"
+        assert report.success_report.plddt_mean == 0.88
+        assert report.success_report.confidence == "high"
+
+        # 验证没有失败报告
+        assert report.failure_report is None
+
+    def test_generate_de_novo_report_failure(
+        self, de_novo_context: WorkflowContext, tmp_path: Path
+    ):
+        """测试失败场景的 de novo 报告生成"""
+        context = de_novo_context
+
+        # 添加失败的步骤结果
+        failed_result = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="failed",
+            failure_type="tool_execution_error",
+            error_message="CUDA out of memory",
+            inputs={"goal": "de_novo_design"},
+            outputs={},
+            metrics={},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+        context.step_results["S1"] = failed_result
+
+        report = generate_de_novo_report(context)
+
+        # 验证状态
+        assert report.status == "failed"
+
+        # 验证失败报告
+        assert report.failure_report is not None
+        assert report.failure_report.failed_step_id == "S1"
+        assert report.failure_report.failed_tool == "protein_mpnn"
+        assert report.failure_report.failure_type == "tool_execution_error"
+        assert report.failure_report.error_message == "CUDA out of memory"
+        assert len(report.failure_report.suggested_next_steps) > 0
+
+    def test_generate_de_novo_report_with_safety_block(
+        self, de_novo_context: WorkflowContext
+    ):
+        """测试安全阻断场景的 de novo 报告生成"""
+        context = de_novo_context
+
+        # 添加安全事件
+        safety_event = SafetyResult(
+            task_id=context.task.task_id,
+            phase="input",
+            scope="task",
+            risk_flags=[
+                RiskFlag(
+                    level="block",
+                    code="BIOSECURITY_RISK",
+                    message="检测到潜在的生物安全风险序列",
+                    scope="input",
+                )
+            ],
+            action="block",
+            timestamp=now_iso(),
+        )
+        context.safety_events.append(safety_event)
+
+        report = generate_de_novo_report(context)
+
+        # 验证状态
+        assert report.status == "failed"
+
+        # 验证失败报告包含安全信息
+        assert report.failure_report is not None
+        assert report.failure_report.safety_action == "block"
+        assert "生物安全风险" in report.failure_report.safety_reason
+
+    def test_write_de_novo_reports(
+        self, de_novo_context: WorkflowContext, tmp_path: Path
+    ):
+        """测试写入 de novo 报告文件"""
+        context = de_novo_context
+
+        # 添加成功的步骤结果
+        context.step_results["S1"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="success",
+            outputs={"sequence": "MKFLKFSLLTAV"},
+            metrics={},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+
+        report = generate_de_novo_report(context)
+        report_dir = tmp_path / "reports"
+
+        json_path, md_path = write_de_novo_reports(report, report_dir)
+
+        # 验证文件创建
+        assert json_path.exists()
+        assert md_path.exists()
+
+        # 验证 JSON 内容
+        json_content = json.loads(json_path.read_text())
+        assert json_content["task_id"] == "denovo_test_001"
+        assert json_content["status"] == "success"
+
+        # 验证 Markdown 内容
+        md_content = md_path.read_text()
+        assert "# De Novo 蛋白设计报告" in md_content
+        assert "denovo_test_001" in md_content
+        assert "✅" in md_content  # 成功状态
+
+    def test_render_de_novo_markdown_success(self, de_novo_context: WorkflowContext):
+        """测试成功场景的 Markdown 渲染"""
+        context = de_novo_context
+        context.step_results["S1"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="success",
+            outputs={"sequence": "MKFLKFSLLTAV"},
+            metrics={},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+
+        report = generate_de_novo_report(context)
+        md_content = _render_de_novo_markdown(report)
+
+        # 验证 Markdown 结构
+        assert "## 任务概览" in md_content
+        assert "## 工具链" in md_content
+        assert "## 执行步骤" in md_content
+        assert "## 设计结果" in md_content
+        assert "✅ success" in md_content
+
+    def test_render_de_novo_markdown_failure(self, de_novo_context: WorkflowContext):
+        """测试失败场景的 Markdown 渲染"""
+        context = de_novo_context
+        context.step_results["S1"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="failed",
+            failure_type="tool_execution_error",
+            error_message="Connection timeout",
+            outputs={},
+            metrics={},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+
+        report = generate_de_novo_report(context)
+        md_content = _render_de_novo_markdown(report)
+
+        # 验证 Markdown 结构
+        assert "## 失败分析" in md_content
+        assert "### 建议的下一步" in md_content
+        assert "❌ failed" in md_content
+        assert "Connection timeout" in md_content
+
+    def test_summarizer_generates_de_novo_reports(
+        self, de_novo_context: WorkflowContext, tmp_path: Path, monkeypatch
+    ):
+        """测试 SummarizerAgent 为 de novo 任务生成专用报告"""
+        import src.agents.summarizer as summarizer_module
+
+        context = de_novo_context
+
+        # 添加步骤结果
+        context.step_results["S1"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="success",
+            outputs={"sequence": "MKFLKFSLLTAV" * 5},
+            metrics={"exec_type": "python"},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+        context.step_results["S2"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S2",
+            tool="esmfold",
+            status="success",
+            outputs={
+                "pdb_path": "/path/to/output.pdb",
+                "metrics": {"plddt_mean": 0.85},
+            },
+            metrics={"exec_type": "nextflow"},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+
+        # 使用临时目录
+        report_dir = tmp_path / "nf" / "output" / "reports"
+        monkeypatch.setattr(
+            summarizer_module,
+            "Path",
+            lambda p: tmp_path / p if p == "output/reports" else Path(p),
+        )
+
+        summarizer = SummarizerAgent()
+        result = summarizer.summarize(context)
+
+        # 验证 de novo 报告路径在 metadata 中
+        assert "de_novo_json_path" in result.metadata
+        assert "de_novo_markdown_path" in result.metadata
+        assert result.metadata["report_source"] == "de_novo_markdown"
+
+        # 验证报告文件存在
+        json_path = Path(result.metadata["de_novo_json_path"])
+        md_path = Path(result.metadata["de_novo_markdown_path"])
+        assert json_path.exists()
+        assert md_path.exists()
+
+    def test_de_novo_report_partial_success(self, de_novo_context: WorkflowContext):
+        """测试部分成功场景（第一步成功，第二步失败）"""
+        context = de_novo_context
+
+        # S1 成功
+        context.step_results["S1"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="success",
+            outputs={"sequence": "MKFLKFSLLTAV"},
+            metrics={},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+
+        # S2 失败
+        context.step_results["S2"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S2",
+            tool="esmfold",
+            status="failed",
+            failure_type="tool_execution_error",
+            error_message="GPU unavailable",
+            outputs={},
+            metrics={},
+            risk_flags=[],
+            timestamp=now_iso(),
+        )
+
+        report = generate_de_novo_report(context)
+
+        # 验证部分成功状态
+        assert report.status == "partial"
+
+        # 验证同时包含成功和失败信息
+        assert report.success_report is not None
+        assert report.success_report.final_sequence == "MKFLKFSLLTAV"
+        assert report.failure_report is not None
+        assert report.failure_report.failed_step_id == "S2"


### PR DESCRIPTION
# feat(summarizer): 从头设计报告最小版本

## 总结

为 SummarizerAgent 添加针对 `de_novo_design` 任务的专用报告生成能力，输出结构化 JSON 和人类可读 Markdown 双格式报告，满足论文写作和系统展示需求。

## 背景

- Summarizer 已具备基础汇总能力，但缺乏针对特定任务类型的结构化报告
- Week5 目标以"可理解性"为首要，为后续论文写作打基础
- 需要清晰展示 de novo 设计流程：序列设计 → 结构预测

## 变更范围

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `src/agents/summarizer.py` | 修改 | 添加 de novo 报告数据模型和生成逻辑 |
| `tests/unit/test_summarizer_agent.py` | 修改 | 添加 11 个测试用例 |
| `scripts/generate_denovo_report_demo.py` | 新增 | 演示脚本 |

## 变更具体内容

### 1. De Novo 报告数据模型

新增 Pydantic 模型用于结构化表达报告内容：

- **`StepSummary`**: 单个步骤的执行摘要（工具、状态、输入/输出）
- **`ToolChainInfo`**: 工具链信息（序列设计工具 → 结构预测工具）
- **`SuccessReport`**: 成功场景内容（序列、PDB路径、pLDDT、置信度）
- **`FailureReport`**: 失败场景内容（失败步骤、原因、安全判定、建议）
- **`DeNovoReport`**: 完整报告结构

### 2. 报告生成逻辑

```
WorkflowContext
    ↓
_is_de_novo_task()  ──判断是否为 de novo 任务
    ↓
generate_de_novo_report()
    ├── _build_tool_chain_info()     ──识别工具链
    ├── _build_step_summary()        ──构建步骤摘要
    ├── _determine_task_status()     ──判断成功/失败/部分成功
    ├── _build_success_report()      ──成功场景
    └── _build_failure_report()      ──失败场景 + 建议
    ↓
write_de_novo_reports()
    ├── JSON 报告  ──供系统/脚本使用
    └── Markdown 报告  ──供人类阅读
```

### 3. SummarizerAgent 集成

当检测到 de novo 任务时，自动生成专用报告：

- 报告路径记录在 `DesignResult.metadata` 中
- 优先使用 Markdown 作为主报告（`report_source: "de_novo_markdown"`）

### 4. Summarizer 当前能力

| 能力 | 说明 |
|------|------|
| 步骤结果汇总 | 从 `step_results` 提取序列、PDB、指标 |
| 可视化产物提取 | 支持 Plotly HTML、metrics JSON |
| 多格式报告 | JSON / HTML / Markdown |
| de novo 专用报告 | 成功/失败/部分成功三种场景 |
| 工具链识别 | 自动识别序列设计和结构预测工具 |

## 变更代码示例

### 成功场景报告（Markdown）

```markdown
# De Novo 蛋白设计报告

## 任务概览
- **任务 ID**: `denovo_success_001`
- **执行状态**: ✔ success

## 工具链
**执行链路**: 序列设计(protein_mpnn) → 结构预测(esmfold)

## 设计结果
- **设计序列**: `MKTAYIAKQRQISFVKSHFS...` (84 aa)
- **pLDDT 均值**: 0.87
- **置信度等级**: high
```

### 失败场景报告（Markdown）

```markdown
## 失败分析
- **失败步骤**: S2
- **失败工具**: esmfold
- **错误信息**: CUDA out of memory
- **安全判定**: warn

### 建议的下一步
1. 检查工具配置和依赖环境
2. 尝试使用备用工具执行
```

### 演示脚本使用

```bash
PYTHONPATH=. uv run python scripts/generate_denovo_report_demo.py
```

输出到 `output/reports/`:
- `denovo_success_001_denovo.json` / `.md`
- `denovo_failure_001_denovo.json` / `.md`

## 影响

- **向后兼容**: 非 de novo 任务行为不变
- **报告目录**: 统一使用 `output/reports/`（与其他产物一致）
- **测试覆盖**: 23 个测试全部通过

## 未来计划

- [ ] 支持更多任务类型的专用报告模板
- [ ] 报告可视化增强（嵌入结构图、pLDDT 分布图）
- [ ] 报告版本管理和对比功能

## 关联

- Closes #106
- 依赖 #103 (de novo 计划模板)
- 依赖 #104 (Executor 产物传递)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)