### PR TITLE
feat(observability): 实现任务 EventLog 时间线视图 (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Then open:
 - `http://127.0.0.1:8000/docs`
 - `http://127.0.0.1:8000/health`
 - `http://127.0.0.1:8000/ui`
+- `http://127.0.0.1:8000/ui/tasks/<task_id>/events`
 
 Detailed demo usage and options:
 

--- a/examples/README_DEMO.md
+++ b/examples/README_DEMO.md
@@ -34,6 +34,7 @@ After startup:
 - API docs: `http://127.0.0.1:8000/docs`
 - Health: `http://127.0.0.1:8000/health`
 - HITL dashboard: `http://127.0.0.1:8000/ui`
+- Event timeline: `http://127.0.0.1:8000/ui/tasks/<task_id>/events`
 
 ## Main Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "thesis-project.dev",
       "devDependencies": {
         "typescript": "^5.9.3"
       }

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -33,6 +33,7 @@ from src.workflow.decision_apply import (
 )
 from src.infra.runtime_init import RuntimeInitResult, initialize_runtime
 from src.models.contracts import PendingActionType, now_iso
+from src.storage.log_store import read_timeline_events
 from src.workflow.context import WorkflowContext
 
 API_DIR = Path(__file__).resolve().parent
@@ -103,6 +104,26 @@ class PendingActionSummary(BaseModel):
     summary: str = Field(..., description="候选摘要")
 
 
+class TaskTimelineEvent(BaseModel):
+    seq: int = Field(..., description="日志行序号(稳定排序键)")
+    task_id: str = Field(..., description="任务 ID")
+    ts: Optional[str] = Field(None, description="事件时间戳")
+    event_type: str = Field(..., description="归一化事件类型")
+    source_event: Optional[str] = Field(None, description="原始事件名")
+    pending_action_id: Optional[str] = None
+    decision_id: Optional[str] = None
+    step_id: Optional[str] = None
+    tool: Optional[str] = None
+    status: Optional[str] = None
+    from_status: Optional[str] = None
+    to_status: Optional[str] = None
+    actor_type: Optional[str] = None
+    summary: str = Field(..., description="事件摘要")
+    highlight: bool = Field(..., description="是否属于关键高亮事件")
+    data: Dict[str, Any] = Field(default_factory=dict)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
 def _render_ui_html(task_id: Optional[str]) -> str:
     template_path = TEMPLATES_DIR / "index.html"
     if not template_path.exists():
@@ -110,6 +131,15 @@ def _render_ui_html(task_id: Optional[str]) -> str:
     raw_html = template_path.read_text(encoding="utf-8")
     bootstrap_payload = json.dumps({"taskId": task_id or ""}, ensure_ascii=True)
     return raw_html.replace("__BOOTSTRAP__", bootstrap_payload)
+
+
+def _render_timeline_ui_html(task_id: str) -> str:
+    template_path = TEMPLATES_DIR / "event_timeline.html"
+    if not template_path.exists():
+        raise HTTPException(status_code=500, detail="timeline template not found")
+    raw_html = template_path.read_text(encoding="utf-8")
+    bootstrap_payload = json.dumps({"taskId": task_id}, ensure_ascii=True)
+    return raw_html.replace("__EVENT_BOOTSTRAP__", bootstrap_payload)
 
 
 def _build_pending_action_summary(pending_action: PendingAction) -> str:
@@ -137,6 +167,11 @@ async def get_hitl_dashboard() -> HTMLResponse:
 @app.get("/ui/tasks/{task_id}", response_class=HTMLResponse)
 async def get_task_detail_view(task_id: str) -> HTMLResponse:
     return HTMLResponse(_render_ui_html(task_id=task_id))
+
+
+@app.get("/ui/tasks/{task_id}/events", response_class=HTMLResponse)
+async def get_task_event_timeline_view(task_id: str) -> HTMLResponse:
+    return HTMLResponse(_render_timeline_ui_html(task_id=task_id))
 
 
 @app.get("/health")
@@ -180,6 +215,30 @@ async def get_task(task_id: str):
     if record is None:
         raise HTTPException(status_code=404, detail="task not found")
     return record
+
+
+@app.get("/tasks/{task_id}/events", response_model=list[TaskTimelineEvent])
+async def get_task_events(task_id: str) -> list[TaskTimelineEvent]:
+    runtime = _ensure_runtime_initialized()
+    timeline = read_timeline_events(task_id, log_dir=runtime.paths.log_dir)
+
+    if task_id not in TASK_STORE and not timeline:
+        raise HTTPException(status_code=404, detail="task not found")
+
+    highlighted = {
+        "STATE_TRANSITION",
+        "PENDING_ACTION_CREATED",
+        "DECISION_APPLIED",
+        "STEP_FINISHED",
+        "STEP_FAILED",
+    }
+    return [
+        TaskTimelineEvent(
+            **event,
+            highlight=event["event_type"] in highlighted,
+        )
+        for event in timeline
+    ]
 
 
 @app.get("/pending-actions", response_model=list[PendingActionSummary])

--- a/src/api/static/css/event-timeline.css
+++ b/src/api/static/css/event-timeline.css
@@ -1,0 +1,138 @@
+:root {
+  --bg: #f3f5fa;
+  --panel: #ffffff;
+  --line: #d8dfeb;
+  --text: #1f2a3d;
+  --muted: #5d6a7f;
+  --accent: #005e9b;
+  --highlight: #fff4df;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top right, #d9e9ff 0, var(--bg) 46%);
+}
+
+.layout {
+  max-width: 1024px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+  display: grid;
+  gap: 14px;
+}
+
+.hero,
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--panel);
+  padding: 16px;
+}
+
+.hero h1 {
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-size: 24px;
+}
+
+.query-form {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+input,
+button {
+  font: inherit;
+}
+
+input {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+  min-width: 260px;
+}
+
+button {
+  border: 1px solid #1f5d95;
+  border-radius: 8px;
+  background: #2c78bf;
+  color: #fff;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.badge {
+  border: 1px solid #afc2de;
+  border-radius: 999px;
+  background: #edf5ff;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
+.badge.waiting {
+  background: #fff6e9;
+  border-color: #e9c788;
+}
+
+.badge.running {
+  background: #edf7ff;
+  border-color: #a9c6e4;
+}
+
+.badge.done {
+  background: #effff2;
+  border-color: #abd9b2;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.timeline-item {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.timeline-item.highlight {
+  background: var(--highlight);
+  border-color: #edc78b;
+}
+
+.event-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.event-meta {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.error {
+  color: #a51a1a;
+}

--- a/src/api/static/js/event-timeline.js
+++ b/src/api/static/js/event-timeline.js
@@ -1,0 +1,215 @@
+function byId(id) {
+    const node = document.getElementById(id);
+    if (!node) {
+        throw new Error(`Missing element: #${id}`);
+    }
+    return node;
+}
+function parseBootstrapTaskId() {
+    const raw = byId("event-bootstrap").textContent;
+    if (!raw) {
+        return "";
+    }
+    try {
+        const parsed = JSON.parse(raw);
+        return parsed.taskId ?? "";
+    }
+    catch {
+        return "";
+    }
+}
+function setMessage(text, isError = false) {
+    const node = byId("message");
+    node.textContent = text;
+    node.className = isError ? "error" : "muted";
+}
+function statusBadgeClass(status) {
+    if (status.startsWith("WAITING_")) {
+        return "badge waiting";
+    }
+    if (status === "RUNNING" || status === "PLANNING" || status === "PLANNED") {
+        return "badge running";
+    }
+    if (status === "DONE") {
+        return "badge done";
+    }
+    return "badge";
+}
+async function parseError(response) {
+    try {
+        const payload = (await response.json());
+        return payload.detail ?? `request failed: ${response.status}`;
+    }
+    catch {
+        return `request failed: ${response.status}`;
+    }
+}
+async function fetchJson(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(await parseError(response));
+    }
+    return (await response.json());
+}
+function renderTaskSummary(task) {
+    const badge = byId("status-badge");
+    badge.textContent = `${task.status}${task.internal_status ? ` / ${task.internal_status}` : ""}`;
+    badge.className = statusBadgeClass(task.status);
+    byId("task-summary").innerHTML = `
+    <p><strong>Task ID:</strong> ${task.id}</p>
+    <p><strong>Goal:</strong> ${task.goal}</p>
+  `;
+}
+function renderTimeline(events) {
+    const list = byId("timeline-list");
+    const count = byId("event-count");
+    count.textContent = String(events.length);
+    list.innerHTML = "";
+    if (!events.length) {
+        list.innerHTML = "<li class=\"timeline-item\">No events found.</li>";
+        return;
+    }
+    for (const event of events) {
+        const item = document.createElement("li");
+        item.className = event.highlight ? "timeline-item highlight" : "timeline-item";
+        const ts = event.ts ?? "-";
+        const stateInfo = event.from_status || event.to_status
+            ? `${event.from_status ?? "?"} -> ${event.to_status ?? "?"}`
+            : event.status ?? "-";
+        item.innerHTML = `
+      <div class="event-title">
+        <span>${event.event_type}</span>
+        <span>${ts}</span>
+      </div>
+      <div class="event-meta">${event.summary}</div>
+      <div class="event-meta">state: ${stateInfo}</div>
+      <div class="event-meta">step: ${event.step_id ?? "-"} | tool: ${event.tool ?? "-"}</div>
+    `;
+        list.appendChild(item);
+    }
+}
+function isWaitingEnter(event) {
+    if (event.event_type === "WAITING_ENTER") {
+        return true;
+    }
+    return (event.event_type === "STATE_TRANSITION" &&
+        typeof event.to_status === "string" &&
+        event.to_status.startsWith("WAITING_"));
+}
+function isWaitingExit(event) {
+    if (event.event_type === "WAITING_EXIT") {
+        return true;
+    }
+    return (event.event_type === "STATE_TRANSITION" &&
+        typeof event.from_status === "string" &&
+        event.from_status.startsWith("WAITING_") &&
+        (!event.to_status || !event.to_status.startsWith("WAITING_")));
+}
+function renderChainSummary(events) {
+    let stage = 0;
+    let chains = 0;
+    for (const event of events) {
+        if (stage === 0) {
+            if (isWaitingEnter(event)) {
+                stage = 1;
+            }
+            continue;
+        }
+        if (stage === 1) {
+            if (event.event_type === "DECISION_APPLIED") {
+                stage = 2;
+            }
+            else if (isWaitingEnter(event)) {
+                stage = 1;
+            }
+            continue;
+        }
+        if (stage === 2) {
+            if (isWaitingExit(event)) {
+                chains += 1;
+                stage = 0;
+            }
+            continue;
+        }
+    }
+    const node = byId("chain-summary");
+    if (chains > 0) {
+        node.textContent = `Detected ${chains} WAITING -> decision -> resume chain(s).`;
+        node.className = "muted";
+        return;
+    }
+    node.textContent =
+        "No complete WAITING -> decision -> resume chain detected yet.";
+    node.className = "muted";
+}
+function updateUrl(taskId) {
+    const nextPath = `/ui/tasks/${encodeURIComponent(taskId)}/events`;
+    if (window.location.pathname !== nextPath) {
+        window.history.replaceState(null, "", nextPath);
+    }
+}
+async function loadTaskTimeline(taskId) {
+    byId("task-id-input").value = taskId;
+    updateUrl(taskId);
+    const events = await fetchJson(`/tasks/${taskId}/events`);
+    try {
+        const task = await fetchJson(`/tasks/${taskId}`);
+        renderTaskSummary(task);
+    }
+    catch {
+        byId("status-badge").textContent = "Task record unavailable";
+        byId("status-badge").className = "badge";
+        byId("task-summary").innerHTML = `
+      <p><strong>Task ID:</strong> ${taskId}</p>
+      <p class="muted">Task detail not found in memory store, timeline is shown from log file.</p>
+    `;
+    }
+    renderTimeline(events);
+    renderChainSummary(events);
+    setMessage("Timeline loaded.");
+}
+function bindEvents() {
+    const form = byId("timeline-query-form");
+    const refreshButton = byId("refresh-button");
+    const input = byId("task-id-input");
+    form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const taskId = input.value.trim();
+        if (!taskId) {
+            setMessage("task id is required.", true);
+            return;
+        }
+        void loadTaskTimeline(taskId).catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            setMessage(message, true);
+        });
+    });
+    refreshButton.addEventListener("click", () => {
+        const taskId = input.value.trim();
+        if (!taskId) {
+            setMessage("task id is required.", true);
+            return;
+        }
+        void loadTaskTimeline(taskId).catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            setMessage(message, true);
+        });
+    });
+}
+async function bootstrap() {
+    bindEvents();
+    const taskId = parseBootstrapTaskId();
+    if (!taskId) {
+        setMessage("Enter task id to load timeline.");
+        return;
+    }
+    try {
+        await loadTaskTimeline(taskId);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setMessage(message, true);
+    }
+}
+void bootstrap();
+export {};

--- a/src/api/static/js/hitl-dashboard.js
+++ b/src/api/static/js/hitl-dashboard.js
@@ -1,4 +1,3 @@
-"use strict";
 const ALLOWED_CHOICES = {
     plan_confirm: ["accept", "replan", "cancel"],
     patch_confirm: ["accept", "replan", "cancel"],
@@ -322,3 +321,4 @@ async function bootstrap() {
     }, 5000);
 }
 void bootstrap();
+export {};

--- a/src/api/static/ts/event-timeline.ts
+++ b/src/api/static/ts/event-timeline.ts
@@ -1,0 +1,264 @@
+interface TaskRecord {
+  id: string;
+  goal: string;
+  status: string;
+  internal_status?: string | null;
+}
+
+interface TaskTimelineEvent {
+  seq: number;
+  task_id: string;
+  ts: string | null;
+  event_type: string;
+  source_event?: string | null;
+  pending_action_id?: string | null;
+  decision_id?: string | null;
+  step_id?: string | null;
+  tool?: string | null;
+  status?: string | null;
+  from_status?: string | null;
+  to_status?: string | null;
+  actor_type?: string | null;
+  summary: string;
+  highlight: boolean;
+  data: Record<string, unknown>;
+  payload: Record<string, unknown>;
+}
+
+function byId<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (!node) {
+    throw new Error(`Missing element: #${id}`);
+  }
+  return node as T;
+}
+
+function parseBootstrapTaskId(): string {
+  const raw = byId<HTMLScriptElement>("event-bootstrap").textContent;
+  if (!raw) {
+    return "";
+  }
+  try {
+    const parsed = JSON.parse(raw) as { taskId?: string };
+    return parsed.taskId ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function setMessage(text: string, isError = false): void {
+  const node = byId<HTMLParagraphElement>("message");
+  node.textContent = text;
+  node.className = isError ? "error" : "muted";
+}
+
+function statusBadgeClass(status: string): string {
+  if (status.startsWith("WAITING_")) {
+    return "badge waiting";
+  }
+  if (status === "RUNNING" || status === "PLANNING" || status === "PLANNED") {
+    return "badge running";
+  }
+  if (status === "DONE") {
+    return "badge done";
+  }
+  return "badge";
+}
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: string };
+    return payload.detail ?? `request failed: ${response.status}`;
+  } catch {
+    return `request failed: ${response.status}`;
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+  return (await response.json()) as T;
+}
+
+function renderTaskSummary(task: TaskRecord): void {
+  const badge = byId<HTMLSpanElement>("status-badge");
+  badge.textContent = `${task.status}${task.internal_status ? ` / ${task.internal_status}` : ""}`;
+  badge.className = statusBadgeClass(task.status);
+  byId<HTMLDivElement>("task-summary").innerHTML = `
+    <p><strong>Task ID:</strong> ${task.id}</p>
+    <p><strong>Goal:</strong> ${task.goal}</p>
+  `;
+}
+
+function renderTimeline(events: TaskTimelineEvent[]): void {
+  const list = byId<HTMLOListElement>("timeline-list");
+  const count = byId<HTMLSpanElement>("event-count");
+  count.textContent = String(events.length);
+  list.innerHTML = "";
+
+  if (!events.length) {
+    list.innerHTML = "<li class=\"timeline-item\">No events found.</li>";
+    return;
+  }
+
+  for (const event of events) {
+    const item = document.createElement("li");
+    item.className = event.highlight ? "timeline-item highlight" : "timeline-item";
+    const ts = event.ts ?? "-";
+    const stateInfo = event.from_status || event.to_status
+      ? `${event.from_status ?? "?"} -> ${event.to_status ?? "?"}`
+      : event.status ?? "-";
+    item.innerHTML = `
+      <div class="event-title">
+        <span>${event.event_type}</span>
+        <span>${ts}</span>
+      </div>
+      <div class="event-meta">${event.summary}</div>
+      <div class="event-meta">state: ${stateInfo}</div>
+      <div class="event-meta">step: ${event.step_id ?? "-"} | tool: ${event.tool ?? "-"}</div>
+    `;
+    list.appendChild(item);
+  }
+}
+
+function isWaitingEnter(event: TaskTimelineEvent): boolean {
+  if (event.event_type === "WAITING_ENTER") {
+    return true;
+  }
+  return (
+    event.event_type === "STATE_TRANSITION" &&
+    typeof event.to_status === "string" &&
+    event.to_status.startsWith("WAITING_")
+  );
+}
+
+function isWaitingExit(event: TaskTimelineEvent): boolean {
+  if (event.event_type === "WAITING_EXIT") {
+    return true;
+  }
+  return (
+    event.event_type === "STATE_TRANSITION" &&
+    typeof event.from_status === "string" &&
+    event.from_status.startsWith("WAITING_") &&
+    (!event.to_status || !event.to_status.startsWith("WAITING_"))
+  );
+}
+
+function renderChainSummary(events: TaskTimelineEvent[]): void {
+  let stage = 0;
+  let chains = 0;
+  for (const event of events) {
+    if (stage === 0) {
+      if (isWaitingEnter(event)) {
+        stage = 1;
+      }
+      continue;
+    }
+    if (stage === 1) {
+      if (event.event_type === "DECISION_APPLIED") {
+        stage = 2;
+      } else if (isWaitingEnter(event)) {
+        stage = 1;
+      }
+      continue;
+    }
+    if (stage === 2) {
+      if (isWaitingExit(event)) {
+        chains += 1;
+        stage = 0;
+      }
+      continue;
+    }
+  }
+
+  const node = byId<HTMLParagraphElement>("chain-summary");
+  if (chains > 0) {
+    node.textContent = `Detected ${chains} WAITING -> decision -> resume chain(s).`;
+    node.className = "muted";
+    return;
+  }
+
+  node.textContent =
+    "No complete WAITING -> decision -> resume chain detected yet.";
+  node.className = "muted";
+}
+
+function updateUrl(taskId: string): void {
+  const nextPath = `/ui/tasks/${encodeURIComponent(taskId)}/events`;
+  if (window.location.pathname !== nextPath) {
+    window.history.replaceState(null, "", nextPath);
+  }
+}
+
+async function loadTaskTimeline(taskId: string): Promise<void> {
+  byId<HTMLInputElement>("task-id-input").value = taskId;
+  updateUrl(taskId);
+
+  const events = await fetchJson<TaskTimelineEvent[]>(`/tasks/${taskId}/events`);
+  try {
+    const task = await fetchJson<TaskRecord>(`/tasks/${taskId}`);
+    renderTaskSummary(task);
+  } catch {
+    byId<HTMLSpanElement>("status-badge").textContent = "Task record unavailable";
+    byId<HTMLSpanElement>("status-badge").className = "badge";
+    byId<HTMLDivElement>("task-summary").innerHTML = `
+      <p><strong>Task ID:</strong> ${taskId}</p>
+      <p class="muted">Task detail not found in memory store, timeline is shown from log file.</p>
+    `;
+  }
+  renderTimeline(events);
+  renderChainSummary(events);
+  setMessage("Timeline loaded.");
+}
+
+function bindEvents(): void {
+  const form = byId<HTMLFormElement>("timeline-query-form");
+  const refreshButton = byId<HTMLButtonElement>("refresh-button");
+  const input = byId<HTMLInputElement>("task-id-input");
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const taskId = input.value.trim();
+    if (!taskId) {
+      setMessage("task id is required.", true);
+      return;
+    }
+    void loadTaskTimeline(taskId).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setMessage(message, true);
+    });
+  });
+
+  refreshButton.addEventListener("click", () => {
+    const taskId = input.value.trim();
+    if (!taskId) {
+      setMessage("task id is required.", true);
+      return;
+    }
+    void loadTaskTimeline(taskId).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setMessage(message, true);
+    });
+  });
+}
+
+async function bootstrap(): Promise<void> {
+  bindEvents();
+  const taskId = parseBootstrapTaskId();
+  if (!taskId) {
+    setMessage("Enter task id to load timeline.");
+    return;
+  }
+
+  try {
+    await loadTaskTimeline(taskId);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setMessage(message, true);
+  }
+}
+
+void bootstrap();
+export {};

--- a/src/api/static/ts/hitl-dashboard.ts
+++ b/src/api/static/ts/hitl-dashboard.ts
@@ -425,3 +425,4 @@ async function bootstrap(): Promise<void> {
 }
 
 void bootstrap();
+export {};

--- a/src/api/templates/event_timeline.html
+++ b/src/api/templates/event_timeline.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Task Event Timeline</title>
+    <link rel="stylesheet" href="/static/css/event-timeline.css" />
+  </head>
+  <body>
+    <main class="layout">
+      <header class="hero">
+        <h1>Task Event Timeline</h1>
+        <p>
+          Trace event history for a task and inspect why the workflow paused or
+          resumed.
+        </p>
+        <form id="timeline-query-form" class="query-form">
+          <input
+            id="task-id-input"
+            name="task_id"
+            type="text"
+            placeholder="Enter task id"
+          />
+          <button type="submit">Load Timeline</button>
+          <button id="refresh-button" type="button">Refresh</button>
+        </form>
+        <p id="message" class="muted"></p>
+      </header>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Task Snapshot</h2>
+          <span id="status-badge" class="badge">Unknown</span>
+        </div>
+        <div id="task-summary">
+          <p>No task loaded.</p>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Chain Detection</h2>
+        <p id="chain-summary" class="muted">
+          Waiting for timeline data to detect WAITING_* decision chain.
+        </p>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
+          <h2>Event Timeline</h2>
+          <span id="event-count" class="badge">0</span>
+        </div>
+        <ol id="timeline-list" class="timeline"></ol>
+      </section>
+    </main>
+
+    <script id="event-bootstrap" type="application/json">
+      __EVENT_BOOTSTRAP__
+    </script>
+    <script type="module" src="/static/js/event-timeline.js"></script>
+  </body>
+</html>

--- a/src/api/templates/index.html
+++ b/src/api/templates/index.html
@@ -14,6 +14,10 @@
           Review waiting decisions, inspect task status, and submit Decision to
           continue FSM.
         </p>
+        <p>
+          Event timeline page:
+          <code>/ui/tasks/&lt;task_id&gt;/events</code>
+        </p>
         <form id="task-query-form" class="task-query">
           <input
             id="task-id-input"

--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, TYPE_CHECKING
 
@@ -22,6 +23,14 @@ def _resolve_default_log_dir() -> Path:
 
 
 DEFAULT_LOG_DIR = _resolve_default_log_dir()
+
+_LEGACY_EVENT_TYPE_MAP = {
+    "TASK_STATUS_CHANGED": "STATE_TRANSITION",
+    "PENDING_ACTION_CREATED": "PENDING_ACTION_CREATED",
+    "DECISION_APPLIED": "DECISION_APPLIED",
+    "STEP_FINISHED": "STEP_FINISHED",
+    "STEP_FAILED": "STEP_FAILED",
+}
 
 
 def append_event(
@@ -95,3 +104,182 @@ def read_event_logs(
                     raise
                 continue
     return events
+
+
+def read_timeline_events(
+    task_id: str,
+    *,
+    log_dir: Path = DEFAULT_LOG_DIR,
+    strict: bool = False,
+) -> list[dict[str, Any]]:
+    """读取任务时间线事件（兼容 event_type / event 两种格式）。"""
+    path = log_dir / f"{task_id}.jsonl"
+    if not path.exists():
+        return []
+
+    events: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for seq, line in enumerate(handle):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                if strict:
+                    raise
+                continue
+            if not isinstance(payload, dict):
+                if strict:
+                    raise ValueError("timeline payload must be a JSON object")
+                continue
+            normalized = _normalize_timeline_event(
+                payload=payload,
+                task_id=task_id,
+                seq=seq,
+            )
+            if normalized is None:
+                continue
+            events.append(normalized)
+
+    events.sort(key=_timeline_sort_key)
+    return events
+
+
+def _normalize_timeline_event(
+    *,
+    payload: dict[str, Any],
+    task_id: str,
+    seq: int,
+) -> dict[str, Any] | None:
+    event_type = _canonical_event_type(payload)
+    if event_type is None:
+        return None
+
+    timestamp = _extract_timestamp(payload)
+    from_status = _string_field(payload, "from_status") or _string_field(
+        payload, "prev_status"
+    )
+    to_status = _string_field(payload, "to_status") or _string_field(
+        payload, "new_status"
+    )
+    event_data = payload.get("data")
+    data = event_data if isinstance(event_data, dict) else {}
+
+    return {
+        "seq": seq,
+        "task_id": _string_field(payload, "task_id") or task_id,
+        "ts": timestamp,
+        "event_type": event_type,
+        "source_event": _string_field(payload, "event")
+        or _string_field(payload, "event_type"),
+        "pending_action_id": _string_field(payload, "pending_action_id"),
+        "decision_id": _string_field(payload, "decision_id"),
+        "step_id": _string_field(payload, "step_id"),
+        "tool": _string_field(payload, "tool"),
+        "status": _string_field(payload, "status"),
+        "from_status": from_status,
+        "to_status": to_status,
+        "actor_type": _string_field(payload, "actor_type"),
+        "summary": _build_event_summary(
+            event_type=event_type,
+            payload=payload,
+            from_status=from_status,
+            to_status=to_status,
+        ),
+        "data": data,
+        "payload": payload,
+    }
+
+
+def _timeline_sort_key(event: dict[str, Any]) -> tuple[int, datetime, int]:
+    parsed_ts = _parse_timestamp(event.get("ts"))
+    if parsed_ts is None:
+        return (1, datetime.max, int(event["seq"]))
+    return (0, parsed_ts, int(event["seq"]))
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _extract_timestamp(payload: dict[str, Any]) -> str | None:
+    ts = _string_field(payload, "ts")
+    if ts:
+        return ts
+    timestamp = _string_field(payload, "timestamp")
+    if timestamp:
+        return timestamp
+    return None
+
+
+def _canonical_event_type(payload: dict[str, Any]) -> str | None:
+    event_type = _string_field(payload, "event_type")
+    if event_type:
+        return event_type
+
+    legacy_event = _string_field(payload, "event")
+    if not legacy_event:
+        return None
+    return _LEGACY_EVENT_TYPE_MAP.get(legacy_event, legacy_event)
+
+
+def _string_field(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _build_event_summary(
+    *,
+    event_type: str,
+    payload: dict[str, Any],
+    from_status: str | None,
+    to_status: str | None,
+) -> str:
+    if event_type == "STATE_TRANSITION":
+        left = from_status or "UNKNOWN"
+        right = to_status or "UNKNOWN"
+        return f"{left} -> {right}"
+
+    if event_type == "PENDING_ACTION_CREATED":
+        action_type = _string_field(payload, "action_type") or "unknown_action"
+        return f"PendingAction created ({action_type})"
+
+    if event_type == "DECISION_APPLIED":
+        choice = _string_field(payload, "choice")
+        if choice is None:
+            decision_data = payload.get("data")
+            if isinstance(decision_data, dict):
+                value = decision_data.get("choice")
+                if isinstance(value, str):
+                    choice = value
+        return f"Decision applied ({choice or 'unknown'})"
+
+    if event_type == "WAITING_ENTER":
+        return "Enter waiting state"
+    if event_type == "WAITING_EXIT":
+        return "Exit waiting state"
+
+    if event_type == "STEP_FAILED":
+        step_id = _string_field(payload, "step_id") or "unknown_step"
+        return f"Step failed ({step_id})"
+
+    if event_type == "STEP_FINISHED":
+        step_id = _string_field(payload, "step_id") or "unknown_step"
+        return f"Step finished ({step_id})"
+
+    return event_type

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -15,9 +15,14 @@ from src.models.validation import (
     CandidateExecutionValidationError,
     validate_plan_executability,
 )
-from src.models.db import TaskRecord, InternalStatus, TERMINAL_INTERNAL_STATUSES
+from src.models.db import (
+    TaskRecord,
+    InternalStatus,
+    TERMINAL_INTERNAL_STATUSES,
+    to_external_status,
+)
 from src.models.event_log import ActorType
-from src.storage.log_store import write_event_log
+from src.storage.log_store import append_event, write_event_log
 from src.workflow.context import WorkflowContext
 from src.workflow.step_runner import StepRunner
 from src.workflow.patch_runner import PatchRunner, PendingPatch
@@ -258,6 +263,7 @@ class PlanRunner:
                             pending_patch,
                         )
                     context.step_results[step_result.step_id] = step_result
+                    self._emit_step_event(context, step_result)
                     # 读取失败分类与可重试标记，供日志/上层使用（不改变控制流）
                     step_result.metrics.setdefault(
                         "failure_type", step_result.failure_type
@@ -721,6 +727,28 @@ class PlanRunner:
             record,
             InternalStatus.FAILED,
             reason=reason,
+        )
+
+    def _emit_step_event(
+        self,
+        context: WorkflowContext,
+        step_result: StepResult,
+    ) -> None:
+        event_name = "STEP_FINISHED" if step_result.status != "failed" else "STEP_FAILED"
+        append_event(
+            context.task.task_id,
+            {
+                "event": event_name,
+                "task_id": context.task.task_id,
+                "step_id": step_result.step_id,
+                "tool": step_result.tool,
+                "status": step_result.status,
+                "failure_type": step_result.failure_type,
+                "error_message": step_result.error_message,
+                "timestamp": step_result.timestamp,
+                "state": context.status.value,
+                "external_status": to_external_status(context.status).value,
+            },
         )
 
 

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -1,4 +1,6 @@
 """API端点测试"""
+import json
+
 import pytest
 import httpx
 
@@ -15,6 +17,7 @@ from src.models.contracts import (
     PlanStep,
 )
 from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.storage.log_store import DEFAULT_LOG_DIR
 
 
 @pytest.mark.api
@@ -38,8 +41,14 @@ class TestAPIEndpoints:
     @pytest.fixture(autouse=True)
     def clear_task_store(self):
         TASK_STORE.clear()
+        if DEFAULT_LOG_DIR.exists():
+            for path in DEFAULT_LOG_DIR.glob("test_api_events_*.jsonl"):
+                path.unlink()
         yield
         TASK_STORE.clear()
+        if DEFAULT_LOG_DIR.exists():
+            for path in DEFAULT_LOG_DIR.glob("test_api_events_*.jsonl"):
+                path.unlink()
 
     async def test_create_task_endpoint(self, client: httpx.AsyncClient):
         """测试创建任务端点"""
@@ -310,6 +319,94 @@ class TestAPIEndpoints:
         static_response = await client.get("/static/js/hitl-dashboard.js")
         assert static_response.status_code == 200
         assert "ALLOWED_CHOICES" in static_response.text
+
+        timeline_response = await client.get("/ui/tasks/task_demo_001/events")
+        assert timeline_response.status_code == 200
+        assert "Task Event Timeline" in timeline_response.text
+
+        timeline_js = await client.get("/static/js/event-timeline.js")
+        assert timeline_js.status_code == 200
+        assert "renderChainSummary" in timeline_js.text
+
+    async def test_get_task_events_timeline_mapping_and_order(
+        self, client: httpx.AsyncClient
+    ):
+        """Event 时间线接口应返回稳定排序及关键类型映射。"""
+        task_id = "test_api_events_001"
+        TASK_STORE[task_id] = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.RUNNING,
+            internal_status=InternalStatus.RUNNING,
+            goal="timeline task",
+            constraints={},
+            metadata={},
+            plan=None,
+            design_result=None,
+            pending_action=None,
+        )
+
+        DEFAULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
+        log_file = DEFAULT_LOG_DIR / f"{task_id}.jsonl"
+        events = [
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": task_id,
+                "from_status": "RUNNING",
+                "to_status": "WAITING_PATCH",
+                "timestamp": "2026-03-08T01:00:01+00:00",
+            },
+            {
+                "event": "PENDING_ACTION_CREATED",
+                "task_id": task_id,
+                "pending_action_id": "pa_001",
+                "action_type": "patch_confirm",
+                "timestamp": "2026-03-08T01:00:02+00:00",
+            },
+            {
+                "event": "STEP_FAILED",
+                "task_id": task_id,
+                "step_id": "S5",
+                "tool": "dummy_tool",
+                "status": "failed",
+                "timestamp": "2026-03-08T01:00:03+00:00",
+            },
+            {
+                "event_type": "DECISION_APPLIED",
+                "task_id": task_id,
+                "decision_id": "decision_001",
+                "pending_action_id": "pa_001",
+                "ts": "2026-03-08T01:00:04+00:00",
+                "data": {"choice": "accept"},
+            },
+            {
+                "event": "STEP_FINISHED",
+                "task_id": task_id,
+                "step_id": "S6",
+                "tool": "dummy_tool",
+                "status": "success",
+                "timestamp": "2026-03-08T01:00:05+00:00",
+            },
+        ]
+        with log_file.open("w", encoding="utf-8") as handle:
+            for event in events:
+                handle.write(json.dumps(event, ensure_ascii=True) + "\n")
+
+        response = await client.get(f"/tasks/{task_id}/events")
+        assert response.status_code == 200
+        data = response.json()
+        assert [entry["event_type"] for entry in data] == [
+            "STATE_TRANSITION",
+            "PENDING_ACTION_CREATED",
+            "STEP_FAILED",
+            "DECISION_APPLIED",
+            "STEP_FINISHED",
+        ]
+        assert all(entry["highlight"] for entry in data)
+
+    async def test_get_task_events_not_found(self, client: httpx.AsyncClient):
+        """task 不存在且无日志时，events 接口返回 404。"""
+        response = await client.get("/tasks/not_found_events_case/events")
+        assert response.status_code == 404
 
     @pytest.mark.parametrize(
         "external_status,internal_status,action_type",


### PR DESCRIPTION
## 关联 Issue

Closes #123

## 目标

实现 Task 级 EventLog 时间线视图，支持追溯“为什么停在这里 / 为什么继续执行”。

## 本次改动

### 1. EventLog 查询接口
- 新增 `GET /tasks/{task_id}/events`
  - 读取任务日志并返回归一化后的时间线事件
  - 支持兼容两类历史日志格式：
    - 结构化事件：`event_type`（如 `WAITING_ENTER` / `DECISION_APPLIED`）
    - 兼容事件：`event`（如 `TASK_STATUS_CHANGED` / `PENDING_ACTION_CREATED`）
  - 对外统一为 `event_type`，并附带摘要字段与高亮标记

### 2. 日志读取与排序能力
- 在 `src/storage/log_store.py` 增加时间线读取能力：
  - 新增 `read_timeline_events()`
  - 新增事件归一化与类型映射逻辑（`TASK_STATUS_CHANGED -> STATE_TRANSITION`）
  - 按时间戳排序，时间戳缺失时按日志行号稳定排序
  - 解决 naive/aware 时间戳混用的排序问题（统一为 UTC 比较）

### 3. 执行阶段补齐 STEP 事件
- 在 `src/workflow/plan_runner.py` 增加 `STEP_FINISHED` / `STEP_FAILED` 事件写入
- 使时间线可覆盖 issue 要求的 `STEP_FINISHED / STEP_FAILED`

### 4. 新增前端时间线页面
- 新增页面路由：`GET /ui/tasks/{task_id}/events`
- 新增页面资源：
  - `src/api/templates/event_timeline.html`
  - `src/api/static/ts/event-timeline.ts`
  - `src/api/static/css/event-timeline.css`
  - `src/api/static/js/event-timeline.js`
- 页面能力：
  - 按时间线展示事件
  - 关键事件高亮：
    - `STATE_TRANSITION`
    - `PENDING_ACTION_CREATED`
    - `DECISION_APPLIED`
    - `STEP_FINISHED` / `STEP_FAILED`
  - 链路检测提示：`WAITING_* -> DECISION_APPLIED -> WAITING_EXIT/状态恢复`

### 5. 文档与入口补充
- 更新 README / demo 文档，增加 Event Timeline 页面入口说明
- 在已有 HITL 首页模板中补充事件页面入口提示

## 验收标准对照（Issue #123）

- [x] 任一任务可查看完整 EventLog
  - 通过 `GET /tasks/{task_id}/events` 返回任务级时间线
- [x] 事件顺序与日志时间一致（严格递增或稳定排序）
  - 有时间戳按时间排序；无时间戳按行号稳定排序
- [x] 覆盖关键事件类型
  - `STATE_TRANSITION`
  - `PENDING_ACTION_CREATED`
  - `DECISION_APPLIED`
  - `STEP_FINISHED` / `STEP_FAILED`
- [x] 清楚看到 WAITING_* -> 决策 -> 继续执行链路
  - 页面提供链路检测与高亮展示

## 关键实现代码

- API 路由与响应模型：`src/api/main.py`
- 日志读取/归一化/排序：`src/storage/log_store.py`
- STEP 事件写入：`src/workflow/plan_runner.py`
- 时间线页面模板：`src/api/templates/event_timeline.html`
- 时间线前端逻辑：`src/api/static/ts/event-timeline.ts`
- 时间线样式：`src/api/static/css/event-timeline.css`
- 编译产物：`src/api/static/js/event-timeline.js`
- 测试：`tests/api/test_api_endpoints.py`

## 测试

已执行：

```bash
uv run pytest tests/api/test_api_endpoints.py -q
uv run pytest tests/unit/test_plan_runner.py -q
```

结果：全部通过。
