### PR TITLE
feat(data): implement issue #145 log-to-training-sample extraction

### DIFF
--- a/scripts/extract_training_samples.py
+++ b/scripts/extract_training_samples.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+LEGACY_EVENT_TYPE_MAP = {
+    "TASK_STATUS_CHANGED": "STATE_TRANSITION",
+    "PENDING_ACTION_CREATED": "PENDING_ACTION_CREATED",
+    "DECISION_APPLIED": "DECISION_APPLIED",
+    "STEP_FINISHED": "STEP_FINISHED",
+    "STEP_FAILED": "STEP_FAILED",
+    "DECISION_SUBMITTED": "DECISION_SUBMITTED",
+}
+
+
+def _read_jsonl(path: Path) -> list[tuple[int, dict[str, Any]]]:
+    rows: list[tuple[int, dict[str, Any]]] = []
+    if not path.exists():
+        return rows
+
+    with path.open("r", encoding="utf-8") as handle:
+        for idx, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if not isinstance(payload, dict):
+                continue
+            rows.append((idx, payload))
+    return rows
+
+
+def _to_event_type(payload: dict[str, Any]) -> str | None:
+    event_type = payload.get("event_type")
+    if isinstance(event_type, str) and event_type.strip():
+        return event_type.strip()
+
+    event = payload.get("event")
+    if isinstance(event, str) and event.strip():
+        normalized = event.strip()
+        return LEGACY_EVENT_TYPE_MAP.get(normalized, normalized)
+    return None
+
+
+def _str_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _json_dump(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=True, sort_keys=True)
+
+
+def _load_tool_catalog(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return {}
+
+    catalog: dict[str, dict[str, Any]] = {}
+    for item in tools:
+        if not isinstance(item, dict):
+            continue
+        tool_id = _str_value(item.get("tool_id")) or _str_value(item.get("id"))
+        if not tool_id:
+            continue
+
+        execution = item.get("execution")
+        provider: str | None = None
+        model_id: str | None = None
+        adapter_mode_default = "unknown"
+        if isinstance(execution, str):
+            adapter_mode_default = "local" if execution == "nextflow" else "unknown"
+        elif isinstance(execution, dict):
+            provider = _str_value(execution.get("provider"))
+            model_id = _str_value(execution.get("model_id"))
+            backend = _str_value(execution.get("backend"))
+            if backend == "remote_model_service":
+                adapter_mode_default = "remote"
+
+        capabilities = item.get("capabilities")
+        capability_id: str | None = None
+        if isinstance(capabilities, list) and capabilities:
+            capability_id = _str_value(capabilities[0])
+
+        io = item.get("io")
+        io_type: str | None = None
+        if isinstance(io, dict):
+            io_type = _str_value(io.get("io_type_id"))
+
+        catalog[tool_id] = {
+            "tool_id": tool_id,
+            "capability_id": capability_id,
+            "io_type": io_type,
+            "adapter_mode": adapter_mode_default,
+            "tool_version": _str_value(item.get("version")),
+            "source_link": _str_value(item.get("source_link")),
+            "provider": provider,
+            "model_id": model_id,
+            "priority": _str_value(item.get("priority")) or "unknown",
+        }
+
+    return catalog
+
+
+def _extract_tooling_fields(
+    candidate: dict[str, Any],
+    tool_catalog: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    metadata = candidate.get("metadata")
+    metadata_dict = metadata if isinstance(metadata, dict) else {}
+
+    tool_id = _str_value(candidate.get("tool_id")) or _str_value(metadata_dict.get("tool_id"))
+    capability_id = _str_value(candidate.get("capability_id")) or _str_value(metadata_dict.get("capability_id"))
+    io_type = _str_value(candidate.get("io_type")) or _str_value(metadata_dict.get("io_type"))
+    adapter_mode = _str_value(candidate.get("adapter_mode")) or _str_value(metadata_dict.get("adapter_mode"))
+    tool_version = _str_value(metadata_dict.get("tool_version"))
+    source_link = _str_value(metadata_dict.get("source_link"))
+    provider = _str_value(metadata_dict.get("provider"))
+    model_id = _str_value(metadata_dict.get("model_id"))
+    priority = _str_value(metadata_dict.get("priority"))
+
+    tool_ref = tool_catalog.get(tool_id) if tool_id else None
+    if tool_ref:
+        capability_id = capability_id or tool_ref.get("capability_id")
+        io_type = io_type or tool_ref.get("io_type")
+        adapter_mode = adapter_mode or tool_ref.get("adapter_mode")
+        tool_version = tool_version or tool_ref.get("tool_version")
+        source_link = source_link or tool_ref.get("source_link")
+        provider = provider or tool_ref.get("provider")
+        model_id = model_id or tool_ref.get("model_id")
+        priority = priority or tool_ref.get("priority")
+
+    return {
+        "tool_id": tool_id,
+        "capability_id": capability_id,
+        "io_type": io_type,
+        "adapter_mode": adapter_mode or "unknown",
+        "tool_version": tool_version,
+        "source_link": source_link,
+        "provider": provider,
+        "model_id": model_id,
+        "priority": priority or "unknown",
+    }
+
+
+def _collect_candidates(
+    snapshots: list[tuple[int, dict[str, Any]]],
+    tool_catalog: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    candidate_rows: list[dict[str, Any]] = []
+    snapshot_ids: list[str] = []
+    pending_action_ids: list[str] = []
+    seen_candidates: set[tuple[str, str]] = set()
+
+    for _, snap in snapshots:
+        snapshot_id = _str_value(snap.get("snapshot_id"))
+        if snapshot_id:
+            snapshot_ids.append(snapshot_id)
+
+        artifacts = snap.get("artifacts")
+        if not isinstance(artifacts, dict):
+            continue
+
+        pending_action = artifacts.get("pending_action")
+        if not isinstance(pending_action, dict):
+            continue
+
+        pending_action_id = _str_value(pending_action.get("pending_action_id"))
+        if pending_action_id:
+            pending_action_ids.append(pending_action_id)
+
+        action_type = _str_value(pending_action.get("action_type"))
+        candidates = pending_action.get("candidates")
+        if not isinstance(candidates, list):
+            continue
+
+        for rank, raw_candidate in enumerate(candidates, start=1):
+            if not isinstance(raw_candidate, dict):
+                continue
+            candidate_id = _str_value(raw_candidate.get("candidate_id"))
+            if not candidate_id:
+                continue
+
+            dedupe_key = (pending_action_id or "", candidate_id)
+            if dedupe_key in seen_candidates:
+                continue
+            seen_candidates.add(dedupe_key)
+
+            tooling = _extract_tooling_fields(raw_candidate, tool_catalog)
+            candidate_rows.append(
+                {
+                    "pending_action_id": pending_action_id,
+                    "action_type": action_type,
+                    "candidate_id": candidate_id,
+                    "rank": rank,
+                    "score_breakdown": raw_candidate.get("score_breakdown") or {},
+                    "risk_level": raw_candidate.get("risk_level"),
+                    "cost_estimate": raw_candidate.get("cost_estimate"),
+                    "explanation": raw_candidate.get("explanation"),
+                    "summary": raw_candidate.get("summary"),
+                    "payload": raw_candidate.get("structured_payload") or raw_candidate.get("payload"),
+                    **tooling,
+                }
+            )
+
+    candidate_rows.sort(key=lambda item: (
+        item.get("pending_action_id") or "",
+        str(item.get("rank") or 0),
+        item.get("candidate_id") or "",
+    ))
+    snapshot_ids = sorted(set(snapshot_ids))
+    pending_action_ids = sorted(set(pending_action_ids))
+    return candidate_rows, snapshot_ids, pending_action_ids
+
+
+def _collect_events(task_id: str, log_rows: list[tuple[int, dict[str, Any]]]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line_no, payload in log_rows:
+        event_type = _to_event_type(payload)
+        if not event_type:
+            continue
+
+        event_id = _str_value(payload.get("id")) or f"{task_id}:{line_no}"
+        data = payload.get("data")
+        data_dict = data if isinstance(data, dict) else {}
+
+        events.append(
+            {
+                "line_no": line_no,
+                "event_id": event_id,
+                "event_type": event_type,
+                "task_id": _str_value(payload.get("task_id")) or task_id,
+                "ts": _str_value(payload.get("ts")) or _str_value(payload.get("timestamp")),
+                "pending_action_id": _str_value(payload.get("pending_action_id")),
+                "decision_id": _str_value(payload.get("decision_id")),
+                "choice": _str_value(payload.get("choice")) or _str_value(data_dict.get("choice")),
+                "selected_candidate_id": _str_value(payload.get("selected_candidate_id"))
+                or _str_value(data_dict.get("selected_candidate_id")),
+                "action_type": _str_value(payload.get("action_type"))
+                or _str_value(data_dict.get("action_type")),
+                "from_status": _str_value(payload.get("from_status")) or _str_value(payload.get("prev_status")),
+                "to_status": _str_value(payload.get("to_status")) or _str_value(payload.get("new_status")),
+                "state": _str_value(payload.get("state")) or _str_value(payload.get("external_status")),
+                "tool": _str_value(payload.get("tool")),
+                "step_id": _str_value(payload.get("step_id")),
+                "status": _str_value(payload.get("status")),
+                "failure_type": _str_value(payload.get("failure_type")) or _str_value(data_dict.get("failure_type")),
+                "error_message": _str_value(payload.get("error_message")),
+            }
+        )
+
+    events.sort(key=lambda item: item["line_no"])
+    return events
+
+
+def _derive_status_path(events: list[dict[str, Any]]) -> list[str]:
+    path: list[str] = []
+    for event in events:
+        if event["event_type"] != "STATE_TRANSITION":
+            continue
+        to_status = event.get("to_status") or event.get("state")
+        if to_status:
+            path.append(to_status)
+    return path
+
+
+def _derive_final_status(events: list[dict[str, Any]]) -> str:
+    status_path = _derive_status_path(events)
+    if status_path:
+        return status_path[-1]
+
+    for event in reversed(events):
+        state = event.get("state")
+        if state:
+            return state
+        to_status = event.get("to_status")
+        if to_status:
+            return to_status
+    return "UNKNOWN"
+
+
+def _collect_step_results(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for event in events:
+        if event["event_type"] not in {"STEP_FINISHED", "STEP_FAILED"}:
+            continue
+        rows.append(
+            {
+                "event_id": event["event_id"],
+                "step_id": event.get("step_id"),
+                "tool": event.get("tool"),
+                "status": event.get("status") or (
+                    "failed" if event["event_type"] == "STEP_FAILED" else "success"
+                ),
+                "failure_type": event.get("failure_type"),
+                "error_message": event.get("error_message"),
+                "ts": event.get("ts"),
+            }
+        )
+    return rows
+
+
+def _collect_decisions(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for event in events:
+        if event["event_type"] not in {"DECISION_SUBMITTED", "DECISION_APPLIED"}:
+            continue
+        rows.append(
+            {
+                "event_id": event["event_id"],
+                "event_type": event["event_type"],
+                "decision_id": event.get("decision_id"),
+                "pending_action_id": event.get("pending_action_id"),
+                "choice": event.get("choice"),
+                "selected_candidate_id": event.get("selected_candidate_id"),
+                "action_type": event.get("action_type"),
+                "ts": event.get("ts"),
+            }
+        )
+    return rows
+
+
+def _select_final_decision(decisions: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for decision in reversed(decisions):
+        if decision["event_type"] == "DECISION_APPLIED":
+            return decision
+    return decisions[-1] if decisions else None
+
+
+def _load_report(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _find_metric_paths(metrics_dir: Path, task_id: str) -> list[str]:
+    paths = sorted(metrics_dir.glob(f"{task_id}_*_metrics.json"))
+    return [str(path) for path in paths]
+
+
+def _build_sample(
+    *,
+    task_id: str,
+    log_path: Path,
+    snapshot_path: Path,
+    report_path: Path,
+    metrics_dir: Path,
+    tool_catalog: dict[str, dict[str, Any]],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    log_rows = _read_jsonl(log_path)
+    snapshot_rows = _read_jsonl(snapshot_path)
+    events = _collect_events(task_id=task_id, log_rows=log_rows)
+    decisions = _collect_decisions(events)
+    selected = _select_final_decision(decisions)
+    candidates, snapshot_ids, pending_action_ids = _collect_candidates(
+        snapshots=snapshot_rows,
+        tool_catalog=tool_catalog,
+    )
+
+    report = _load_report(report_path)
+    step_results = _collect_step_results(events)
+    status_path = _derive_status_path(events)
+    final_status = _derive_final_status(events)
+
+    first_ts = next((item.get("ts") for item in events if item.get("ts")), None)
+    last_ts = next((item.get("ts") for item in reversed(events) if item.get("ts")), None)
+
+    event_ids = [item["event_id"] for item in events]
+    decision_event_ids = [item["event_id"] for item in decisions]
+    step_failure_types = sorted({
+        item["failure_type"]
+        for item in step_results
+        if isinstance(item.get("failure_type"), str) and item.get("failure_type")
+    })
+
+    selected_candidate = None
+    selected_candidate_id = selected.get("selected_candidate_id") if selected else None
+    if selected_candidate_id:
+        selected_candidate = next(
+            (item for item in candidates if item.get("candidate_id") == selected_candidate_id),
+            None,
+        )
+
+    report_metadata = report.get("metadata")
+    report_metadata_dict = report_metadata if isinstance(report_metadata, dict) else {}
+
+    sample = {
+        "sample_id": f"sample::{task_id}",
+        "context": {
+            "task_id": task_id,
+            "status_path": status_path,
+            "start_status": status_path[0] if status_path else None,
+            "end_status": status_path[-1] if status_path else final_status,
+            "has_hitl": bool(pending_action_ids),
+            "time_window": {
+                "first_ts": first_ts,
+                "last_ts": last_ts,
+            },
+            "report_created_at": report_metadata_dict.get("created_at"),
+            "plan_metadata": report_metadata_dict.get("plan_metadata"),
+        },
+        "candidates": candidates,
+        "selected": {
+            "decision_id": selected.get("decision_id") if selected else None,
+            "pending_action_id": selected.get("pending_action_id") if selected else None,
+            "choice": selected.get("choice") if selected else None,
+            "selected_candidate_id": selected_candidate_id,
+            "selected_candidate": selected_candidate,
+            "action_type": selected.get("action_type") if selected else None,
+            "event_id": selected.get("event_id") if selected else None,
+            "ts": selected.get("ts") if selected else None,
+        },
+        "outcome": {
+            "final_status": final_status,
+            "result": (
+                "success"
+                if final_status == "DONE"
+                else "failed"
+                if final_status == "FAILED"
+                else "cancelled"
+                if final_status == "CANCELLED"
+                else "unknown"
+            ),
+            "step_results": step_results,
+            "step_failure_types": step_failure_types,
+            "report_path": str(report_path) if report_path.exists() else None,
+            "metrics_paths": _find_metric_paths(metrics_dir, task_id),
+            "structure_pdb_path": report.get("structure_pdb_path"),
+            "scores": report.get("scores") if isinstance(report.get("scores"), dict) else {},
+        },
+        "audit_trace": {
+            "task_id": task_id,
+            "event_log_path": str(log_path),
+            "snapshot_path": str(snapshot_path) if snapshot_path.exists() else None,
+            "event_ids": event_ids,
+            "decision_event_ids": decision_event_ids,
+            "pending_action_ids": pending_action_ids,
+            "snapshot_ids": snapshot_ids,
+            "decision_history": decisions,
+        },
+    }
+
+    mapping_rows = [
+        {
+            "sample_id": sample["sample_id"],
+            "task_id": task_id,
+            "event_id": event["event_id"],
+            "line_no": event["line_no"],
+            "event_type": event["event_type"],
+            "ts": event.get("ts"),
+            "pending_action_id": event.get("pending_action_id"),
+            "decision_id": event.get("decision_id"),
+            "step_id": event.get("step_id"),
+            "tool": event.get("tool"),
+        }
+        for event in events
+    ]
+
+    return sample, mapping_rows
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(_json_dump(row) + "\n")
+
+
+def extract_training_samples(
+    *,
+    logs_dir: Path,
+    snapshots_dir: Path,
+    reports_dir: Path,
+    metrics_dir: Path,
+    tool_kg_path: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    if not logs_dir.exists():
+        raise FileNotFoundError(f"logs dir not found: {logs_dir}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tool_catalog = _load_tool_catalog(tool_kg_path)
+
+    samples: list[dict[str, Any]] = []
+    mapping_rows: list[dict[str, Any]] = []
+
+    log_files = sorted(logs_dir.glob("*.jsonl"))
+    for log_path in log_files:
+        task_id = log_path.stem
+        snapshot_path = snapshots_dir / f"{task_id}.jsonl"
+        report_path = reports_dir / f"{task_id}.json"
+
+        sample, sample_mapping = _build_sample(
+            task_id=task_id,
+            log_path=log_path,
+            snapshot_path=snapshot_path,
+            report_path=report_path,
+            metrics_dir=metrics_dir,
+            tool_catalog=tool_catalog,
+        )
+        samples.append(sample)
+        mapping_rows.extend(sample_mapping)
+
+    samples.sort(key=lambda item: item["sample_id"])
+    mapping_rows.sort(key=lambda item: (item["task_id"], item["line_no"], item["event_id"]))
+
+    samples_path = output_dir / "samples.jsonl"
+    mapping_path = output_dir / "sample_event_mapping.jsonl"
+    stats_path = output_dir / "stats.json"
+
+    _write_jsonl(samples_path, samples)
+    _write_jsonl(mapping_path, mapping_rows)
+
+    final_status_counter = Counter(sample["outcome"]["final_status"] for sample in samples)
+    step_status_counter = Counter(
+        step.get("status")
+        for sample in samples
+        for step in sample["outcome"]["step_results"]
+        if step.get("status")
+    )
+    decision_choice_counter = Counter(
+        history.get("choice")
+        for sample in samples
+        for history in sample["audit_trace"]["decision_history"]
+        if history.get("choice")
+    )
+
+    tool_by_id = Counter(
+        candidate.get("tool_id") or "unknown"
+        for sample in samples
+        for candidate in sample["candidates"]
+    )
+    tool_by_capability = Counter(
+        candidate.get("capability_id") or "unknown"
+        for sample in samples
+        for candidate in sample["candidates"]
+    )
+    tool_by_adapter = Counter(
+        candidate.get("adapter_mode") or "unknown"
+        for sample in samples
+        for candidate in sample["candidates"]
+    )
+    tool_by_priority = Counter(
+        candidate.get("priority") or "unknown"
+        for sample in samples
+        for candidate in sample["candidates"]
+    )
+
+    samples_with_hitl = sum(1 for sample in samples if sample["context"]["has_hitl"])
+    samples_with_events = sum(
+        1 for sample in samples if len(sample["audit_trace"]["event_ids"]) > 0
+    )
+
+    stats = {
+        "input": {
+            "logs_dir": str(logs_dir),
+            "snapshots_dir": str(snapshots_dir),
+            "reports_dir": str(reports_dir),
+            "metrics_dir": str(metrics_dir),
+            "tool_kg_path": str(tool_kg_path),
+            "log_file_count": len(log_files),
+        },
+        "output": {
+            "samples_path": str(samples_path),
+            "mapping_path": str(mapping_path),
+            "stats_path": str(stats_path),
+        },
+        "counts": {
+            "total_samples": len(samples),
+            "total_mapping_rows": len(mapping_rows),
+            "samples_with_hitl": samples_with_hitl,
+            "hitl_ratio": round(samples_with_hitl / len(samples), 6) if samples else 0.0,
+        },
+        "status_distribution": dict(sorted(final_status_counter.items())),
+        "step_status_distribution": dict(sorted(step_status_counter.items())),
+        "decision_choice_distribution": dict(sorted(decision_choice_counter.items())),
+        "tool_distribution": {
+            "by_tool_id": dict(sorted(tool_by_id.items())),
+            "by_capability_id": dict(sorted(tool_by_capability.items())),
+            "by_adapter_mode": dict(sorted(tool_by_adapter.items())),
+            "by_priority": dict(sorted(tool_by_priority.items())),
+        },
+        "traceability": {
+            "samples_with_task_id": sum(1 for sample in samples if sample["context"]["task_id"]),
+            "samples_with_event_ids": samples_with_events,
+            "mapping_rows_with_event_id": sum(1 for row in mapping_rows if row.get("event_id")),
+        },
+    }
+
+    with stats_path.open("w", encoding="utf-8") as handle:
+        handle.write(_json_dump(stats) + "\n")
+
+    return stats
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Extract reproducible training samples from task logs/snapshots.",
+    )
+    parser.add_argument("--logs-dir", type=Path, default=Path("data/logs"))
+    parser.add_argument("--snapshots-dir", type=Path, default=Path("data/snapshots"))
+    parser.add_argument("--reports-dir", type=Path, default=Path("output/reports"))
+    parser.add_argument("--metrics-dir", type=Path, default=Path("output/metrics"))
+    parser.add_argument("--tool-kg-path", type=Path, default=Path("src/kg/protein_tool_kg.json"))
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output/training/w11-data-1"),
+        help="Directory for samples.jsonl, sample_event_mapping.jsonl, stats.json",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    stats = extract_training_samples(
+        logs_dir=args.logs_dir,
+        snapshots_dir=args.snapshots_dir,
+        reports_dir=args.reports_dir,
+        metrics_dir=args.metrics_dir,
+        tool_kg_path=args.tool_kg_path,
+        output_dir=args.output_dir,
+    )
+
+    print("Extraction completed")
+    print(_json_dump(stats["counts"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extract_training_samples.py
+++ b/scripts/extract_training_samples.py
@@ -16,6 +16,8 @@ LEGACY_EVENT_TYPE_MAP = {
     "DECISION_SUBMITTED": "DECISION_SUBMITTED",
 }
 
+DEFAULT_EXTENSION_KG_PATH = Path("src/kg/protein_tool_kg/extension_draft_v0.1.json")
+
 
 def _read_jsonl(path: Path) -> list[tuple[int, dict[str, Any]]]:
     rows: list[tuple[int, dict[str, Any]]] = []
@@ -57,7 +59,46 @@ def _json_dump(data: Any) -> str:
     return json.dumps(data, ensure_ascii=True, sort_keys=True)
 
 
-def _load_tool_catalog(path: Path) -> dict[str, dict[str, Any]]:
+def _first_string(value: Any) -> str | None:
+    if isinstance(value, str):
+        return _str_value(value)
+    if isinstance(value, list):
+        for item in value:
+            text = _str_value(item)
+            if text:
+                return text
+    return None
+
+
+def _normalize_adapter_mode(value: str | None) -> str:
+    text = _str_value(value)
+    if not text:
+        return "unknown"
+    normalized = text.lower()
+    if normalized in {"local", "remote", "mock", "hybrid", "unknown"}:
+        return normalized
+    if normalized in {"nextflow", "python"}:
+        return "local"
+    if normalized in {"remote_model_service", "external_api"}:
+        return "remote"
+    return "unknown"
+
+
+def _normalize_priority(value: str | None) -> str:
+    text = _str_value(value)
+    if not text:
+        return "unknown"
+    normalized = text.upper()
+    if normalized in {"P0", "P1", "P2"}:
+        return normalized
+    return "unknown"
+
+
+def _load_tool_catalog(
+    path: Path,
+    *,
+    extension_path: Path | None = None,
+) -> dict[str, dict[str, Any]]:
     if not path.exists():
         return {}
 
@@ -81,13 +122,13 @@ def _load_tool_catalog(path: Path) -> dict[str, dict[str, Any]]:
         model_id: str | None = None
         adapter_mode_default = "unknown"
         if isinstance(execution, str):
-            adapter_mode_default = "local" if execution == "nextflow" else "unknown"
+            adapter_mode_default = _normalize_adapter_mode(execution)
         elif isinstance(execution, dict):
             provider = _str_value(execution.get("provider"))
             model_id = _str_value(execution.get("model_id"))
-            backend = _str_value(execution.get("backend"))
-            if backend == "remote_model_service":
-                adapter_mode_default = "remote"
+            adapter_mode_default = _normalize_adapter_mode(
+                _str_value(execution.get("backend"))
+            )
 
         capabilities = item.get("capabilities")
         capability_id: str | None = None
@@ -108,8 +149,51 @@ def _load_tool_catalog(path: Path) -> dict[str, dict[str, Any]]:
             "source_link": _str_value(item.get("source_link")),
             "provider": provider,
             "model_id": model_id,
-            "priority": _str_value(item.get("priority")) or "unknown",
+            "priority": _normalize_priority(_str_value(item.get("priority"))),
         }
+
+    if extension_path and extension_path.exists():
+        with extension_path.open("r", encoding="utf-8") as handle:
+            extension_payload = json.load(handle)
+
+        candidates = extension_payload.get("tool_candidates")
+        if isinstance(candidates, list):
+            for item in candidates:
+                if not isinstance(item, dict):
+                    continue
+                tool_id = _str_value(item.get("tool_id"))
+                if not tool_id:
+                    continue
+
+                current = catalog.setdefault(
+                    tool_id,
+                    {
+                        "tool_id": tool_id,
+                        "capability_id": None,
+                        "io_type": None,
+                        "adapter_mode": "unknown",
+                        "tool_version": None,
+                        "source_link": None,
+                        "provider": None,
+                        "model_id": None,
+                        "priority": "unknown",
+                    },
+                )
+
+                if not current.get("capability_id"):
+                    current["capability_id"] = _first_string(item.get("capability_id"))
+                if not current.get("io_type"):
+                    current["io_type"] = _first_string(item.get("io_type"))
+                if current.get("adapter_mode") in {None, "unknown"}:
+                    current["adapter_mode"] = _normalize_adapter_mode(
+                        _first_string(item.get("adapter_modes"))
+                    )
+                if not current.get("source_link"):
+                    current["source_link"] = _first_string(item.get("official_links"))
+
+                extension_priority = _normalize_priority(_str_value(item.get("priority")))
+                if current.get("priority") in {None, "unknown"} and extension_priority != "unknown":
+                    current["priority"] = extension_priority
 
     return catalog
 
@@ -129,7 +213,7 @@ def _extract_tooling_fields(
     source_link = _str_value(metadata_dict.get("source_link"))
     provider = _str_value(metadata_dict.get("provider"))
     model_id = _str_value(metadata_dict.get("model_id"))
-    priority = _str_value(metadata_dict.get("priority"))
+    priority = _normalize_priority(_str_value(metadata_dict.get("priority")))
 
     tool_ref = tool_catalog.get(tool_id) if tool_id else None
     if tool_ref:
@@ -140,7 +224,7 @@ def _extract_tooling_fields(
         source_link = source_link or tool_ref.get("source_link")
         provider = provider or tool_ref.get("provider")
         model_id = model_id or tool_ref.get("model_id")
-        priority = priority or tool_ref.get("priority")
+        priority = priority if priority != "unknown" else tool_ref.get("priority")
 
     return {
         "tool_id": tool_id,
@@ -486,13 +570,17 @@ def extract_training_samples(
     reports_dir: Path,
     metrics_dir: Path,
     tool_kg_path: Path,
+    tool_extension_kg_path: Path | None = None,
     output_dir: Path,
 ) -> dict[str, Any]:
     if not logs_dir.exists():
         raise FileNotFoundError(f"logs dir not found: {logs_dir}")
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    tool_catalog = _load_tool_catalog(tool_kg_path)
+    tool_catalog = _load_tool_catalog(
+        tool_kg_path,
+        extension_path=tool_extension_kg_path,
+    )
 
     samples: list[dict[str, Any]] = []
     mapping_rows: list[dict[str, Any]] = []
@@ -571,6 +659,9 @@ def extract_training_samples(
             "reports_dir": str(reports_dir),
             "metrics_dir": str(metrics_dir),
             "tool_kg_path": str(tool_kg_path),
+            "tool_extension_kg_path": (
+                str(tool_extension_kg_path) if tool_extension_kg_path else None
+            ),
             "log_file_count": len(log_files),
         },
         "output": {
@@ -616,6 +707,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--metrics-dir", type=Path, default=Path("output/metrics"))
     parser.add_argument("--tool-kg-path", type=Path, default=Path("src/kg/protein_tool_kg.json"))
     parser.add_argument(
+        "--tool-extension-kg-path",
+        type=Path,
+        default=DEFAULT_EXTENSION_KG_PATH,
+        help="Optional extension tool catalog containing priority and adapter metadata.",
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path("output/training/w11-data-1"),
@@ -634,6 +731,7 @@ def main() -> int:
         reports_dir=args.reports_dir,
         metrics_dir=args.metrics_dir,
         tool_kg_path=args.tool_kg_path,
+        tool_extension_kg_path=args.tool_extension_kg_path,
         output_dir=args.output_dir,
     )
 

--- a/scripts/w11-data-1-log-to-sample-extraction.md
+++ b/scripts/w11-data-1-log-to-sample-extraction.md
@@ -1,0 +1,100 @@
+# W11-Data-1: 日志到训练样本抽取说明
+
+## 目标
+
+从运行产物中抽取训练样本，统一输出以下结构：
+
+- `context`
+- `candidates`
+- `selected`
+- `outcome`
+- `audit_trace`
+
+并提供样本到原始事件的映射与统计结果。
+
+## 输入来源
+
+- 日志：`data/logs/*.jsonl`
+- 快照：`data/snapshots/*.jsonl`
+- 报告：`output/reports/*.json`
+- 指标：`output/metrics/*.json`
+- ToolKG：`src/kg/protein_tool_kg.json`
+
+## 使用方式
+
+```bash
+uv run python scripts/extract_training_samples.py \
+  --logs-dir data/logs \
+  --snapshots-dir data/snapshots \
+  --reports-dir output/reports \
+  --metrics-dir output/metrics \
+  --tool-kg-path src/kg/protein_tool_kg.json \
+  --output-dir output/training/w11-data-1
+```
+
+## 输出文件
+
+- `samples.jsonl`：训练样本（每个 task 一条样本）
+- `sample_event_mapping.jsonl`：样本与原始事件映射（逐事件）
+- `stats.json`：抽取统计（总量、成功/失败、HITL 占比、工具分布）
+
+## 关键字段
+
+### `context`
+
+- `task_id`
+- `status_path`
+- `start_status` / `end_status`
+- `has_hitl`
+- `time_window.first_ts/last_ts`
+
+### `candidates`
+
+每个候选包含：
+
+- `candidate_id`
+- `score_breakdown`
+- `risk_level`
+- `cost_estimate`
+- `payload`
+- `tool_id`
+- `capability_id`
+- `io_type`
+- `adapter_mode`
+- `tool_version`
+- `source_link`
+- `provider`
+- `model_id`
+
+### `selected`
+
+- `decision_id`
+- `pending_action_id`
+- `choice`
+- `selected_candidate_id`
+- `action_type`
+- `event_id`
+- `ts`
+
+### `outcome`
+
+- `final_status`
+- `result`
+- `step_results`
+- `step_failure_types`
+- `report_path`
+- `metrics_paths`
+
+### `audit_trace`
+
+- `event_log_path`
+- `snapshot_path`
+- `event_ids`
+- `decision_event_ids`
+- `pending_action_ids`
+- `snapshot_ids`
+- `decision_history`
+
+## 可复现性说明
+
+脚本按 `task_id` 和事件行号稳定排序输出；同一输入目录重复执行可得到一致的样本与映射结果。

--- a/scripts/w11-data-1-log-to-sample-extraction.md
+++ b/scripts/w11-data-1-log-to-sample-extraction.md
@@ -29,6 +29,7 @@ uv run python scripts/extract_training_samples.py \
   --reports-dir output/reports \
   --metrics-dir output/metrics \
   --tool-kg-path src/kg/protein_tool_kg.json \
+  --tool-extension-kg-path src/kg/protein_tool_kg/extension_draft_v0.1.json \
   --output-dir output/training/w11-data-1
 ```
 
@@ -65,6 +66,9 @@ uv run python scripts/extract_training_samples.py \
 - `source_link`
 - `provider`
 - `model_id`
+- `priority`（`P0/P1/P2/unknown`）
+
+其中 `priority`、扩展 `source_link`、以及部分 `adapter_mode` 会优先从 `tool-extension-kg` 合并（默认读取 `src/kg/protein_tool_kg/extension_draft_v0.1.json`），用于 Requirement-2 的工具分层统计。
 
 ### `selected`
 

--- a/tests/unit/test_extract_training_samples.py
+++ b/tests/unit/test_extract_training_samples.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path("scripts/extract_training_samples.py")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=True) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            rows.append(json.loads(text))
+    return rows
+
+
+def _run_extractor(tmp_path: Path, output_dir: Path) -> None:
+    logs_dir = tmp_path / "logs"
+    snapshots_dir = tmp_path / "snapshots"
+    reports_dir = tmp_path / "reports"
+    metrics_dir = tmp_path / "metrics"
+
+    main_task_id = "task_aaaa1111"
+    hitl_task_id = "task_hitl_0001"
+
+    _write_jsonl(
+        logs_dir / f"{main_task_id}.jsonl",
+        [
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": main_task_id,
+                "from_status": "CREATED",
+                "to_status": "PLANNING",
+                "state": "PLANNING",
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": main_task_id,
+                "from_status": "PLANNING",
+                "to_status": "PLANNED",
+                "state": "PLANNED",
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": main_task_id,
+                "from_status": "PLANNED",
+                "to_status": "RUNNING",
+                "state": "RUNNING",
+            },
+            {
+                "event": "STEP_FINISHED",
+                "task_id": main_task_id,
+                "step_id": "S1",
+                "tool": "esmfold",
+                "status": "success",
+                "timestamp": "2026-03-14T10:00:00+00:00",
+                "state": "RUNNING",
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": main_task_id,
+                "from_status": "RUNNING",
+                "to_status": "SUMMARIZING",
+                "state": "SUMMARIZING",
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": main_task_id,
+                "from_status": "SUMMARIZING",
+                "to_status": "DONE",
+                "state": "DONE",
+            },
+        ],
+    )
+
+    _write_jsonl(
+        logs_dir / f"{hitl_task_id}.jsonl",
+        [
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": hitl_task_id,
+                "from_status": "PLANNING",
+                "to_status": "WAITING_PLAN_CONFIRM",
+                "state": "WAITING_PLAN_CONFIRM",
+            },
+            {
+                "event": "DECISION_SUBMITTED",
+                "task_id": hitl_task_id,
+                "pending_action_id": "pa_hitl_1",
+                "decision_id": "decision_hitl_1",
+                "choice": "accept",
+                "selected_candidate_id": "plan_a",
+                "state": "WAITING_PLAN_CONFIRM",
+            },
+            {
+                "id": "evt-applied-1",
+                "event_type": "DECISION_APPLIED",
+                "task_id": hitl_task_id,
+                "pending_action_id": "pa_hitl_1",
+                "decision_id": "decision_hitl_1",
+                "prev_status": "WAITING_PLAN_CONFIRM",
+                "new_status": "PLANNED",
+                "ts": "2026-03-14T10:01:00+00:00",
+                "data": {
+                    "choice": "accept",
+                    "selected_candidate_id": "plan_a",
+                    "action_type": "plan_confirm",
+                },
+            },
+            {
+                "id": "evt-exit-1",
+                "event_type": "WAITING_EXIT",
+                "task_id": hitl_task_id,
+                "pending_action_id": "pa_hitl_1",
+                "prev_status": "WAITING_PLAN_CONFIRM",
+                "new_status": "PLANNED",
+                "ts": "2026-03-14T10:01:01+00:00",
+                "data": {
+                    "action_type": "plan_confirm",
+                    "action_status": "decided",
+                    "waiting_state": "WAITING_PLAN_CONFIRM",
+                },
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": hitl_task_id,
+                "from_status": "PLANNED",
+                "to_status": "RUNNING",
+                "state": "RUNNING",
+            },
+            {
+                "event": "STEP_FAILED",
+                "task_id": hitl_task_id,
+                "step_id": "S2",
+                "tool": "nim_esmfold",
+                "status": "failed",
+                "failure_type": "timeout",
+                "error_message": "timeout",
+                "timestamp": "2026-03-14T10:02:00+00:00",
+                "state": "RUNNING",
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": hitl_task_id,
+                "from_status": "RUNNING",
+                "to_status": "FAILED",
+                "state": "FAILED",
+            },
+        ],
+    )
+
+    _write_jsonl(
+        snapshots_dir / f"{hitl_task_id}.jsonl",
+        [
+            {
+                "snapshot_id": "snapshot_hitl_1",
+                "task_id": hitl_task_id,
+                "state": "PLANNED",
+                "artifacts": {
+                    "pending_action": {
+                        "pending_action_id": "pa_hitl_1",
+                        "task_id": hitl_task_id,
+                        "action_type": "plan_confirm",
+                        "default_recommendation": "plan_a",
+                        "candidates": [
+                            {
+                                "candidate_id": "plan_a",
+                                "structured_payload": {
+                                    "task_id": hitl_task_id,
+                                    "steps": [{"id": "S1", "tool": "nim_esmfold", "inputs": {}, "metadata": {}}],
+                                    "constraints": {},
+                                    "metadata": {},
+                                    "explanation": None,
+                                },
+                                "score_breakdown": {"overall": 0.88},
+                                "risk_level": "low",
+                                "cost_estimate": "medium",
+                                "tool_id": "nim_esmfold",
+                                "capability_id": "structure_prediction",
+                                "io_type": "sequence_to_structure",
+                                "adapter_mode": "remote",
+                                "metadata": {
+                                    "tool_version": "1.2.3",
+                                    "source_link": "https://example.com/nim_esmfold",
+                                    "provider": "nvidia_nim",
+                                    "model_id": "nvidia/esmfold",
+                                },
+                            },
+                            {
+                                "candidate_id": "plan_b",
+                                "structured_payload": {
+                                    "task_id": hitl_task_id,
+                                    "steps": [{"id": "S1", "tool": "esmfold", "inputs": {}, "metadata": {}}],
+                                    "constraints": {},
+                                    "metadata": {},
+                                    "explanation": None,
+                                },
+                                "score_breakdown": {"overall": 0.7},
+                                "risk_level": "low",
+                                "cost_estimate": "low",
+                                "tool_id": "esmfold",
+                                "metadata": {},
+                            },
+                        ],
+                    }
+                },
+            }
+        ],
+    )
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    with (reports_dir / f"{main_task_id}.json").open("w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "task_id": main_task_id,
+                "structure_pdb_path": "output/pdb/task_aaaa1111_S1.pdb",
+                "scores": {"plddt_mean": 0.9},
+                "metadata": {"created_at": "2026-03-14T10:00:00+00:00"},
+            },
+            handle,
+            ensure_ascii=True,
+        )
+
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    with (metrics_dir / f"{main_task_id}_S1_metrics.json").open("w", encoding="utf-8") as handle:
+        json.dump({"task_id": main_task_id, "step_id": "S1", "tool": "esmfold"}, handle, ensure_ascii=True)
+
+    cmd = [
+        sys.executable,
+        str(SCRIPT_PATH),
+        "--logs-dir",
+        str(logs_dir),
+        "--snapshots-dir",
+        str(snapshots_dir),
+        "--reports-dir",
+        str(reports_dir),
+        "--metrics-dir",
+        str(metrics_dir),
+        "--output-dir",
+        str(output_dir),
+    ]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+class TestExtractTrainingSamplesScript:
+    def test_extract_outputs_are_traceable(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "out"
+        _run_extractor(tmp_path=tmp_path, output_dir=output_dir)
+
+        samples = _read_jsonl(output_dir / "samples.jsonl")
+        mapping_rows = _read_jsonl(output_dir / "sample_event_mapping.jsonl")
+        stats = json.loads((output_dir / "stats.json").read_text(encoding="utf-8"))
+
+        assert len(samples) == 2
+        assert all("context" in sample for sample in samples)
+        assert all("candidates" in sample for sample in samples)
+        assert all("selected" in sample for sample in samples)
+        assert all("outcome" in sample for sample in samples)
+        assert all("audit_trace" in sample for sample in samples)
+
+        hitl_sample = next(sample for sample in samples if sample["context"]["task_id"] == "task_hitl_0001")
+        assert hitl_sample["selected"]["decision_id"] == "decision_hitl_1"
+        assert hitl_sample["selected"]["selected_candidate_id"] == "plan_a"
+        assert "evt-applied-1" in hitl_sample["audit_trace"]["event_ids"]
+        assert any(c["tool_id"] == "nim_esmfold" for c in hitl_sample["candidates"])
+        assert any(c["tool_version"] == "1.2.3" for c in hitl_sample["candidates"])
+
+        assert any(row["event_id"] == "evt-applied-1" for row in mapping_rows)
+        assert stats["counts"]["total_samples"] == 2
+        assert stats["counts"]["samples_with_hitl"] == 1
+        assert stats["traceability"]["samples_with_event_ids"] == 2
+        assert stats["decision_choice_distribution"].get("accept", 0) >= 1
+
+    def test_extract_is_reproducible_for_same_input(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "out"
+        _run_extractor(tmp_path=tmp_path, output_dir=output_dir)
+
+        first_samples = (output_dir / "samples.jsonl").read_text(encoding="utf-8")
+        first_mapping = (output_dir / "sample_event_mapping.jsonl").read_text(encoding="utf-8")
+        first_stats = (output_dir / "stats.json").read_text(encoding="utf-8")
+
+        _run_extractor(tmp_path=tmp_path, output_dir=output_dir)
+
+        second_samples = (output_dir / "samples.jsonl").read_text(encoding="utf-8")
+        second_mapping = (output_dir / "sample_event_mapping.jsonl").read_text(encoding="utf-8")
+        second_stats = (output_dir / "stats.json").read_text(encoding="utf-8")
+
+        assert first_samples == second_samples
+        assert first_mapping == second_mapping
+        assert first_stats == second_stats

--- a/tests/unit/test_extract_training_samples.py
+++ b/tests/unit/test_extract_training_samples.py
@@ -34,6 +34,8 @@ def _run_extractor(tmp_path: Path, output_dir: Path) -> None:
     snapshots_dir = tmp_path / "snapshots"
     reports_dir = tmp_path / "reports"
     metrics_dir = tmp_path / "metrics"
+    tool_kg_path = tmp_path / "protein_tool_kg.json"
+    tool_extension_kg_path = tmp_path / "protein_tool_kg_extension.json"
 
     main_task_id = "task_aaaa1111"
     hitl_task_id = "task_hitl_0001"
@@ -216,12 +218,89 @@ def _run_extractor(tmp_path: Path, output_dir: Path) -> None:
                                 "tool_id": "esmfold",
                                 "metadata": {},
                             },
+                            {
+                                "candidate_id": "plan_bad_meta",
+                                "structured_payload": {
+                                    "task_id": hitl_task_id,
+                                    "steps": [{"id": "S1", "tool": "openfold", "inputs": {}, "metadata": {}}],
+                                    "constraints": {},
+                                    "metadata": {},
+                                    "explanation": None,
+                                },
+                                "score_breakdown": {"overall": 0.5},
+                                "risk_level": "medium",
+                                "cost_estimate": "high",
+                                "tool_id": "openfold",
+                                "metadata": {
+                                    "priority": 1,
+                                    "adapter_mode": {"bad": "shape"},
+                                    "provider": ["unexpected"],
+                                },
+                            },
                         ],
                     }
                 },
             }
         ],
     )
+
+    with tool_kg_path.open("w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "tools": [
+                    {
+                        "tool_id": "nim_esmfold",
+                        "capabilities": ["structure_prediction"],
+                        "io": {"io_type_id": "sequence_to_structure"},
+                        "execution": {"backend": "remote_model_service", "provider": "nvidia_nim", "model_id": "nvidia/esmfold"},
+                        "version": "1.0.0",
+                    },
+                    {
+                        "tool_id": "esmfold",
+                        "capabilities": ["structure_prediction"],
+                        "io": {"io_type_id": "sequence_to_structure"},
+                        "execution": "nextflow",
+                        "version": "1.0.0",
+                    },
+                ]
+            },
+            handle,
+            ensure_ascii=True,
+        )
+
+    with tool_extension_kg_path.open("w", encoding="utf-8") as handle:
+        json.dump(
+            {
+                "tool_candidates": [
+                    {
+                        "tool_id": "nim_esmfold",
+                        "capability_id": ["structure_prediction"],
+                        "io_type": ["sequence_to_structure"],
+                        "adapter_modes": ["remote_model_service"],
+                        "priority": "P0",
+                        "official_links": ["https://build.nvidia.com/explore/discover"],
+                    },
+                    {
+                        "tool_id": "esmfold",
+                        "capability_id": ["structure_prediction"],
+                        "io_type": ["sequence_to_structure"],
+                        "adapter_modes": ["nextflow"],
+                        "priority": "P0",
+                        "official_links": ["https://github.com/facebookresearch/esm"],
+                    },
+                    {
+                        "tool_id": "openfold",
+                        "capability_id": ["structure_prediction"],
+                        "io_type": ["sequence_to_structure"],
+                        "adapter_modes": ["python"],
+                        "priority": "P0",
+                        "official_links": ["https://github.com/aqlaboratory/openfold"],
+                    },
+                ]
+            },
+            handle,
+            ensure_ascii=True,
+        )
 
     reports_dir.mkdir(parents=True, exist_ok=True)
     with (reports_dir / f"{main_task_id}.json").open("w", encoding="utf-8") as handle:
@@ -251,6 +330,10 @@ def _run_extractor(tmp_path: Path, output_dir: Path) -> None:
         str(reports_dir),
         "--metrics-dir",
         str(metrics_dir),
+        "--tool-kg-path",
+        str(tool_kg_path),
+        "--tool-extension-kg-path",
+        str(tool_extension_kg_path),
         "--output-dir",
         str(output_dir),
     ]
@@ -281,12 +364,18 @@ class TestExtractTrainingSamplesScript:
         assert "evt-applied-1" in hitl_sample["audit_trace"]["event_ids"]
         assert any(c["tool_id"] == "nim_esmfold" for c in hitl_sample["candidates"])
         assert any(c["tool_version"] == "1.2.3" for c in hitl_sample["candidates"])
+        openfold_candidate = next(c for c in hitl_sample["candidates"] if c["candidate_id"] == "plan_bad_meta")
+        assert openfold_candidate["priority"] == "P0"
+        assert openfold_candidate["adapter_mode"] == "local"
+        assert openfold_candidate["source_link"] == "https://github.com/aqlaboratory/openfold"
+        assert openfold_candidate["provider"] is None
 
         assert any(row["event_id"] == "evt-applied-1" for row in mapping_rows)
         assert stats["counts"]["total_samples"] == 2
         assert stats["counts"]["samples_with_hitl"] == 1
         assert stats["traceability"]["samples_with_event_ids"] == 2
         assert stats["decision_choice_distribution"].get("accept", 0) >= 1
+        assert stats["tool_distribution"]["by_priority"]["P0"] == 3
 
     def test_extract_is_reproducible_for_same_input(self, tmp_path: Path) -> None:
         output_dir = tmp_path / "out"


### PR DESCRIPTION
## 关联 Issue
- Closes #145

## 背景与目的
Week11 的训练 MVP 需要可复现的“日志 -> 训练样本”链路。本 PR 在不改变 FSM/HITL/Agent 边界的前提下，实现了从运行产物抽取训练样本、事件映射与统计报告的基础能力，支撑后续 #146（质量门禁）与 #148（训练流程）。

## 本次实现内容
### 1) 抽取脚本（批量运行）
- 新增 `scripts/extract_training_samples.py`
- 输入来源：
  - `data/logs/*.jsonl`
  - `data/snapshots/*.jsonl`
  - `output/reports/*.json`
  - `output/metrics/*.json`
  - `src/kg/protein_tool_kg.json`
- 输出产物：
  - `samples.jsonl`
  - `sample_event_mapping.jsonl`
  - `stats.json`

### 2) 样本结构固化
每条样本输出以下五段：
- `context`
- `candidates`
- `selected`
- `outcome`
- `audit_trace`

并补齐可追溯字段：`task_id/event_id/pending_action_id/decision_id/snapshot_id`（按可用性提取）。

### 3) Requirement-2 工具字段并入
在候选层抽取并保留：
- `tool_id`
- `capability_id`
- `io_type`
- `adapter_mode`
- `tool_version`
- `source_link`
- `provider`
- `model_id`

### 4) 测试与文档
- 新增单测：`tests/unit/test_extract_training_samples.py`
  - 样本结构完整性
  - 追溯映射正确性
  - 同输入重复运行一致性（可复现）
- 新增说明：`scripts/w11-data-1-log-to-sample-extraction.md`
  - 抽取命令
  - 字段说明
  - 输出说明

## 实现原理（简述）
1. **事件归一化**：兼容 `event_type` 与 legacy `event`，统一为内部事件类型。
2. **稳定排序保证复现**：按 `task_id`、日志行号、样本主键与 JSON key 排序输出，避免非确定性漂移。
3. **快照候选回流**：从 `snapshot.artifacts.pending_action.candidates` 提取候选，并做去重。
4. **决策链重建**：从 `DECISION_SUBMITTED/DECISION_APPLIED` 重建 `selected` 与 `decision_history`。
5. **多源聚合**：将 report/metrics 与日志结果合并到 `outcome`，形成训练可用样本单元。

## 验收标准对照
- [x] 同输入日志可重复生成一致样本集
- [x] 任一样本可追溯回原始 task/event
- [x] 输出统计可用于 Week11-12 评估基线

## 验证记录
### 自动化测试
```bash
uv run pytest tests/unit/test_extract_training_samples.py -q
```
结果：2 passed

### 冒烟运行（真实数据）
```bash
uv run python scripts/extract_training_samples.py --output-dir output/training/w11-data-1
```
结果摘要：
- total_samples = 36
- total_mapping_rows = 258
- samples_with_hitl = 4
- hitl_ratio = 0.111111

## 变更文件
- `scripts/extract_training_samples.py`
- `tests/unit/test_extract_training_samples.py`
- `scripts/w11-data-1-log-to-sample-extraction.md`
