### PR TITLE
feat(models): align CandidateSetOutput v1 contracts and validation (W10-01 / #138)

### DIFF
--- a/examples/CANDIDATE_SET_OUTPUT_V1.md
+++ b/examples/CANDIDATE_SET_OUTPUT_V1.md
@@ -1,0 +1,37 @@
+# CandidateSetOutput v1 Field Dictionary
+
+This document defines the `CandidateSetOutput v1` field semantics used by Planner output and HITL consumption.
+
+## Candidate fields
+
+- `candidate_id`: stable candidate identifier.
+- `structured_payload`: structured object to execute (`Plan` or `PlanPatch` in current runtime).
+- `score_breakdown`: score map with required keys:
+  - `feasibility`
+  - `objective`
+  - `risk`
+  - `cost`
+  - `overall`
+- `risk_level`: `low | medium | high`.
+- `cost_estimate`: `low | medium | high`.
+- `explanation`: explanation for this candidate.
+- `summary`: optional short summary for display.
+- `metadata`: optional extension map.
+
+## CandidateSet fields
+
+- `candidates`: Top-K candidate list sorted by rank.
+- `default_recommendation`: default recommended `candidate_id`.
+- `explanation`: explanation for the whole candidate set.
+
+## Backward compatibility policy (additive-only)
+
+- Legacy `payload` is kept and treated as equivalent to `structured_payload`.
+- Legacy `default_suggestion` is kept and treated as equivalent to `default_recommendation`.
+- If both legacy/new fields are provided, they must be consistent.
+
+## Validation expectations
+
+- Candidate IDs must be unique in one candidate set.
+- `default_recommendation` must point to an existing candidate.
+- For v1 strict validation, every candidate must provide full v1 fields.

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -207,19 +207,70 @@ class PendingActionStatus(str, Enum):
 
 
 class PendingActionCandidate(BaseModel):
-    """候选方案的最小封装。
+    """候选方案封装（兼容 CandidateSetOutput v1）。
 
     Attributes:
         candidate_id: 候选唯一标识。
-        payload: 候选承载的对象（Plan 或 PlanPatch）。
+        payload: 兼容字段，等价于 structured_payload。
+        structured_payload: 候选承载的结构化对象（Plan 或 PlanPatch）。
+        score_breakdown: 候选打分拆解（feasibility/objective/risk/cost/overall）。
+        risk_level: 风险等级（low/medium/high）。
+        cost_estimate: 成本等级（low/medium/high）。
+        explanation: 候选解释。
         summary: 候选摘要信息。
         metadata: 额外元数据。
     """
 
     candidate_id: str
-    payload: Plan | PlanPatch
+    payload: Plan | PlanPatch | None = None
+    structured_payload: Plan | PlanPatch | None = None
+    score_breakdown: Dict[str, float] = Field(default_factory=dict)
+    risk_level: Literal["low", "medium", "high"] | None = None
+    cost_estimate: Literal["low", "medium", "high"] | None = None
+    explanation: str | None = None
     summary: Optional[str] = None
     metadata: Dict = Field(default_factory=dict)
+
+    @field_validator("candidate_id")
+    @classmethod
+    def _validate_candidate_id(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("candidate_id must not be empty")
+        return normalized
+
+    @field_validator("score_breakdown")
+    @classmethod
+    def _validate_score_breakdown(
+        cls, value: Dict[str, float]
+    ) -> Dict[str, float]:
+        normalized: Dict[str, float] = {}
+        for key, score in value.items():
+            if isinstance(score, bool) or not isinstance(score, (int, float)):
+                raise ValueError(f"score_breakdown[{key}] must be numeric")
+            normalized[key] = float(score)
+        return normalized
+
+    @model_validator(mode="after")
+    def _sync_payload_fields(self):
+        payload = self.payload
+        structured_payload = self.structured_payload
+        if payload is None and structured_payload is None:
+            raise ValueError(
+                "either payload or structured_payload must be provided"
+            )
+        if payload is None:
+            self.payload = structured_payload
+            return self
+        if structured_payload is None:
+            self.structured_payload = payload
+            return self
+        if (
+            type(payload) is not type(structured_payload)
+            or payload.model_dump() != structured_payload.model_dump()
+        ):
+            raise ValueError("payload and structured_payload must be equivalent")
+        return self
 
 
 class PendingAction(BaseModel):
@@ -232,7 +283,8 @@ class PendingAction(BaseModel):
         candidates: 候选集合。
         explanation: 解释说明文本。
         status: PendingAction 当前状态。
-        default_suggestion: 默认建议候选 ID。
+        default_suggestion: 兼容字段，等价于 default_recommendation。
+        default_recommendation: 默认建议候选 ID（CandidateSetOutput v1）。
         created_at: 创建时间戳。
         decided_at: 决策完成时间戳。
         created_by: 创建者标识（通常为 system）。
@@ -245,9 +297,23 @@ class PendingAction(BaseModel):
     explanation: str
     status: PendingActionStatus = PendingActionStatus.PENDING
     default_suggestion: Optional[str] = None
+    default_recommendation: Optional[str] = None
     created_at: str = Field(default_factory=now_iso)
     decided_at: Optional[str] = None
     created_by: str = "system"
+
+    @model_validator(mode="after")
+    def _sync_default_recommendation(self):
+        suggestion = self.default_suggestion
+        recommendation = self.default_recommendation
+        if suggestion and recommendation and suggestion != recommendation:
+            raise ValueError(
+                "default_suggestion and default_recommendation must match"
+            )
+        resolved = recommendation or suggestion
+        self.default_suggestion = resolved
+        self.default_recommendation = resolved
+        return self
 
 
 class DecisionChoice(str, Enum):

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -28,6 +28,83 @@ class DecisionValidationError(ValueError):
     """Decision 与 PendingAction 约束冲突时抛出。"""
 
 
+class CandidateSetValidationError(ValueError):
+    """CandidateSetOutput 契约校验失败时抛出。"""
+
+
+REQUIRED_SCORE_BREAKDOWN_FIELDS = frozenset(
+    {"feasibility", "objective", "risk", "cost", "overall"}
+)
+
+
+def validate_candidate_set_output(
+    pending_action: PendingAction,
+    *,
+    require_v1_fields: bool = True,
+    require_default_recommendation: bool = True,
+) -> None:
+    """校验 CandidateSetOutput 契约（用于 Planner/HITL 输出）。
+
+    Args:
+        pending_action: 待校验的 PendingAction 对象。
+        require_v1_fields: 是否要求每个候选必须包含 v1 字段集。
+        require_default_recommendation: 是否要求存在默认推荐候选。
+
+    Raises:
+        CandidateSetValidationError: 候选字段或集合约束不满足。
+    """
+    if not pending_action.candidates:
+        raise CandidateSetValidationError("candidates must not be empty")
+
+    seen_ids: set[str] = set()
+    for candidate in pending_action.candidates:
+        candidate_id = _resolve_candidate_id(candidate)
+        if not candidate_id:
+            raise CandidateSetValidationError("candidate_id is required")
+        if candidate_id in seen_ids:
+            raise CandidateSetValidationError(
+                f"candidate_id {candidate_id} is duplicated"
+            )
+        seen_ids.add(candidate_id)
+        if require_v1_fields:
+            _validate_candidate_v1_fields(candidate, candidate_id)
+
+    default_id = (
+        pending_action.default_recommendation or pending_action.default_suggestion
+    )
+    if require_default_recommendation and not default_id:
+        raise CandidateSetValidationError(
+            "default_recommendation is required for candidate set output"
+        )
+    if default_id and default_id not in seen_ids:
+        raise CandidateSetValidationError(
+            "default_recommendation is not in candidates"
+        )
+
+
+def _validate_candidate_v1_fields(
+    candidate: PendingActionCandidate, candidate_id: str
+) -> None:
+    if candidate.structured_payload is None:
+        raise CandidateSetValidationError(
+            f"{candidate_id}.structured_payload is required"
+        )
+    if not candidate.score_breakdown:
+        raise CandidateSetValidationError(f"{candidate_id}.score_breakdown is required")
+    missing_keys = REQUIRED_SCORE_BREAKDOWN_FIELDS - set(candidate.score_breakdown)
+    if missing_keys:
+        missing = ", ".join(sorted(missing_keys))
+        raise CandidateSetValidationError(
+            f"{candidate_id}.score_breakdown missing keys: {missing}"
+        )
+    if candidate.risk_level is None:
+        raise CandidateSetValidationError(f"{candidate_id}.risk_level is required")
+    if candidate.cost_estimate is None:
+        raise CandidateSetValidationError(f"{candidate_id}.cost_estimate is required")
+    if not candidate.explanation:
+        raise CandidateSetValidationError(f"{candidate_id}.explanation is required")
+
+
 def validate_decision_for_pending_action(
     pending_action: PendingAction,
     decision: Decision,

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -42,6 +42,7 @@ def build_pending_action(
     *,
     pending_action_id: Optional[str] = None,
     default_suggestion: Optional[str] = None,
+    default_recommendation: Optional[str] = None,
     explanation: str,
     created_by: str = "system",
 ) -> PendingAction:
@@ -53,6 +54,7 @@ def build_pending_action(
         candidates: 候选集合（可为空）。
         pending_action_id: 可选的 PendingAction ID（默认自动生成）。
         default_suggestion: 默认建议的候选 ID。
+        default_recommendation: CandidateSetOutput v1 默认推荐候选 ID。
         explanation: 解释说明文本。
         created_by: 创建者标识（默认 system）。
 
@@ -66,6 +68,7 @@ def build_pending_action(
         status=PendingActionStatus.PENDING,
         candidates=list(candidates or []),
         default_suggestion=default_suggestion,
+        default_recommendation=default_recommendation,
         explanation=explanation,
         created_at=now_iso(),
         decided_at=None,
@@ -120,6 +123,7 @@ def enter_waiting_state(
             "action_type": pending_action.action_type.value,
             "candidate_ids": [c.candidate_id for c in pending_action.candidates],
             "default_suggestion": pending_action.default_suggestion,
+            "default_recommendation": pending_action.default_recommendation,
         }
     )
 

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -1,6 +1,10 @@
 """数据契约模型单元测试"""
 import pytest
+from pydantic import ValidationError
 from src.models.contracts import (
+    PendingAction,
+    PendingActionCandidate,
+    PendingActionType,
     ProteinDesignTask,
     Plan,
     PlanStep,
@@ -210,3 +214,82 @@ class TestSafetyResult:
         assert result.task_id == "task_001"
         assert result.phase == "input"
         assert result.action == "allow"
+
+
+@pytest.mark.unit
+class TestCandidateSetContracts:
+    """CandidateSetOutput v1 契约测试。"""
+
+    def test_candidate_payload_syncs_to_structured_payload(self, sample_plan: Plan):
+        candidate = PendingActionCandidate(
+            candidate_id="plan_a",
+            payload=sample_plan,
+        )
+
+        assert candidate.payload == sample_plan
+        assert candidate.structured_payload == sample_plan
+
+    def test_candidate_structured_payload_backfills_payload(self, sample_plan: Plan):
+        candidate = PendingActionCandidate(
+            candidate_id="plan_b",
+            structured_payload=sample_plan,
+        )
+
+        assert candidate.structured_payload == sample_plan
+        assert candidate.payload == sample_plan
+
+    def test_candidate_non_numeric_score_rejected(self, sample_plan: Plan):
+        with pytest.raises(ValueError, match="score_breakdown\\.overall"):
+            PendingActionCandidate(
+                candidate_id="plan_c",
+                payload=sample_plan,
+                score_breakdown={"overall": "high"},  # type: ignore[arg-type]
+            )
+
+    def test_candidate_invalid_risk_or_cost_enum_rejected(self, sample_plan: Plan):
+        with pytest.raises(ValidationError):
+            PendingActionCandidate(
+                candidate_id="plan_d",
+                payload=sample_plan,
+                risk_level="warn",  # type: ignore[arg-type]
+                cost_estimate="low",
+            )
+        with pytest.raises(ValidationError):
+            PendingActionCandidate(
+                candidate_id="plan_e",
+                payload=sample_plan,
+                risk_level="low",
+                cost_estimate="expensive",  # type: ignore[arg-type]
+            )
+
+    def test_pending_action_default_recommendation_compat(self, sample_task, sample_plan):
+        candidate = PendingActionCandidate(candidate_id="plan_a", payload=sample_plan)
+        action = PendingAction(
+            pending_action_id="pa_001",
+            task_id=sample_task.task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            candidates=[candidate],
+            explanation="test",
+            default_suggestion="plan_a",
+        )
+
+        assert action.default_suggestion == "plan_a"
+        assert action.default_recommendation == "plan_a"
+
+    def test_pending_action_conflicting_default_fields_rejected(
+        self, sample_task, sample_plan
+    ):
+        candidate = PendingActionCandidate(candidate_id="plan_a", payload=sample_plan)
+        with pytest.raises(
+            ValueError,
+            match="default_suggestion and default_recommendation must match",
+        ):
+            PendingAction(
+                pending_action_id="pa_002",
+                task_id=sample_task.task_id,
+                action_type=PendingActionType.PLAN_CONFIRM,
+                candidates=[candidate],
+                explanation="test",
+                default_suggestion="plan_a",
+                default_recommendation="plan_b",
+            )

--- a/tests/unit/test_decision_validation.py
+++ b/tests/unit/test_decision_validation.py
@@ -9,7 +9,9 @@ from src.models.contracts import (
     now_iso,
 )
 from src.models.validation import (
+    CandidateSetValidationError,
     DecisionValidationError,
+    validate_candidate_set_output,
     validate_decision_for_pending_action,
 )
 
@@ -107,3 +109,120 @@ def test_valid_accept_passes(sample_task, sample_plan):
     )
 
     validate_decision_for_pending_action(pending_action, decision)
+
+
+@pytest.mark.unit
+def test_candidate_set_v1_validation_passes(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_ok",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.4,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a is balanced",
+            )
+        ],
+        default_recommendation="plan_a",
+        explanation="test",
+    )
+
+    validate_candidate_set_output(pending_action)
+
+
+@pytest.mark.unit
+def test_candidate_set_missing_required_score_key_rejected(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_missing_score",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a",
+            )
+        ],
+        default_recommendation="plan_a",
+        explanation="test",
+    )
+
+    with pytest.raises(
+        CandidateSetValidationError,
+        match="score_breakdown missing keys: cost",
+    ):
+        validate_candidate_set_output(pending_action)
+
+
+@pytest.mark.unit
+def test_candidate_set_default_recommendation_must_exist(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_bad_default",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.4,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a",
+            )
+        ],
+        default_recommendation="plan_x",
+        explanation="test",
+    )
+
+    with pytest.raises(
+        CandidateSetValidationError,
+        match="default_recommendation is not in candidates",
+    ):
+        validate_candidate_set_output(pending_action)
+
+
+@pytest.mark.unit
+def test_candidate_set_backward_compat_payload_only_passes(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_compat",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                payload=sample_plan,
+            )
+        ],
+        explanation="test",
+        default_suggestion="plan_a",
+    )
+
+    validate_candidate_set_output(
+        pending_action,
+        require_v1_fields=False,
+        require_default_recommendation=False,
+    )


### PR DESCRIPTION
## 背景与变更原因（Why）

本 PR 落地 Week 10 的高优先级契约任务：`CandidateSetOutput v1` 字段对齐（#138）。

这次改动的核心原因不是“新增字段”本身，而是要解决一个更关键的问题：
- 当前系统在 Planner/HITL/Validation/后续数据抽取之间，对候选字段语义还不够统一；
- 如果不先冻结并统一字段口径，后续 Top-K 生成、风险成本门控、HITL 展示、训练样本抽取会出现多套语义并行，导致链路不可审计、不可复现、不可稳定迭代。

因此，本 PR 目标是先把“契约层”和“校验层”打稳，给后续能力建设提供统一地基。

## 变更范围（What changed）

代码改动：
- `src/models/contracts.py`
- `src/models/validation.py`
- `src/workflow/pending_action.py`

测试改动：
- `tests/unit/test_contracts.py`
- `tests/unit/test_decision_validation.py`

文档改动：
- `examples/CANDIDATE_SET_OUTPUT_V1.md`

主要实现点：
- `PendingActionCandidate` 增加 v1 字段：
  - `structured_payload`
  - `score_breakdown`
  - `risk_level`
  - `cost_estimate`
  - `explanation`
- 兼容旧字段：
  - `payload` 保留，并与 `structured_payload` 做一致性同步
  - `default_suggestion` 保留，并与 `default_recommendation` 同步
- 新增 `validate_candidate_set_output(...)`，提供 CandidateSet v1 完整性与一致性校验能力
- `build_pending_action(...)` 支持 `default_recommendation`，并在事件日志 payload 中输出新旧两个字段

## 高风险说明（Risk-focused）

本 PR 风险高，原因是它修改了核心契约模型，影响面天然跨模块（模型层、工作流层、API/HITL 消费链路、后续训练数据）。

具体风险点：
- 契约模型是系统共享边界，一旦字段语义不稳定，会放大为跨模块不一致；
- `PendingActionCandidate` 的结构变化会影响历史调用路径；
- 默认建议字段从单字段演进到双字段（兼容期）容易造成语义漂移。

本 PR 的控制策略：
- 坚持 additive-only，不删除旧字段；
- 新旧字段双向同步并做冲突校验；
- 增加单测覆盖合法/非法/兼容路径，优先保证行为可预测。

## 对未来的影响（Future impact）

正向影响（关键）：
- 为 W10-02/W10-03/W10-04 提供统一字段底座，减少后续重复返工；
- 为 HITL 展示与决策记录提供稳定字段口径；
- 为 Week11 数据抽取、Week12 训练评估提供可追溯的数据契约前提；
- 让“候选可审计性”从文档约束变成代码约束。

对后续开发的约束：
- 后续 Planner 输出需要逐步切换到 v1 字段为主；
- 新逻辑应优先读 `structured_payload/default_recommendation`，旧字段仅用于兼容；
- 如要把 v1 校验升级为强制门禁，应在 Planner 输出或 WAITING_* 入口接入 `validate_candidate_set_output`。

## 测试与验证（Validation）

执行：
- `uv run pytest tests/unit/test_contracts.py tests/unit/test_decision_validation.py tests/unit/test_decision_apply.py`

结果：
- `39 passed, 1 warning`

覆盖重点：
- 字段缺失与类型错误
- 非法 risk/cost 枚举
- default recommendation 非法引用
- 旧字段兼容消费路径

## 非目标（Out of scope）

本 PR 不包含：
- Top-K 候选生成逻辑
- 风险/成本打分算法
- FSM 状态机与 Agent 角色边界变更

## 关联

- Issue: #138
