### PR TITLE
[W6-Tools-1] 接入 ProtGPT2 作为 de novo 起始序列生成节点并贯通执行链路（refs #124）

### DIFF
--- a/src/adapters/builtins.py
+++ b/src/adapters/builtins.py
@@ -6,6 +6,7 @@ from src.adapters.dummy_adapter import DummyToolAdapter
 from src.adapters.esmfold_adapter import ESMFoldAdapter
 from src.adapters.nim_adapter import NIMESMFoldAdapter
 from src.adapters.protein_mpnn_adapter import ProteinMPNNAdapter
+from src.adapters.protgpt2_adapter import ProtGPT2Adapter
 from src.adapters.registry import get_adapter, register_adapter
 from src.tools.visualization.adapter import VisualizationToolAdapter
 
@@ -44,3 +45,7 @@ def ensure_builtin_adapters() -> None:
         get_adapter(ProteinMPNNAdapter.tool_id)
     except KeyError:
         register_adapter(ProteinMPNNAdapter())
+    try:
+        get_adapter(ProtGPT2Adapter.tool_id)
+    except KeyError:
+        register_adapter(ProtGPT2Adapter())

--- a/src/adapters/protgpt2_adapter.py
+++ b/src/adapters/protgpt2_adapter.py
@@ -1,0 +1,241 @@
+"""
+ProtGPT2Adapter - ProtGPT2 远程序列生成适配器
+
+通过 RemoteModelInvocationService 调用远程 PLM REST 服务，输出：
+- sequence
+- candidates
+- artifacts
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from time import perf_counter, sleep
+from typing import Any, Dict, Optional, Tuple
+
+from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.engines.provider_config import get_provider_config
+from src.engines.remote_model_service import (
+    JobStatus,
+    RESTModelInvocationService,
+    RemoteModelInvocationService,
+)
+from src.models.contracts import PlanStep
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureCode, FailureType, StepRunError
+
+__all__ = ["ProtGPT2Adapter"]
+
+
+class ProtGPT2Adapter(BaseToolAdapter):
+    """ProtGPT2 远程序列生成适配器（REST）"""
+
+    tool_id = "protgpt2"
+    adapter_id = "protgpt2"
+
+    def __init__(
+        self,
+        service: Optional[RemoteModelInvocationService] = None,
+        *,
+        base_url: Optional[str] = None,
+        output_dir: str | Path | None = None,
+    ) -> None:
+        if service is None:
+            resolved_base_url = base_url or _resolve_plm_rest_base_url()
+            service = RESTModelInvocationService(resolved_base_url)
+        self.service = service
+        self.output_dir = Path(output_dir or "output/sequences")
+
+    def resolve_inputs(
+        self,
+        step: PlanStep,
+        context: WorkflowContext,
+    ) -> Dict[str, Any]:
+        resolved: Dict[str, Any] = {}
+
+        for key, val in step.inputs.items():
+            if isinstance(val, str) and "." in val:
+                step_id, field = val.split(".", 1)
+                if step_id and step_id.startswith("S"):
+                    if not context.has_step_result(step_id):
+                        raise ValueError(
+                            f"Failed to resolve input reference '{val}' "
+                            f"for step '{step.id}': step '{step_id}' not found in context"
+                        )
+                    try:
+                        resolved_value = context.get_step_output(step_id, field)
+                    except KeyError as exc:
+                        raise ValueError(
+                            f"Failed to resolve input reference '{val}' "
+                            f"for step '{step.id}': field '{field}' not found in step '{step_id}' outputs"
+                        ) from exc
+                    resolved[key] = resolved_value
+                    continue
+            resolved[key] = val
+
+        if "goal" not in resolved:
+            resolved["goal"] = context.task.goal
+        if "length_range" not in resolved:
+            length_range = context.task.constraints.get("length_range")
+            if isinstance(length_range, (list, tuple)) and len(length_range) == 2:
+                resolved["length_range"] = [int(length_range[0]), int(length_range[1])]
+        if "prompt" not in resolved:
+            prompt = context.task.constraints.get("prompt")
+            if isinstance(prompt, str) and prompt:
+                resolved["prompt"] = prompt
+        if "num_candidates" not in resolved:
+            num_candidates = context.task.constraints.get("num_candidates")
+            if isinstance(num_candidates, int) and num_candidates > 0:
+                resolved["num_candidates"] = num_candidates
+
+        goal = resolved.get("goal")
+        if not isinstance(goal, str) or not goal.strip():
+            raise ValueError(
+                f"Missing required input 'goal' for ProtGPT2 step '{step.id}'"
+            )
+
+        resolved["task_id"] = context.task.task_id
+        resolved["step_id"] = step.id
+        return resolved
+
+    def run_local(
+        self,
+        inputs: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        return self.run_remote(inputs, output_dir=self.output_dir)
+
+    def run_remote(
+        self,
+        inputs: Dict[str, Any],
+        output_dir: Optional[Path] = None,
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        t0 = perf_counter()
+        task_id = str(inputs.get("task_id", "unknown"))
+        step_id = str(inputs.get("step_id", "unknown"))
+
+        payload = _build_submit_payload(inputs)
+        job_id = self.service.submit_job(
+            payload=payload, task_id=task_id, step_id=step_id
+        )
+
+        final_status = self._wait_for_completion(job_id)
+        if final_status == JobStatus.FAILED:
+            raise StepRunError(
+                failure_type=FailureType.TOOL_ERROR,
+                message=f"Remote job {job_id} failed",
+                code=FailureCode.REMOTE_JOB_FAILED.value,
+            )
+
+        actual_output_dir = Path(output_dir or self.output_dir)
+        actual_output_dir.mkdir(parents=True, exist_ok=True)
+        raw_outputs = self.service.download_results(
+            job_id=job_id, output_dir=actual_output_dir
+        )
+        outputs = _normalize_generation_outputs(raw_outputs)
+
+        duration_ms = int((perf_counter() - t0) * 1000)
+        metrics = {
+            "exec_type": "remote",
+            "duration_ms": duration_ms,
+            "job_id": job_id,
+            "provider": "plm_rest",
+        }
+        return outputs, metrics
+
+    def _wait_for_completion(self, job_id: str) -> JobStatus:
+        if hasattr(self.service, "wait_for_completion"):
+            return self.service.wait_for_completion(job_id)
+
+        max_attempts = 60
+        poll_interval = 5.0
+        for _ in range(max_attempts):
+            status = self.service.poll_status(job_id)
+            if status in (JobStatus.COMPLETED, JobStatus.FAILED):
+                return status
+            if status == JobStatus.UNKNOWN:
+                raise StepRunError(
+                    failure_type=FailureType.NON_RETRYABLE,
+                    message=f"Job {job_id} status is unknown",
+                    code=FailureCode.REMOTE_JOB_UNKNOWN.value,
+                )
+            sleep(poll_interval)
+        raise StepRunError(
+            failure_type=FailureType.RETRYABLE,
+            message=f"Job {job_id} polling timeout",
+            code=FailureCode.REMOTE_POLL_TIMEOUT.value,
+        )
+
+
+def _resolve_plm_rest_base_url() -> str:
+    try:
+        config = get_provider_config("plm_rest")
+    except KeyError:
+        return "http://localhost:8100"
+    return config.base_url or "http://localhost:8100"
+
+
+def _build_submit_payload(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    passthrough_keys = (
+        "goal",
+        "length_range",
+        "num_candidates",
+        "num_return_sequences",
+        "prompt",
+        "max_new_tokens",
+        "top_k",
+        "top_p",
+        "temperature",
+        "repetition_penalty",
+        "do_sample",
+        "eos_token_id",
+    )
+    for key in passthrough_keys:
+        if key in inputs:
+            payload[key] = inputs[key]
+    if "num_return_sequences" not in payload and "num_candidates" in payload:
+        payload["num_return_sequences"] = payload["num_candidates"]
+    return payload
+
+
+def _normalize_generation_outputs(outputs: Dict[str, Any]) -> Dict[str, Any]:
+    normalized = dict(outputs or {})
+
+    sequence = normalized.get("sequence")
+    candidates_raw = normalized.get("candidates")
+    candidates: list[dict[str, Any]] = []
+
+    if isinstance(candidates_raw, list):
+        for item in candidates_raw:
+            if isinstance(item, dict):
+                seq = item.get("sequence")
+                if isinstance(seq, str) and seq:
+                    entry = {"sequence": seq}
+                    if "score" in item:
+                        entry["score"] = item.get("score")
+                    candidates.append(entry)
+
+    if (not isinstance(sequence, str) or not sequence) and candidates:
+        sequence = candidates[0]["sequence"]
+
+    if isinstance(sequence, str) and sequence and not candidates:
+        candidates = [{"sequence": sequence}]
+
+    if not isinstance(sequence, str) or not sequence:
+        raise StepRunError(
+            failure_type=FailureType.TOOL_ERROR,
+            message="Remote ProtGPT2 result missing 'sequence'",
+            code=FailureCode.TOOL_EXECUTION_ERROR.value,
+        )
+
+    artifacts = normalized.get("artifacts")
+    if isinstance(artifacts, list):
+        normalized["artifacts"] = {
+            "files": [str(path) for path in artifacts],
+        }
+    elif not isinstance(artifacts, dict):
+        normalized["artifacts"] = {}
+
+    normalized["sequence"] = sequence
+    normalized["candidates"] = candidates
+    return normalized

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -668,6 +668,7 @@ def _build_de_novo_plan(
 ) -> Plan:
     constraints = task.constraints or {}
     available_inputs: Set[str] = set(constraints.keys())
+    available_inputs.add("goal")
     template_pdb = _extract_template_pdb(constraints)
     if template_pdb:
         available_inputs.add("pdb_path")
@@ -678,7 +679,7 @@ def _build_de_novo_plan(
     try:
         sequence_tool = _select_tool_by_capability(
             registry=registry,
-            capability="sequence_design",
+            capability="sequence_generation",
             available_inputs=available_inputs,
             safety_level=safety_level,
             io_hint=None,
@@ -688,7 +689,7 @@ def _build_de_novo_plan(
         fallback_inputs = _collect_registry_inputs(registry)
         sequence_tool = _select_tool_by_capability(
             registry=registry,
-            capability="sequence_design",
+            capability="sequence_generation",
             available_inputs=fallback_inputs,
             safety_level=safety_level,
             io_hint=None,
@@ -723,6 +724,12 @@ def _build_de_novo_plan(
     length_range = _extract_length_range(constraints)
     if length_range:
         step_inputs["length_range"] = length_range
+    prompt = constraints.get("prompt")
+    if isinstance(prompt, str) and prompt:
+        step_inputs["prompt"] = prompt
+    num_candidates = constraints.get("num_candidates")
+    if isinstance(num_candidates, int) and num_candidates > 0:
+        step_inputs["num_candidates"] = num_candidates
     if template_pdb:
         step_inputs["pdb_path"] = template_pdb
 
@@ -790,7 +797,7 @@ def _build_de_novo_explanation(sequence_tool_id: str, structure_tool_id: str) ->
         compat_note = f"KG compat.from={', '.join(str(item) for item in compat_from)}"
 
     parts = [
-        "de_novo_design 任务采用序列设计→结构预测两步链路。",
+        "de_novo_design 任务采用序列生成→结构预测两步链路。",
         f"ProteinToolKG 显示 {seq_name}({sequence_tool_id}) 能力={seq_caps}。{seq_desc}",
         f"ProteinToolKG 显示 {struct_name}({structure_tool_id}) 能力={struct_caps}。{struct_desc}",
     ]

--- a/src/kg/protein_tool_kg.json
+++ b/src/kg/protein_tool_kg.json
@@ -13,6 +13,12 @@
       "name": "Sequence Design",
       "domain": "protein/design",
       "description": "Design amino acid sequences from a structural backbone or template."
+    },
+    {
+      "capability_id": "sequence_generation",
+      "name": "Sequence Generation",
+      "domain": "protein/design",
+      "description": "Generate initial de novo protein sequence candidates from goals or prompts."
     }
   ],
   "io_types": [
@@ -29,6 +35,13 @@
       "output_types": ["sequence"],
       "combinable": true,
       "description": "Design sequences from structural backbone inputs."
+    },
+    {
+      "io_type_id": "goal_to_sequence_candidates",
+      "input_types": ["goal"],
+      "output_types": ["sequence", "sequence_candidates"],
+      "combinable": true,
+      "description": "Generate candidate protein sequences from goal and optional prompt constraints."
     },
     {
       "io_type_id": "sequence_msa_to_structure",
@@ -204,6 +217,51 @@
       },
       "failure_modes": ["invalid_backbone", "missing_backbone"],
       "preferred_next": ["esmfold", "nim_esmfold", "alphafold"],
+      "version": "1.0.0"
+    },
+    {
+      "id": "protgpt2",
+      "tool_id": "protgpt2",
+      "name": "ProtGPT2",
+      "domain": "protein/design",
+      "description": "PLM-based de novo sequence generator via remote ProtGPT2 REST service.",
+      "capabilities": ["sequence_generation"],
+      "io": {
+        "io_type_id": "goal_to_sequence_candidates",
+        "inputs": {
+          "goal": "str"
+        },
+        "outputs": {
+          "sequence": "str",
+          "candidates": "list",
+          "artifacts": "dict"
+        },
+        "input_types": ["goal"],
+        "output_types": ["sequence", "sequence_candidates"],
+        "combinable": true
+      },
+      "constraints": {
+        "preconditions": ["goal_provided"],
+        "resource_assumptions": ["network_available", "plm_rest_service_available"],
+        "model_assumptions": ["protgpt2_ready"],
+        "limits": {
+          "max_new_tokens": 512,
+          "num_candidates_max": 64
+        }
+      },
+      "execution": {
+        "backend": "remote_model_service",
+        "provider": "plm_rest",
+        "model_id": "nferruz/ProtGPT2",
+        "sync_mode": true
+      },
+      "cost_score": 0.35,
+      "safety_level": 1,
+      "compat": {
+        "from": []
+      },
+      "failure_modes": ["timeout", "invalid_generation"],
+      "preferred_next": ["esmfold", "nim_esmfold", "protein_mpnn"],
       "version": "1.0.0"
     },
     {

--- a/tests/integration/test_nim_esmfold.py
+++ b/tests/integration/test_nim_esmfold.py
@@ -9,10 +9,11 @@ from pathlib import Path
 import pytest
 
 from src.adapters.nim_adapter import NIMESMFoldAdapter
-from src.adapters.protein_mpnn_adapter import ProteinMPNNAdapter
+from src.adapters.protgpt2_adapter import ProtGPT2Adapter
 from src.adapters.registry import ADAPTER_REGISTRY, register_adapter
 from src.agents.executor import ExecutorAgent
 from src.agents.planner import PlannerAgent
+from src.engines.remote_model_service import JobStatus, RemoteModelInvocationService
 from src.models.contracts import Plan, PlanStep, ProteinDesignTask
 from src.models.db import InternalStatus
 from src.workflow.context import WorkflowContext
@@ -38,6 +39,24 @@ def _restore_registry(snapshot: tuple[dict, dict]) -> None:
     ADAPTER_REGISTRY._by_tool_id.update(tool_snapshot)
     ADAPTER_REGISTRY._by_adapter_id.clear()
     ADAPTER_REGISTRY._by_adapter_id.update(adapter_snapshot)
+
+
+class _MockPLMService(RemoteModelInvocationService):
+    def submit_job(self, payload, task_id, step_id) -> str:
+        return f"mock_plm_{task_id}_{step_id}"
+
+    def poll_status(self, job_id: str) -> JobStatus:
+        return JobStatus.COMPLETED
+
+    def wait_for_completion(self, job_id: str) -> JobStatus:
+        return JobStatus.COMPLETED
+
+    def download_results(self, job_id: str, output_dir: Path):
+        return {
+            "sequence": "ACDEFGHIKLMNPQRSTVWY",
+            "candidates": [{"sequence": "ACDEFGHIKLMNPQRSTVWY", "score": -0.1}],
+            "artifacts": [],
+        }
 
 
 @pytest.fixture
@@ -99,7 +118,7 @@ def test_de_novo_with_nim(
     tmp_path: Path,
     clean_registry: None,
 ) -> None:
-    """Execute a de novo plan (ProteinMPNN -> NIM ESMFold)."""
+    """Execute a de novo plan (ProtGPT2 -> NIM ESMFold)."""
     template_path = tmp_path / "template.pdb"
     template_path.write_text("HEADER    TEMPLATE\nEND\n", encoding="utf-8")
 
@@ -117,13 +136,11 @@ def test_de_novo_with_nim(
     plan = planner.plan(task)
 
     assert len(plan.steps) == 2
-    assert plan.steps[0].tool == "protein_mpnn"
+    assert plan.steps[0].tool == "protgpt2"
     assert plan.steps[1].tool == "nim_esmfold"
     assert plan.steps[1].inputs.get("sequence") == "S1.sequence"
 
-    register_adapter(
-        ProteinMPNNAdapter(artifacts_dir=tmp_path / "artifacts")
-    )
+    register_adapter(ProtGPT2Adapter(service=_MockPLMService(), output_dir=tmp_path / "seq"))
     register_adapter(NIMESMFoldAdapter(output_dir=tmp_path / "pdb"))
 
     context = WorkflowContext(

--- a/tests/unit/test_kg_client_backend.py
+++ b/tests/unit/test_kg_client_backend.py
@@ -20,6 +20,13 @@ def test_find_tools_by_backend_remote_model_service() -> None:
     assert tool_ids == {"nim_esmfold"}
 
 
+def test_find_tools_by_backend_plm_rest() -> None:
+    tools = find_tools_by_backend("remote_model_service", "plm_rest")
+    tool_ids = {tool["id"] for tool in tools}
+
+    assert tool_ids == {"protgpt2"}
+
+
 def test_find_tools_by_backend_nextflow() -> None:
     tools = find_tools_by_backend("nextflow")
     tool_ids = {tool["id"] for tool in tools}
@@ -35,3 +42,10 @@ def test_mpnn_to_nim_esmfold_chain_is_compatible() -> None:
     nim_inputs = set(tools["nim_esmfold"]["io"]["inputs"].keys())
 
     assert nim_inputs.issubset(mpnn_outputs)
+
+
+def test_protgpt2_has_sequence_generation_capability() -> None:
+    tools = find_tools_by_capability("sequence_generation")
+    tool_ids = {tool["id"] for tool in tools}
+
+    assert "protgpt2" in tool_ids

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -52,9 +52,9 @@ class TestPlannerAgent:
 
         assert len(plan.steps) == 2
         assert [step.id for step in plan.steps] == ["S1", "S2"]
-        assert plan.steps[0].tool == "protein_mpnn"
+        assert plan.steps[0].tool == "protgpt2"
         assert plan.steps[1].tool == "esmfold"
-        assert plan.steps[0].inputs["pdb_path"] == "data/template.pdb"
+        assert plan.steps[0].inputs["goal"] == "de_novo_design"
         assert plan.steps[0].inputs["length_range"] == [40, 60]
         assert plan.steps[1].inputs["sequence"] == "S1.sequence"
         assert plan.explanation

--- a/tests/unit/test_protein_tool_kg.py
+++ b/tests/unit/test_protein_tool_kg.py
@@ -1,25 +1,28 @@
 from src.kg.kg_client import load_tool_kg
 
 
-def test_kg_includes_protein_mpnn_and_design_capability() -> None:
+def test_kg_includes_plm_and_design_capabilities() -> None:
     kg = load_tool_kg()
     tool_ids = {tool["id"] for tool in kg["tools"]}
     capability_ids = {cap["capability_id"] for cap in kg["capabilities"]}
     io_type_ids = {io_type["io_type_id"] for io_type in kg["io_types"]}
 
     assert "protein_mpnn" in tool_ids
+    assert "protgpt2" in tool_ids
     assert "sequence_design" in capability_ids
+    assert "sequence_generation" in capability_ids
     assert "structure_to_sequence" in io_type_ids
+    assert "goal_to_sequence_candidates" in io_type_ids
 
 
-def test_design_to_prediction_chain_is_compatible() -> None:
+def test_generation_to_prediction_chain_is_compatible() -> None:
     kg = load_tool_kg()
     tools = {tool["id"]: tool for tool in kg["tools"]}
 
-    mpnn = tools["protein_mpnn"]
+    protgpt2 = tools["protgpt2"]
     esmfold = tools["esmfold"]
 
-    mpnn_outputs = set(mpnn["io"]["outputs"].keys())
+    generation_outputs = set(protgpt2["io"]["outputs"].keys())
     esmfold_inputs = set(esmfold["io"]["inputs"].keys())
 
-    assert esmfold_inputs.issubset(mpnn_outputs)
+    assert esmfold_inputs.issubset(generation_outputs)

--- a/tests/unit/test_protgpt2_adapter.py
+++ b/tests/unit/test_protgpt2_adapter.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.adapters.protgpt2_adapter import ProtGPT2Adapter
+from src.engines.remote_model_service import JobStatus
+from src.models.contracts import PlanStep, ProteinDesignTask, StepResult
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType, StepRunError
+
+
+@pytest.fixture
+def mock_service() -> Mock:
+    service = Mock()
+    service.submit_job.return_value = "plm_job_123"
+    service.wait_for_completion.return_value = JobStatus.COMPLETED
+    service.download_results.return_value = {
+        "sequence": "ACDEFGHIK",
+        "candidates": [
+            {"sequence": "ACDEFGHIK", "score": -0.1},
+            {"sequence": "ACDEFGHIM", "score": -0.2},
+        ],
+        "artifacts": ["/tmp/candidates.fasta", "/tmp/summary.json"],
+    }
+    return service
+
+
+@pytest.fixture
+def context() -> WorkflowContext:
+    task = ProteinDesignTask(
+        task_id="task_plm_001",
+        goal="de_novo_design",
+        constraints={"length_range": [30, 40]},
+    )
+    return WorkflowContext(task=task)
+
+
+def test_resolve_inputs_includes_defaults(
+    mock_service: Mock,
+    context: WorkflowContext,
+) -> None:
+    adapter = ProtGPT2Adapter(service=mock_service)
+    step = PlanStep(
+        id="S1",
+        tool="protgpt2",
+        inputs={},
+        metadata={},
+    )
+
+    resolved = adapter.resolve_inputs(step, context)
+
+    assert resolved["goal"] == "de_novo_design"
+    assert resolved["length_range"] == [30, 40]
+    assert resolved["task_id"] == "task_plm_001"
+    assert resolved["step_id"] == "S1"
+
+
+def test_resolve_inputs_reference_syntax(
+    mock_service: Mock,
+    context: WorkflowContext,
+) -> None:
+    adapter = ProtGPT2Adapter(service=mock_service)
+    context.step_results["S1"] = StepResult(
+        task_id="task_plm_001",
+        step_id="S1",
+        tool="dummy",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        outputs={"prompt": "<|endoftext|>ACD"},
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp="2026-01-01T00:00:00+00:00",
+    )
+    step = PlanStep(
+        id="S2",
+        tool="protgpt2",
+        inputs={"prompt": "S1.prompt", "goal": "de_novo_design"},
+        metadata={},
+    )
+
+    resolved = adapter.resolve_inputs(step, context)
+    assert resolved["prompt"] == "<|endoftext|>ACD"
+
+
+def test_run_remote_success_normalizes_outputs(mock_service: Mock) -> None:
+    adapter = ProtGPT2Adapter(service=mock_service)
+    outputs, metrics = adapter.run_remote(
+        {
+            "goal": "de_novo_design",
+            "length_range": [50, 60],
+            "num_candidates": 2,
+            "task_id": "task_plm_001",
+            "step_id": "S1",
+        }
+    )
+
+    mock_service.submit_job.assert_called_once_with(
+        payload={
+            "goal": "de_novo_design",
+            "length_range": [50, 60],
+            "num_candidates": 2,
+            "num_return_sequences": 2,
+        },
+        task_id="task_plm_001",
+        step_id="S1",
+    )
+    mock_service.wait_for_completion.assert_called_once_with("plm_job_123")
+    mock_service.download_results.assert_called_once()
+
+    assert outputs["sequence"] == "ACDEFGHIK"
+    assert len(outputs["candidates"]) == 2
+    assert outputs["artifacts"]["files"] == [
+        "/tmp/candidates.fasta",
+        "/tmp/summary.json",
+    ]
+    assert metrics["exec_type"] == "remote"
+    assert metrics["provider"] == "plm_rest"
+    assert metrics["job_id"] == "plm_job_123"
+
+
+def test_run_remote_fails_when_sequence_missing(mock_service: Mock) -> None:
+    mock_service.download_results.return_value = {"candidates": [], "artifacts": []}
+    adapter = ProtGPT2Adapter(service=mock_service)
+
+    with pytest.raises(StepRunError) as exc_info:
+        adapter.run_remote(
+            {
+                "goal": "de_novo_design",
+                "task_id": "task_plm_001",
+                "step_id": "S1",
+            }
+        )
+
+    assert exc_info.value.failure_type == FailureType.TOOL_ERROR
+    assert "missing 'sequence'" in str(exc_info.value)
+
+
+def test_run_remote_job_failed(mock_service: Mock) -> None:
+    mock_service.wait_for_completion.return_value = JobStatus.FAILED
+    adapter = ProtGPT2Adapter(service=mock_service)
+
+    with pytest.raises(StepRunError) as exc_info:
+        adapter.run_remote(
+            {
+                "goal": "de_novo_design",
+                "task_id": "task_plm_001",
+                "step_id": "S1",
+            }
+        )
+
+    assert exc_info.value.failure_type == FailureType.TOOL_ERROR
+    assert "failed" in str(exc_info.value)


### PR DESCRIPTION
## Summary

本 PR 完成 Issue #124 的核心目标：将 PLM（ProtGPT2）作为 de novo 任务的起始序列生成工具正式接入系统，并让 Planner/Executor 能基于 KG 产出并执行 `sequence_generation -> structure_prediction` 的两步链路。

## Background

- 依赖上下文：#132 已建立远程调用抽象，#134（PR #135）已提供可运行的 ProtGPT2 REST 服务端。
- 当前缺口：de novo 首步仍未使用真实 PLM 节点，Planner 默认起始能力不是 `sequence_generation`。
- 本 PR 保持 FSM/Agent 职责边界不变，仅扩展工具节点、适配器与 Planner 选型逻辑。

## Key Requirements

1. Plan 中出现 PLM step，且 tool_id 与 KG 一致（`protgpt2`）。
2. de novo 严格从 `sequence_generation` 起步，PLM 为起始节点。
3. Executor 可执行 PLM step，并输出 `sequence/candidates/artifacts`。
4. 下游结构工具可消费 `S1.sequence`。
5. 单元测试覆盖 KG 查询 + Planner 生成 + Adapter 执行。

## Changes

### `src/kg/protein_tool_kg.json`
- 新增 capability `sequence_generation`、IOType `goal_to_sequence_candidates`。
- 新增工具节点 `protgpt2`，执行后端为 `remote_model_service`，provider 为 `plm_rest`。
- 定义 PLM 输入/输出与运行约束，保证 Planner 可检索且链路 I/O 闭合。

### `src/adapters/protgpt2_adapter.py`
- 新增 `ProtGPT2Adapter`，复用 `RESTModelInvocationService` 的 submit/poll/download。
- 支持输入引用语义（`Sx.field`）与 de novo 默认参数补全（`goal/length_range`）。
- 输出归一化为 `sequence/candidates/artifacts`，并对缺失 `sequence` 做明确失败分类。

### `src/adapters/builtins.py`
- 注册 `ProtGPT2Adapter`，使默认执行环境可直接解析 `protgpt2`。

### `src/agents/planner.py`
- de novo 首步能力由 `sequence_design` 严格切换为 `sequence_generation`。
- 首步输入固定包含 `goal`，并透传 `length_range/prompt/num_candidates`。
- 说明文本同步改为“序列生成 -> 结构预测”。

### `tests/unit/test_protein_tool_kg.py`
- 更新 KG 断言：包含 `protgpt2`、`sequence_generation`、`goal_to_sequence_candidates`。
- 兼容性断言改为 PLM 生成输出可被结构预测输入消费。

### `tests/unit/test_kg_client_backend.py`
- 新增 `find_tools_by_backend("remote_model_service", "plm_rest")` 断言。
- 新增 `find_tools_by_capability("sequence_generation")` 命中 `protgpt2` 断言。

### `tests/unit/test_planner_agent.py`
- de novo 模板断言更新为 `S1.tool == protgpt2`。
- 保持 `S2.inputs.sequence == "S1.sequence"`，验证链路衔接。

### `tests/unit/test_protgpt2_adapter.py`
- 新增适配器单测：默认输入解析、引用语义、远程成功、结果缺失失败、job 失败。

### `tests/integration/test_nim_esmfold.py`
- de novo 集成链路从 `ProteinMPNN -> NIM ESMFold` 更新为 `ProtGPT2 -> NIM ESMFold`。
- 使用 mock PLM 远程服务保证测试稳定、无外部依赖。

## Validation

已执行：
- `uv run pytest tests/unit/test_protein_tool_kg.py tests/unit/test_kg_client_backend.py tests/unit/test_planner_agent.py tests/unit/test_protgpt2_adapter.py`
- `uv run pytest tests/integration/test_nim_esmfold.py`
- `uv run pytest tests/unit`

结果：
- 上述测试全部通过（`23 passed` / `3 passed` / `344 passed`）。

## Impact

正向影响：
- de novo 起始节点与设计文档对齐为 PLM 序列生成。
- Planner 与 Executor 的真实工具链闭环从“可声明”提升到“可执行”。
- 为 #125 与论文流程复现提供稳定输入起点。

潜在负向影响：
- 若 `plm_rest` 服务不可达，真实运行 de novo 首步会失败（测试已通过 mock 隔离）。

风险评估：
- 中低风险；改动集中在 KG/Adapter/Planner 与测试层，不涉及 FSM 状态定义与 Agent 边界重构。

## Links

- Refs: #124
- Depends on: #132, #134
- Related: #135
