### PR TITLE
一键启动Demo并补齐运行时初始化/健康测试/冒烟验证

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Thesis Project Demo
+
+Minimal end-to-end demo launcher for the multi-agent protein design workflow.
+
+## One Command
+
+```bash
+./run_demo.sh
+```
+
+Then open:
+
+- `http://127.0.0.1:8000/docs`
+- `http://127.0.0.1:8000/health`
+
+Detailed demo usage and options:
+
+- `examples/README_DEMO.md`

--- a/configs/demo_task.json
+++ b/configs/demo_task.json
@@ -1,0 +1,16 @@
+{
+  "goal": "Design a stable mini-protein and produce a structure preview",
+  "constraints": {
+    "sequence": "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR",
+    "length_range": [
+      30,
+      80
+    ],
+    "safety_level": 1
+  },
+  "metadata": {
+    "demo": true,
+    "created_by": "run_demo",
+    "notes": "Minimal API smoke payload"
+  }
+}

--- a/examples/README_DEMO.md
+++ b/examples/README_DEMO.md
@@ -1,93 +1,78 @@
-# ESMFold 远程调用 + HITL + 恢复演示
+# One-Command Demo
 
-本演示脚本覆盖以下链路：
+This repository provides a one-command launcher for the minimal end-to-end demo:
 
-```
-Planner → WAITING_PLAN_CONFIRM → (恢复) → 决策 → Executor(远程 ESMFold) → Summarizer
-```
+- FastAPI input layer (`/docs`, `/health`, `/tasks`)
+- Planner/Executor/Safety/Summarizer workflow chain
+- Runtime resources (ProteinToolKG, logs, snapshots, output dirs)
 
-它演示了：
-- ✅ Planner 生成计划（支持切换 LLM Provider）
-- ✅ 远程 ESMFold 调用（mock/real）
-- ✅ HITL 进入 WAITING_PLAN_CONFIRM
-- ✅ EventLog + Snapshot 恢复
-- ✅ Summarizer 汇总并产出报告
+## Quick Start
 
-## 快速开始（Mock 模式）
-
-无需 GPU 或远程服务：
+From repository root:
 
 ```bash
-python -m pip install -r requirements.txt
-python examples/demo_esmfold_end_to_end.py --mode mock
+./run_demo.sh
 ```
 
-## 真实模式（对接远程 ESMFold 服务）
+What this does:
 
-远程服务需实现 REST API（见 `docs/remote_model_invocation.md`）：
+1. Checks runtime prerequisites (Python 3.12, `uv`, optional Nextflow).
+2. Initializes runtime resources:
+   - `output/`
+   - `data/logs/`
+   - `data/snapshots/`
+   - `src/kg/protein_tool_kg.json` load check
+3. Starts FastAPI service.
+4. Runs smoke check:
+   - `GET /health` must return `200`
+   - `POST /tasks` creates a demo task
+   - `GET /tasks/{id}` observes task status
+   - verifies EventLog file `data/logs/{task_id}.jsonl`
+
+After startup:
+
+- API docs: `http://127.0.0.1:8000/docs`
+- Health: `http://127.0.0.1:8000/health`
+
+## Main Options
 
 ```bash
-python examples/demo_esmfold_end_to_end.py \
-  --mode real \
-  --remote-url http://<host>:<port>
+./run_demo.sh --port 8010 --model-backend mock --mock-tools
 ```
 
-或使用环境变量：
+Useful flags:
+
+- `--host`, `--port`: API bind address
+- `--model-backend`: backend label for demo metadata
+- `--mock-tools` / `--no-mock-tools`: toggle mock mode flag
+- `--data-dir`, `--output-dir`: runtime directories
+- `--kg-path`: ProteinToolKG file path
+- `--smoke-test` / `--no-smoke-test`: enable/disable smoke run
+- `--smoke-task-config`: task payload JSON (default `configs/demo_task.json`)
+- `--exit-after-smoke`: exit after checks (useful in CI)
+
+All arguments are implemented in `scripts/run_demo.py`.
+
+## Cleanup
 
 ```bash
-export ESMFOLD_API_URL="http://<host>:<port>"
-python examples/demo_esmfold_end_to_end.py --mode real
+./run_demo.sh clean
 ```
 
-## Planner Provider 切换（可选）
+This resets:
 
-默认使用内置 Planner（`--planner-provider none`）。
+- `output/`
+- `data/logs/`
+- `data/snapshots/`
 
-示例：使用 Nemotron 规划（需配置 API Key）：
+## Manual Smoke Commands
+
+If you start demo with `--no-smoke-test`, use:
 
 ```bash
-python examples/demo_esmfold_end_to_end.py \
-  --mode mock \
-  --planner-provider nemotron
+curl -sS http://127.0.0.1:8000/health
+curl -sS -X POST http://127.0.0.1:8000/tasks \
+  -H 'content-type: application/json' \
+  -d @configs/demo_task.json
+curl -sS http://127.0.0.1:8000/tasks/<task_id>
 ```
-
-Provider 定义在 `configs/llm_providers.json`，你也可以通过 `--provider-config` 指向自定义配置。
-
-## 输出结构
-
-默认输出目录为 `demo_output/`：
-
-```
-demo_output/
-├── task.json
-├── plan.json
-├── pending_action.json
-├── recovery.json
-├── step_results.json
-├── design_result.json
-└── task_record.json
-```
-
-此外，快照与事件日志会写入：
-
-```
-data/snapshots/{task_id}.jsonl
-data/logs/{task_id}.jsonl
-```
-
-`recovery.json` 会记录恢复时的状态对齐与回放信息。
-
-## 远程服务 API 约定
-
-脚本使用 `RemoteESMFoldAdapter + RESTModelInvocationService`，远程服务需满足：
-
-- `POST /predict`
-- `GET /job/{job_id}`
-- `GET /results/{job_id}`
-
-完整协议详见：`docs/remote_model_invocation.md`
-
-## 相关文档
-
-- `docs/remote_model_invocation.md`
-- `docs/snapshot-recovery.md`

--- a/run_demo.sh
+++ b/run_demo.sh
@@ -1,126 +1,17 @@
-#!/bin/bash
-# ESMFold 远程调用 + HITL 恢复演示 - 快速运行脚本
-#
-# 使用方法:
-#   ./run_demo.sh          # 运行模拟模式
-#   ./run_demo.sh real     # 运行真实模式（需要云端服务）
-#   ./run_demo.sh clean    # 清理输出目录
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -e
-
-# 颜色定义
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# 打印函数
-print_header() {
-  echo -e "${BLUE}======================================================================${NC}"
-  echo -e "${BLUE}  $1${NC}"
-  echo -e "${BLUE}======================================================================${NC}"
-}
-
-print_info() {
-  echo -e "${GREEN}✓${NC} $1"
-}
-
-print_warning() {
-  echo -e "${YELLOW}⚠${NC} $1"
-}
-
-print_error() {
-  echo -e "${RED}✗${NC} $1"
-}
-
-# 获取脚本所在目录
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# 解析参数
-MODE="${1:-mock}"
-
-# 处理命令
-case "$MODE" in
-clean)
-  print_header "清理输出目录"
-  if [ -d "demo_output" ]; then
-    rm -rf demo_output
-    print_info "已删除 demo_output/"
-  else
-    print_info "输出目录不存在，无需清理"
-  fi
+if [[ "${1:-}" == "clean" ]]; then
+  mkdir -p output data/logs data/snapshots
+  find output -type f ! -name ".gitkeep" -delete
+  find output -mindepth 1 -type d -empty -delete
+  find data/logs -type f -name "*.jsonl" -delete
+  find data/snapshots -type f -name "*.jsonl" -delete
+  echo "cleaned output/, data/logs/, data/snapshots/"
   exit 0
-  ;;
-
-mock)
-  print_header "ESMFold 远程调用演示（模拟模式）"
-  ;;
-
-real)
-  print_header "ESMFold 远程调用演示（真实模式）"
-  print_warning "真实模式需要远程 ESMFold 服务"
-  print_warning "请确保已配置环境变量："
-  echo "  - ESMFOLD_API_URL"
-  echo ""
-  ;;
-
-*)
-  print_error "未知模式: $MODE"
-  echo ""
-  echo "使用方法:"
-  echo "  ./run_demo.sh          # 运行模拟模式"
-  echo "  ./run_demo.sh real     # 运行真实模式"
-  echo "  ./run_demo.sh clean    # 清理输出目录"
-  exit 1
-  ;;
-esac
-
-# 检查 Python 环境
-print_info "检查 Python 环境..."
-if ! command -v python &>/dev/null; then
-  print_error "Python 未安装"
-  exit 1
 fi
 
-PYTHON_VERSION=$(python --version 2>&1 | awk '{print $2}')
-print_info "Python 版本: $PYTHON_VERSION"
-
-# 检查项目依赖
-print_info "检查项目依赖..."
-if [ ! -f "requirements.txt" ]; then
-  print_warning "requirements.txt 不存在"
-else
-  print_info "依赖文件存在"
-fi
-
-# 运行演示
-print_header "开始运行演示"
-echo ""
-
-if [ "$MODE" = "mock" ]; then
-  python examples/demo_esmfold_end_to_end.py --mode mock
-else
-  python examples/demo_esmfold_end_to_end.py --mode real
-fi
-
-EXIT_CODE=$?
-
-# 显示结果
-echo ""
-if [ $EXIT_CODE -eq 0 ]; then
-  print_header "演示完成"
-  print_info "所有 artifacts 已保存到: demo_output/"
-  echo ""
-  echo "生成的文件:"
-  if [ -d "demo_output" ]; then
-    tree -L 2 demo_output/ 2>/dev/null || find demo_output/ -type f
-  fi
-  echo ""
-  print_info "可用于论文的材料已准备好"
-else
-  print_header "演示失败"
-  print_error "退出代码: $EXIT_CODE"
-  exit $EXIT_CODE
-fi
+exec uv run --with uvicorn python scripts/run_demo.py "$@"

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.infra.runtime_init import RuntimeInitResult, initialize_runtime
+from src.kg.kg_client import ToolKGError
+
+TERMINAL_STATUSES = {"DONE", "FAILED", "CANCELLED"}
+WAITING_STATUSES = {
+    "WAITING_PLAN_CONFIRM",
+    "WAITING_PATCH_CONFIRM",
+    "WAITING_REPLAN_CONFIRM",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="One-command demo launcher (API + workflow smoke check)."
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="FastAPI bind host")
+    parser.add_argument("--port", type=int, default=8000, help="FastAPI bind port")
+    parser.add_argument(
+        "--app",
+        default="src.api.main:app",
+        help="ASGI app import path for uvicorn",
+    )
+    parser.add_argument(
+        "--model-backend",
+        default="mock",
+        help="Model backend label for demo metadata (mock/real/etc.)",
+    )
+    parser.add_argument(
+        "--mock-tools",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Toggle mock tool mode flag for demo runtime",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data"),
+        help="Data directory root (contains logs/snapshots)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output"),
+        help="Output directory root",
+    )
+    parser.add_argument(
+        "--kg-path",
+        type=Path,
+        default=Path("src/kg/protein_tool_kg.json"),
+        help="ProteinToolKG file path",
+    )
+    parser.add_argument(
+        "--smoke-test",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run API smoke check after server startup",
+    )
+    parser.add_argument(
+        "--smoke-timeout",
+        type=float,
+        default=20.0,
+        help="Timeout seconds for smoke task polling",
+    )
+    parser.add_argument(
+        "--startup-timeout",
+        type=float,
+        default=20.0,
+        help="Timeout seconds waiting for /health to become ready",
+    )
+    parser.add_argument(
+        "--smoke-task-config",
+        type=Path,
+        default=Path("configs/demo_task.json"),
+        help="JSON file used by smoke test POST /tasks payload",
+    )
+    parser.add_argument(
+        "--check-nextflow",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Warn when Nextflow is unavailable",
+    )
+    parser.add_argument(
+        "--exit-after-smoke",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Exit immediately after smoke test passes",
+    )
+    return parser.parse_args()
+
+
+def require_python_312() -> None:
+    if sys.version_info < (3, 12):
+        version = ".".join(str(x) for x in sys.version_info[:3])
+        raise RuntimeError(
+            f"Python 3.12+ is required, current version is {version}. "
+            "Use `uv python install 3.12` and rerun."
+        )
+
+
+def require_command(name: str) -> None:
+    if shutil.which(name) is None:
+        raise RuntimeError(f"Required command not found: {name}")
+
+
+def maybe_warn_nextflow(enabled: bool) -> None:
+    if not enabled:
+        return
+    if shutil.which("nextflow") is None:
+        print("[WARN] nextflow not found, demo will run without Nextflow integration.")
+
+
+def load_smoke_payload(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise RuntimeError(f"Smoke task config not found: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Smoke task config is invalid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Smoke task config must be a JSON object")
+    if "goal" not in payload:
+        raise RuntimeError("Smoke task config must include `goal`")
+    payload.setdefault("constraints", {})
+    payload.setdefault("metadata", {})
+    return payload
+
+
+def wait_for_health(base_url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: str | None = None
+    with httpx.Client(timeout=2.0) as client:
+        while time.monotonic() < deadline:
+            try:
+                response = client.get(f"{base_url}/health")
+                if response.status_code == 200:
+                    return
+                last_error = f"HTTP {response.status_code}"
+            except Exception as exc:  # pragma: no cover - best effort diagnostics
+                last_error = str(exc)
+            time.sleep(0.4)
+    raise RuntimeError(
+        f"API did not become healthy within {timeout:.1f}s (last error: {last_error})"
+    )
+
+
+def run_smoke(base_url: str, payload: dict[str, Any], timeout: float, data_dir: Path) -> None:
+    request_timeout = max(10.0, timeout)
+    with httpx.Client(timeout=httpx.Timeout(request_timeout, connect=5.0)) as client:
+        health = client.get(f"{base_url}/health")
+        if health.status_code != 200:
+            raise RuntimeError(f"GET /health failed: {health.status_code}")
+
+        create = client.post(f"{base_url}/tasks", json=payload)
+        if create.status_code != 200:
+            raise RuntimeError(
+                f"POST /tasks failed: {create.status_code} {create.text.strip()}"
+            )
+        create_data = create.json()
+        task_id = create_data.get("id")
+        if not task_id:
+            raise RuntimeError("POST /tasks response missing task id")
+
+        seen_status: list[str] = []
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            detail = client.get(f"{base_url}/tasks/{task_id}")
+            if detail.status_code != 200:
+                raise RuntimeError(f"GET /tasks/{task_id} failed: {detail.status_code}")
+            task = detail.json()
+            status = str(task.get("status"))
+            if not seen_status or seen_status[-1] != status:
+                seen_status.append(status)
+            if status in TERMINAL_STATUSES or status in WAITING_STATUSES:
+                break
+            time.sleep(0.5)
+
+        if not seen_status:
+            raise RuntimeError("No task status observed during smoke test")
+
+        if seen_status[-1] not in TERMINAL_STATUSES and seen_status[-1] not in WAITING_STATUSES:
+            raise RuntimeError(
+                "Task status did not reach terminal/waiting state within timeout; "
+                f"last status={seen_status[-1]}"
+            )
+
+        log_file = data_dir / "logs" / f"{task_id}.jsonl"
+        if not log_file.exists():
+            raise RuntimeError(
+                f"Expected EventLog file was not created: {log_file}"
+            )
+
+        print(f"[SMOKE] task_id={task_id}")
+        print(f"[SMOKE] statuses={seen_status}")
+        print(f"[SMOKE] event_log={log_file}")
+
+
+def start_server(args: argparse.Namespace) -> tuple[subprocess.Popen[Any], str]:
+    env = os.environ.copy()
+    env["PROTEIN_DATA_DIR"] = str(args.data_dir)
+    env["PROTEIN_LOG_DIR"] = str(args.data_dir / "logs")
+    env["PROTEIN_SNAPSHOT_DIR"] = str(args.data_dir / "snapshots")
+    env["PROTEIN_OUTPUT_DIR"] = str(args.output_dir)
+    env["PROTEIN_KG_PATH"] = str(args.kg_path)
+    env["PROTEIN_MODEL_BACKEND"] = args.model_backend
+    env["PROTEIN_DEMO_MOCK_TOOLS"] = "1" if args.mock_tools else "0"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        args.app,
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+    ]
+    process: subprocess.Popen[Any] = subprocess.Popen(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+    base_url = f"http://{args.host}:{args.port}"
+    return process, base_url
+
+
+def terminate_process(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    process.send_signal(signal.SIGINT)
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+def describe_runtime(result: RuntimeInitResult) -> None:
+    print(f"[INIT] kg={result.paths.kg_path} (tools={result.tool_count})")
+    print(f"[INIT] output_dir={result.paths.output_dir}")
+    print(f"[INIT] log_dir={result.paths.log_dir}")
+    print(f"[INIT] snapshot_dir={result.paths.snapshot_dir}")
+
+
+def main() -> int:
+    args = parse_args()
+    server: subprocess.Popen[Any] | None = None
+    try:
+        require_python_312()
+        require_command("uv")
+        maybe_warn_nextflow(args.check_nextflow)
+
+        runtime = initialize_runtime(
+            kg_path=args.kg_path,
+            output_dir=args.output_dir,
+            data_dir=args.data_dir,
+            log_dir=args.data_dir / "logs",
+            snapshot_dir=args.data_dir / "snapshots",
+        )
+        describe_runtime(runtime)
+
+        payload = load_smoke_payload(args.smoke_task_config) if args.smoke_test else {}
+
+        server, base_url = start_server(args)
+        wait_for_health(base_url, args.startup_timeout)
+        print(f"[READY] API docs: {base_url}/docs")
+        print(f"[READY] Health:   {base_url}/health")
+
+        if args.smoke_test:
+            run_smoke(base_url, payload, args.smoke_timeout, args.data_dir)
+
+        if args.exit_after_smoke:
+            return 0
+
+        print("[RUNNING] Press Ctrl+C to stop demo server.")
+        while True:
+            code = server.poll()
+            if code is not None:
+                return code
+            time.sleep(0.6)
+    except ToolKGError as exc:
+        print(f"[ERROR] KG initialization failed: {exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        return 0
+    except Exception as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if server is not None:
+            terminate_process(server)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
@@ -25,6 +27,7 @@ from src.workflow.decision_apply import (
     DecisionApplyError,
     DecisionConflictError,
 )
+from src.infra.runtime_init import RuntimeInitResult, initialize_runtime
 from src.models.contracts import PendingActionType, now_iso
 from src.workflow.context import WorkflowContext
 
@@ -32,6 +35,34 @@ app = FastAPI(title="Protein Design Agent System (Mini Demo)", version="0.5.2")
 
 # 简单的内存存储，之后可以换成数据库或文件
 TASK_STORE: Dict[str, TaskRecord] = {}
+RUNTIME_INIT: Optional[RuntimeInitResult] = None
+
+
+def _path_from_env(env_key: str) -> Optional[Path]:
+    raw = os.getenv(env_key)
+    if raw is None or raw == "":
+        return None
+    return Path(raw)
+
+
+def _ensure_runtime_initialized() -> RuntimeInitResult:
+    global RUNTIME_INIT
+    if RUNTIME_INIT is not None:
+        return RUNTIME_INIT
+
+    RUNTIME_INIT = initialize_runtime(
+        kg_path=_path_from_env("PROTEIN_KG_PATH"),
+        output_dir=_path_from_env("PROTEIN_OUTPUT_DIR"),
+        data_dir=_path_from_env("PROTEIN_DATA_DIR"),
+        log_dir=_path_from_env("PROTEIN_LOG_DIR"),
+        snapshot_dir=_path_from_env("PROTEIN_SNAPSHOT_DIR"),
+    )
+    return RUNTIME_INIT
+
+
+@app.on_event("startup")
+async def _startup_init() -> None:
+    _ensure_runtime_initialized()
 
 
 class TaskCreateRequest(BaseModel):
@@ -49,6 +80,23 @@ class DecisionSubmitRequest(BaseModel):
     )
     decided_by: str = Field(..., description="决策者标识")
     comment: Optional[str] = Field(None, description="可选的决策备注")
+
+
+@app.get("/health")
+async def health() -> Dict[str, Any]:
+    runtime = _ensure_runtime_initialized()
+    return {
+        "status": "ok",
+        "task_count": len(TASK_STORE),
+        "kg_tool_count": runtime.tool_count,
+        "paths": {
+            "kg": str(runtime.paths.kg_path),
+            "output": str(runtime.paths.output_dir),
+            "data": str(runtime.paths.data_dir),
+            "logs": str(runtime.paths.log_dir),
+            "snapshots": str(runtime.paths.snapshot_dir),
+        },
+    }
 
 
 @app.post("/tasks", response_model=TaskRecord)

--- a/src/infra/runtime_init.py
+++ b/src/infra/runtime_init.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from src.kg.kg_client import ToolKGError, load_tool_kg
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    """Resolved runtime paths used by demo/API bootstrap."""
+
+    kg_path: Path
+    output_dir: Path
+    data_dir: Path
+    log_dir: Path
+    snapshot_dir: Path
+
+
+@dataclass(frozen=True)
+class RuntimeInitResult:
+    """Initialization summary for health checks and startup logging."""
+
+    paths: RuntimePaths
+    tool_count: int
+
+
+def resolve_runtime_paths(
+    *,
+    kg_path: Optional[Path] = None,
+    output_dir: Optional[Path] = None,
+    data_dir: Optional[Path] = None,
+    log_dir: Optional[Path] = None,
+    snapshot_dir: Optional[Path] = None,
+) -> RuntimePaths:
+    resolved_data_dir = data_dir or Path("data")
+    resolved_log_dir = log_dir or (resolved_data_dir / "logs")
+    resolved_snapshot_dir = snapshot_dir or (resolved_data_dir / "snapshots")
+    resolved_output_dir = output_dir or Path("output")
+    resolved_kg_path = kg_path or (Path("src") / "kg" / "protein_tool_kg.json")
+
+    return RuntimePaths(
+        kg_path=resolved_kg_path,
+        output_dir=resolved_output_dir,
+        data_dir=resolved_data_dir,
+        log_dir=resolved_log_dir,
+        snapshot_dir=resolved_snapshot_dir,
+    )
+
+
+def initialize_runtime(
+    *,
+    kg_path: Optional[Path] = None,
+    output_dir: Optional[Path] = None,
+    data_dir: Optional[Path] = None,
+    log_dir: Optional[Path] = None,
+    snapshot_dir: Optional[Path] = None,
+) -> RuntimeInitResult:
+    """Ensure runtime directories exist and ProteinToolKG is readable."""
+    paths = resolve_runtime_paths(
+        kg_path=kg_path,
+        output_dir=output_dir,
+        data_dir=data_dir,
+        log_dir=log_dir,
+        snapshot_dir=snapshot_dir,
+    )
+
+    paths.output_dir.mkdir(parents=True, exist_ok=True)
+    paths.log_dir.mkdir(parents=True, exist_ok=True)
+    paths.snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    kg = load_tool_kg(paths.kg_path)
+    tools = kg.get("tools", [])
+    if not isinstance(tools, list):
+        raise ToolKGError("ProteinToolKG 'tools' must be a list")
+
+    return RuntimeInitResult(paths=paths, tool_count=len(tools))

--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Mapping, TYPE_CHECKING
 
@@ -8,7 +9,19 @@ if TYPE_CHECKING:
     from src.models.event_log import EventLog
 
 # 事件日志默认目录，按 task_id 写入 jsonl 文件
-DEFAULT_LOG_DIR = Path("data/logs")
+
+
+def _resolve_default_log_dir() -> Path:
+    explicit = os.getenv("PROTEIN_LOG_DIR")
+    if explicit:
+        return Path(explicit)
+    data_dir = os.getenv("PROTEIN_DATA_DIR")
+    if data_dir:
+        return Path(data_dir) / "logs"
+    return Path("data/logs")
+
+
+DEFAULT_LOG_DIR = _resolve_default_log_dir()
 
 
 def append_event(

--- a/src/storage/snapshot_store.py
+++ b/src/storage/snapshot_store.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, List, Mapping, Optional
 
 from src.models.contracts import TaskSnapshot
 
-DEFAULT_SNAPSHOT_DIR = Path("data/snapshots")
+
+def _resolve_default_snapshot_dir() -> Path:
+    explicit = os.getenv("PROTEIN_SNAPSHOT_DIR")
+    if explicit:
+        return Path(explicit)
+    data_dir = os.getenv("PROTEIN_DATA_DIR")
+    if data_dir:
+        return Path(data_dir) / "snapshots"
+    return Path("data/snapshots")
+
+
+DEFAULT_SNAPSHOT_DIR = _resolve_default_snapshot_dir()
 
 
 def append_snapshot(

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -52,6 +52,16 @@ class TestAPIEndpoints:
         assert data["goal"] == "设计一个测试蛋白质"
         assert data["status"] == ExternalStatus.DONE.value
 
+    async def test_health_endpoint(self, client: httpx.AsyncClient):
+        """测试健康检查端点"""
+        response = await client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "kg_tool_count" in data
+        assert "paths" in data
+        assert "logs" in data["paths"]
+
     async def test_create_task_with_minimal_data(self, client: httpx.AsyncClient):
         """测试使用最少数据创建任务"""
         response = await client.post(

--- a/tests/unit/test_runtime_init.py
+++ b/tests/unit/test_runtime_init.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.infra.runtime_init import initialize_runtime, resolve_runtime_paths
+from src.kg.kg_client import ToolKGError
+
+
+@pytest.mark.unit
+def test_resolve_runtime_paths_defaults():
+    paths = resolve_runtime_paths()
+
+    assert paths.kg_path == Path("src/kg/protein_tool_kg.json")
+    assert paths.output_dir == Path("output")
+    assert paths.data_dir == Path("data")
+    assert paths.log_dir == Path("data/logs")
+    assert paths.snapshot_dir == Path("data/snapshots")
+
+
+@pytest.mark.unit
+def test_initialize_runtime_creates_dirs_and_counts_tools(tmp_path: Path):
+    kg_path = tmp_path / "kg.json"
+    kg_path.write_text(json.dumps({"tools": [{"id": "dummy_tool"}]}), encoding="utf-8")
+
+    data_dir = tmp_path / "data"
+    output_dir = tmp_path / "output"
+    result = initialize_runtime(
+        kg_path=kg_path,
+        data_dir=data_dir,
+        output_dir=output_dir,
+        log_dir=data_dir / "logs",
+        snapshot_dir=data_dir / "snapshots",
+    )
+
+    assert result.tool_count == 1
+    assert result.paths.output_dir.exists()
+    assert result.paths.log_dir.exists()
+    assert result.paths.snapshot_dir.exists()
+
+
+@pytest.mark.unit
+def test_initialize_runtime_rejects_invalid_kg_tools(tmp_path: Path):
+    kg_path = tmp_path / "kg.json"
+    kg_path.write_text(json.dumps({"tools": {"id": "invalid"}}), encoding="utf-8")
+
+    with pytest.raises(ToolKGError):
+        initialize_runtime(kg_path=kg_path)


### PR DESCRIPTION
## Related

- Closes #120

## 背景与目标

本 PR 实现 #120 ，目标是让新 clone 仓库后通过一条命令启动最小可验证闭环, 并自动完成运行时资源准备与基础可验证检查.

## 变更范围

- 一键启动入口与参数统一
- 运行时资源初始化(KG, 目录)
- API 启动时初始化与健康检查端点
- 最小 demo 配置与文档
- 冒烟与单元/API测试补充

## 主要改动

### 统一入口脚本(`run_demo.sh` + `scripts/run_demo.py`)

- 新增 Python 启动器, 支持统一参数: `host/port`, `model backend`, `mock` 开关, `data/output/kg` 路径, `smoke` 开关与超时等\
  `script/run_demo.py`
- `run_demo.sh` 改为一键入口, 默认执行启动器; `clean` 子命令清理 demo 产物\
  `run_demo.sh`
- 启动器包含环境检查: Python 3.12, uv, 可选 nextflow 检查, 并提供可行动错误信息与退出码

### 自动初始化与资源准备

- 新增运行时初始化模块, 统一创建并校验:
  - `output/`
  - `data/logs/`
  - `data/snapshots/`
  - `src/kg/protein_tool_kg.json` 可读并 `tools` 为 `list`

`src/infra/runtime_init.py`

### API 启动与工作流联通

- FastAPI 启动事件中执行 `runtime init`\
  `src/api/main.py`

- 新增 `GET /health`, 返回 `status, task` 数, 关键路径, `KG tool` 数\
  `src/api/main.py`

- 启动器自带 smoke:

  - 调整 `GET /health`
  - 调整 `POST /tasks`
  - 轮询 `GET /tasks/{id}`
  - 校验 `data/logs/{task_id}.jsonl` 已生成

  `scripts/run_demo.py`

### 最小 Demo 配置与文档

- 新增最小 smoke payload: `configs/demo_task.json`
- 新增根 README 一键启动入口说明: `README.md`
- 重写 demo 文档, 指向一键命令与验收步骤: `examples/README_DEMO.md`

### 测试补充

- 新增 runtime init 单测: `tests/unit/test_runtime_init.py`
- API 测试新增 `/health` 断言: `tests/api/test_api_endpoints.py`

## 验收标准对照

- [x] 新 clone 后按照 README/README_DEMO 一条命令启动
- [x] `GET /docs` 或 `GET /health` 返回 200
- [x] 能创建任务并观察状态变化
- [x] 自动生成 `outputs/` 与 `data/logs/`
- [x] 失败提示明确且包含退出码

## 验证记录

### 自动化测试

执行:

```bash
uv run pytest tests/unit/test_runtime_init.py tests/api/test_api_endpoints.py
```

结果:

- 26 passed

### 一键启动冒烟

执行:

```bash
./run_demo.sh --exit-after-smoke
```

关键结果:

- `/health 200`
- `POST /tasks 200`
- `GET /tasks/{id} 200`
- `data/logs/{task_id}.jsonl` 已生成

## 风险与兼容性

- 保持既有 `/tasks` 与决策接口行为不变; 新增能力为向后兼容
- `run_demo.sh clean` 仅清理 demo 产物与日志快照文件, 不删除 tracked .gitkeep
- 使用 `uv run --with uvicorn` 避免对全局环境额外安装要求
