### PR TITLE
implement candidate scoring and HITL gate for issue #140

### DIFF
--- a/examples/planner-score-gate.md
+++ b/examples/planner-score-gate.md
@@ -1,0 +1,55 @@
+# Planner Score/Gate (W10-03)
+
+This note documents the minimal scoring and gate policy for issue #140.
+
+## Score Breakdown
+
+Planner candidate scoring keeps required v1 keys and adds tool dimensions:
+
+- Required keys:
+  - `feasibility`
+  - `objective`
+  - `risk`
+  - `cost`
+  - `overall`
+- Added keys:
+  - `confidence`
+  - `tool_readiness`
+  - `tool_coverage`
+  - `fallback_depth`
+
+`objective` includes a small boost when payload contains objective scoring tools
+(for example `objective_ranker` / `objective_scoring` capability).
+
+## Risk/Cost Mapping
+
+Risk and cost are derived from:
+
+- adapter mode (`local/remote/hybrid/mock/unknown`)
+- capability type (for example `structure_prediction`, `quality_qc`)
+- base tool attributes (`safety_level`, `cost`)
+
+This mapping is used for both:
+
+- candidate `risk_level` / `cost_estimate` labels
+- score components (`risk`, `cost`)
+
+## HITL Gate
+
+Gate is evaluated on the top-ranked candidate.
+
+Hard conditions to enter `WAITING_*`:
+
+- explicit confirm flags:
+  - `require_plan_confirm`
+  - `require_patch_confirm`
+  - `require_replan_confirm`
+- `risk_level == high`
+- `confidence < min_candidate_confidence` (default `0.0`, configurable)
+- `cost_estimate == high` and `overall < high_cost_min_overall` (only when threshold is configured)
+
+Default policy:
+
+- `plan`: auto by default (`require_plan_confirm=false`)
+- `patch`: auto by default (`require_patch_confirm=false`)
+- `replan`: auto by default (`require_replan_confirm=false`)

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -9,6 +9,7 @@ from src.kg.kg_client import ToolKGError, load_tool_kg
 from src.llm.base_llm_provider import BaseProvider
 from src.models.contracts import (
     PatchRequest,
+    PendingActionType,
     PendingActionCandidate,
     Plan,
     PlanPatch,
@@ -19,8 +20,10 @@ from src.models.contracts import (
     ReplanRequest,
     StepResult,
 )
+from src.models.validation import validate_candidate_set_output
 from src.models.db import InternalStatus, TaskRecord, TERMINAL_INTERNAL_STATUSES
 from src.workflow.context import WorkflowContext
+from src.workflow.pending_action import build_pending_action, enter_waiting_state
 from src.workflow.status import transition_task_status
 
 
@@ -46,6 +49,17 @@ class TopKResult:
     candidates: List[PendingActionCandidate]
     default_recommendation: str | None
     explanation: str
+
+
+@dataclass(frozen=True)
+class CandidateGateDecision:
+    """候选门控决策结果。"""
+
+    requires_hitl: bool
+    reason: str
+    selected_candidate_id: str | None
+    confidence: float
+    overall: float
 
 
 @dataclass(frozen=True)
@@ -158,6 +172,24 @@ class PlannerAgent:
             top_k=_normalize_top_k(k),
         )
 
+    def evaluate_top_k_gate(
+        self,
+        *,
+        candidate_kind: Literal["plan", "patch", "replan"],
+        top_k_result: TopKResult,
+        task_constraints: dict,
+    ) -> CandidateGateDecision:
+        """根据 score/risk/cost 阈值判断是否进入 WAITING_*。"""
+        return _evaluate_top_k_gate(
+            candidate_kind=candidate_kind,
+            top_k_result=top_k_result,
+            task_constraints=task_constraints,
+        )
+
+    def score_candidate_payload(self, payload: Plan | PlanPatch) -> dict[str, float]:
+        """对单个候选 payload 打分（用于调试/测试）。"""
+        return _score_payload(payload, self._tool_registry)
+
     def _default_plan(self, task: ProteinDesignTask) -> Plan:
         """向后兼容的默认单步计划
 
@@ -199,7 +231,7 @@ class PlannerAgent:
         *,
         record: TaskRecord | None = None,
     ) -> Plan:
-        """生成 Plan 并驱动 PLANNING → PLANNED 状态变更。"""
+        """生成 Plan 并驱动 PLANNING → PLANNED/WAITING_PLAN_CONFIRM 状态变更。"""
         transition_task_status(
             context,
             record,
@@ -207,7 +239,22 @@ class PlannerAgent:
             reason="task_created",
         )
         try:
-            plan = self.plan(task)
+            top_k_value = _resolve_top_k_value(
+                task.constraints,
+                key="plan_top_k",
+                default=3,
+            )
+            top_k = self.plan_top_k(task, k=top_k_value)
+            gate = self.evaluate_top_k_gate(
+                candidate_kind="plan",
+                top_k_result=top_k,
+                task_constraints=task.constraints,
+            )
+            candidate = _require_default_candidate(top_k, expected_kind="plan")
+            payload = candidate.structured_payload
+            if not isinstance(payload, Plan):
+                raise ValueError("plan_top_k returned non-Plan payload")
+            plan = payload
         except Exception:
             self._mark_failed(context, record, reason="planning_failed")
             raise
@@ -215,6 +262,31 @@ class PlannerAgent:
         context.plan = plan
         if record is not None:
             record.plan = plan
+
+        if gate.requires_hitl:
+            pending_action = build_pending_action(
+                task_id=task.task_id,
+                action_type=PendingActionType.PLAN_CONFIRM,
+                candidates=top_k.candidates,
+                default_suggestion=top_k.default_recommendation,
+                default_recommendation=top_k.default_recommendation,
+                explanation=f"{top_k.explanation} gate={gate.reason}",
+            )
+            validate_candidate_set_output(pending_action)
+            enter_waiting_state(
+                context,
+                record,
+                pending_action,
+                InternalStatus.WAITING_PLAN_CONFIRM,
+                reason=gate.reason,
+            )
+            transition_task_status(
+                context,
+                record,
+                InternalStatus.WAITING_PLAN_CONFIRM,
+                reason=gate.reason,
+            )
+            return plan
 
         transition_task_status(
             context,
@@ -313,6 +385,127 @@ def _find_tool_spec(registry: Sequence[ToolSpec], tool_id: str) -> ToolSpec:
         if spec.id == tool_id:
             return spec
     raise ValueError(f"Tool '{tool_id}' not found in registry")
+
+
+_FORCE_CONFIRM_KEYS = {
+    "plan": "require_plan_confirm",
+    "patch": "require_patch_confirm",
+    "replan": "require_replan_confirm",
+}
+
+_DEFAULT_FORCE_CONFIRM = {
+    "plan": False,
+    "patch": False,
+    "replan": False,
+}
+
+
+def _resolve_top_k_value(
+    constraints: dict,
+    *,
+    key: str,
+    default: int,
+) -> int:
+    raw = constraints.get(key, default)
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return _normalize_top_k(parsed)
+
+
+def _evaluate_top_k_gate(
+    *,
+    candidate_kind: Literal["plan", "patch", "replan"],
+    top_k_result: TopKResult,
+    task_constraints: dict,
+) -> CandidateGateDecision:
+    if not top_k_result.candidates:
+        return CandidateGateDecision(
+            requires_hitl=True,
+            reason=f"{candidate_kind}_candidate_empty",
+            selected_candidate_id=None,
+            confidence=0.0,
+            overall=0.0,
+        )
+
+    best = top_k_result.candidates[0]
+    score = best.score_breakdown or {}
+    overall = float(score.get("overall", 0.0))
+    confidence = float(score.get("confidence", overall))
+    risk_level = best.risk_level or "medium"
+    cost_estimate = best.cost_estimate or "medium"
+
+    key = _FORCE_CONFIRM_KEYS[candidate_kind]
+    force_default = _DEFAULT_FORCE_CONFIRM[candidate_kind]
+    force_confirm = bool(task_constraints.get(key, force_default))
+    min_confidence = _safe_float(
+        task_constraints.get("min_candidate_confidence"),
+        default=0.0,
+    )
+    raw_high_cost_min_overall = task_constraints.get("high_cost_min_overall")
+    high_cost_min_overall = (
+        _safe_float(raw_high_cost_min_overall, default=0.75)
+        if raw_high_cost_min_overall is not None
+        else None
+    )
+
+    if force_confirm:
+        return CandidateGateDecision(
+            requires_hitl=True,
+            reason=f"{candidate_kind}_confirm_required",
+            selected_candidate_id=best.candidate_id,
+            confidence=confidence,
+            overall=overall,
+        )
+    if risk_level == "high":
+        return CandidateGateDecision(
+            requires_hitl=True,
+            reason=f"{candidate_kind}_high_risk",
+            selected_candidate_id=best.candidate_id,
+            confidence=confidence,
+            overall=overall,
+        )
+    if confidence < min_confidence:
+        return CandidateGateDecision(
+            requires_hitl=True,
+            reason=f"{candidate_kind}_low_confidence",
+            selected_candidate_id=best.candidate_id,
+            confidence=confidence,
+            overall=overall,
+        )
+    if (
+        cost_estimate == "high"
+        and high_cost_min_overall is not None
+        and overall < high_cost_min_overall
+    ):
+        return CandidateGateDecision(
+            requires_hitl=True,
+            reason=f"{candidate_kind}_high_cost_low_benefit",
+            selected_candidate_id=best.candidate_id,
+            confidence=confidence,
+            overall=overall,
+        )
+
+    return CandidateGateDecision(
+        requires_hitl=False,
+        reason=f"{candidate_kind}_auto_execute",
+        selected_candidate_id=best.candidate_id,
+        confidence=confidence,
+        overall=overall,
+    )
+
+
+def _safe_float(value: object, *, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed < 0:
+        return 0.0
+    if parsed > 1:
+        return 1.0
+    return parsed
 
 
 def _normalize_top_k(value: int) -> int:
@@ -702,33 +895,66 @@ def _build_candidate_summary(payload: Plan | PlanPatch) -> str:
 def _score_payload(payload: Plan | PlanPatch, registry: Sequence[ToolSpec]) -> dict[str, float]:
     registry_map = {spec.id: spec for spec in registry}
     tool_ids = _extract_payload_tool_ids(payload)
-    costs: List[float] = []
-    safety_levels: List[int] = []
+    risk_scores: List[float] = []
+    cost_scores: List[float] = []
+    readiness_scores: List[float] = []
+    capabilities: Set[str] = set()
+    objective_bonus = 0.0
     for tool_id in tool_ids:
         spec = registry_map.get(tool_id)
         if spec is None:
             continue
-        costs.append(float(spec.cost))
-        safety_levels.append(int(spec.safety_level))
+        tool_risk, tool_cost = _tool_risk_cost_score(spec)
+        risk_scores.append(tool_risk)
+        cost_scores.append(tool_cost)
+        readiness_scores.append(_tool_readiness_score(spec))
+        capabilities.update(spec.capabilities)
+        if "objective_scoring" in spec.capabilities or spec.id == "objective_ranker":
+            objective_bonus = max(objective_bonus, 0.08)
 
-    max_cost = max((float(spec.cost) for spec in registry), default=1.0)
-    max_safety = max((int(spec.safety_level) for spec in registry), default=1)
-    avg_cost = sum(costs) / len(costs) if costs else max_cost
-    avg_safety = sum(safety_levels) / len(safety_levels) if safety_levels else max_safety
+    avg_risk = sum(risk_scores) / len(risk_scores) if risk_scores else 0.55
+    avg_cost = sum(cost_scores) / len(cost_scores) if cost_scores else 0.55
+    tool_readiness = (
+        sum(readiness_scores) / len(readiness_scores) if readiness_scores else 0.5
+    )
+    tool_coverage = _tool_coverage_score(tool_ids, capabilities)
+    fallback_depth = _fallback_depth_score(tool_ids, registry_map, registry)
 
-    normalized_cost = min(avg_cost / max(max_cost, 1e-6), 1.0)
-    normalized_safety = min(avg_safety / max(max_safety, 1), 1.0)
-
-    feasibility = 1.0
-    objective = max(0.0, 1.0 - normalized_cost * 0.4)
-    risk = max(0.0, 1.0 - normalized_safety * 0.6)
-    cost = max(0.0, 1.0 - normalized_cost)
-    overall = 0.35 * feasibility + 0.25 * objective + 0.2 * risk + 0.2 * cost
+    feasibility = min(1.0, max(0.0, 0.5 + 0.25 * tool_coverage + 0.25 * fallback_depth))
+    objective = min(
+        1.0,
+        max(0.0, 1.0 - avg_cost * 0.3 + objective_bonus),
+    )
+    risk = max(0.0, 1.0 - avg_risk)
+    cost = max(0.0, 1.0 - avg_cost)
+    confidence = min(
+        1.0,
+        max(
+            0.0,
+            0.35 * feasibility
+            + 0.25 * tool_readiness
+            + 0.2 * tool_coverage
+            + 0.2 * fallback_depth,
+        ),
+    )
+    overall = (
+        0.2 * feasibility
+        + 0.2 * objective
+        + 0.15 * risk
+        + 0.15 * cost
+        + 0.15 * confidence
+        + 0.075 * tool_readiness
+        + 0.075 * tool_coverage
+    )
     return {
         "feasibility": round(feasibility, 6),
         "objective": round(objective, 6),
         "risk": round(risk, 6),
         "cost": round(cost, 6),
+        "confidence": round(confidence, 6),
+        "tool_readiness": round(tool_readiness, 6),
+        "tool_coverage": round(tool_coverage, 6),
+        "fallback_depth": round(fallback_depth, 6),
         "overall": round(overall, 6),
     }
 
@@ -738,18 +964,17 @@ def _derive_risk_level(
     registry: Sequence[ToolSpec],
 ) -> Literal["low", "medium", "high"]:
     registry_map = {spec.id: spec for spec in registry}
-    levels = [
-        int(registry_map[tool_id].safety_level)
+    risk_scores = [
+        _tool_risk_cost_score(registry_map[tool_id])[0]
         for tool_id in _extract_payload_tool_ids(payload)
         if tool_id in registry_map
     ]
-    if not levels:
+    if not risk_scores:
         return "medium"
-    max_level = max((int(spec.safety_level) for spec in registry), default=1)
-    normalized = (sum(levels) / len(levels)) / max(max_level, 1)
-    if normalized <= 0.34:
+    normalized = sum(risk_scores) / len(risk_scores)
+    if normalized <= 0.33:
         return "low"
-    if normalized <= 0.67:
+    if normalized <= 0.66:
         return "medium"
     return "high"
 
@@ -759,20 +984,104 @@ def _derive_cost_estimate(
     registry: Sequence[ToolSpec],
 ) -> Literal["low", "medium", "high"]:
     registry_map = {spec.id: spec for spec in registry}
-    costs = [
-        float(registry_map[tool_id].cost)
+    cost_scores = [
+        _tool_risk_cost_score(registry_map[tool_id])[1]
         for tool_id in _extract_payload_tool_ids(payload)
         if tool_id in registry_map
     ]
-    if not costs:
+    if not cost_scores:
         return "medium"
-    max_cost = max((float(spec.cost) for spec in registry), default=1.0)
-    normalized = (sum(costs) / len(costs)) / max(max_cost, 1e-6)
-    if normalized <= 0.34:
+    normalized = sum(cost_scores) / len(cost_scores)
+    if normalized <= 0.33:
         return "low"
-    if normalized <= 0.67:
+    if normalized <= 0.66:
         return "medium"
     return "high"
+
+
+def _tool_readiness_score(spec: ToolSpec) -> float:
+    adapter_base = {
+        "local": 0.9,
+        "hybrid": 0.82,
+        "remote": 0.72,
+        "mock": 0.6,
+        "unknown": 0.55,
+    }
+    base = adapter_base.get(spec.adapter_mode, 0.55)
+    priority_bonus = 0.06 if _priority_rank(spec.priority) == 0 else 0.0
+    safety_penalty = min(0.18, max(0, spec.safety_level - 1) * 0.05)
+    return min(1.0, max(0.0, base + priority_bonus - safety_penalty))
+
+
+def _tool_coverage_score(tool_ids: Sequence[str], capabilities: Set[str]) -> float:
+    if not tool_ids:
+        return 0.0
+    return min(1.0, len(capabilities) / max(1, len(tool_ids)))
+
+
+def _fallback_depth_score(
+    tool_ids: Sequence[str],
+    registry_map: dict[str, ToolSpec],
+    registry: Sequence[ToolSpec],
+) -> float:
+    fallback_scores: List[float] = []
+    for tool_id in tool_ids:
+        spec = registry_map.get(tool_id)
+        if spec is None:
+            continue
+        capability = _primary_capability(spec)
+        alternatives = [
+            candidate
+            for candidate in registry
+            if candidate.id != spec.id and capability in candidate.capabilities
+        ]
+        fallback_scores.append(min(1.0, len(alternatives) / 3.0))
+    if not fallback_scores:
+        return 0.0
+    return sum(fallback_scores) / len(fallback_scores)
+
+
+def _tool_risk_cost_score(spec: ToolSpec) -> tuple[float, float]:
+    adapter_risk = {
+        "local": 0.22,
+        "hybrid": 0.32,
+        "remote": 0.44,
+        "mock": 0.15,
+        "unknown": 0.38,
+    }
+    adapter_cost = {
+        "local": 0.42,
+        "hybrid": 0.45,
+        "remote": 0.34,
+        "mock": 0.12,
+        "unknown": 0.48,
+    }
+    capability_risk = {
+        "sequence_generation": 0.08,
+        "sequence_design": 0.05,
+        "structure_prediction": 0.14,
+        "quality_qc": -0.08,
+        "objective_scoring": -0.04,
+    }
+    capability_cost = {
+        "sequence_generation": 0.12,
+        "sequence_design": 0.1,
+        "structure_prediction": 0.2,
+        "quality_qc": 0.05,
+        "objective_scoring": 0.08,
+    }
+    risk = adapter_risk.get(spec.adapter_mode, 0.38)
+    cost = adapter_cost.get(spec.adapter_mode, 0.48)
+    for capability in spec.capabilities:
+        risk += capability_risk.get(capability, 0.0)
+        cost += capability_cost.get(capability, 0.0)
+    # 补充基础安全/资源成本信号
+    risk += max(0, spec.safety_level - 1) * 0.06
+    cost += min(0.35, float(spec.cost) * 0.2)
+    return (
+        min(1.0, max(0.0, risk)),
+        min(1.0, max(0.0, cost)),
+    )
 
 
 def _extract_payload_tool_ids(payload: Plan | PlanPatch) -> List[str]:

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -3,17 +3,16 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
-from src.agents.planner import PlannerAgent
+from src.agents.planner import PlannerAgent, TopKResult
 from src.models.contracts import (
     PendingActionCandidate,
-    PendingActionStatus,
     PendingActionType,
     Plan,
     PlanPatch,
     PlanStep,
     StepResult,
-    now_iso,
 )
+from src.models.validation import validate_candidate_set_output
 from src.models.db import TaskRecord, InternalStatus
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
@@ -101,47 +100,96 @@ class PatchRunner:
                 failed_result=result,
                 context=context,
             )
-            plan_patch = self._planner.patch(patch_request)
+            candidate_set_v1_ready = True
+            try:
+                patch_top_k = self._planner.patch_top_k(
+                    patch_request,
+                    k=_resolve_top_k(context.task.constraints.get("patch_top_k"), default=3),
+                )
+                selected_candidate = next(
+                    (
+                        candidate
+                        for candidate in patch_top_k.candidates
+                        if candidate.candidate_id == patch_top_k.default_recommendation
+                    ),
+                    patch_top_k.candidates[0] if patch_top_k.candidates else None,
+                )
+                if selected_candidate is None:
+                    raise ValueError("patch_top_k returned no candidates")
+                payload = selected_candidate.structured_payload
+                if not isinstance(payload, PlanPatch):
+                    raise ValueError("patch_top_k default candidate is not PlanPatch")
+                plan_patch = payload
+            except Exception:
+                # 回退到旧路径，保持对自定义 Planner.patch 的兼容
+                plan_patch = self._planner.patch(patch_request)
+                patch_candidate = PendingActionCandidate(
+                    candidate_id=f"patch_{step.id.lower()}",
+                    payload=plan_patch,
+                    summary="fallback patch candidate",
+                    metadata={"reason": patch_reason},
+                )
+                patch_top_k = TopKResult(
+                    candidates=[patch_candidate],
+                    default_recommendation=patch_candidate.candidate_id,
+                    explanation="fallback patch_top_k generated from planner.patch",
+                )
+                candidate_set_v1_ready = False
+            gate = self._planner.evaluate_top_k_gate(
+                candidate_kind="patch",
+                top_k_result=patch_top_k,
+                task_constraints=context.task.constraints,
+            )
         except Exception:
             _enter_replan_waiting(context, record, reason="patch_failed")
             raise
 
-        patch_candidate = PendingActionCandidate(
-            candidate_id=f"patch_{step.id.lower()}",
-            payload=plan_patch,
-            summary="auto-generated patch candidate",
-            metadata={"reason": patch_reason},
-        )
-        pending_action = build_pending_action(
-            task_id=context.task.task_id,
-            action_type=PendingActionType.PATCH_CONFIRM,
-            candidates=[patch_candidate],
-            default_suggestion=patch_candidate.candidate_id,
-            explanation="patch candidate generated after step failure",
-        )
-        enter_waiting_state(
-            context,
-            record,
-            pending_action,
-            InternalStatus.WAITING_PATCH,
-        )
+        if gate.requires_hitl:
+            pending_action = build_pending_action(
+                task_id=context.task.task_id,
+                action_type=PendingActionType.PATCH_CONFIRM,
+                candidates=patch_top_k.candidates,
+                default_suggestion=patch_top_k.default_recommendation,
+                default_recommendation=patch_top_k.default_recommendation,
+                explanation=f"{patch_top_k.explanation} gate={gate.reason}",
+            )
+            validate_candidate_set_output(
+                pending_action,
+                require_v1_fields=candidate_set_v1_ready,
+            )
+            enter_waiting_state(
+                context,
+                record,
+                pending_action,
+                InternalStatus.WAITING_PATCH,
+            )
+            transition_task_status(
+                context,
+                record,
+                InternalStatus.WAITING_PATCH,
+                reason=gate.reason,
+            )
+            return PatchRunOutcome(
+                plan=plan,
+                step_results=[],
+                next_step_index=step_index,
+            )
+
         transition_task_status(
             context,
             record,
             InternalStatus.WAITING_PATCH,
-            reason=patch_reason,
+            reason="patch_auto_path",
         )
         transition_task_status(
             context,
             record,
             InternalStatus.PATCHING,
-            reason="patch_start",
+            reason="patch_start_auto",
         )
         try:
             patched_plan = apply_patch(plan, plan_patch)
         except Exception:
-            pending_action.status = PendingActionStatus.CANCELLED
-            pending_action.decided_at = now_iso()
             _enter_replan_waiting(context, record, reason="patch_failed")
             raise
 
@@ -280,3 +328,13 @@ def _has_insert_before_target(plan_patch: PlanPatch, target_id: str) -> bool:
         op.op == "insert_step_before" and op.target == target_id
         for op in plan_patch.operations
     )
+
+
+def _resolve_top_k(value: object, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return 1
+    return parsed

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -236,6 +236,8 @@ class PlanRunner:
                     pending_patches[outcome.pending_patch.target_step_id] = (
                         outcome.pending_patch
                     )
+                if context.status == InternalStatus.WAITING_PATCH:
+                    return plan
 
                 failed_result: StepResult | None = None
                 blocked_by_safety = False
@@ -353,6 +355,8 @@ class PlanRunner:
                 and not _should_require_replan_confirm(exc)
             ):
                 replanned_plan = self._perform_replan(plan, context, record, exc)
+                if context.status == InternalStatus.WAITING_REPLAN:
+                    return replanned_plan
                 return self.run_plan(
                     replanned_plan,
                     context,
@@ -538,7 +542,57 @@ class PlanRunner:
             reason=str(error),
         )
         try:
-            replanned_plan = self._planner.replan(request)
+            try:
+                replan_top_k = self._planner.replan_top_k(
+                    request,
+                    k=_resolve_top_k(context.task.constraints.get("replan_top_k"), default=3),
+                )
+                gate = self._planner.evaluate_top_k_gate(
+                    candidate_kind="replan",
+                    top_k_result=replan_top_k,
+                    task_constraints=context.task.constraints,
+                )
+                if gate.requires_hitl:
+                    waiting_action = build_pending_action(
+                        task_id=context.task.task_id,
+                        action_type=PendingActionType.REPLAN_CONFIRM,
+                        candidates=replan_top_k.candidates,
+                        default_suggestion=replan_top_k.default_recommendation,
+                        default_recommendation=replan_top_k.default_recommendation,
+                        explanation=f"{replan_top_k.explanation} gate={gate.reason}",
+                    )
+                    enter_waiting_state(
+                        context,
+                        record,
+                        waiting_action,
+                        InternalStatus.WAITING_REPLAN,
+                        reason=gate.reason,
+                    )
+                    transition_task_status(
+                        context,
+                        record,
+                        InternalStatus.WAITING_REPLAN,
+                        reason=gate.reason,
+                    )
+                    return plan
+
+                selected = next(
+                    (
+                        candidate
+                        for candidate in replan_top_k.candidates
+                        if candidate.candidate_id == replan_top_k.default_recommendation
+                    ),
+                    replan_top_k.candidates[0] if replan_top_k.candidates else None,
+                )
+                if selected is None:
+                    raise ValueError("replan_top_k returned empty candidates")
+                payload = selected.structured_payload
+                if not isinstance(payload, Plan):
+                    raise ValueError("replan_top_k selected payload is not Plan")
+                replanned_plan = payload
+            except Exception:
+                # 回退到旧 replan()，保持既有 Planner stub 兼容
+                replanned_plan = self._planner.replan(request)
         except Exception as exc:
             transition_task_status(
                 context,
@@ -625,3 +679,13 @@ def _should_require_replan_confirm(error: PlanRunError) -> bool:
         error.failure_type == FailureType.SAFETY_BLOCK
         or error.code in {"SAFETY_TASK_INPUT_BLOCK", "SAFETY_FINAL_BLOCK", "SAFETY_POST_BLOCK"}
     )
+
+
+def _resolve_top_k(value: object, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed <= 0:
+        return 1
+    return parsed

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -4,12 +4,19 @@ from src.adapters.builtins import ensure_builtin_adapters
 from src.models.db import (
     ExternalStatus,
     InternalStatus,
+    TERMINAL_INTERNAL_STATUSES,
     TaskRecord,
 )
 from src.agents.planner import PlannerAgent
 from src.agents.executor import ExecutorAgent
 from src.agents.summarizer import SummarizerAgent
 from src.workflow.context import WorkflowContext
+
+_WAITING_INTERNAL_STATUSES = {
+    InternalStatus.WAITING_PLAN_CONFIRM,
+    InternalStatus.WAITING_PATCH,
+    InternalStatus.WAITING_REPLAN,
+}
 
 
 def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
@@ -46,10 +53,14 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
 
     # 1. 规划
     plan = planner.plan_with_status(task, ctx, record=record)
+    if ctx.status in _WAITING_INTERNAL_STATUSES:
+        return record
 
     # 2. 执行
     # 注意：PlanRunner 会负责 PLANNED → RUNNING → SUMMARIZING
     executor.run_plan(plan, ctx, record=record, finalize_status=False)
+    if ctx.status in _WAITING_INTERNAL_STATUSES or ctx.status in TERMINAL_INTERNAL_STATUSES:
+        return record
 
     # 3. 汇总
     executor.summarize_and_finalize(ctx, record, summarizer)

--- a/tests/integration/test_candidate_score_gate.py
+++ b/tests/integration/test_candidate_score_gate.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import pytest
+
+import src.agents.planner as planner_module
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.models.contracts import Plan, PlanStep, ProteinDesignTask, StepResult, now_iso
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType
+from src.workflow.patch_runner import PatchRunner
+
+
+def _registry() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            id="protgpt2",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence", "sequence_candidates"),
+            cost=0.35,
+            safety_level=1,
+            io_type="goal_to_sequence_candidates",
+            adapter_mode="remote",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="esmfold",
+            capabilities=("structure_prediction",),
+            inputs=("sequence",),
+            outputs=("pdb_path", "plddt"),
+            cost=0.6,
+            safety_level=1,
+            io_type="sequence_to_structure",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="nim_esmfold",
+            capabilities=("structure_prediction",),
+            inputs=("sequence",),
+            outputs=("pdb_path", "plddt"),
+            cost=0.3,
+            safety_level=1,
+            io_type="sequence_to_structure",
+            adapter_mode="remote",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="protein_mpnn",
+            capabilities=("sequence_design",),
+            inputs=("pdb_path",),
+            outputs=("sequence",),
+            cost=0.4,
+            safety_level=1,
+            io_type="structure_to_sequence",
+            adapter_mode="remote",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="biopython_qc",
+            capabilities=("quality_qc",),
+            inputs=("sequence", "pdb_path"),
+            outputs=("qc_metrics",),
+            cost=0.2,
+            safety_level=1,
+            io_type="sequence_structure_to_qc_metrics",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("objective_scoring",),
+            inputs=("candidates",),
+            outputs=("score_table", "top_k"),
+            cost=0.25,
+            safety_level=1,
+            io_type="candidates_to_objective_scores_topk",
+            adapter_mode="local",
+            priority="P0",
+        ),
+    ]
+
+
+def _kg() -> dict:
+    return {
+        "capabilities": [
+            {"capability_id": "sequence_generation", "name": "Sequence Generation", "domain": "protein/design"},
+            {"capability_id": "structure_prediction", "name": "Structure Prediction", "domain": "protein/structure"},
+            {"capability_id": "sequence_design", "name": "Sequence Design", "domain": "protein/design"},
+            {"capability_id": "quality_qc", "name": "Quality QC", "domain": "protein/qc"},
+            {"capability_id": "objective_scoring", "name": "Objective Scoring", "domain": "protein/score"},
+        ],
+        "io_types": [
+            {"io_type_id": "goal_to_sequence_candidates", "input_types": ["goal"], "output_types": ["sequence"], "combinable": True},
+            {"io_type_id": "sequence_to_structure", "input_types": ["sequence"], "output_types": ["structure_pdb", "plddt"], "combinable": True},
+            {"io_type_id": "structure_to_sequence", "input_types": ["structure_pdb"], "output_types": ["sequence"], "combinable": True},
+            {"io_type_id": "sequence_structure_to_qc_metrics", "input_types": ["sequence", "structure_pdb"], "output_types": ["qc_metrics"], "combinable": True},
+            {"io_type_id": "candidates_to_objective_scores_topk", "input_types": ["candidates"], "output_types": ["score_table", "top_k"], "combinable": True},
+        ],
+        "tools": [
+            {
+                "id": "protgpt2",
+                "capabilities": ["sequence_generation"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "goal_to_sequence_candidates",
+                    "inputs": {"goal": "str"},
+                    "outputs": {"sequence": "str", "sequence_candidates": "list"},
+                },
+                "execution": {"backend": "remote_model_service", "provider": "plm_rest"},
+                "constraints": {},
+            },
+            {
+                "id": "esmfold",
+                "capabilities": ["structure_prediction"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {"sequence": "str"},
+                    "outputs": {"pdb_path": "path", "plddt": "float"},
+                },
+                "execution": "nextflow",
+                "constraints": {},
+            },
+            {
+                "id": "nim_esmfold",
+                "capabilities": ["structure_prediction"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {"sequence": "str"},
+                    "outputs": {"pdb_path": "path", "plddt": "float"},
+                },
+                "execution": {"backend": "remote_model_service", "provider": "nvidia_nim"},
+                "constraints": {},
+            },
+            {
+                "id": "protein_mpnn",
+                "capabilities": ["sequence_design"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "structure_to_sequence",
+                    "inputs": {"pdb_path": "path"},
+                    "outputs": {"sequence": "str"},
+                },
+                "execution": {"backend": "remote_model_service", "provider": "nvidia_nim"},
+                "constraints": {},
+            },
+            {
+                "id": "biopython_qc",
+                "capabilities": ["quality_qc"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_structure_to_qc_metrics",
+                    "inputs": {"sequence": "str", "pdb_path": "path"},
+                    "outputs": {"qc_metrics": "dict"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "objective_ranker",
+                "capabilities": ["objective_scoring"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "candidates_to_objective_scores_topk",
+                    "inputs": {"candidates": "list"},
+                    "outputs": {"score_table": "dict", "top_k": "list"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+        ],
+    }
+
+
+class _FailThenSuccessStepRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self.calls.append(step.tool)
+        if len(self.calls) == 1:
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.RETRYABLE,
+                error_message="boom",
+                error_details={},
+                outputs={},
+                metrics={"retry_exhausted": True},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={"pdb_path": "/tmp/a.pdb", "plddt": 0.91},
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+@pytest.mark.integration
+def test_plan_gate_waiting_and_auto_paths(monkeypatch):
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _kg())
+    planner = PlannerAgent(tool_registry=_registry())
+
+    waiting_task = ProteinDesignTask(
+        task_id="gate_plan_waiting",
+        goal="de_novo_design",
+        constraints={"length_range": [30, 50], "min_candidate_confidence": 0.99},
+        metadata={},
+    )
+    waiting_ctx = WorkflowContext(
+        task=waiting_task,
+        plan=None,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.CREATED,
+    )
+    waiting_record = TaskRecord(
+        id=waiting_task.task_id,
+        status=ExternalStatus.CREATED,
+        internal_status=InternalStatus.CREATED,
+        goal=waiting_task.goal,
+        constraints=waiting_task.constraints,
+        metadata=waiting_task.metadata,
+        plan=None,
+    )
+    planner.plan_with_status(waiting_task, waiting_ctx, record=waiting_record)
+    assert waiting_ctx.status == InternalStatus.WAITING_PLAN_CONFIRM
+    assert waiting_record.status == ExternalStatus.WAITING_PLAN_CONFIRM
+    assert waiting_ctx.pending_action is not None
+
+    auto_task = ProteinDesignTask(
+        task_id="gate_plan_auto",
+        goal="de_novo_design",
+        constraints={
+            "length_range": [30, 50],
+            "min_candidate_confidence": 0.2,
+            "require_plan_confirm": False,
+        },
+        metadata={},
+    )
+    auto_ctx = WorkflowContext(
+        task=auto_task,
+        plan=None,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.CREATED,
+    )
+    auto_record = TaskRecord(
+        id=auto_task.task_id,
+        status=ExternalStatus.CREATED,
+        internal_status=InternalStatus.CREATED,
+        goal=auto_task.goal,
+        constraints=auto_task.constraints,
+        metadata=auto_task.metadata,
+        plan=None,
+    )
+    planner.plan_with_status(auto_task, auto_ctx, record=auto_record)
+    assert auto_ctx.status == InternalStatus.PLANNED
+    assert auto_record.status == ExternalStatus.PLANNED
+
+
+@pytest.mark.integration
+def test_patch_gate_waiting_and_auto_paths(monkeypatch):
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _kg())
+    planner = PlannerAgent(tool_registry=_registry())
+    step_runner = _FailThenSuccessStepRunner()
+    patch_runner = PatchRunner(step_runner=step_runner, planner_agent=planner)
+
+    def run_once(task_id: str, require_patch_confirm: bool) -> tuple[WorkflowContext, TaskRecord]:
+        task = ProteinDesignTask(
+            task_id=task_id,
+            goal="patch-test",
+            constraints={
+                "sequence": "MKTAYIAK",
+                "require_patch_confirm": require_patch_confirm,
+                "min_candidate_confidence": 0.2,
+            },
+            metadata={},
+        )
+        plan = Plan(
+            task_id=task_id,
+            steps=[PlanStep(id="S1", tool="esmfold", inputs={"sequence": "MKTAYIAK"}, metadata={})],
+            constraints=task.constraints,
+            metadata={},
+        )
+        context = WorkflowContext(
+            task=task,
+            plan=plan,
+            step_results={},
+            safety_events=[],
+            design_result=None,
+            status=InternalStatus.RUNNING,
+        )
+        record = TaskRecord(
+            id=task.task_id,
+            status=ExternalStatus.RUNNING,
+            internal_status=InternalStatus.RUNNING,
+            goal=task.goal,
+            constraints=task.constraints,
+            metadata=task.metadata,
+            plan=plan,
+        )
+        patch_runner.run_step_with_patch(plan, 0, context, record=record)
+        return context, record
+
+    waiting_ctx, waiting_record = run_once("gate_patch_waiting", True)
+    assert waiting_ctx.status == InternalStatus.WAITING_PATCH
+    assert waiting_record.status == ExternalStatus.WAITING_PATCH_CONFIRM
+    assert waiting_ctx.pending_action is not None
+
+    step_runner.calls.clear()
+    auto_ctx, auto_record = run_once("gate_patch_auto", False)
+    assert auto_ctx.status == InternalStatus.PATCHING
+    assert auto_record.status == ExternalStatus.WAITING_PATCH_CONFIRM

--- a/tests/unit/test_patch_runner.py
+++ b/tests/unit/test_patch_runner.py
@@ -64,12 +64,26 @@ class FakePlanner(PlannerAgent):
         super().__init__(
             tool_registry=[
                 ToolSpec(
-                    id="esmfold",
+                    id="failing_tool",
                     capabilities=("structure_prediction",),
-                    inputs=("sequence",),
-                    outputs=("pdb_path", "plddt"),
+                    inputs=(),
+                    outputs=("dummy_output",),
                     cost=1,
                     safety_level=1,
+                    io_type="sequence_to_structure",
+                    adapter_mode="local",
+                    priority="P0",
+                ),
+                ToolSpec(
+                    id="patched_tool",
+                    capabilities=("structure_prediction",),
+                    inputs=(),
+                    outputs=("dummy_output",),
+                    cost=0.5,
+                    safety_level=1,
+                    io_type="sequence_to_structure",
+                    adapter_mode="local",
+                    priority="P0",
                 )
             ]
         )
@@ -88,7 +102,64 @@ class FakePlanner(PlannerAgent):
         return PlanPatch(task_id=request.task_id, operations=[op], metadata={})
 
 
-def test_patch_runner_triggers_patch_and_records_meta(sample_task):
+def _mock_patch_kg():
+    return {
+        "capabilities": [
+            {
+                "capability_id": "structure_prediction",
+                "name": "Structure Prediction",
+                "domain": "protein/structure",
+                "description": "test",
+            }
+        ],
+        "io_types": [
+            {
+                "io_type_id": "sequence_to_structure",
+                "input_types": ["sequence"],
+                "output_types": ["structure_pdb"],
+                "combinable": True,
+            }
+        ],
+        "tools": [
+            {
+                "id": "failing_tool",
+                "capabilities": ["structure_prediction"],
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {},
+                    "outputs": {"dummy_output": "str"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "patched_tool",
+                "capabilities": ["structure_prediction"],
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {},
+                    "outputs": {"dummy_output": "str"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+        ],
+    }
+
+
+def test_patch_runner_triggers_patch_and_records_meta(sample_task, monkeypatch):
+    monkeypatch.setattr("src.agents.planner.load_tool_kg", lambda: _mock_patch_kg())
+    sample_task = sample_task.model_copy(
+        update={
+            "constraints": {
+                **sample_task.constraints,
+                "require_patch_confirm": False,
+                "min_candidate_confidence": 0.0,
+                "high_cost_min_overall": 0.0,
+            }
+        },
+        deep=True,
+    )
     plan = Plan(
         task_id=sample_task.task_id,
         steps=[PlanStep(id="S1", tool="failing_tool", inputs={}, metadata={})],
@@ -121,8 +192,7 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task):
     patched_plan = outcome.plan
     patched_result = outcome.step_results[0]
 
-    # patch 应被触发
-    assert planner.requests, "Planner.patch should be called"
+    # patch 应被触发并自动应用
     assert step_runner.calls == ["failing_tool", "patched_tool"]
 
     # plan 应被替换为 patched 版本
@@ -143,11 +213,60 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task):
     assert patch_meta["patched_status"] == "success"
     prev_attempt = patch_meta["previous_attempt"]
     assert prev_attempt["attempt_history"][0]["failure_type"] == "RETRYABLE"
+    assert context.status == InternalStatus.PATCHING
+    assert record.status == ExternalStatus.WAITING_PATCH_CONFIRM
+    assert record.pending_action is None
+
+
+def test_patch_runner_enters_waiting_patch_when_gate_requires_hitl(sample_task, monkeypatch):
+    monkeypatch.setattr("src.agents.planner.load_tool_kg", lambda: _mock_patch_kg())
+    sample_task = sample_task.model_copy(
+        update={
+            "constraints": {
+                **sample_task.constraints,
+                "require_patch_confirm": True,
+            }
+        },
+        deep=True,
+    )
+    plan = Plan(
+        task_id=sample_task.task_id,
+        steps=[PlanStep(id="S1", tool="failing_tool", inputs={}, metadata={})],
+        constraints={},
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=sample_task,
+        plan=None,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.RUNNING,
+    )
+    record = TaskRecord(
+        id=sample_task.task_id,
+        status=ExternalStatus.RUNNING,
+        internal_status=InternalStatus.RUNNING,
+        goal=sample_task.goal,
+        constraints=sample_task.constraints,
+        metadata=sample_task.metadata,
+        plan=plan,
+    )
+
+    step_runner = FakeStepRunner()
+    planner = FakePlanner()
+    patch_runner = PatchRunner(step_runner=step_runner, planner_agent=planner)
+
+    outcome = patch_runner.run_step_with_patch(plan, 0, context, record=record)
+
+    assert step_runner.calls == ["failing_tool"]
+    assert not outcome.step_results
+    assert outcome.next_step_index == 0
+    assert context.status == InternalStatus.WAITING_PATCH
     assert record.status == ExternalStatus.WAITING_PATCH_CONFIRM
     assert record.pending_action is not None
     assert record.pending_action.action_type == PendingActionType.PATCH_CONFIRM
     assert record.pending_action.status == PendingActionStatus.PENDING
-    assert record.pending_action.explanation
 
 
 def test_patch_runner_enters_waiting_replan_on_patch_error(sample_task):

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -6,6 +6,7 @@ from src.agents.planner import PlannerAgent, ToolSpec
 from src.kg.kg_client import ToolKGError
 from src.models.contracts import (
     PatchRequest,
+    PendingActionType,
     Plan,
     PlanPatch,
     PlanStep,
@@ -14,6 +15,8 @@ from src.models.contracts import (
     StepResult,
     now_iso,
 )
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.workflow.context import WorkflowContext
 
 
 def _topk_registry() -> list[ToolSpec]:
@@ -73,6 +76,39 @@ def _topk_registry() -> list[ToolSpec]:
             adapter_mode="local",
             priority="P1",
         ),
+        ToolSpec(
+            id="protein_mpnn",
+            capabilities=("sequence_design",),
+            inputs=("pdb_path",),
+            outputs=("sequence",),
+            cost=0.4,
+            safety_level=1,
+            io_type="structure_to_sequence",
+            adapter_mode="remote",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="biopython_qc",
+            capabilities=("quality_qc",),
+            inputs=("sequence", "pdb_path"),
+            outputs=("qc_metrics",),
+            cost=0.2,
+            safety_level=1,
+            io_type="sequence_structure_to_qc_metrics",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("objective_scoring",),
+            inputs=("candidates",),
+            outputs=("score_table", "top_k"),
+            cost=0.25,
+            safety_level=1,
+            io_type="candidates_to_objective_scores_topk",
+            adapter_mode="local",
+            priority="P0",
+        ),
     ]
 
 
@@ -81,10 +117,16 @@ def _topk_mock_kg() -> dict:
         "capabilities": [
             {"capability_id": "sequence_generation", "name": "Sequence Generation", "domain": "protein/design"},
             {"capability_id": "structure_prediction", "name": "Structure Prediction", "domain": "protein/structure"},
+            {"capability_id": "sequence_design", "name": "Sequence Design", "domain": "protein/design"},
+            {"capability_id": "quality_qc", "name": "Quality QC", "domain": "protein/qc"},
+            {"capability_id": "objective_scoring", "name": "Objective Scoring", "domain": "protein/score"},
         ],
         "io_types": [
             {"io_type_id": "goal_to_sequence_candidates", "input_types": ["goal"], "output_types": ["sequence"], "combinable": True},
             {"io_type_id": "sequence_to_structure", "input_types": ["sequence"], "output_types": ["structure_pdb", "plddt"], "combinable": True},
+            {"io_type_id": "structure_to_sequence", "input_types": ["structure_pdb"], "output_types": ["sequence"], "combinable": True},
+            {"io_type_id": "sequence_structure_to_qc_metrics", "input_types": ["sequence", "structure_pdb"], "output_types": ["qc_metrics"], "combinable": True},
+            {"io_type_id": "candidates_to_objective_scores_topk", "input_types": ["candidates"], "output_types": ["score_table", "top_k"], "combinable": True},
         ],
         "tools": [
             {
@@ -145,6 +187,42 @@ def _topk_mock_kg() -> dict:
                     "outputs": {"pdb_path": "path", "plddt": "float"},
                 },
                 "execution": "nextflow",
+                "constraints": {},
+            },
+            {
+                "id": "protein_mpnn",
+                "capabilities": ["sequence_design"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "structure_to_sequence",
+                    "inputs": {"pdb_path": "path"},
+                    "outputs": {"sequence": "str"},
+                },
+                "execution": {"backend": "remote_model_service", "provider": "nvidia_nim"},
+                "constraints": {},
+            },
+            {
+                "id": "biopython_qc",
+                "capabilities": ["quality_qc"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_structure_to_qc_metrics",
+                    "inputs": {"sequence": "str", "pdb_path": "path"},
+                    "outputs": {"qc_metrics": "dict"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "objective_ranker",
+                "capabilities": ["objective_scoring"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "candidates_to_objective_scores_topk",
+                    "inputs": {"candidates": "list"},
+                    "outputs": {"score_table": "dict", "top_k": "list"},
+                },
+                "execution": "python",
                 "constraints": {},
             },
         ],
@@ -345,13 +423,19 @@ class TestPlannerAgent:
         assert 1 <= len(topk.candidates) <= 3
         for candidate in topk.candidates:
             assert isinstance(candidate.structured_payload, PlanPatch)
-            assert set(candidate.score_breakdown) == {
+            assert {
                 "feasibility",
                 "objective",
                 "risk",
                 "cost",
                 "overall",
-            }
+            }.issubset(set(candidate.score_breakdown))
+            assert {
+                "confidence",
+                "tool_readiness",
+                "tool_coverage",
+                "fallback_depth",
+            }.issubset(set(candidate.score_breakdown))
             assert candidate.risk_level in {"low", "medium", "high"}
             assert candidate.cost_estimate in {"low", "medium", "high"}
             assert candidate.tool_id is not None
@@ -388,3 +472,145 @@ class TestPlannerAgent:
             assert isinstance(candidate.structured_payload, Plan)
             payload = candidate.structured_payload
             assert payload.metadata.get("replan_mode") == "suffix_replan"
+
+    def test_plan_with_status_enters_waiting_plan_confirm_when_low_confidence(self, monkeypatch):
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        planner = PlannerAgent(tool_registry=_topk_registry())
+        task = ProteinDesignTask(
+            task_id="task_plan_waiting",
+            goal="de_novo_design",
+            constraints={
+                "length_range": [30, 50],
+                "require_plan_confirm": False,
+                "min_candidate_confidence": 0.99,
+            },
+            metadata={},
+        )
+        context = WorkflowContext(
+            task=task,
+            plan=None,
+            step_results={},
+            safety_events=[],
+            design_result=None,
+            status=InternalStatus.CREATED,
+        )
+        record = TaskRecord(
+            id=task.task_id,
+            status=ExternalStatus.CREATED,
+            internal_status=InternalStatus.CREATED,
+            goal=task.goal,
+            constraints=task.constraints,
+            metadata=task.metadata,
+            plan=None,
+        )
+
+        planner.plan_with_status(task, context, record=record)
+
+        assert context.status == InternalStatus.WAITING_PLAN_CONFIRM
+        assert context.pending_action is not None
+        assert context.pending_action.action_type == PendingActionType.PLAN_CONFIRM
+        assert context.pending_action.default_recommendation is not None
+        assert record.status == ExternalStatus.WAITING_PLAN_CONFIRM
+
+    def test_plan_with_status_auto_planned_when_gate_passes(self, monkeypatch):
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        planner = PlannerAgent(tool_registry=_topk_registry())
+        task = ProteinDesignTask(
+            task_id="task_plan_auto",
+            goal="de_novo_design",
+            constraints={
+                "length_range": [30, 50],
+                "require_plan_confirm": False,
+                "min_candidate_confidence": 0.2,
+            },
+            metadata={},
+        )
+        context = WorkflowContext(
+            task=task,
+            plan=None,
+            step_results={},
+            safety_events=[],
+            design_result=None,
+            status=InternalStatus.CREATED,
+        )
+        record = TaskRecord(
+            id=task.task_id,
+            status=ExternalStatus.CREATED,
+            internal_status=InternalStatus.CREATED,
+            goal=task.goal,
+            constraints=task.constraints,
+            metadata=task.metadata,
+            plan=None,
+        )
+
+        planner.plan_with_status(task, context, record=record)
+
+        assert context.status == InternalStatus.PLANNED
+        assert context.pending_action is None
+        assert context.plan is not None
+        assert record.status == ExternalStatus.PLANNED
+
+    def test_remote_structure_prediction_has_higher_risk_than_local(self, monkeypatch):
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        planner = PlannerAgent(tool_registry=_topk_registry())
+        topk = planner.patch_top_k(_patch_request_for_topk(), k=3)
+
+        by_tool = {c.tool_id: c for c in topk.candidates}
+        assert "nim_esmfold" in by_tool
+        assert "openfold" in by_tool
+        assert by_tool["nim_esmfold"].score_breakdown["risk"] <= by_tool["openfold"].score_breakdown["risk"]
+
+    def test_p0_combo_scores_include_tool_dimensions(self, monkeypatch):
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        planner = PlannerAgent(tool_registry=_topk_registry())
+
+        protgpt2_esmfold = Plan(
+            task_id="score_combo_1",
+            steps=[
+                PlanStep(id="S1", tool="protgpt2", inputs={"goal": "de_novo_design"}, metadata={}),
+                PlanStep(id="S2", tool="esmfold", inputs={"sequence": "S1.sequence"}, metadata={}),
+            ],
+            constraints={},
+            metadata={},
+        )
+        protein_mpnn_esmfold = Plan(
+            task_id="score_combo_2",
+            steps=[
+                PlanStep(id="S1", tool="protein_mpnn", inputs={"pdb_path": "/tmp/input.pdb"}, metadata={}),
+                PlanStep(id="S2", tool="esmfold", inputs={"sequence": "S1.sequence"}, metadata={}),
+            ],
+            constraints={},
+            metadata={},
+        )
+        qc_objective = Plan(
+            task_id="score_combo_3",
+            steps=[
+                PlanStep(
+                    id="S1",
+                    tool="biopython_qc",
+                    inputs={"sequence": "MKT", "pdb_path": "/tmp/input.pdb"},
+                    metadata={},
+                ),
+                PlanStep(
+                    id="S2",
+                    tool="objective_ranker",
+                    inputs={"candidates": "S1.qc_metrics"},
+                    metadata={},
+                ),
+            ],
+            constraints={},
+            metadata={},
+        )
+
+        score_1 = planner.score_candidate_payload(protgpt2_esmfold)
+        score_2 = planner.score_candidate_payload(protein_mpnn_esmfold)
+        score_3 = planner.score_candidate_payload(qc_objective)
+
+        for score in (score_1, score_2, score_3):
+            assert "tool_readiness" in score
+            assert "tool_coverage" in score
+            assert "fallback_depth" in score
+            assert "confidence" in score
+            assert 0.0 <= score["overall"] <= 1.0
+
+        assert score_3["objective"] >= score_1["objective"]


### PR DESCRIPTION
## Related

- Closes #140

## Background

在 #139 完成 Top-K 候选生成后, 本PR实现 "如何选候选" 的最小可用版本:

- 结构化 `score_breakdown`
- `risk_level / cost_estimate` 分级
- `score + risk/cost` 门控, 驱动自动执行或进入 `WAITING_*`

同时并入 Requirement-2: 工具维度评分, P0 组合场景覆盖

## Changes

### Phase 1: Planner 评分与门控核心

文件:

- `src/agents/planner.py`

主要内容:

- 新增候选门控决策结构: `CandidateGateDecision`
- 新增门口接口 `evaluate_top_k_gate(...)`
- 新增调试/测试评分接口 `score_candidate_payload(...)`
- 扩展 `score_breakdown`:
  - 保留 v1 必选: `feasibility/objective/risk/cost/overall`
  - 新增: `confidence/tool_readiness/tool_coverage/fallback_depth`
- 引入工具维度评分逻辑:
  - 按照 `capability + adapter_mode + safety_level + cost` 计算风险/成本信号
  - 对 `objective_scoring/objective_ranker` 提供 objective 加权加成
- `plan_with_status` 接入门控:
  - 满足 gate 条件时进入 `WAITING_PLAN_CONFIRM`
  - 否则走原自动路径 `PLANNED`

### Phase 2: Workflow 门控接线

文件:

- `src/workflow/patch_runner.py`
- `src/workflow/plan_runner.py`
- `src/workflow/workflow.py`

主要内容:

- `PatchRunner` 接入 `patch_top_k + gate`:
  - gate 命中: 进入 `WAITING_PATCH`
  - gate 通过: 自动进入 patch 引用路径
  - 保留对旧 `planner.patch()` 的回退兼容
- `PlanRunner`:
  - 在 `WAITING_PATCH` 时暂停继续执行
  - 在 replan 路径接入 `replan_top_k + gate`
  - gate 命中时保留 `WAITING_REPLAN`, 等待人工决策
  - 保留丢旧 `planner.replan()` 的回退兼容
- `run_task_sync`:
  - 当任务进入任意 `WAITING_*` 状态时提前返回, 避免继续自动推进

### Phase 3: 测试与文档

文件：

- `tests/unit/test_planner_agent.py`
- `tests/unit/test_patch_runner.py`
- `tests/integration/test_candidate_score_gate.py` (new)
- `examples/planner-score-gate.md` (new)

主要内容:

- 新增单测覆盖:
  - `plan_with_status` 的 waiting/auto 分支
  - 远程与本地工具风险差异
  - P0 工具组合评分维度存在性与 objective 加权
- 更新 patch runner 单测
  - 自动 patch 分支
  - `require_patch_confirm` 触发 WAITING_PATCH 分支
- 新增集成测试:
  - Plan gate: 自动推进 vs WAITING_PLAN_CONFIRM
  - Patch gate: 自动 patch vs WAITING_PATCH_CONFIRM
- 文档补充评分维度与阈值口径

## 门控规则

对 Top-1 候选执行 gate, 任一满足则进入 `WAITING_*`:

- 显式确认开关: `require_plan_confire / require_patch_confirm / require_replan_confirm`
- `risk_level == high`
- `confidence < min_candidate_confidence`
- 配置 `high_cost_min_overall` 且 `cost_estimate == high` 且 `overall` 低于阈值

默认行为:

- `plan`: auto
- `patch`: auto
- `replan`: auto

## Risks

- 未新增 FSM 状态
- 对旧 stub/测试暴露兼容
- Schema 仍为 additive-only

## 测试

已执行：

- `uv run pytest tests/unit/test_planner_agent.py tests/unit/ test_patch_runner.py tests/unit/test_plan_runner.py tests/unit/ test_planner_with_provider.py tests/unit/ test_decision_validation.py tests/integration/ test_candidate_score_gate.py tests/integration/test_workflow.py -q`

结果：

- `85 passed`
