### PR TITLE
feat(ui): 实现 HITL PendingAction 决策页面 (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Then open:
 
 - `http://127.0.0.1:8000/docs`
 - `http://127.0.0.1:8000/health`
+- `http://127.0.0.1:8000/ui`
 
 Detailed demo usage and options:
 

--- a/examples/README_DEMO.md
+++ b/examples/README_DEMO.md
@@ -33,6 +33,7 @@ After startup:
 
 - API docs: `http://127.0.0.1:8000/docs`
 - Health: `http://127.0.0.1:8000/health`
+- HITL dashboard: `http://127.0.0.1:8000/ui`
 
 ## Main Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,25 @@
   "name": "thesis-project.dev",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,1 +1,11 @@
-{}
+{
+  "name": "thesis-project.dev",
+  "private": true,
+  "scripts": {
+    "build:ui": "tsc -p tsconfig.json",
+    "check:ui": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,17 +1,21 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
 from src.models.contracts import (
     ProteinDesignTask,
     Decision,
     DecisionChoice,
+    PendingAction,
     PendingActionStatus,
 )
 from src.models.db import TaskRecord
@@ -31,7 +35,12 @@ from src.infra.runtime_init import RuntimeInitResult, initialize_runtime
 from src.models.contracts import PendingActionType, now_iso
 from src.workflow.context import WorkflowContext
 
+API_DIR = Path(__file__).resolve().parent
+TEMPLATES_DIR = API_DIR / "templates"
+STATIC_DIR = API_DIR / "static"
+
 app = FastAPI(title="Protein Design Agent System (Mini Demo)", version="0.5.2")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 # 简单的内存存储，之后可以换成数据库或文件
 TASK_STORE: Dict[str, TaskRecord] = {}
@@ -82,6 +91,54 @@ class DecisionSubmitRequest(BaseModel):
     comment: Optional[str] = Field(None, description="可选的决策备注")
 
 
+class PendingActionSummary(BaseModel):
+    pending_action_id: str = Field(..., description="PendingAction ID")
+    task_id: str = Field(..., description="所属任务 ID")
+    action_type: PendingActionType = Field(..., description="待决策类型")
+    status: PendingActionStatus = Field(..., description="PendingAction 状态")
+    created_at: str = Field(..., description="创建时间")
+    candidate_count: int = Field(..., description="候选数量")
+    default_suggestion: Optional[str] = Field(None, description="默认建议候选 ID")
+    explanation: str = Field(..., description="待决策说明")
+    summary: str = Field(..., description="候选摘要")
+
+
+def _render_ui_html(task_id: Optional[str]) -> str:
+    template_path = TEMPLATES_DIR / "index.html"
+    if not template_path.exists():
+        raise HTTPException(status_code=500, detail="UI template not found")
+    raw_html = template_path.read_text(encoding="utf-8")
+    bootstrap_payload = json.dumps({"taskId": task_id or ""}, ensure_ascii=True)
+    return raw_html.replace("__BOOTSTRAP__", bootstrap_payload)
+
+
+def _build_pending_action_summary(pending_action: PendingAction) -> str:
+    if not pending_action.candidates:
+        return pending_action.explanation
+
+    snippets: list[str] = []
+    for candidate in pending_action.candidates[:2]:
+        text = candidate.summary or candidate.explanation or candidate.candidate_id
+        snippets.append(text.strip())
+
+    summary = " | ".join(snippets)
+    hidden_count = len(pending_action.candidates) - len(snippets)
+    if hidden_count > 0:
+        summary = f"{summary} | +{hidden_count} more"
+    return summary
+
+
+@app.get("/", response_class=HTMLResponse)
+@app.get("/ui", response_class=HTMLResponse)
+async def get_hitl_dashboard() -> HTMLResponse:
+    return HTMLResponse(_render_ui_html(task_id=None))
+
+
+@app.get("/ui/tasks/{task_id}", response_class=HTMLResponse)
+async def get_task_detail_view(task_id: str) -> HTMLResponse:
+    return HTMLResponse(_render_ui_html(task_id=task_id))
+
+
 @app.get("/health")
 async def health() -> Dict[str, Any]:
     runtime = _ensure_runtime_initialized()
@@ -123,6 +180,44 @@ async def get_task(task_id: str):
     if record is None:
         raise HTTPException(status_code=404, detail="task not found")
     return record
+
+
+@app.get("/pending-actions", response_model=list[PendingActionSummary])
+async def list_pending_actions(
+    status: Optional[PendingActionStatus] = Query(
+        default=PendingActionStatus.PENDING
+    ),
+    task_id: Optional[str] = Query(default=None),
+) -> list[PendingActionSummary]:
+    summaries: list[PendingActionSummary] = []
+
+    for record in TASK_STORE.values():
+        if task_id is not None and record.id != task_id:
+            continue
+        pending_action = record.pending_action
+        if pending_action is None:
+            continue
+        if status is not None and pending_action.status != status:
+            continue
+
+        summaries.append(
+            PendingActionSummary(
+                pending_action_id=pending_action.pending_action_id,
+                task_id=record.id,
+                action_type=pending_action.action_type,
+                status=pending_action.status,
+                created_at=pending_action.created_at,
+                candidate_count=len(pending_action.candidates),
+                default_suggestion=(
+                    pending_action.default_suggestion
+                    or pending_action.default_recommendation
+                ),
+                explanation=pending_action.explanation,
+                summary=_build_pending_action_summary(pending_action),
+            )
+        )
+
+    return summaries
 
 
 @app.post("/pending-actions/{pending_action_id}/decision", response_model=TaskRecord)

--- a/src/api/static/css/hitl-dashboard.css
+++ b/src/api/static/css/hitl-dashboard.css
@@ -1,0 +1,181 @@
+:root {
+  --bg: #f4f7fb;
+  --panel: #ffffff;
+  --line: #d7deea;
+  --text: #1f2a3d;
+  --muted: #5d6a7f;
+  --accent: #0f6db2;
+  --warn: #a86400;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  color: var(--text);
+  background: linear-gradient(180deg, #eef4ff 0%, var(--bg) 55%);
+}
+
+.layout {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 16px 56px;
+  display: grid;
+  gap: 14px;
+}
+
+.hero {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.hero p {
+  color: var(--muted);
+}
+
+.task-query {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+button {
+  border: 1px solid #2359a6;
+  background: #2b74d0;
+  color: #fff;
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.chip {
+  display: inline-block;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
+.chip.waiting {
+  color: #9b5800;
+  border-color: #efcf8f;
+  background: #fff7e8;
+}
+
+.chip.active {
+  color: #0f6db2;
+  border-color: #aac8e3;
+  background: #eaf4ff;
+}
+
+.chip.done {
+  color: #12702a;
+  border-color: #a9dfb8;
+  background: #eaffee;
+}
+
+.chip.muted {
+  color: var(--muted);
+}
+
+.pending-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.pending-table th,
+.pending-table td {
+  border-top: 1px solid var(--line);
+  text-align: left;
+  padding: 8px;
+  vertical-align: top;
+}
+
+.pending-table tr:hover {
+  background: #f6faff;
+}
+
+.row-action {
+  border: 1px solid #7f96bf;
+  background: #fff;
+  color: #274271;
+  font-size: 13px;
+  padding: 4px 8px;
+}
+
+.candidate-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.error {
+  color: #aa1a1a;
+}
+
+.reserved-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.reserved-grid article {
+  border: 1px dashed var(--line);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+@media (max-width: 760px) {
+  .pending-table {
+    display: block;
+    overflow-x: auto;
+  }
+}

--- a/src/api/static/js/hitl-dashboard.js
+++ b/src/api/static/js/hitl-dashboard.js
@@ -1,0 +1,324 @@
+"use strict";
+const ALLOWED_CHOICES = {
+    plan_confirm: ["accept", "replan", "cancel"],
+    patch_confirm: ["accept", "replan", "cancel"],
+    replan_confirm: ["accept", "continue", "cancel"],
+};
+const state = {
+    selectedTaskId: null,
+};
+function byId(id) {
+    const element = document.getElementById(id);
+    if (!element) {
+        throw new Error(`Missing element: #${id}`);
+    }
+    return element;
+}
+function formatActionType(actionType) {
+    return actionType.replace("_", " ").toUpperCase();
+}
+function parseBootstrapTaskId() {
+    const raw = byId("app-bootstrap").textContent;
+    if (!raw) {
+        return "";
+    }
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed.taskId ?? "";
+    }
+    catch {
+        return "";
+    }
+}
+function setGlobalMessage(message, isError = false) {
+    const node = byId("global-message");
+    node.textContent = message;
+    node.className = isError ? "error" : "muted";
+}
+function statusChipClass(status) {
+    if (status.startsWith("WAITING_")) {
+        return "chip waiting";
+    }
+    if (status === "DONE") {
+        return "chip done";
+    }
+    if (status === "RUNNING" || status === "PLANNING" || status === "PLANNED") {
+        return "chip active";
+    }
+    return "chip muted";
+}
+async function parseError(response) {
+    try {
+        const payload = (await response.json());
+        return payload.detail ?? `Request failed: ${response.status}`;
+    }
+    catch {
+        return `Request failed: ${response.status}`;
+    }
+}
+async function getJson(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(await parseError(response));
+    }
+    return (await response.json());
+}
+function renderPendingActions(items) {
+    const tbody = byId("pending-actions-body");
+    const counter = byId("pending-count");
+    counter.textContent = String(items.length);
+    tbody.innerHTML = "";
+    if (!items.length) {
+        const row = document.createElement("tr");
+        const cell = document.createElement("td");
+        cell.colSpan = 6;
+        cell.textContent = "No pending actions.";
+        row.appendChild(cell);
+        tbody.appendChild(row);
+        return;
+    }
+    for (const item of items) {
+        const row = document.createElement("tr");
+        const openCell = document.createElement("td");
+        const openButton = document.createElement("button");
+        openButton.type = "button";
+        openButton.className = "row-action";
+        openButton.textContent = "Open";
+        openButton.addEventListener("click", () => {
+            state.selectedTaskId = item.task_id;
+            byId("task-id-input").value = item.task_id;
+            updateUrlForTask(item.task_id);
+            void refreshTaskDetail();
+        });
+        openCell.appendChild(openButton);
+        row.appendChild(openCell);
+        const taskCell = document.createElement("td");
+        taskCell.textContent = item.task_id;
+        row.appendChild(taskCell);
+        const typeCell = document.createElement("td");
+        typeCell.textContent = formatActionType(item.action_type);
+        row.appendChild(typeCell);
+        const candidateCell = document.createElement("td");
+        candidateCell.textContent = String(item.candidate_count);
+        row.appendChild(candidateCell);
+        const defaultCell = document.createElement("td");
+        defaultCell.textContent = item.default_suggestion ?? "-";
+        row.appendChild(defaultCell);
+        const summaryCell = document.createElement("td");
+        summaryCell.textContent = item.summary || item.explanation;
+        row.appendChild(summaryCell);
+        tbody.appendChild(row);
+    }
+}
+function renderReservedSections(task) {
+    const safetyCount = task.safety_events?.length ?? 0;
+    byId("reserved-safety").textContent =
+        safetyCount > 0
+            ? `Safety events: ${safetyCount} (details can be expanded later).`
+            : "No safety events yet. Area reserved for event cards.";
+    const reportPath = task.design_result?.report_path ?? "";
+    byId("reserved-report").textContent = reportPath
+        ? `Report path: ${reportPath}`
+        : "No report yet. Area reserved for report preview.";
+    byId("reserved-steps").textContent =
+        "Step timeline area reserved for future execution details.";
+}
+function renderTaskDetail(task) {
+    const badge = byId("task-state-badge");
+    badge.textContent = `${task.status}${task.internal_status ? ` / ${task.internal_status}` : ""}`;
+    badge.className = statusChipClass(task.status);
+    const container = byId("task-detail");
+    const pending = task.pending_action;
+    const lines = [
+        `<p><strong>Task ID:</strong> ${task.id}</p>`,
+        `<p><strong>Goal:</strong> ${task.goal}</p>`,
+    ];
+    if (pending) {
+        const defaultSuggestion = pending.default_suggestion ?? pending.default_recommendation ?? "-";
+        lines.push(`<p><strong>Action Type:</strong> ${pending.action_type}</p>`);
+        lines.push(`<p><strong>Default Suggestion:</strong> ${defaultSuggestion}</p>`);
+        lines.push(`<p><strong>Explanation:</strong> ${pending.explanation}</p>`);
+        const candidateLines = pending.candidates.map((candidate) => {
+            const risk = candidate.risk_level ?? "-";
+            const cost = candidate.cost_estimate ?? "-";
+            const summary = candidate.summary ?? candidate.explanation ?? "No summary";
+            return `<li><strong>${candidate.candidate_id}</strong> | risk=${risk} | cost=${cost}<br/>${summary}</li>`;
+        });
+        lines.push(`<ul class="candidate-list">${candidateLines.join("")}</ul>`);
+    }
+    else {
+        lines.push("<p>No pending action for this task.</p>");
+    }
+    container.innerHTML = lines.join("");
+    renderReservedSections(task);
+    renderDecisionForm(pending ?? null);
+}
+function renderDecisionForm(pendingAction) {
+    const container = byId("decision-form-container");
+    container.innerHTML = "";
+    if (!pendingAction || !state.selectedTaskId) {
+        container.innerHTML = "<p>No pending action for the selected task.</p>";
+        return;
+    }
+    const allowed = ALLOWED_CHOICES[pendingAction.action_type];
+    const defaultSuggestion = pendingAction.default_suggestion ?? pendingAction.default_recommendation ?? "";
+    const form = document.createElement("form");
+    form.id = "decision-form";
+    form.innerHTML = `
+    <label for="decision-choice">Choice</label>
+    <select id="decision-choice" name="choice">
+      ${allowed.map((choice) => `<option value="${choice}">${choice}</option>`).join("")}
+    </select>
+    <label for="decision-candidate">Candidate (required for accept)</label>
+    <select id="decision-candidate" name="candidate">
+      <option value="">-- Select candidate --</option>
+      ${pendingAction.candidates
+        .map((candidate) => {
+        const selected = candidate.candidate_id === defaultSuggestion ? " selected" : "";
+        return `<option value="${candidate.candidate_id}"${selected}>${candidate.candidate_id}</option>`;
+    })
+        .join("")}
+    </select>
+    <label for="decision-by">Decided By</label>
+    <input id="decision-by" name="decided_by" type="text" value="ui_user" />
+    <label for="decision-comment">Comment</label>
+    <textarea id="decision-comment" name="comment" rows="3" placeholder="optional note"></textarea>
+    <button type="submit">Submit Decision</button>
+  `;
+    container.appendChild(form);
+    const choiceNode = byId("decision-choice");
+    const candidateNode = byId("decision-candidate");
+    const syncCandidateState = () => {
+        const isAccept = choiceNode.value === "accept";
+        candidateNode.disabled = !isAccept;
+        if (!isAccept) {
+            candidateNode.value = "";
+        }
+    };
+    syncCandidateState();
+    choiceNode.addEventListener("change", syncCandidateState);
+    form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        void submitDecision(pendingAction.pending_action_id);
+    });
+}
+async function submitDecision(pendingActionId) {
+    if (!state.selectedTaskId) {
+        setGlobalMessage("Task id is required before submitting decision.", true);
+        return;
+    }
+    const choiceNode = byId("decision-choice");
+    const candidateNode = byId("decision-candidate");
+    const decidedByNode = byId("decision-by");
+    const commentNode = byId("decision-comment");
+    const choice = choiceNode.value;
+    const selectedCandidate = candidateNode.value.trim();
+    if (choice === "accept" && !selectedCandidate) {
+        setGlobalMessage("accept requires selected candidate id.", true);
+        return;
+    }
+    const payload = {
+        choice,
+        decided_by: decidedByNode.value.trim() || "ui_user",
+    };
+    if (choice === "accept") {
+        payload.selected_candidate_id = selectedCandidate;
+    }
+    if (commentNode.value.trim()) {
+        payload.comment = commentNode.value.trim();
+    }
+    const response = await fetch(`/pending-actions/${pendingActionId}/decision`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+        const detail = await parseError(response);
+        if (response.status === 409) {
+            setGlobalMessage(`Decision conflict (409): ${detail}`, true);
+        }
+        else {
+            setGlobalMessage(detail, true);
+        }
+        return;
+    }
+    setGlobalMessage("Decision submitted. Refreshing task state.");
+    await Promise.all([refreshPendingActions(), refreshTaskDetail()]);
+}
+async function refreshPendingActions() {
+    try {
+        const records = await getJson("/pending-actions");
+        renderPendingActions(records);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setGlobalMessage(message, true);
+    }
+}
+async function refreshTaskDetail() {
+    const taskId = state.selectedTaskId;
+    if (!taskId) {
+        return;
+    }
+    try {
+        const task = await getJson(`/tasks/${taskId}`);
+        renderTaskDetail(task);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        byId("task-detail").innerHTML = `<p class="error">${message}</p>`;
+        byId("decision-form-container").innerHTML =
+            "<p>No pending action for the selected task.</p>";
+        setGlobalMessage(message, true);
+    }
+}
+function updateUrlForTask(taskId) {
+    if (window.location.pathname === `/ui/tasks/${taskId}`) {
+        return;
+    }
+    window.history.replaceState(null, "", `/ui/tasks/${encodeURIComponent(taskId)}`);
+}
+function bindEvents() {
+    const form = byId("task-query-form");
+    const refreshButton = byId("refresh-button");
+    const input = byId("task-id-input");
+    form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const taskId = input.value.trim();
+        if (!taskId) {
+            setGlobalMessage("Task id is empty. Showing pending actions only.");
+            state.selectedTaskId = null;
+            return;
+        }
+        state.selectedTaskId = taskId;
+        updateUrlForTask(taskId);
+        void refreshTaskDetail();
+    });
+    refreshButton.addEventListener("click", () => {
+        void refreshPendingActions();
+        if (state.selectedTaskId) {
+            void refreshTaskDetail();
+        }
+    });
+}
+async function bootstrap() {
+    bindEvents();
+    const taskIdFromPath = parseBootstrapTaskId();
+    if (taskIdFromPath) {
+        state.selectedTaskId = taskIdFromPath;
+        byId("task-id-input").value = taskIdFromPath;
+    }
+    await refreshPendingActions();
+    if (state.selectedTaskId) {
+        await refreshTaskDetail();
+    }
+    window.setInterval(() => {
+        void refreshPendingActions();
+        if (state.selectedTaskId) {
+            void refreshTaskDetail();
+        }
+    }, 5000);
+}
+void bootstrap();

--- a/src/api/static/ts/hitl-dashboard.ts
+++ b/src/api/static/ts/hitl-dashboard.ts
@@ -1,0 +1,427 @@
+type PendingActionType = "plan_confirm" | "patch_confirm" | "replan_confirm";
+type DecisionChoice = "accept" | "replan" | "continue" | "cancel";
+
+interface PendingActionSummary {
+  pending_action_id: string;
+  task_id: string;
+  action_type: PendingActionType;
+  status: string;
+  created_at: string;
+  candidate_count: number;
+  default_suggestion: string | null;
+  explanation: string;
+  summary: string;
+}
+
+interface PendingActionCandidate {
+  candidate_id: string;
+  summary?: string | null;
+  explanation?: string | null;
+  risk_level?: string | null;
+  cost_estimate?: string | null;
+  score_breakdown?: Record<string, number>;
+}
+
+interface PendingAction {
+  pending_action_id: string;
+  action_type: PendingActionType;
+  default_suggestion?: string | null;
+  default_recommendation?: string | null;
+  explanation: string;
+  candidates: PendingActionCandidate[];
+}
+
+interface DesignResult {
+  report_path?: string | null;
+  scores?: Record<string, number>;
+}
+
+interface TaskRecord {
+  id: string;
+  status: string;
+  internal_status?: string | null;
+  goal: string;
+  pending_action?: PendingAction | null;
+  safety_events?: unknown[];
+  design_result?: DesignResult | null;
+}
+
+const ALLOWED_CHOICES: Record<PendingActionType, DecisionChoice[]> = {
+  plan_confirm: ["accept", "replan", "cancel"],
+  patch_confirm: ["accept", "replan", "cancel"],
+  replan_confirm: ["accept", "continue", "cancel"],
+};
+
+const state: { selectedTaskId: string | null } = {
+  selectedTaskId: null,
+};
+
+function byId<T extends HTMLElement>(id: string): T {
+  const element = document.getElementById(id);
+  if (!element) {
+    throw new Error(`Missing element: #${id}`);
+  }
+  return element as T;
+}
+
+function formatActionType(actionType: PendingActionType): string {
+  return actionType.replace("_", " ").toUpperCase();
+}
+
+function parseBootstrapTaskId(): string {
+  const raw = byId<HTMLScriptElement>("app-bootstrap").textContent;
+  if (!raw) {
+    return "";
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { taskId?: string };
+    return parsed.taskId ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function setGlobalMessage(message: string, isError = false): void {
+  const node = byId<HTMLParagraphElement>("global-message");
+  node.textContent = message;
+  node.className = isError ? "error" : "muted";
+}
+
+function statusChipClass(status: string): string {
+  if (status.startsWith("WAITING_")) {
+    return "chip waiting";
+  }
+  if (status === "DONE") {
+    return "chip done";
+  }
+  if (status === "RUNNING" || status === "PLANNING" || status === "PLANNED") {
+    return "chip active";
+  }
+  return "chip muted";
+}
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: string };
+    return payload.detail ?? `Request failed: ${response.status}`;
+  } catch {
+    return `Request failed: ${response.status}`;
+  }
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+  return (await response.json()) as T;
+}
+
+function renderPendingActions(items: PendingActionSummary[]): void {
+  const tbody = byId<HTMLTableSectionElement>("pending-actions-body");
+  const counter = byId<HTMLSpanElement>("pending-count");
+  counter.textContent = String(items.length);
+  tbody.innerHTML = "";
+
+  if (!items.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 6;
+    cell.textContent = "No pending actions.";
+    row.appendChild(cell);
+    tbody.appendChild(row);
+    return;
+  }
+
+  for (const item of items) {
+    const row = document.createElement("tr");
+
+    const openCell = document.createElement("td");
+    const openButton = document.createElement("button");
+    openButton.type = "button";
+    openButton.className = "row-action";
+    openButton.textContent = "Open";
+    openButton.addEventListener("click", () => {
+      state.selectedTaskId = item.task_id;
+      byId<HTMLInputElement>("task-id-input").value = item.task_id;
+      updateUrlForTask(item.task_id);
+      void refreshTaskDetail();
+    });
+    openCell.appendChild(openButton);
+    row.appendChild(openCell);
+
+    const taskCell = document.createElement("td");
+    taskCell.textContent = item.task_id;
+    row.appendChild(taskCell);
+
+    const typeCell = document.createElement("td");
+    typeCell.textContent = formatActionType(item.action_type);
+    row.appendChild(typeCell);
+
+    const candidateCell = document.createElement("td");
+    candidateCell.textContent = String(item.candidate_count);
+    row.appendChild(candidateCell);
+
+    const defaultCell = document.createElement("td");
+    defaultCell.textContent = item.default_suggestion ?? "-";
+    row.appendChild(defaultCell);
+
+    const summaryCell = document.createElement("td");
+    summaryCell.textContent = item.summary || item.explanation;
+    row.appendChild(summaryCell);
+
+    tbody.appendChild(row);
+  }
+}
+
+function renderReservedSections(task: TaskRecord): void {
+  const safetyCount = task.safety_events?.length ?? 0;
+  byId<HTMLParagraphElement>("reserved-safety").textContent =
+    safetyCount > 0
+      ? `Safety events: ${safetyCount} (details can be expanded later).`
+      : "No safety events yet. Area reserved for event cards.";
+
+  const reportPath = task.design_result?.report_path ?? "";
+  byId<HTMLParagraphElement>("reserved-report").textContent = reportPath
+    ? `Report path: ${reportPath}`
+    : "No report yet. Area reserved for report preview.";
+
+  byId<HTMLParagraphElement>("reserved-steps").textContent =
+    "Step timeline area reserved for future execution details.";
+}
+
+function renderTaskDetail(task: TaskRecord): void {
+  const badge = byId<HTMLSpanElement>("task-state-badge");
+  badge.textContent = `${task.status}${task.internal_status ? ` / ${task.internal_status}` : ""}`;
+  badge.className = statusChipClass(task.status);
+
+  const container = byId<HTMLDivElement>("task-detail");
+  const pending = task.pending_action;
+  const lines: string[] = [
+    `<p><strong>Task ID:</strong> ${task.id}</p>`,
+    `<p><strong>Goal:</strong> ${task.goal}</p>`,
+  ];
+
+  if (pending) {
+    const defaultSuggestion =
+      pending.default_suggestion ?? pending.default_recommendation ?? "-";
+    lines.push(`<p><strong>Action Type:</strong> ${pending.action_type}</p>`);
+    lines.push(`<p><strong>Default Suggestion:</strong> ${defaultSuggestion}</p>`);
+    lines.push(`<p><strong>Explanation:</strong> ${pending.explanation}</p>`);
+
+    const candidateLines = pending.candidates.map((candidate) => {
+      const risk = candidate.risk_level ?? "-";
+      const cost = candidate.cost_estimate ?? "-";
+      const summary = candidate.summary ?? candidate.explanation ?? "No summary";
+      return `<li><strong>${candidate.candidate_id}</strong> | risk=${risk} | cost=${cost}<br/>${summary}</li>`;
+    });
+    lines.push(`<ul class="candidate-list">${candidateLines.join("")}</ul>`);
+  } else {
+    lines.push("<p>No pending action for this task.</p>");
+  }
+
+  container.innerHTML = lines.join("");
+  renderReservedSections(task);
+  renderDecisionForm(pending ?? null);
+}
+
+function renderDecisionForm(pendingAction: PendingAction | null): void {
+  const container = byId<HTMLDivElement>("decision-form-container");
+  container.innerHTML = "";
+
+  if (!pendingAction || !state.selectedTaskId) {
+    container.innerHTML = "<p>No pending action for the selected task.</p>";
+    return;
+  }
+
+  const allowed = ALLOWED_CHOICES[pendingAction.action_type];
+  const defaultSuggestion =
+    pendingAction.default_suggestion ?? pendingAction.default_recommendation ?? "";
+
+  const form = document.createElement("form");
+  form.id = "decision-form";
+  form.innerHTML = `
+    <label for="decision-choice">Choice</label>
+    <select id="decision-choice" name="choice">
+      ${allowed.map((choice) => `<option value="${choice}">${choice}</option>`).join("")}
+    </select>
+    <label for="decision-candidate">Candidate (required for accept)</label>
+    <select id="decision-candidate" name="candidate">
+      <option value="">-- Select candidate --</option>
+      ${pendingAction.candidates
+        .map((candidate) => {
+          const selected = candidate.candidate_id === defaultSuggestion ? " selected" : "";
+          return `<option value="${candidate.candidate_id}"${selected}>${candidate.candidate_id}</option>`;
+        })
+        .join("")}
+    </select>
+    <label for="decision-by">Decided By</label>
+    <input id="decision-by" name="decided_by" type="text" value="ui_user" />
+    <label for="decision-comment">Comment</label>
+    <textarea id="decision-comment" name="comment" rows="3" placeholder="optional note"></textarea>
+    <button type="submit">Submit Decision</button>
+  `;
+
+  container.appendChild(form);
+
+  const choiceNode = byId<HTMLSelectElement>("decision-choice");
+  const candidateNode = byId<HTMLSelectElement>("decision-candidate");
+
+  const syncCandidateState = (): void => {
+    const isAccept = choiceNode.value === "accept";
+    candidateNode.disabled = !isAccept;
+    if (!isAccept) {
+      candidateNode.value = "";
+    }
+  };
+
+  syncCandidateState();
+  choiceNode.addEventListener("change", syncCandidateState);
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    void submitDecision(pendingAction.pending_action_id);
+  });
+}
+
+async function submitDecision(pendingActionId: string): Promise<void> {
+  if (!state.selectedTaskId) {
+    setGlobalMessage("Task id is required before submitting decision.", true);
+    return;
+  }
+
+  const choiceNode = byId<HTMLSelectElement>("decision-choice");
+  const candidateNode = byId<HTMLSelectElement>("decision-candidate");
+  const decidedByNode = byId<HTMLInputElement>("decision-by");
+  const commentNode = byId<HTMLTextAreaElement>("decision-comment");
+
+  const choice = choiceNode.value as DecisionChoice;
+  const selectedCandidate = candidateNode.value.trim();
+  if (choice === "accept" && !selectedCandidate) {
+    setGlobalMessage("accept requires selected candidate id.", true);
+    return;
+  }
+
+  const payload: {
+    choice: DecisionChoice;
+    selected_candidate_id?: string;
+    decided_by: string;
+    comment?: string;
+  } = {
+    choice,
+    decided_by: decidedByNode.value.trim() || "ui_user",
+  };
+  if (choice === "accept") {
+    payload.selected_candidate_id = selectedCandidate;
+  }
+  if (commentNode.value.trim()) {
+    payload.comment = commentNode.value.trim();
+  }
+
+  const response = await fetch(`/pending-actions/${pendingActionId}/decision`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const detail = await parseError(response);
+    if (response.status === 409) {
+      setGlobalMessage(`Decision conflict (409): ${detail}`, true);
+    } else {
+      setGlobalMessage(detail, true);
+    }
+    return;
+  }
+
+  setGlobalMessage("Decision submitted. Refreshing task state.");
+  await Promise.all([refreshPendingActions(), refreshTaskDetail()]);
+}
+
+async function refreshPendingActions(): Promise<void> {
+  try {
+    const records = await getJson<PendingActionSummary[]>("/pending-actions");
+    renderPendingActions(records);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setGlobalMessage(message, true);
+  }
+}
+
+async function refreshTaskDetail(): Promise<void> {
+  const taskId = state.selectedTaskId;
+  if (!taskId) {
+    return;
+  }
+
+  try {
+    const task = await getJson<TaskRecord>(`/tasks/${taskId}`);
+    renderTaskDetail(task);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    byId<HTMLDivElement>("task-detail").innerHTML = `<p class="error">${message}</p>`;
+    byId<HTMLDivElement>("decision-form-container").innerHTML =
+      "<p>No pending action for the selected task.</p>";
+    setGlobalMessage(message, true);
+  }
+}
+
+function updateUrlForTask(taskId: string): void {
+  if (window.location.pathname === `/ui/tasks/${taskId}`) {
+    return;
+  }
+  window.history.replaceState(null, "", `/ui/tasks/${encodeURIComponent(taskId)}`);
+}
+
+function bindEvents(): void {
+  const form = byId<HTMLFormElement>("task-query-form");
+  const refreshButton = byId<HTMLButtonElement>("refresh-button");
+  const input = byId<HTMLInputElement>("task-id-input");
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const taskId = input.value.trim();
+    if (!taskId) {
+      setGlobalMessage("Task id is empty. Showing pending actions only.");
+      state.selectedTaskId = null;
+      return;
+    }
+    state.selectedTaskId = taskId;
+    updateUrlForTask(taskId);
+    void refreshTaskDetail();
+  });
+
+  refreshButton.addEventListener("click", () => {
+    void refreshPendingActions();
+    if (state.selectedTaskId) {
+      void refreshTaskDetail();
+    }
+  });
+}
+
+async function bootstrap(): Promise<void> {
+  bindEvents();
+
+  const taskIdFromPath = parseBootstrapTaskId();
+  if (taskIdFromPath) {
+    state.selectedTaskId = taskIdFromPath;
+    byId<HTMLInputElement>("task-id-input").value = taskIdFromPath;
+  }
+
+  await refreshPendingActions();
+  if (state.selectedTaskId) {
+    await refreshTaskDetail();
+  }
+
+  window.setInterval(() => {
+    void refreshPendingActions();
+    if (state.selectedTaskId) {
+      void refreshTaskDetail();
+    }
+  }, 5000);
+}
+
+void bootstrap();

--- a/src/api/templates/index.html
+++ b/src/api/templates/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>HITL PendingAction Dashboard</title>
+    <link rel="stylesheet" href="/static/css/hitl-dashboard.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <header class="hero">
+        <h1>HITL PendingAction Dashboard</h1>
+        <p>
+          Review waiting decisions, inspect task status, and submit Decision to
+          continue FSM.
+        </p>
+        <form id="task-query-form" class="task-query">
+          <input
+            id="task-id-input"
+            name="task_id"
+            type="text"
+            placeholder="Enter task id (optional)"
+          />
+          <button type="submit">Load Task</button>
+          <button id="refresh-button" type="button">Refresh</button>
+        </form>
+        <p id="global-message" role="status"></p>
+      </header>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Pending Actions</h2>
+          <span id="pending-count" class="chip">0</span>
+        </div>
+        <table class="pending-table">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Task</th>
+              <th>Type</th>
+              <th>Candidates</th>
+              <th>Default</th>
+              <th>Summary</th>
+            </tr>
+          </thead>
+          <tbody id="pending-actions-body"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Task Detail</h2>
+          <span id="task-state-badge" class="chip muted">No task loaded</span>
+        </div>
+        <div id="task-detail">
+          <p>Select a task from pending actions or enter a task id above.</p>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Decision</h2>
+        <div id="decision-form-container">
+          <p>No pending action for the selected task.</p>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Reserved Display Areas</h2>
+        <div class="reserved-grid">
+          <article>
+            <h3>Step Timeline</h3>
+            <p id="reserved-steps">Reserved for step execution timeline.</p>
+          </article>
+          <article>
+            <h3>Safety Events</h3>
+            <p id="reserved-safety">Reserved for safety warnings and blocks.</p>
+          </article>
+          <article>
+            <h3>Report Preview</h3>
+            <p id="reserved-report">Reserved for report path and final scores.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <script id="app-bootstrap" type="application/json">
+      __BOOTSTRAP__
+    </script>
+    <script type="module" src="/static/js/hitl-dashboard.js"></script>
+  </body>
+</html>

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -35,6 +35,12 @@ class TestAPIEndpoints:
         ) as client:
             yield client
 
+    @pytest.fixture(autouse=True)
+    def clear_task_store(self):
+        TASK_STORE.clear()
+        yield
+        TASK_STORE.clear()
+
     async def test_create_task_endpoint(self, client: httpx.AsyncClient):
         """测试创建任务端点"""
         response = await client.post(
@@ -179,6 +185,131 @@ class TestAPIEndpoints:
         assert created["goal"] == retrieved["goal"]
         assert created["constraints"] == retrieved["constraints"]
         assert created["metadata"] == retrieved["metadata"]
+
+    async def test_get_pending_actions_default_only_pending(
+        self, client: httpx.AsyncClient
+    ):
+        """默认只返回 pending 状态的 PendingAction。"""
+        pending_task_id = "task_pending_list_a"
+        decided_task_id = "task_pending_list_b"
+
+        pending_action = PendingAction(
+            pending_action_id="pa_pending",
+            task_id=pending_task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            status=PendingActionStatus.PENDING,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="plan_a",
+                    payload=Plan(task_id=pending_task_id, steps=[], constraints={}, metadata={}),
+                )
+            ],
+            default_suggestion="plan_a",
+            explanation="please confirm initial plan",
+        )
+        decided_action = PendingAction(
+            pending_action_id="pa_decided",
+            task_id=decided_task_id,
+            action_type=PendingActionType.PATCH_CONFIRM,
+            status=PendingActionStatus.DECIDED,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="patch_a",
+                    payload=PlanPatch(task_id=decided_task_id, operations=[], metadata={}),
+                )
+            ],
+            explanation="already decided",
+        )
+
+        TASK_STORE[pending_task_id] = TaskRecord(
+            id=pending_task_id,
+            status=ExternalStatus.WAITING_PLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+            goal="pending task",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=pending_action,
+        )
+        TASK_STORE[decided_task_id] = TaskRecord(
+            id=decided_task_id,
+            status=ExternalStatus.WAITING_PATCH_CONFIRM,
+            internal_status=InternalStatus.WAITING_PATCH,
+            goal="decided task",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=decided_action,
+        )
+
+        response = await client.get("/pending-actions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["pending_action_id"] == "pa_pending"
+        assert data[0]["candidate_count"] == 1
+        assert data[0]["default_suggestion"] == "plan_a"
+        assert "plan_a" in data[0]["summary"]
+
+    async def test_get_pending_actions_supports_status_and_task_filters(
+        self, client: httpx.AsyncClient
+    ):
+        """支持按 status/task_id 过滤 pending action 列表。"""
+        task_id = "task_pending_filter"
+        action = PendingAction(
+            pending_action_id="pa_filter",
+            task_id=task_id,
+            action_type=PendingActionType.REPLAN_CONFIRM,
+            status=PendingActionStatus.DECIDED,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="replan_a",
+                    payload=Plan(task_id=task_id, steps=[], constraints={}, metadata={}),
+                )
+            ],
+            explanation="decided replan",
+        )
+        TASK_STORE[task_id] = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.WAITING_REPLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_REPLAN,
+            goal="filter task",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=action,
+        )
+
+        response = await client.get(
+            "/pending-actions",
+            params={"status": PendingActionStatus.DECIDED.value, "task_id": task_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["pending_action_id"] == "pa_filter"
+        assert data[0]["task_id"] == task_id
+
+    async def test_ui_routes_and_static_assets_available(
+        self, client: httpx.AsyncClient
+    ):
+        """前端 UI 页面和静态资源可访问。"""
+        dashboard_response = await client.get("/ui")
+        assert dashboard_response.status_code == 200
+        assert "HITL PendingAction Dashboard" in dashboard_response.text
+
+        task_view_response = await client.get("/ui/tasks/task_demo_001")
+        assert task_view_response.status_code == 200
+        assert "HITL PendingAction Dashboard" in task_view_response.text
+
+        static_response = await client.get("/static/js/hitl-dashboard.js")
+        assert static_response.status_code == 200
+        assert "ALLOWED_CHOICES" in static_response.text
 
     @pytest.mark.parametrize(
         "external_status,internal_status,action_type",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "noEmitOnError": true,
+    "rootDir": "src/api/static/ts",
+    "outDir": "src/api/static/js",
+    "newLine": "lf"
+  },
+  "include": ["src/api/static/ts/**/*.ts"]
+}


### PR DESCRIPTION
## 关联 Issue

Closes #122

## 目标

实现项目首个前端 HITL 决策界面，完整打通 PendingAction/Decision 闭环，让 WAITING_* 状态在 UI 中可见、可决策、可推进。

## 本次改动

### 1. API 与页面入口
- 新增 `GET /pending-actions`：
  - 支持 `status`（默认 `pending`）与 `task_id` 过滤
  - 返回 PendingAction 摘要（`action_type`、`candidate_count`、`default_suggestion`、`explanation`、`summary`）
- 新增 UI 路由：
  - `GET /ui`
  - `GET /ui/tasks/{task_id}`
- 挂载静态资源目录：`/static`

### 2. 首次前端实现（TypeScript）
- 新增 HITL Dashboard 页面（首次引入 `src/api/templates/`、`src/api/static/`）
- 页面包含：
  - PendingAction 列表
  - Task Detail 联动展示（状态 + pending_action）
  - Decision 提交表单
  - 预留展示区（Step Timeline / Safety Events / Report Preview）
- 决策选项按 `action_type` 限制：
  - `plan_confirm`: `accept/replan/cancel`
  - `patch_confirm`: `accept/replan/cancel`
  - `replan_confirm`: `accept/continue/cancel`
- 通过 `POST /pending-actions/{id}/decision` 提交决策
- 处理 409 冲突并在 UI 提示
- 5s 轮询刷新，保持列表与详情联动

### 3. TS 构建与文档
- 增加最小 TypeScript 构建配置与脚本
- README / Demo 文档新增 `/ui` 入口说明

## 关键实现决策与原因

### 决策 1：前端与 FastAPI 同仓同服务（模板 + 静态资源）
- 实现：将页面放在 `src/api/templates/`，脚本样式放在 `src/api/static/`，由 FastAPI 直接提供。
- 原因：
  - 这是项目首次前端实现，优先最小可运行方案，避免额外前端工程和部署链路。
  - 便于与现有 API（`/tasks`、`/pending-actions`、`/decision`）联调，降低 Demo 演示复杂度。

### 决策 2：新增 `GET /pending-actions` 摘要接口，而不是在前端遍历所有任务
- 实现：后端直接提供 PendingAction 列表摘要接口。
- 原因：
  - 与设计文档和 issue 要求对齐（用于待办列表）。
  - 降低前端聚合复杂度，明确接口职责边界。

### 决策 3：非法决策“前端约束 + 后端兜底”双保险
- 实现：UI 按 `action_type` 限制可选项，同时保留后端校验与 409/400 返回。
- 原因：
  - 前端提升可用性，减少误操作。
  - 后端保证契约一致性，避免绕过 UI 的非法请求。

### 决策 4：轮询而非引入 WebSocket
- 实现：5s 定时刷新 pending 列表与 task 详情。
- 原因：
  - 当前是首次前端落地，需求以“可展示、可联动”为主。
  - 轮询实现简单、风险低，足以覆盖本次验收。

### 决策 5：预留展示区而不一次性做全
- 实现：Step Timeline / Safety / Report 先提供结构化占位。
- 原因：
  - 对齐 issue“结合项目和设计书预留展示部分”的要求。
  - 控制范围，避免在首次前端引入过多非核心功能。

## 验收标准对照（Issue #122）

- [x] WAITING_* 状态下必然出现决策 UI
  - 任务存在 `pending_action` 时渲染决策区与候选信息。
- [x] PendingAction 列表与 `GET /pending-actions` 一致
  - 列表由该接口直接驱动。
- [x] Decision 提交后状态联动正确
  - 调用既有 Decision apply 逻辑推进状态；
  - 前端刷新后 PendingAction 消失、任务状态更新。
- [x] 非法决策处理
  - UI 按 `action_type` 禁用非法选择；
  - API 返回 409 时前端明确提示。

## 风险点与缓解

### 风险 1：轮询造成不必要请求开销
- 说明：当前固定 5s 轮询，在任务数量增大时可能增加服务负载。
- 缓解：后续可改为“仅在页面可见时轮询”、指数退避或 SSE/WebSocket 推送。

### 风险 2：`GET /pending-actions` 摘要字段与未来模型演进耦合
- 说明：目前 summary 为后端拼接摘要，未来若 Candidate 字段扩展，摘要规则可能需调整。
- 缓解：后续可将摘要生成策略下沉为独立函数/模块并补充契约测试。

### 风险 3：前端状态与后端真实状态的瞬时不一致
- 说明：提交决策后到下一次刷新前，页面可能短暂显示旧状态。
- 缓解：当前提交后立即主动刷新列表+详情，已降低窗口；后续可考虑乐观更新或事件推送。

### 风险 4：UI 仅覆盖 issue 核心路径，报告/步骤展示仍是占位
- 说明：当前“可展示+可决策”完成，但未做完整执行过程可视化。
- 缓解：已预留结构化区域，便于后续按 issue 分阶段扩展。

## 关键实现代码

- API/UI 路由与 pending 列表：`src/api/main.py`
- 前端模板：`src/api/templates/index.html`
- 前端逻辑（TS）：`src/api/static/ts/hitl-dashboard.ts`
- 前端样式：`src/api/static/css/hitl-dashboard.css`
- 前端编译产物：`src/api/static/js/hitl-dashboard.js`
- 构建配置：`package.json`, `tsconfig.json`
- 测试：`tests/api/test_api_endpoints.py`

## 测试

已执行：

```bash
uv run pytest tests/api/test_api_endpoints.py -q
```

结果：`26 passed`
