### PR TITLE
implement #138 Requirement2 tool metadata in CandidateSetOutput

### DIFF
--- a/examples/CANDIDATE_SET_OUTPUT_V1.md
+++ b/examples/CANDIDATE_SET_OUTPUT_V1.md
@@ -18,6 +18,22 @@ This document defines the `CandidateSetOutput v1` field semantics used by Planne
 - `summary`: optional short summary for display.
 - `metadata`: optional extension map.
 
+### Tool metadata fields (Requirement-2)
+
+Candidate tool fields are represented as top-level fields and synchronized into `metadata`:
+
+- `tool_id`: required in v1 strict mode.
+- `capability_id`: required in v1 strict mode.
+- `io_type`: required in v1 strict mode.
+- `adapter_mode`: optional at input, defaults to `unknown` when any tool field exists.
+  - allowed values: `local | remote | mock | hybrid | unknown`
+
+Validation policy:
+
+- In `require_v1_fields=True`, all four tool keys must be present after normalization.
+- `metadata.tool_id/capability_id/io_type/adapter_mode` must be present for downstream extraction.
+- If both top-level and `metadata.*` values are provided, they must match.
+
 ## CandidateSet fields
 
 - `candidates`: Top-K candidate list sorted by rank.
@@ -35,3 +51,13 @@ This document defines the `CandidateSetOutput v1` field semantics used by Planne
 - Candidate IDs must be unique in one candidate set.
 - `default_recommendation` must point to an existing candidate.
 - For v1 strict validation, every candidate must provide full v1 fields.
+- For Requirement-2 strict validation, every candidate must provide tool metadata fields.
+
+## Training extraction alignment (#145)
+
+The following keys are intentionally aligned with training extraction schema naming:
+
+- `tool_id`
+- `capability_id`
+- `io_type`
+- `adapter_mode`

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Literal
+from typing import Any, Dict, List, Optional, Literal, cast
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
@@ -217,6 +217,10 @@ class PendingActionCandidate(BaseModel):
         risk_level: 风险等级（low/medium/high）。
         cost_estimate: 成本等级（low/medium/high）。
         explanation: 候选解释。
+        tool_id: 工具标识（与 metadata.tool_id 同步）。
+        capability_id: 工具能力标识（与 metadata.capability_id 同步）。
+        io_type: I/O 类型标识（与 metadata.io_type 同步）。
+        adapter_mode: 适配器模式（local/remote/mock/hybrid/unknown）。
         summary: 候选摘要信息。
         metadata: 额外元数据。
     """
@@ -228,6 +232,10 @@ class PendingActionCandidate(BaseModel):
     risk_level: Literal["low", "medium", "high"] | None = None
     cost_estimate: Literal["low", "medium", "high"] | None = None
     explanation: str | None = None
+    tool_id: str | None = None
+    capability_id: str | None = None
+    io_type: str | None = None
+    adapter_mode: Literal["local", "remote", "mock", "hybrid", "unknown"] | None = None
     summary: Optional[str] = None
     metadata: Dict = Field(default_factory=dict)
 
@@ -251,6 +259,16 @@ class PendingActionCandidate(BaseModel):
             normalized[key] = float(score)
         return normalized
 
+    @field_validator("tool_id", "capability_id", "io_type")
+    @classmethod
+    def _validate_tool_fields(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("tool metadata fields must not be empty")
+        return normalized
+
     @model_validator(mode="after")
     def _sync_payload_fields(self):
         payload = self.payload
@@ -271,6 +289,95 @@ class PendingActionCandidate(BaseModel):
         ):
             raise ValueError("payload and structured_payload must be equivalent")
         return self
+
+    @model_validator(mode="after")
+    def _sync_tool_metadata(self):
+        metadata = dict(self.metadata or {})
+        self.metadata = metadata
+
+        self.tool_id = _sync_metadata_field(
+            metadata,
+            field_name="tool_id",
+            field_value=self.tool_id,
+        )
+        self.capability_id = _sync_metadata_field(
+            metadata,
+            field_name="capability_id",
+            field_value=self.capability_id,
+        )
+        self.io_type = _sync_metadata_field(
+            metadata,
+            field_name="io_type",
+            field_value=self.io_type,
+        )
+        self.adapter_mode = _sync_adapter_mode(
+            metadata,
+            field_value=self.adapter_mode,
+        )
+
+        has_any_tooling = any(
+            value is not None for value in (self.tool_id, self.capability_id, self.io_type)
+        )
+        if has_any_tooling and self.adapter_mode is None:
+            self.adapter_mode = "unknown"
+            metadata["adapter_mode"] = self.adapter_mode
+
+        return self
+
+
+def _sync_metadata_field(
+    metadata: Dict[str, Any],
+    *,
+    field_name: str,
+    field_value: str | None,
+) -> str | None:
+    metadata_value = metadata.get(field_name)
+    if metadata_value is None:
+        if field_value is not None:
+            metadata[field_name] = field_value
+        return field_value
+    if not isinstance(metadata_value, str):
+        raise ValueError(f"metadata.{field_name} must be a string")
+    normalized = metadata_value.strip()
+    if not normalized:
+        raise ValueError(f"metadata.{field_name} must not be empty")
+    if field_value is None:
+        return normalized
+    if field_value != normalized:
+        raise ValueError(f"metadata.{field_name} must match {field_name}")
+    metadata[field_name] = field_value
+    return field_value
+
+
+def _sync_adapter_mode(
+    metadata: Dict[str, Any],
+    *,
+    field_value: Literal["local", "remote", "mock", "hybrid", "unknown"] | None,
+) -> Literal["local", "remote", "mock", "hybrid", "unknown"] | None:
+    metadata_value = metadata.get("adapter_mode")
+    if metadata_value is None:
+        if field_value is not None:
+            metadata["adapter_mode"] = field_value
+        return field_value
+    if not isinstance(metadata_value, str):
+        raise ValueError("metadata.adapter_mode must be a string")
+    normalized = metadata_value.strip().lower()
+    allowed = {"local", "remote", "mock", "hybrid", "unknown"}
+    if normalized not in allowed:
+        raise ValueError(
+            "metadata.adapter_mode must be one of "
+            "local, remote, mock, hybrid, unknown"
+        )
+    if field_value is None:
+        metadata["adapter_mode"] = normalized
+        return cast(
+            Literal["local", "remote", "mock", "hybrid", "unknown"],
+            normalized,
+        )
+    if field_value != normalized:
+        raise ValueError("metadata.adapter_mode must match adapter_mode")
+    metadata["adapter_mode"] = field_value
+    return field_value
 
 
 class PendingAction(BaseModel):

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -35,6 +35,9 @@ class CandidateSetValidationError(ValueError):
 REQUIRED_SCORE_BREAKDOWN_FIELDS = frozenset(
     {"feasibility", "objective", "risk", "cost", "overall"}
 )
+REQUIRED_TOOL_METADATA_WITH_DEFAULTS = frozenset(
+    {"tool_id", "capability_id", "io_type", "adapter_mode"}
+)
 
 
 def validate_candidate_set_output(
@@ -103,6 +106,34 @@ def _validate_candidate_v1_fields(
         raise CandidateSetValidationError(f"{candidate_id}.cost_estimate is required")
     if not candidate.explanation:
         raise CandidateSetValidationError(f"{candidate_id}.explanation is required")
+    _validate_candidate_tool_fields(candidate, candidate_id)
+
+
+def _validate_candidate_tool_fields(
+    candidate: PendingActionCandidate, candidate_id: str
+) -> None:
+    if candidate.tool_id is None:
+        raise CandidateSetValidationError(f"{candidate_id}.tool_id is required")
+    if candidate.capability_id is None:
+        raise CandidateSetValidationError(
+            f"{candidate_id}.capability_id is required"
+        )
+    if candidate.io_type is None:
+        raise CandidateSetValidationError(f"{candidate_id}.io_type is required")
+    if candidate.adapter_mode is None:
+        raise CandidateSetValidationError(f"{candidate_id}.adapter_mode is required")
+
+    metadata = candidate.metadata or {}
+    missing_metadata = [
+        key
+        for key in REQUIRED_TOOL_METADATA_WITH_DEFAULTS
+        if key not in metadata or metadata.get(key) in (None, "")
+    ]
+    if missing_metadata:
+        missing = ", ".join(sorted(missing_metadata))
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata missing tool keys: {missing}"
+        )
 
 
 def validate_decision_for_pending_action(

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -262,6 +262,65 @@ class TestCandidateSetContracts:
                 cost_estimate="expensive",  # type: ignore[arg-type]
             )
 
+    def test_candidate_tool_fields_sync_to_metadata(self, sample_plan: Plan):
+        candidate = PendingActionCandidate(
+            candidate_id="plan_tool_sync",
+            payload=sample_plan,
+            tool_id="esmfold",
+            capability_id="structure_prediction",
+            io_type="sequence_to_structure",
+        )
+
+        assert candidate.tool_id == "esmfold"
+        assert candidate.capability_id == "structure_prediction"
+        assert candidate.io_type == "sequence_to_structure"
+        assert candidate.adapter_mode == "unknown"
+        assert candidate.metadata["tool_id"] == "esmfold"
+        assert candidate.metadata["capability_id"] == "structure_prediction"
+        assert candidate.metadata["io_type"] == "sequence_to_structure"
+        assert candidate.metadata["adapter_mode"] == "unknown"
+
+    def test_candidate_tool_fields_can_backfill_from_metadata(self, sample_plan: Plan):
+        candidate = PendingActionCandidate(
+            candidate_id="plan_tool_meta",
+            payload=sample_plan,
+            metadata={
+                "tool_id": "nim_esmfold",
+                "capability_id": "structure_prediction",
+                "io_type": "sequence_to_structure",
+                "adapter_mode": "remote",
+            },
+        )
+
+        assert candidate.tool_id == "nim_esmfold"
+        assert candidate.capability_id == "structure_prediction"
+        assert candidate.io_type == "sequence_to_structure"
+        assert candidate.adapter_mode == "remote"
+
+    def test_candidate_tool_metadata_conflict_rejected(self, sample_plan: Plan):
+        with pytest.raises(ValueError, match="metadata\\.tool_id must match tool_id"):
+            PendingActionCandidate(
+                candidate_id="plan_tool_conflict",
+                payload=sample_plan,
+                tool_id="esmfold",
+                metadata={"tool_id": "protein_mpnn"},
+            )
+
+    def test_candidate_invalid_adapter_mode_in_metadata_rejected(
+        self, sample_plan: Plan
+    ):
+        with pytest.raises(ValueError, match="metadata\\.adapter_mode must be one of"):
+            PendingActionCandidate(
+                candidate_id="plan_tool_bad_mode",
+                payload=sample_plan,
+                metadata={
+                    "tool_id": "esmfold",
+                    "capability_id": "structure_prediction",
+                    "io_type": "sequence_to_structure",
+                    "adapter_mode": "cloud",
+                },
+            )
+
     def test_pending_action_default_recommendation_compat(self, sample_task, sample_plan):
         candidate = PendingActionCandidate(candidate_id="plan_a", payload=sample_plan)
         action = PendingAction(

--- a/tests/unit/test_decision_validation.py
+++ b/tests/unit/test_decision_validation.py
@@ -131,6 +131,10 @@ def test_candidate_set_v1_validation_passes(sample_task, sample_plan):
                 risk_level="low",
                 cost_estimate="medium",
                 explanation="candidate a is balanced",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                io_type="sequence_to_structure",
+                adapter_mode="remote",
             )
         ],
         default_recommendation="plan_a",
@@ -159,6 +163,10 @@ def test_candidate_set_missing_required_score_key_rejected(sample_task, sample_p
                 risk_level="low",
                 cost_estimate="medium",
                 explanation="candidate a",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                io_type="sequence_to_structure",
+                adapter_mode="remote",
             )
         ],
         default_recommendation="plan_a",
@@ -192,6 +200,10 @@ def test_candidate_set_default_recommendation_must_exist(sample_task, sample_pla
                 risk_level="low",
                 cost_estimate="medium",
                 explanation="candidate a",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                io_type="sequence_to_structure",
+                adapter_mode="remote",
             )
         ],
         default_recommendation="plan_x",
@@ -203,6 +215,72 @@ def test_candidate_set_default_recommendation_must_exist(sample_task, sample_pla
         match="default_recommendation is not in candidates",
     ):
         validate_candidate_set_output(pending_action)
+
+
+@pytest.mark.unit
+def test_candidate_set_missing_tool_fields_rejected(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_missing_tooling",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.4,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a",
+            )
+        ],
+        default_recommendation="plan_a",
+        explanation="test",
+    )
+
+    with pytest.raises(
+        CandidateSetValidationError,
+        match="plan_a\\.tool_id is required",
+    ):
+        validate_candidate_set_output(pending_action)
+
+
+@pytest.mark.unit
+def test_candidate_set_tooling_defaults_adapter_mode_to_unknown(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_tooling_default_mode",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.4,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                io_type="sequence_to_structure",
+            )
+        ],
+        default_recommendation="plan_a",
+        explanation="test",
+    )
+
+    validate_candidate_set_output(pending_action)
+    assert pending_action.candidates[0].adapter_mode == "unknown"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Related

Refs #138

## Background

本 PR 只实现 issue #138 中 Requirement-2 并入: 工具接入(Candidate 契约)\
不重复实现 PR#154 中已完成的 CandidateSetOutput v1 基础契约内容.

## 本 PR 范围

### Candidate 工具字段

在 PendingActionCandidate 增加并标准化以下字段:

- `tool_id`
- `capability_id`
- `io_type`
- `adapter_mode(local | remote | mock | hybrid | unknown)`

并实现顶层字段与 `metadata.*` 的同步与一致性校验

文件:

- `src/models/contracts.py`
- `tests/unit/test_contracts.py`

### 必填/默认策略与校验规则

在 `validate_candidate_set_output(..., require_v1_fields=True)` 下新增 Requirement2 校验:

- 候选必须提供: `tool_id/capability_id/io_type/adapter_mode`
- `metadata` 中必须存在对应键: `metadata.tool_id/capability_id/io_type/adapter_mode`
- 若存在工具字段但未提供 `adapter_mode`, 默认补为 `unknown`

文件:

- `src/models/validation.py`
- `tests/unit/test_decision_validation.py`

### 字段字典

更新候选字段说明, 明确:

- Requirement2 工具字段语义
- 必填规则
- 默认值策略
- 与后续训练抽取字段命名对齐

文件:

- `example/CANDIDATE_SET_OUTPUT_V1.md`

## 兼容性说明

- 保持 additive-only, 不删除旧字段
- 旧候选在非严格模式仍可消费
- 新增的是严格模式下的工具字段约束, 不改变决策 FSM/Agent 角色边界

## 验收标准对照(Requirement2)

- [x] 候选 payload 元数据补充 `tool_id/capability/io_type/adapter_mode`
- [x] 明确字段必填与默认值 (`adapter_mode` 默认 `unknown`)
- [x] 字段字典对齐训练抽取说明
- [x] backward compatibility 测试覆盖旧候选消费路径

## 测试

执行:

```bash
uv run pytest tests/unit/test_contracts.py tests/unit/test_decision_validation.py
```

结果:

- 30 passed
