### PR TITLE
feat(remote): add PLM REST server reference implementation

### DIFF
--- a/configs/model_providers.json
+++ b/configs/model_providers.json
@@ -13,6 +13,22 @@
           "nvidia/esm2nv"
         ]
       }
+    },
+    "plm_rest": {
+      "provider_type": "plm_rest",
+      "description": "PLM remote REST service provider",
+      "base_url": "http://localhost:8100",
+      "api_key_env": "PLM_REST_API_TOKEN",
+      "timeout": 60,
+      "max_retries": 3,
+      "extra": {
+        "endpoints": {
+          "predict": "/predict",
+          "job": "/job/{id}",
+          "results": "/results/{id}"
+        },
+        "auth_header": "Authorization: Bearer <token>"
+      }
     }
   }
 }

--- a/scripts/remote/plm_rest_server/README.md
+++ b/scripts/remote/plm_rest_server/README.md
@@ -1,0 +1,118 @@
+# PLM REST 服务（参考实现）
+
+本目录提供可复用的 PLM 远程调用 REST 协议，以及可直接运行的参考实现。
+
+## 接口端点
+
+1. `POST /predict`
+- 请求：
+```json
+{
+  "task_id": "task_001",
+  "step_id": "S1",
+  "inputs": {
+    "goal": "design a soluble binder",
+    "length_range": [60, 120],
+    "num_candidates": 4,
+    "prompt": "MKT..."
+  }
+}
+```
+- 响应：
+```json
+{
+  "job_id": "plm_..."
+}
+```
+
+2. `GET /job/{id}`
+- 响应（`pending|running|completed|failed|unknown`）：
+```json
+{
+  "job_id": "plm_...",
+  "status": "completed"
+}
+```
+- 失败响应：
+```json
+{
+  "job_id": "plm_...",
+  "status": "failed",
+  "failure": {
+    "code": "REMOTE_JOB_FAILED",
+    "message": "...",
+    "failure_type": "tool_error",
+    "retryable": false
+  }
+}
+```
+
+3. `GET /results/{id}`
+- 响应：
+```json
+{
+  "job_id": "plm_...",
+  "outputs": {
+    "sequence": "ACDE...",
+    "candidates": [
+      {"sequence": "ACDE...", "score": 0.95}
+    ],
+    "artifacts": {
+      "fasta_path": "candidates.fasta",
+      "summary_path": "summary.json"
+    }
+  },
+  "artifacts": [
+    {
+      "name": "candidates.fasta",
+      "url": "http://host/files/plm_xxx/candidates.fasta",
+      "type": "file"
+    }
+  ]
+}
+```
+
+4. `GET /files/{job_id}/{filename}`
+- `artifacts[].url` 对应的产物下载端点。
+
+## 错误响应 Envelope
+
+所有非成功响应统一使用：
+```json
+{
+  "error": {
+    "code": "REMOTE_RESULTS_NOT_READY",
+    "message": "Job 'plm_xxx' is not completed",
+    "retryable": true,
+    "details": {}
+  }
+}
+```
+
+## 作业目录约定
+
+每个作业落盘到：
+`<remote_base_dir>/<job_id>/`
+
+必需文件：
+- `status.json`
+- `outputs.json`（completed 时生成）
+- `artifacts/`
+
+## 运行方式
+
+示例：
+```bash
+uv run uvicorn scripts.remote.plm_rest_server.app:app --host 0.0.0.0 --port 8100
+```
+
+可选环境变量：
+- `PLM_REST_BASE_DIR`（默认：`./output/remote/plm_jobs`）
+- `PLM_REST_API_TOKEN`（若设置，请求需携带 `Authorization: Bearer <token>`）
+
+## Runner
+
+`run_plm_job.py` 是当前 issue 范围内的 stub runner。
+- 读取标准化输入 payload
+- 生成最小输出：`outputs.sequence` 与 `outputs.candidates`
+- 写入产物（`candidates.fasta`、`summary.json`）

--- a/scripts/remote/plm_rest_server/app.py
+++ b/scripts/remote/plm_rest_server/app.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel, Field
+
+from scripts.remote.plm_rest_server.run_plm_job import run_plm_job
+
+
+ALLOWED_STATUSES = {"pending", "running", "completed", "failed", "unknown"}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _error_response(
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    retryable: bool,
+    details: Optional[Dict[str, Any]] = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error": {
+                "code": code,
+                "message": message,
+                "retryable": retryable,
+                "details": details or {},
+            }
+        },
+    )
+
+
+class APIError(Exception):
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+        retryable: bool = False,
+        details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.details = details or {}
+
+
+class PredictRequest(BaseModel):
+    task_id: str
+    step_id: str
+    inputs: Dict[str, Any] = Field(default_factory=dict)
+
+
+def _read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def _job_dir(base_dir: Path, job_id: str) -> Path:
+    return base_dir / job_id
+
+
+def _status_path(base_dir: Path, job_id: str) -> Path:
+    return _job_dir(base_dir, job_id) / "status.json"
+
+
+def _outputs_path(base_dir: Path, job_id: str) -> Path:
+    return _job_dir(base_dir, job_id) / "outputs.json"
+
+
+def _input_path(base_dir: Path, job_id: str) -> Path:
+    return _job_dir(base_dir, job_id) / "input.json"
+
+
+def _execute_job(base_dir: Path, job_id: str) -> None:
+    job_dir = _job_dir(base_dir, job_id)
+    input_payload = _read_json(_input_path(base_dir, job_id), {})
+    run_plm_job(job_id=job_id, job_dir=job_dir, input_payload=input_payload)
+
+
+def _build_app(base_dir: Path, api_token: str) -> FastAPI:
+    app = FastAPI(title="PLM REST Server", version="0.1.0")
+    app.state.remote_base_dir = base_dir
+    app.state.api_token = api_token
+
+    @app.middleware("http")
+    async def auth_middleware(request: Request, call_next):  # type: ignore[no-untyped-def]
+        token = app.state.api_token
+        if token:
+            auth_header = request.headers.get("Authorization", "")
+            expected = f"Bearer {token}"
+            if auth_header != expected:
+                return _error_response(
+                    status_code=401,
+                    code="UNAUTHORIZED",
+                    message="Missing or invalid bearer token",
+                    retryable=False,
+                )
+        return await call_next(request)
+
+    @app.exception_handler(APIError)
+    async def handle_api_error(_request: Request, exc: APIError) -> JSONResponse:
+        return _error_response(
+            status_code=exc.status_code,
+            code=exc.code,
+            message=exc.message,
+            retryable=exc.retryable,
+            details=exc.details,
+        )
+
+    @app.exception_handler(HTTPException)
+    async def handle_http_exception(_request: Request, exc: HTTPException) -> JSONResponse:
+        return _error_response(
+            status_code=exc.status_code,
+            code="HTTP_EXCEPTION",
+            message=str(exc.detail),
+            retryable=False,
+        )
+
+    @app.exception_handler(Exception)
+    async def handle_unexpected(_request: Request, exc: Exception) -> JSONResponse:
+        return _error_response(
+            status_code=500,
+            code="INTERNAL_SERVER_ERROR",
+            message="Unhandled server error",
+            retryable=True,
+            details={"exception": str(exc)},
+        )
+
+    @app.post("/predict")
+    def predict(payload: PredictRequest, background_tasks: BackgroundTasks) -> Dict[str, str]:
+        job_id = f"plm_{uuid4().hex}"
+        job_dir = _job_dir(base_dir, job_id)
+        (job_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+
+        _write_json(
+            _status_path(base_dir, job_id),
+            {
+                "job_id": job_id,
+                "status": "pending",
+                "updated_at": _now_iso(),
+            },
+        )
+        _write_json(_input_path(base_dir, job_id), payload.model_dump())
+        background_tasks.add_task(_execute_job, base_dir, job_id)
+        return {"job_id": job_id}
+
+    @app.get("/job/{job_id}")
+    def get_job_status(job_id: str) -> Dict[str, Any]:
+        status_payload = _read_json(_status_path(base_dir, job_id), None)
+        if status_payload is None:
+            raise APIError(
+                status_code=404,
+                code="REMOTE_JOB_NOT_FOUND",
+                message=f"Job '{job_id}' does not exist",
+                retryable=False,
+                details={"job_id": job_id},
+            )
+
+        status = str(status_payload.get("status", "unknown")).lower()
+        if status not in ALLOWED_STATUSES:
+            status = "unknown"
+
+        response = {
+            "job_id": job_id,
+            "status": status,
+        }
+        if status == "failed" and isinstance(status_payload.get("failure"), dict):
+            response["failure"] = status_payload["failure"]
+        return response
+
+    @app.get("/results/{job_id}")
+    def get_results(job_id: str, request: Request) -> Dict[str, Any]:
+        status_payload = _read_json(_status_path(base_dir, job_id), None)
+        if status_payload is None:
+            raise APIError(
+                status_code=404,
+                code="REMOTE_JOB_NOT_FOUND",
+                message=f"Job '{job_id}' does not exist",
+                retryable=False,
+                details={"job_id": job_id},
+            )
+
+        status = str(status_payload.get("status", "unknown")).lower()
+        if status != "completed":
+            raise APIError(
+                status_code=409,
+                code="REMOTE_RESULTS_NOT_READY",
+                message=f"Job '{job_id}' is not completed",
+                retryable=status in {"pending", "running"},
+                details={"job_id": job_id, "status": status},
+            )
+
+        outputs = _read_json(_outputs_path(base_dir, job_id), {})
+        artifact_dir = _job_dir(base_dir, job_id) / "artifacts"
+        artifacts = []
+        if artifact_dir.exists():
+            for file_path in sorted(artifact_dir.iterdir()):
+                if not file_path.is_file():
+                    continue
+                artifacts.append(
+                    {
+                        "name": file_path.name,
+                        "url": str(
+                            request.url_for(
+                                "download_artifact",
+                                job_id=job_id,
+                                filename=file_path.name,
+                            )
+                        ),
+                        "type": "file",
+                    }
+                )
+
+        return {
+            "job_id": job_id,
+            "outputs": outputs,
+            "artifacts": artifacts,
+        }
+
+    @app.get("/files/{job_id}/{filename}", name="download_artifact")
+    def download_artifact(job_id: str, filename: str) -> FileResponse:
+        path = _job_dir(base_dir, job_id) / "artifacts" / filename
+        if not path.exists() or not path.is_file():
+            raise APIError(
+                status_code=404,
+                code="ARTIFACT_NOT_FOUND",
+                message=f"Artifact '{filename}' does not exist for job '{job_id}'",
+                retryable=False,
+            )
+        return FileResponse(path=path)
+
+    return app
+
+
+def create_app(
+    *,
+    remote_base_dir: Optional[Path] = None,
+    api_token: Optional[str] = None,
+) -> FastAPI:
+    base_dir = Path(remote_base_dir or os.getenv("PLM_REST_BASE_DIR", "./output/remote/plm_jobs"))
+    base_dir.mkdir(parents=True, exist_ok=True)
+    token = api_token if api_token is not None else os.getenv("PLM_REST_API_TOKEN", "")
+    return _build_app(base_dir=base_dir, api_token=token)
+
+
+app = create_app()

--- a/scripts/remote/plm_rest_server/run_plm_job.py
+++ b/scripts/remote/plm_rest_server/run_plm_job.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+AMINO_ACIDS = "ACDEFGHIKLMNPQRSTVWY"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
+def _normalize_length_range(value: Any) -> tuple[int, int]:
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        min_len = max(1, int(value[0]))
+        max_len = max(min_len, int(value[1]))
+        return min_len, max_len
+    return (60, 120)
+
+
+def _normalize_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(parsed, 1)
+
+
+def _seed_rng(*parts: str) -> random.Random:
+    text = "|".join(parts)
+    seed = int(hashlib.sha256(text.encode("utf-8")).hexdigest(), 16) % (2**32)
+    return random.Random(seed)
+
+
+def _generate_candidates(
+    rng: random.Random,
+    *,
+    min_len: int,
+    max_len: int,
+    num_candidates: int,
+) -> List[Dict[str, Any]]:
+    candidates: List[Dict[str, Any]] = []
+    for _ in range(num_candidates):
+        seq_len = rng.randint(min_len, max_len)
+        sequence = "".join(rng.choice(AMINO_ACIDS) for _ in range(seq_len))
+        score = round(rng.uniform(0.5, 0.99), 4)
+        candidates.append(
+            {
+                "sequence": sequence,
+                "score": score,
+            }
+        )
+    return candidates
+
+
+def _write_artifacts(
+    *,
+    job_dir: Path,
+    job_id: str,
+    task_id: str,
+    step_id: str,
+    candidates: List[Dict[str, Any]],
+) -> None:
+    artifact_dir = job_dir / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    fasta_path = artifact_dir / "candidates.fasta"
+    with fasta_path.open("w", encoding="utf-8") as handle:
+        for idx, item in enumerate(candidates, start=1):
+            handle.write(f">{job_id}_candidate_{idx}\n")
+            handle.write(f"{item['sequence']}\n")
+
+    summary_path = artifact_dir / "summary.json"
+    summary = {
+        "job_id": job_id,
+        "task_id": task_id,
+        "step_id": step_id,
+        "num_candidates": len(candidates),
+        "top_score": max(item["score"] for item in candidates),
+    }
+    _write_json(summary_path, summary)
+
+
+def run_plm_job(
+    *,
+    job_id: str,
+    job_dir: Path,
+    input_payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    status_path = job_dir / "status.json"
+    outputs_path = job_dir / "outputs.json"
+    job_dir.mkdir(parents=True, exist_ok=True)
+
+    task_id = str(input_payload.get("task_id", "unknown"))
+    step_id = str(input_payload.get("step_id", "unknown"))
+    inputs = input_payload.get("inputs", {})
+    if not isinstance(inputs, dict):
+        inputs = {}
+
+    _write_json(
+        status_path,
+        {
+            "job_id": job_id,
+            "status": "running",
+            "updated_at": _now_iso(),
+        },
+    )
+
+    try:
+        if bool(inputs.get("force_fail", False)):
+            raise RuntimeError("force_fail requested by input payload")
+
+        length_range = _normalize_length_range(inputs.get("length_range"))
+        num_candidates = _normalize_positive_int(inputs.get("num_candidates"), 4)
+        goal = str(inputs.get("goal", ""))
+        prompt = str(inputs.get("prompt", ""))
+        rng = _seed_rng(job_id, task_id, step_id, goal, prompt)
+
+        candidates = _generate_candidates(
+            rng,
+            min_len=length_range[0],
+            max_len=length_range[1],
+            num_candidates=num_candidates,
+        )
+        selected = max(candidates, key=lambda item: item["score"])
+
+        _write_artifacts(
+            job_dir=job_dir,
+            job_id=job_id,
+            task_id=task_id,
+            step_id=step_id,
+            candidates=candidates,
+        )
+
+        outputs = {
+            "sequence": selected["sequence"],
+            "candidates": candidates,
+            "artifacts": {
+                "fasta_path": "candidates.fasta",
+                "summary_path": "summary.json",
+            },
+        }
+        _write_json(outputs_path, outputs)
+        _write_json(
+            status_path,
+            {
+                "job_id": job_id,
+                "status": "completed",
+                "updated_at": _now_iso(),
+            },
+        )
+        return outputs
+
+    except Exception as exc:
+        failure = {
+            "code": "REMOTE_JOB_FAILED",
+            "message": str(exc),
+            "failure_type": "tool_error",
+            "retryable": False,
+        }
+        _write_json(
+            status_path,
+            {
+                "job_id": job_id,
+                "status": "failed",
+                "updated_at": _now_iso(),
+                "failure": failure,
+            },
+        )
+        return {"failure": failure}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run a PLM job (stub implementation)")
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--job-dir", required=True)
+    parser.add_argument("--input-json", required=True)
+    args = parser.parse_args()
+
+    job_dir = Path(args.job_dir)
+    input_json = Path(args.input_json)
+    payload = json.loads(input_json.read_text(encoding="utf-8"))
+    run_plm_job(job_id=args.job_id, job_dir=job_dir, input_payload=payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_plm_rest_server.py
+++ b/tests/unit/test_plm_rest_server.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from scripts.remote.plm_rest_server.app import create_app
+from scripts.remote.plm_rest_server.run_plm_job import run_plm_job
+
+
+def test_plm_rest_happy_path(tmp_path: Path) -> None:
+    app = create_app(remote_base_dir=tmp_path)
+    client = TestClient(app)
+
+    response = client.post(
+        "/predict",
+        json={
+            "task_id": "task_001",
+            "step_id": "S1",
+            "inputs": {
+                "length_range": [12, 16],
+                "num_candidates": 3,
+            },
+        },
+    )
+    assert response.status_code == 200
+    job_id = response.json()["job_id"]
+
+    status_response = client.get(f"/job/{job_id}")
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "completed"
+
+    results_response = client.get(f"/results/{job_id}")
+    assert results_response.status_code == 200
+    body = results_response.json()
+    assert body["job_id"] == job_id
+    assert "sequence" in body["outputs"]
+    assert "candidates" in body["outputs"]
+    assert len(body["outputs"]["candidates"]) == 3
+    assert len(body["artifacts"]) >= 1
+
+    artifact = body["artifacts"][0]
+    assert artifact["url"].startswith("http://testserver/files/")
+    download = client.get(artifact["url"])
+    assert download.status_code == 200
+
+
+def test_plm_rest_failed_job_contains_failure(tmp_path: Path) -> None:
+    app = create_app(remote_base_dir=tmp_path)
+    client = TestClient(app)
+
+    response = client.post(
+        "/predict",
+        json={
+            "task_id": "task_002",
+            "step_id": "S1",
+            "inputs": {
+                "force_fail": True,
+            },
+        },
+    )
+    job_id = response.json()["job_id"]
+
+    status_response = client.get(f"/job/{job_id}")
+    assert status_response.status_code == 200
+    payload = status_response.json()
+    assert payload["status"] == "failed"
+    assert payload["failure"]["code"] == "REMOTE_JOB_FAILED"
+
+    results_response = client.get(f"/results/{job_id}")
+    assert results_response.status_code == 409
+    error_payload = results_response.json()["error"]
+    assert error_payload["code"] == "REMOTE_RESULTS_NOT_READY"
+
+
+def test_plm_rest_error_envelope_and_auth(tmp_path: Path) -> None:
+    app = create_app(remote_base_dir=tmp_path, api_token="token-123")
+    client = TestClient(app)
+
+    unauthorized = client.get("/job/not_exist")
+    assert unauthorized.status_code == 401
+    assert unauthorized.json()["error"]["code"] == "UNAUTHORIZED"
+
+    not_found = client.get(
+        "/job/not_exist",
+        headers={"Authorization": "Bearer token-123"},
+    )
+    assert not_found.status_code == 404
+    assert not_found.json()["error"]["code"] == "REMOTE_JOB_NOT_FOUND"
+
+
+def test_run_plm_job_writes_expected_files(tmp_path: Path) -> None:
+    job_id = "plm_job_direct_001"
+    job_dir = tmp_path / job_id
+    payload = {
+        "task_id": "task_003",
+        "step_id": "S3",
+        "inputs": {
+            "num_candidates": 2,
+            "length_range": [8, 10],
+        },
+    }
+
+    outputs = run_plm_job(job_id=job_id, job_dir=job_dir, input_payload=payload)
+    assert "sequence" in outputs
+    assert len(outputs["candidates"]) == 2
+
+    status = json.loads((job_dir / "status.json").read_text(encoding="utf-8"))
+    assert status["status"] == "completed"
+    assert (job_dir / "outputs.json").exists()
+    assert (job_dir / "artifacts" / "candidates.fasta").exists()

--- a/tests/unit/test_provider_config.py
+++ b/tests/unit/test_provider_config.py
@@ -83,3 +83,12 @@ def test_get_provider_config_missing_provider(tmp_path, monkeypatch):
 
     with pytest.raises(KeyError):
         provider_config.get_provider_config("missing")
+
+
+def test_default_model_providers_contains_plm_rest():
+    configs = load_provider_config(provider_config.DEFAULT_PROVIDER_CONFIG_PATH)
+
+    assert "plm_rest" in configs
+    plm = configs["plm_rest"]
+    assert plm.provider_type == "plm_rest"
+    assert plm.base_url == "http://localhost:8100"


### PR DESCRIPTION
## Summary

本 PR 实现 issue #132 的前置目标: 提供 PLM 远程调用的 REST 协议, 可运行的参考服务, stub runner, provider 配置与最小测试闭环.\
实现范围覆盖提交作业, 状态轮询, 结果下载, 产物下载, 以及统一错误 envelope 与失败态 failure 结构.

## Background

当前系统已具备远程调用抽象(`RemoteModelInvocationService`/ `RESTModelInvocationService`), 但缺少可复用的PLM远程服务规范与落地实现, 导致 `#124` 无法基于远程服务接入PLM.

本PR对齐 #132 目标, 并与既有远程服务调用语义保持一致(`/predict`, `/job/{id}`, `/results/{id}` + 产物 URL 下载)

## Key Requirements (from #132)

1. 定义 REST 协议与数据约定(端点, 状态枚举, 错误模型, 结果结构)
1. 提供可运行的远端参考服务, 按 `remote_base_dir/<job_id>/` 实现
1. 提供 runner 生成最小输出: `outputs.sequence`, `outputs.candidates`
1. 补充本地 provider 配置(`plm_test`)
1. 增加最小测试覆盖 REST 协议关键路径

## Changes

1. `scripts/remote/plm_test_server/app.py`
   实现 FastAPI 服务器, 提供 `POST /predict`, `GET /job/{job_id}`, `GET /results/{job_id}`, `GET /files/{job_id}/{filename}`.\
   统一错误 envelope (`error.code/message/retryable/details`), 并在 `failed` 状态透传 `failure` 结构.\\
1. `scripts/remote/plm_rest_server/run_plm_job.py`
   新增 stub runner: 规范化输入, 生成候选序列 (`sequence` + `score`), 写入 `outputs.json` 与产物文件.\
   失败路径写入 `status.json` 的 failure 结构, 和 `/job` failed 响应契约一致
1. `scripts/remote/plm_rest_server/README.md`
   新增协议与运行文档, 明确端点, 状态枚举, 错误 envelope, 作业目录约定, 运行方式与环境变量.
1. `configs/model_providers.json`
   新增 `plm_test provider`, 沿用现有配置解析键名 (`provider_type/base_url/api_key_env/timemout/max_retries/extra`)
1. `tests/unit/test_plm_reset_server.py`
   新增 REST 服务测试: happy path, failed job + failure, 错误 envelope + auth, runner 输出检查
1. `tests/unit/test_provider_config.py`
   补充默认 provider 配置测试, 校验 `plm_rest` 可被加载与解析.

## Design Decisions

1. 错误模型使用同一 envelope, 避免各端点异常响应不一致, 便于客户端统一处理.
1. `artifacts[].url` 返回可直接GET的HTTP url(由 `/files/...` 提供), 匹配现有 REST 客户端下载逻辑
1. 本期 runner 采用 stub 实现(可重复生成候选, 支持 `force_fail`), 优先满足 #132 的前置, 不引入真实模型依赖

## Impact

1. 正向影响
   为 PLM 远程调用提供可运行基线, 打通 "提交 - 轮询 - 下载" 的完整链路. 为后续 #124 接入 提供稳定接口与测试基础.
1. 风险评估
   低. 主要风险在于未来真实推理接入时的性能与资源管理, 当前协议层和语义已可复用

## Verification

已经执行: `uv run pytest tests/unit/test_plm_rest_server.py tests/unit/test_provider_config.py`

结果: 10 passed

## Links

- Closes #132
- Depends on #76
- Depends on #108
- Blocks #124
