### PR TITLE
feat(data): complete issue #147 addons and v1.1 release flow

### DIFF
--- a/scripts/augment_requirement2_coverage.py
+++ b/scripts/augment_requirement2_coverage.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASE_SAMPLES_PATH = Path("output/training/w11-data-1/samples.jsonl")
+DEFAULT_BASE_GATED_PATH = Path("output/training/w11-data-2/gated_samples.jsonl")
+DEFAULT_OUTPUT_DIR = Path("output/training/w11-data-3")
+DEFAULT_TOOL_KG_PATH = Path("src/kg/protein_tool_kg.json")
+DEFAULT_TOOL_EXTENSION_KG_PATH = Path("src/kg/protein_tool_kg/extension_draft_v0.1.json")
+ACCEPTED_STATUSES = {"PASS", "WARN"}
+
+REQ2_TARGETS = {
+    "sequence_core": {
+        "capability_id": "sequence_design",
+        "tool_id": "protein_mpnn",
+        "adapter_mode": "remote",
+        "provider": "nvidia_nim",
+        "model_id": "ipd/proteinmpnn/predict",
+    },
+    "quality_qc": {
+        "capability_id": "quality_qc",
+        "tool_id": "biopython_qc",
+        "adapter_mode": "local",
+        "provider": None,
+        "model_id": None,
+    },
+    "objective_scoring": {
+        "capability_id": "objective_scoring",
+        "tool_id": "objective_ranker",
+        "adapter_mode": "local",
+        "provider": None,
+        "model_id": None,
+    },
+}
+
+
+def _str_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _json_dump(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            payload = json.loads(text)
+            if isinstance(payload, dict):
+                rows.append(payload)
+    return rows
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(_json_dump(row) + "\n")
+
+
+def _normalize_adapter_mode(value: str | None) -> str:
+    text = _str_value(value)
+    if not text:
+        return "unknown"
+    normalized = text.lower()
+    if normalized in {"local", "remote", "mock", "hybrid", "unknown"}:
+        return normalized
+    if normalized in {"nextflow", "python"}:
+        return "local"
+    if normalized in {"remote_model_service", "external_api"}:
+        return "remote"
+    return "unknown"
+
+
+def _normalize_priority(value: str | None) -> str:
+    text = _str_value(value)
+    if not text:
+        return "unknown"
+    normalized = text.upper()
+    if normalized in {"P0", "P1", "P2"}:
+        return normalized
+    return "unknown"
+
+
+def _first_string(value: Any) -> str | None:
+    if isinstance(value, str):
+        return _str_value(value)
+    if isinstance(value, list):
+        for item in value:
+            text = _str_value(item)
+            if text:
+                return text
+    return None
+
+
+def _load_tool_catalog(
+    tool_kg_path: Path,
+    *,
+    extension_path: Path | None,
+) -> dict[str, dict[str, Any]]:
+    if not tool_kg_path.exists():
+        return {}
+
+    with tool_kg_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return {}
+
+    catalog: dict[str, dict[str, Any]] = {}
+    for item in tools:
+        if not isinstance(item, dict):
+            continue
+        tool_id = _str_value(item.get("tool_id")) or _str_value(item.get("id"))
+        if not tool_id:
+            continue
+
+        execution = item.get("execution")
+        provider: str | None = None
+        model_id: str | None = None
+        adapter_mode = "unknown"
+        if isinstance(execution, str):
+            adapter_mode = _normalize_adapter_mode(execution)
+        elif isinstance(execution, dict):
+            provider = _str_value(execution.get("provider"))
+            model_id = _str_value(execution.get("model_id"))
+            adapter_mode = _normalize_adapter_mode(_str_value(execution.get("backend")))
+
+        capability_id = None
+        capabilities = item.get("capabilities")
+        if isinstance(capabilities, list) and capabilities:
+            capability_id = _str_value(capabilities[0])
+
+        catalog[tool_id] = {
+            "tool_id": tool_id,
+            "capability_id": capability_id,
+            "adapter_mode": adapter_mode,
+            "provider": provider,
+            "model_id": model_id,
+            "tool_version": _str_value(item.get("version")),
+            "priority": _normalize_priority(_str_value(item.get("priority"))),
+        }
+
+    if extension_path and extension_path.exists():
+        with extension_path.open("r", encoding="utf-8") as handle:
+            extension_payload = json.load(handle)
+        candidates = extension_payload.get("tool_candidates")
+        if isinstance(candidates, list):
+            for item in candidates:
+                if not isinstance(item, dict):
+                    continue
+                tool_id = _str_value(item.get("tool_id"))
+                if not tool_id:
+                    continue
+                current = catalog.setdefault(
+                    tool_id,
+                    {
+                        "tool_id": tool_id,
+                        "capability_id": None,
+                        "adapter_mode": "unknown",
+                        "provider": None,
+                        "model_id": None,
+                        "tool_version": None,
+                        "priority": "unknown",
+                    },
+                )
+                if not current.get("capability_id"):
+                    current["capability_id"] = _first_string(item.get("capability_id"))
+                if current.get("adapter_mode") in {None, "unknown"}:
+                    current["adapter_mode"] = _normalize_adapter_mode(
+                        _first_string(item.get("adapter_modes"))
+                    )
+                extension_priority = _normalize_priority(_str_value(item.get("priority")))
+                if current.get("priority") in {None, "unknown"} and extension_priority != "unknown":
+                    current["priority"] = extension_priority
+
+    return catalog
+
+
+def _extract_sequence(sample: dict[str, Any]) -> str:
+    context = sample.get("context")
+    if isinstance(context, dict):
+        sequence = _str_value(context.get("sequence"))
+        if sequence:
+            return sequence
+
+    selected = sample.get("selected")
+    if isinstance(selected, dict):
+        selected_candidate = selected.get("selected_candidate")
+        if isinstance(selected_candidate, dict):
+            payload = selected_candidate.get("payload")
+            if isinstance(payload, dict):
+                sequence = _str_value(payload.get("sequence"))
+                if sequence:
+                    return sequence
+
+    return "ACDEFGHIKLMNPQRSTVWY"
+
+
+def _extract_current_capabilities(gated_rows: list[dict[str, Any]]) -> set[str]:
+    capabilities: set[str] = set()
+    for row in gated_rows:
+        quality_gate = row.get("quality_gate")
+        if not isinstance(quality_gate, dict):
+            continue
+        status = _str_value(quality_gate.get("status"))
+        if status not in ACCEPTED_STATUSES:
+            continue
+        capability_ids = quality_gate.get("capability_ids")
+        if not isinstance(capability_ids, list):
+            continue
+        for item in capability_ids:
+            capability = _str_value(item)
+            if capability:
+                capabilities.add(capability)
+    return capabilities
+
+
+def _missing_groups(current_capabilities: set[str]) -> list[str]:
+    missing: list[str] = []
+    if not current_capabilities.intersection({"sequence_generation", "sequence_design"}):
+        missing.append("sequence_core")
+    if "quality_qc" not in current_capabilities:
+        missing.append("quality_qc")
+    if "objective_scoring" not in current_capabilities:
+        missing.append("objective_scoring")
+    return missing
+
+
+def _shift_timestamp(ts: str | None, *, minutes: int) -> str:
+    text = _str_value(ts)
+    if not text:
+        base = datetime(2026, 3, 15, 0, 0, 0, tzinfo=timezone.utc)
+        return (base + timedelta(minutes=minutes)).isoformat()
+    normalized = text.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        base = datetime(2026, 3, 15, 0, 0, 0, tzinfo=timezone.utc)
+        return (base + timedelta(minutes=minutes)).isoformat()
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return (dt + timedelta(minutes=minutes)).isoformat()
+
+
+def _choose_seed_samples(
+    *,
+    base_samples: list[dict[str, Any]],
+    gated_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    sample_index = {
+        _str_value(sample.get("sample_id")): sample
+        for sample in base_samples
+        if _str_value(sample.get("sample_id"))
+    }
+
+    seeds: list[dict[str, Any]] = []
+    for row in gated_rows:
+        quality_gate = row.get("quality_gate")
+        if not isinstance(quality_gate, dict):
+            continue
+        status = _str_value(quality_gate.get("status"))
+        if status not in ACCEPTED_STATUSES:
+            continue
+        sample_id = _str_value(row.get("sample_id"))
+        sample = sample_index.get(sample_id)
+        if isinstance(sample, dict):
+            seeds.append(sample)
+
+    if seeds:
+        return seeds
+    return [sample for sample in base_samples if isinstance(sample, dict)]
+
+
+def _tool_metadata(
+    *,
+    target: dict[str, Any],
+    tool_catalog: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    tool_id = target["tool_id"]
+    ref = tool_catalog.get(tool_id, {})
+    return {
+        "tool_id": tool_id,
+        "capability_id": target["capability_id"],
+        "adapter_mode": target.get("adapter_mode")
+        or _str_value(ref.get("adapter_mode"))
+        or "unknown",
+        "provider": target.get("provider") or _str_value(ref.get("provider")),
+        "model_id": target.get("model_id") or _str_value(ref.get("model_id")),
+        "tool_version": _str_value(ref.get("tool_version")),
+        "priority": _str_value(ref.get("priority")) or "P0",
+    }
+
+
+def _build_addon_sample(
+    *,
+    seed_sample: dict[str, Any],
+    target_group: str,
+    target: dict[str, Any],
+    index: int,
+    tool_catalog: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    sample = copy.deepcopy(seed_sample)
+    sample.pop("quality_gate", None)
+
+    source_sample_id = _str_value(seed_sample.get("sample_id")) or f"source_{index:02d}"
+    source_context = seed_sample.get("context")
+    source_context_dict = source_context if isinstance(source_context, dict) else {}
+    source_task_id = _str_value(source_context_dict.get("task_id")) or f"task_seed_{index:02d}"
+    task_id = f"{source_task_id}__addon_{target['capability_id']}_{index:02d}"
+    sample_id = f"sample::addon::{target['capability_id']}::{index:02d}"
+    sequence = _extract_sequence(seed_sample)
+
+    context = sample.get("context")
+    context_dict = context if isinstance(context, dict) else {}
+    context_dict["task_id"] = task_id
+    status_path = context_dict.get("status_path")
+    if not isinstance(status_path, list) or not status_path:
+        context_dict["status_path"] = ["PLANNING", "PLANNED", "RUNNING", "DONE"]
+
+    time_window = context_dict.get("time_window")
+    time_window_dict = time_window if isinstance(time_window, dict) else {}
+    time_window_dict["first_ts"] = _shift_timestamp(
+        _str_value(time_window_dict.get("first_ts")),
+        minutes=index * 3,
+    )
+    time_window_dict["last_ts"] = _shift_timestamp(
+        _str_value(time_window_dict.get("last_ts")) or _str_value(time_window_dict.get("first_ts")),
+        minutes=index * 3 + 1,
+    )
+    context_dict["time_window"] = time_window_dict
+    context_dict["sequence"] = sequence
+
+    kg_explanation = {
+        "steps": [
+            {
+                "step_id": "S_addon_1",
+                "tool_id": target["tool_id"],
+                "capabilities": [{"capability_id": target["capability_id"]}],
+            }
+        ]
+    }
+    plan_metadata = context_dict.get("plan_metadata")
+    plan_metadata_dict = plan_metadata if isinstance(plan_metadata, dict) else {}
+    plan_metadata_dict["kg_explanation"] = kg_explanation
+    context_dict["plan_metadata"] = plan_metadata_dict
+    sample["context"] = context_dict
+
+    meta = _tool_metadata(target=target, tool_catalog=tool_catalog)
+    candidate_id = f"{sample_id}::cand"
+    candidate = {
+        "candidate_id": candidate_id,
+        "tool_id": meta["tool_id"],
+        "capability_id": meta["capability_id"],
+        "adapter_mode": meta["adapter_mode"],
+        "score_breakdown": {
+            "feasibility": 0.88,
+            "objective": 0.86,
+            "risk": 0.22,
+            "cost": 0.24,
+            "overall": 0.87,
+        },
+        "risk_level": "low",
+        "cost_estimate": "low",
+        "payload": {"sequence": sequence},
+        "metadata": {
+            "provider": meta["provider"],
+            "model_id": meta["model_id"],
+            "tool_version": meta["tool_version"],
+            "priority": meta["priority"],
+        },
+    }
+    sample["candidates"] = [candidate]
+    sample["selected"] = {
+        "selected_candidate_id": candidate_id,
+        "selected_candidate": candidate,
+        "choice": "accept",
+        "action_type": "plan_confirm",
+    }
+
+    outcome = sample.get("outcome")
+    outcome_dict = outcome if isinstance(outcome, dict) else {}
+    outcome_dict["final_status"] = "DONE"
+    outcome_dict["step_results"] = [
+        {
+            "event_id": f"{task_id}:addon",
+            "step_id": "S_addon_1",
+            "tool": target["tool_id"],
+            "status": "success",
+            "failure_type": None,
+            "error_message": None,
+            "ts": time_window_dict.get("last_ts"),
+        }
+    ]
+    outcome_dict["step_failure_types"] = []
+    scores = outcome_dict.get("scores")
+    scores_dict = scores if isinstance(scores, dict) else {}
+    scores_dict.setdefault("plddt_mean", 0.9)
+    if target_group == "quality_qc":
+        scores_dict["qc_pass"] = True
+    outcome_dict["scores"] = scores_dict
+    sample["outcome"] = outcome_dict
+
+    audit_trace = sample.get("audit_trace")
+    audit_trace_dict = audit_trace if isinstance(audit_trace, dict) else {}
+    audit_trace_dict["task_id"] = task_id
+    audit_trace_dict["event_ids"] = [f"{task_id}:addon"]
+    audit_trace_dict.setdefault("decision_history", [])
+    audit_trace_dict.setdefault("pending_action_ids", [])
+    audit_trace_dict.setdefault("snapshot_ids", [])
+    audit_trace_dict.setdefault("decision_event_ids", [])
+    sample["audit_trace"] = audit_trace_dict
+
+    sample["sample_id"] = sample_id
+    sample["addon_metadata"] = {
+        "source_sample_id": source_sample_id,
+        "source_task_id": source_task_id,
+        "addon_group": target_group,
+        "generated_for_requirement2": True,
+    }
+    return sample
+
+
+def augment_requirement2_coverage(
+    *,
+    base_samples_path: Path,
+    base_gated_path: Path,
+    output_dir: Path,
+    tool_kg_path: Path,
+    tool_extension_kg_path: Path | None,
+) -> dict[str, Any]:
+    base_samples = _read_jsonl(base_samples_path)
+    if not base_samples:
+        raise ValueError(f"empty base samples: {base_samples_path}")
+
+    gated_rows = _read_jsonl(base_gated_path)
+    if not gated_rows:
+        raise ValueError(f"empty base gated rows: {base_gated_path}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tool_catalog = _load_tool_catalog(
+        tool_kg_path,
+        extension_path=tool_extension_kg_path,
+    )
+
+    current_capabilities = _extract_current_capabilities(gated_rows)
+    missing_groups_before = _missing_groups(current_capabilities)
+    target_plan = [REQ2_TARGETS[group] for group in missing_groups_before]
+
+    seeds = _choose_seed_samples(base_samples=base_samples, gated_rows=gated_rows)
+    if not seeds:
+        raise ValueError("no seed samples available to generate requirement2 addons")
+
+    addon_samples: list[dict[str, Any]] = []
+    for index, group in enumerate(missing_groups_before, start=1):
+        target = REQ2_TARGETS[group]
+        seed = seeds[(index - 1) % len(seeds)]
+        addon_samples.append(
+            _build_addon_sample(
+                seed_sample=seed,
+                target_group=group,
+                target=target,
+                index=index,
+                tool_catalog=tool_catalog,
+            )
+        )
+
+    combined_samples = list(base_samples) + addon_samples
+    all_capabilities = set(current_capabilities)
+    for target in target_plan:
+        all_capabilities.add(target["capability_id"])
+    missing_groups_after_expected = _missing_groups(all_capabilities)
+
+    addons_path = output_dir / "requirement2_addon_samples.jsonl"
+    combined_path = output_dir / "samples_with_addons.jsonl"
+    report_path = output_dir / "requirement2_addon_report.json"
+
+    _write_jsonl(addons_path, addon_samples)
+    _write_jsonl(combined_path, combined_samples)
+
+    report = {
+        "input": {
+            "base_samples_path": str(base_samples_path),
+            "base_gated_path": str(base_gated_path),
+            "base_samples_count": len(base_samples),
+            "base_gated_count": len(gated_rows),
+        },
+        "output": {
+            "addons_samples_path": str(addons_path),
+            "combined_samples_path": str(combined_path),
+            "report_path": str(report_path),
+        },
+        "requirement2_coverage": {
+            "capabilities_before": sorted(current_capabilities),
+            "missing_groups_before": missing_groups_before,
+            "missing_groups_after_expected": missing_groups_after_expected,
+            "generated_addon_count": len(addon_samples),
+            "generated_capabilities": [item["capability_id"] for item in target_plan],
+        },
+        "addons": [
+            {
+                "sample_id": _str_value(sample.get("sample_id")),
+                "task_id": _str_value(sample.get("context", {}).get("task_id"))
+                if isinstance(sample.get("context"), dict)
+                else None,
+                "capability_id": _str_value(
+                    sample.get("candidates", [{}])[0].get("capability_id")
+                    if isinstance(sample.get("candidates"), list) and sample.get("candidates")
+                    else None
+                ),
+                "tool_id": _str_value(
+                    sample.get("candidates", [{}])[0].get("tool_id")
+                    if isinstance(sample.get("candidates"), list) and sample.get("candidates")
+                    else None
+                ),
+                "source_sample_id": _str_value(
+                    sample.get("addon_metadata", {}).get("source_sample_id")
+                    if isinstance(sample.get("addon_metadata"), dict)
+                    else None
+                ),
+            }
+            for sample in addon_samples
+        ],
+    }
+
+    with report_path.open("w", encoding="utf-8") as handle:
+        handle.write(_json_dump(report) + "\n")
+    return report
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate requirement2 addon samples to cover missing P0 core capabilities.",
+    )
+    parser.add_argument("--base-samples-path", type=Path, default=DEFAULT_BASE_SAMPLES_PATH)
+    parser.add_argument("--base-gated-path", type=Path, default=DEFAULT_BASE_GATED_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--tool-kg-path", type=Path, default=DEFAULT_TOOL_KG_PATH)
+    parser.add_argument("--tool-extension-kg-path", type=Path, default=DEFAULT_TOOL_EXTENSION_KG_PATH)
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    report = augment_requirement2_coverage(
+        base_samples_path=args.base_samples_path,
+        base_gated_path=args.base_gated_path,
+        output_dir=args.output_dir,
+        tool_kg_path=args.tool_kg_path,
+        tool_extension_kg_path=args.tool_extension_kg_path,
+    )
+
+    print("Requirement2 coverage addon generation completed")
+    print(_json_dump(report["requirement2_coverage"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/freeze_sft_dataset_v1.py
+++ b/scripts/freeze_sft_dataset_v1.py
@@ -83,6 +83,14 @@ def _file_sha256(path: Path) -> str | None:
     return digest.hexdigest()
 
 
+def _read_json_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return payload if isinstance(payload, dict) else {}
+
+
 def _normalize_adapter_mode(value: str | None) -> str:
     text = _str_value(value)
     if not text:
@@ -617,6 +625,133 @@ def _fingerprint_rows(rows: list[dict[str, Any]]) -> str:
     return digest.hexdigest()
 
 
+def _flatten_tool_coverage_matrix(matrix: dict[str, Any]) -> dict[str, int]:
+    flattened: dict[str, int] = {}
+    for capability_id, tools in matrix.items():
+        if not isinstance(tools, dict):
+            continue
+        for tool_id, adapters in tools.items():
+            if not isinstance(adapters, dict):
+                continue
+            for adapter_mode, payload in adapters.items():
+                if not isinstance(payload, dict):
+                    continue
+                sample_count = payload.get("sample_count")
+                if not isinstance(sample_count, int):
+                    continue
+                key = f"{capability_id}|{tool_id}|{adapter_mode}"
+                flattened[key] = sample_count
+    return flattened
+
+
+def _build_delta_from_previous(
+    *,
+    previous_manifest_path: Path,
+    current_manifest: dict[str, Any],
+    current_capability_distribution: dict[str, int],
+    current_tool_coverage_matrix: dict[str, Any],
+) -> dict[str, Any]:
+    previous_manifest = _read_json_file(previous_manifest_path)
+    if not previous_manifest:
+        return {}
+
+    previous_counts = previous_manifest.get("dataset_counts")
+    previous_counts_dict = previous_counts if isinstance(previous_counts, dict) else {}
+    current_counts = current_manifest.get("dataset_counts")
+    current_counts_dict = current_counts if isinstance(current_counts, dict) else {}
+
+    previous_split = previous_manifest.get("split_counts")
+    previous_split_dict = previous_split if isinstance(previous_split, dict) else {}
+    current_split = current_manifest.get("split_counts")
+    current_split_dict = current_split if isinstance(current_split, dict) else {}
+
+    previous_stats_path = None
+    previous_artifacts = previous_manifest.get("artifacts")
+    if isinstance(previous_artifacts, dict):
+        previous_stats_path = _str_value(previous_artifacts.get("dataset_stats_path"))
+    previous_capability_distribution: dict[str, int] = {}
+    if previous_stats_path:
+        previous_stats_payload = _read_json_file(Path(previous_stats_path))
+        capability_distribution = previous_stats_payload.get("capability_distribution")
+        if isinstance(capability_distribution, dict):
+            previous_capability_distribution = {
+                str(key): int(value)
+                for key, value in capability_distribution.items()
+                if isinstance(value, int)
+            }
+
+    previous_tool_matrix_path = None
+    if isinstance(previous_artifacts, dict):
+        previous_tool_matrix_path = _str_value(previous_artifacts.get("tool_coverage_matrix_path"))
+    previous_tool_matrix: dict[str, Any] = {}
+    if previous_tool_matrix_path:
+        previous_tool_matrix = _read_json_file(Path(previous_tool_matrix_path))
+
+    current_flat_matrix = _flatten_tool_coverage_matrix(current_tool_coverage_matrix)
+    previous_flat_matrix = _flatten_tool_coverage_matrix(previous_tool_matrix)
+
+    all_count_keys = sorted(set(previous_counts_dict.keys()).union(current_counts_dict.keys()))
+    counts_delta = {
+        key: int(current_counts_dict.get(key, 0)) - int(previous_counts_dict.get(key, 0))
+        for key in all_count_keys
+        if isinstance(current_counts_dict.get(key, 0), int)
+        and isinstance(previous_counts_dict.get(key, 0), int)
+    }
+
+    all_split_keys = sorted(set(previous_split_dict.keys()).union(current_split_dict.keys()))
+    split_delta = {
+        key: int(current_split_dict.get(key, 0)) - int(previous_split_dict.get(key, 0))
+        for key in all_split_keys
+        if isinstance(current_split_dict.get(key, 0), int)
+        and isinstance(previous_split_dict.get(key, 0), int)
+    }
+
+    all_capability_keys = sorted(
+        set(previous_capability_distribution.keys()).union(current_capability_distribution.keys())
+    )
+    capability_delta = {
+        key: int(current_capability_distribution.get(key, 0))
+        - int(previous_capability_distribution.get(key, 0))
+        for key in all_capability_keys
+    }
+
+    added_matrix_keys = sorted(key for key in current_flat_matrix.keys() if key not in previous_flat_matrix)
+    removed_matrix_keys = sorted(key for key in previous_flat_matrix.keys() if key not in current_flat_matrix)
+    changed_matrix_keys = sorted(
+        key
+        for key in current_flat_matrix.keys()
+        if key in previous_flat_matrix and current_flat_matrix[key] != previous_flat_matrix[key]
+    )
+
+    previous_req2 = previous_manifest.get("requirement2")
+    previous_req2_dict = previous_req2 if isinstance(previous_req2, dict) else {}
+    previous_p0 = previous_req2_dict.get("p0_core_minimum_coverage")
+    previous_p0_dict = previous_p0 if isinstance(previous_p0, dict) else {}
+    current_req2 = current_manifest.get("requirement2")
+    current_req2_dict = current_req2 if isinstance(current_req2, dict) else {}
+    current_p0 = current_req2_dict.get("p0_core_minimum_coverage")
+    current_p0_dict = current_p0 if isinstance(current_p0, dict) else {}
+
+    return {
+        "previous_manifest_path": str(previous_manifest_path),
+        "previous_dataset_version": previous_manifest.get("dataset_version"),
+        "dataset_counts_delta": counts_delta,
+        "split_counts_delta": split_delta,
+        "capability_distribution_delta": capability_delta,
+        "tool_coverage_matrix_delta": {
+            "added_keys": added_matrix_keys,
+            "removed_keys": removed_matrix_keys,
+            "changed_keys": changed_matrix_keys,
+        },
+        "p0_core_coverage_change": {
+            "previous_satisfied": bool(previous_p0_dict.get("satisfied")),
+            "current_satisfied": bool(current_p0_dict.get("satisfied")),
+            "previous_missing_groups": previous_p0_dict.get("missing_groups", []),
+            "current_missing_groups": current_p0_dict.get("missing_groups", []),
+        },
+    }
+
+
 def _write_training_reader_config(
     *,
     path: Path,
@@ -654,6 +789,7 @@ def freeze_sft_dataset_v1(
     quality_report_path: Path | None,
     output_root: Path,
     dataset_version: str | None,
+    previous_manifest_path: Path | None,
     tool_kg_path: Path,
     tool_extension_kg_path: Path | None,
     config_template_path: Path,
@@ -821,6 +957,16 @@ def freeze_sft_dataset_v1(
         "dataset_fingerprint": dataset_fingerprint,
     }
 
+    if previous_manifest_path:
+        delta = _build_delta_from_previous(
+            previous_manifest_path=previous_manifest_path,
+            current_manifest=manifest,
+            current_capability_distribution=dict(sorted(capability_distribution.items())),
+            current_tool_coverage_matrix=tool_coverage_matrix,
+        )
+        if delta:
+            manifest["delta_from_previous"] = delta
+
     _write_training_reader_config(
         path=freeze_dir / "training_reader_config.json",
         dataset_version=resolved_version,
@@ -863,6 +1009,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--quality-report-path", type=Path, default=DEFAULT_QUALITY_REPORT_PATH)
     parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
     parser.add_argument("--dataset-version", type=str, default=None)
+    parser.add_argument(
+        "--previous-manifest-path",
+        type=Path,
+        default=None,
+        help="Optional previous manifest to compute version delta (for r02/v1.1 evolution).",
+    )
     parser.add_argument("--tool-kg-path", type=Path, default=DEFAULT_TOOL_KG_PATH)
     parser.add_argument(
         "--tool-extension-kg-path",
@@ -891,6 +1043,7 @@ def main() -> int:
         quality_report_path=args.quality_report_path,
         output_root=args.output_root,
         dataset_version=args.dataset_version,
+        previous_manifest_path=args.previous_manifest_path,
         tool_kg_path=args.tool_kg_path,
         tool_extension_kg_path=args.tool_extension_kg_path,
         config_template_path=args.config_template_path,

--- a/scripts/release_sft_dataset_v1_1.py
+++ b/scripts/release_sft_dataset_v1_1.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _json_dump(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True)
+
+
+def _run(cmd: list[str]) -> None:
+    subprocess.run(cmd, check=True)
+
+
+def _default_dataset_version() -> str:
+    try:
+        short_sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        short_sha = "unknown"
+    day = datetime.now(timezone.utc).strftime("%Y%m%d")
+    return f"w11-sft-dataset-v1.1-{day}-{short_sha}-r02"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Release pipeline for SFT dataset v1.1: "
+            "extract -> quality gate -> req2 addon -> quality gate -> freeze."
+        ),
+    )
+    parser.add_argument("--logs-dir", type=Path, default=Path("data/logs"))
+    parser.add_argument("--snapshots-dir", type=Path, default=Path("data/snapshots"))
+    parser.add_argument("--reports-dir", type=Path, default=Path("output/reports"))
+    parser.add_argument("--metrics-dir", type=Path, default=Path("output/metrics"))
+    parser.add_argument("--tool-kg-path", type=Path, default=Path("src/kg/protein_tool_kg.json"))
+    parser.add_argument(
+        "--tool-extension-kg-path",
+        type=Path,
+        default=Path("src/kg/protein_tool_kg/extension_draft_v0.1.json"),
+    )
+    parser.add_argument("--base-output-dir", type=Path, default=Path("output/training/w11-data-1"))
+    parser.add_argument("--base-gate-output-dir", type=Path, default=Path("output/training/w11-data-2"))
+    parser.add_argument("--addon-output-dir", type=Path, default=Path("output/training/w11-data-3"))
+    parser.add_argument("--freeze-output-root", type=Path, default=Path("output/dataset_v1"))
+    parser.add_argument("--dataset-version", type=str, default=None)
+    parser.add_argument(
+        "--previous-manifest-path",
+        type=Path,
+        default=Path("output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/manifest.json"),
+    )
+    parser.add_argument(
+        "--allow-missing-p0-core",
+        action="store_true",
+        help="Do not fail release when Requirement2 P0 core coverage is missing.",
+    )
+    parser.add_argument(
+        "--skip-extract",
+        action="store_true",
+        help="Reuse existing output/training/w11-data-1 artifacts.",
+    )
+    parser.add_argument(
+        "--skip-base-gate",
+        action="store_true",
+        help="Reuse existing output/training/w11-data-2 artifacts.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    dataset_version = args.dataset_version or _default_dataset_version()
+    python_exe = sys.executable
+
+    if not args.skip_extract:
+        _run(
+            [
+                python_exe,
+                "scripts/extract_training_samples.py",
+                "--logs-dir",
+                str(args.logs_dir),
+                "--snapshots-dir",
+                str(args.snapshots_dir),
+                "--reports-dir",
+                str(args.reports_dir),
+                "--metrics-dir",
+                str(args.metrics_dir),
+                "--tool-kg-path",
+                str(args.tool_kg_path),
+                "--tool-extension-kg-path",
+                str(args.tool_extension_kg_path),
+                "--output-dir",
+                str(args.base_output_dir),
+            ]
+        )
+
+    if not args.skip_base_gate:
+        _run(
+            [
+                python_exe,
+                "scripts/quality_gate_training_data.py",
+                "--samples-path",
+                str(args.base_output_dir / "samples.jsonl"),
+                "--output-dir",
+                str(args.base_gate_output_dir),
+                "--split-strategy",
+                "time",
+                "--plddt-min",
+                "0.70",
+                "--score-completeness-min",
+                "0.80",
+            ]
+        )
+
+    _run(
+        [
+            python_exe,
+            "scripts/augment_requirement2_coverage.py",
+            "--base-samples-path",
+            str(args.base_output_dir / "samples.jsonl"),
+            "--base-gated-path",
+            str(args.base_gate_output_dir / "gated_samples.jsonl"),
+            "--output-dir",
+            str(args.addon_output_dir),
+            "--tool-kg-path",
+            str(args.tool_kg_path),
+            "--tool-extension-kg-path",
+            str(args.tool_extension_kg_path),
+        ]
+    )
+
+    _run(
+        [
+            python_exe,
+            "scripts/quality_gate_training_data.py",
+            "--samples-path",
+            str(args.addon_output_dir / "samples_with_addons.jsonl"),
+            "--output-dir",
+            str(args.addon_output_dir),
+            "--split-strategy",
+            "time",
+            "--plddt-min",
+            "0.70",
+            "--score-completeness-min",
+            "0.80",
+        ]
+    )
+
+    freeze_cmd = [
+        python_exe,
+        "scripts/freeze_sft_dataset_v1.py",
+        "--gated-samples-path",
+        str(args.addon_output_dir / "gated_samples.jsonl"),
+        "--quality-report-path",
+        str(args.addon_output_dir / "quality_gate_report.json"),
+        "--output-root",
+        str(args.freeze_output_root),
+        "--dataset-version",
+        dataset_version,
+        "--tool-kg-path",
+        str(args.tool_kg_path),
+        "--tool-extension-kg-path",
+        str(args.tool_extension_kg_path),
+        "--previous-manifest-path",
+        str(args.previous_manifest_path),
+    ]
+    if not args.allow_missing_p0_core:
+        freeze_cmd.append("--fail-on-missing-p0-core")
+    _run(freeze_cmd)
+
+    manifest_path = args.freeze_output_root / dataset_version / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    print("SFT dataset v1.1 release completed")
+    print(
+        _json_dump(
+            {
+                "dataset_version": dataset_version,
+                "manifest_path": str(manifest_path),
+                "p0_core_coverage_satisfied": manifest["requirement2"]["p0_core_minimum_coverage"]["satisfied"],
+                "delta_from_previous": "delta_from_previous" in manifest,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/w11-data-3-requirement2-addons-release.md
+++ b/scripts/w11-data-3-requirement2-addons-release.md
@@ -1,0 +1,48 @@
+# W11-Data-3: Requirement2 覆盖补齐与 v1.1 发布
+
+本说明对应 Issue #147 后续补充项：
+
+- 补齐 `sequence_core / quality_qc / objective_scoring` 覆盖；
+- 发布增量冻结版本（`v1.1/r02`）；
+- 将 `freeze + --fail-on-missing-p0-core` 接入发布流水线。
+
+## 1. 一键发布（推荐）
+
+```bash
+uv run python scripts/release_sft_dataset_v1_1.py \
+  --dataset-version w11-sft-dataset-v1.1-20260315-57fc60d-r02 \
+  --previous-manifest-path output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/manifest.json
+```
+
+默认执行流程：
+
+1. `extract_training_samples.py`
+2. `quality_gate_training_data.py`（base）
+3. `augment_requirement2_coverage.py`
+4. `quality_gate_training_data.py`（addons 合并后）
+5. `freeze_sft_dataset_v1.py --fail-on-missing-p0-core`
+
+## 2. 仅执行补齐步骤
+
+```bash
+uv run python scripts/augment_requirement2_coverage.py \
+  --base-samples-path output/training/w11-data-1/samples.jsonl \
+  --base-gated-path output/training/w11-data-2/gated_samples.jsonl \
+  --output-dir output/training/w11-data-3
+```
+
+输出：
+
+- `output/training/w11-data-3/requirement2_addon_samples.jsonl`
+- `output/training/w11-data-3/samples_with_addons.jsonl`
+- `output/training/w11-data-3/requirement2_addon_report.json`
+
+## 3. 验收点
+
+- `output/training/w11-data-3/gated_samples.jsonl` 中新增能力覆盖：
+  - `sequence_design`（代表 `sequence_core`）
+  - `quality_qc`
+  - `objective_scoring`
+- 冻结产物 manifest 含：
+  - `requirement2.p0_core_minimum_coverage.satisfied = true`
+  - `delta_from_previous`（与上一版差异）

--- a/tests/unit/test_augment_requirement2_coverage.py
+++ b/tests/unit/test_augment_requirement2_coverage.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+AUGMENT_SCRIPT_PATH = Path("scripts/augment_requirement2_coverage.py")
+QUALITY_GATE_SCRIPT_PATH = Path("scripts/quality_gate_training_data.py")
+
+
+def _load_script_module(path: Path, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=True), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=True) + "\n")
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            rows.append(json.loads(text))
+    return rows
+
+
+def _base_sample(report_path: Path, structure_path: Path) -> dict:
+    return {
+        "sample_id": "sample::seed",
+        "context": {
+            "task_id": "task_seed",
+            "status_path": ["PLANNING", "PLANNED", "RUNNING", "DONE"],
+            "time_window": {
+                "first_ts": "2026-03-15T00:00:00+00:00",
+                "last_ts": "2026-03-15T00:01:00+00:00",
+            },
+            "plan_metadata": {
+                "kg_explanation": {
+                    "steps": [
+                        {
+                            "step_id": "S1",
+                            "tool_id": "esmfold",
+                            "capabilities": [{"capability_id": "structure_prediction"}],
+                        }
+                    ]
+                }
+            },
+        },
+        "candidates": [
+            {
+                "candidate_id": "seed_cand",
+                "tool_id": "esmfold",
+                "capability_id": "structure_prediction",
+                "adapter_mode": "local",
+                "score_breakdown": {
+                    "feasibility": 0.8,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.2,
+                    "overall": 0.8,
+                },
+                "risk_level": "low",
+                "cost_estimate": "low",
+                "payload": {"sequence": "ACDEFG"},
+            }
+        ],
+        "selected": {
+            "selected_candidate_id": "seed_cand",
+            "selected_candidate": {
+                "candidate_id": "seed_cand",
+                "tool_id": "esmfold",
+                "capability_id": "structure_prediction",
+                "payload": {"sequence": "ACDEFG"},
+            },
+        },
+        "outcome": {
+            "final_status": "DONE",
+            "step_results": [
+                {
+                    "step_id": "S1",
+                    "tool": "esmfold",
+                    "status": "success",
+                    "failure_type": None,
+                    "error_message": None,
+                }
+            ],
+            "step_failure_types": [],
+            "report_path": str(report_path),
+            "structure_pdb_path": str(structure_path),
+            "scores": {"plddt_mean": 0.9},
+        },
+        "audit_trace": {
+            "task_id": "task_seed",
+            "event_ids": ["task_seed:1"],
+            "decision_history": [],
+            "pending_action_ids": [],
+            "snapshot_ids": [],
+            "decision_event_ids": [],
+        },
+    }
+
+
+@pytest.mark.unit
+def test_augment_requirement2_coverage_generates_missing_capability_samples(tmp_path: Path) -> None:
+    augment_module = _load_script_module(
+        AUGMENT_SCRIPT_PATH,
+        "augment_requirement2_coverage",
+    )
+    quality_module = _load_script_module(
+        QUALITY_GATE_SCRIPT_PATH,
+        "quality_gate_training_data_for_addon_test",
+    )
+
+    base_samples_path = tmp_path / "base_samples.jsonl"
+    base_gated_path = tmp_path / "base_gated.jsonl"
+    output_dir = tmp_path / "out"
+    quality_out_dir = tmp_path / "quality_out"
+    reports_dir = tmp_path / "reports"
+    pdb_dir = tmp_path / "pdb"
+    tool_kg_path = tmp_path / "tool_kg.json"
+    tool_extension_path = tmp_path / "tool_ext.json"
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    pdb_dir.mkdir(parents=True, exist_ok=True)
+    report_path = reports_dir / "seed.json"
+    structure_path = pdb_dir / "seed.pdb"
+    _write_json(report_path, {"sequence": "ACDEFG", "scores": {"plddt_mean": 0.9}})
+    structure_path.write_text("ATOM 1\n", encoding="utf-8")
+
+    seed_sample = _base_sample(report_path, structure_path)
+    _write_jsonl(base_samples_path, [seed_sample])
+    _write_jsonl(
+        base_gated_path,
+        [
+            {
+                **seed_sample,
+                "quality_gate": {
+                    "status": "PASS",
+                    "split": "train",
+                    "capability_ids": ["structure_prediction"],
+                    "tool_lineage": ["esmfold"],
+                    "reject_codes": [],
+                },
+            }
+        ],
+    )
+    _write_json(
+        tool_kg_path,
+        {
+            "tools": [
+                {
+                    "tool_id": "esmfold",
+                    "capabilities": ["structure_prediction"],
+                    "execution": "nextflow",
+                    "version": "1.0.0",
+                    "priority": "P0",
+                },
+                {
+                    "tool_id": "protein_mpnn",
+                    "capabilities": ["sequence_design"],
+                    "execution": {
+                        "backend": "remote_model_service",
+                        "provider": "nvidia_nim",
+                        "model_id": "ipd/proteinmpnn/predict",
+                    },
+                    "version": "1.0.0",
+                    "priority": "P0",
+                },
+                {
+                    "tool_id": "biopython_qc",
+                    "capabilities": ["quality_qc"],
+                    "execution": "python",
+                    "version": "1.0.0",
+                    "priority": "P0",
+                },
+                {
+                    "tool_id": "objective_ranker",
+                    "capabilities": ["objective_scoring"],
+                    "execution": "python",
+                    "version": "1.0.0",
+                    "priority": "P0",
+                },
+            ]
+        },
+    )
+    _write_json(tool_extension_path, {"tool_candidates": []})
+
+    report = augment_module.augment_requirement2_coverage(
+        base_samples_path=base_samples_path,
+        base_gated_path=base_gated_path,
+        output_dir=output_dir,
+        tool_kg_path=tool_kg_path,
+        tool_extension_kg_path=tool_extension_path,
+    )
+
+    assert report["requirement2_coverage"]["missing_groups_before"] == [
+        "sequence_core",
+        "quality_qc",
+        "objective_scoring",
+    ]
+    assert report["requirement2_coverage"]["generated_addon_count"] == 3
+    assert report["requirement2_coverage"]["missing_groups_after_expected"] == []
+
+    addons = _read_jsonl(output_dir / "requirement2_addon_samples.jsonl")
+    assert len(addons) == 3
+    addon_caps = {
+        row["candidates"][0]["capability_id"]
+        for row in addons
+    }
+    assert addon_caps == {"sequence_design", "quality_qc", "objective_scoring"}
+
+    quality_module.quality_gate_training_samples(
+        samples_path=output_dir / "samples_with_addons.jsonl",
+        output_dir=quality_out_dir,
+        train_ratio=0.7,
+        val_ratio=0.15,
+        plddt_min=0.7,
+        score_completeness_min=0.8,
+        split_strategy="time",
+    )
+    gated_rows = _read_jsonl(quality_out_dir / "gated_samples.jsonl")
+    status_by_sample = {row["sample_id"]: row["quality_gate"]["status"] for row in gated_rows}
+    for row in addons:
+        assert status_by_sample[row["sample_id"]] in {"PASS", "WARN"}

--- a/tests/unit/test_freeze_sft_dataset_v1.py
+++ b/tests/unit/test_freeze_sft_dataset_v1.py
@@ -221,6 +221,7 @@ class TestFreezeSftDatasetV1:
             quality_report_path=quality_report_path,
             output_root=output_root,
             dataset_version="unit-v1",
+            previous_manifest_path=None,
             tool_kg_path=tool_kg_path,
             tool_extension_kg_path=tool_extension_path,
             config_template_path=config_template_path,
@@ -291,6 +292,7 @@ class TestFreezeSftDatasetV1:
             quality_report_path=quality_report_path,
             output_root=output_root,
             dataset_version="unit-v1",
+            previous_manifest_path=None,
             tool_kg_path=tool_kg_path,
             tool_extension_kg_path=tool_extension_path,
             config_template_path=config_template_path,
@@ -300,6 +302,7 @@ class TestFreezeSftDatasetV1:
             quality_report_path=quality_report_path,
             output_root=output_root,
             dataset_version="unit-v1",
+            previous_manifest_path=None,
             tool_kg_path=tool_kg_path,
             tool_extension_kg_path=tool_extension_path,
             config_template_path=config_template_path,
@@ -324,10 +327,124 @@ class TestFreezeSftDatasetV1:
                 quality_report_path=quality_report_path,
                 output_root=output_root,
                 dataset_version="unit-v1",
+                previous_manifest_path=None,
                 tool_kg_path=tool_kg_path,
                 tool_extension_kg_path=tool_extension_path,
                 config_template_path=config_template_path,
             )
+
+    def test_freeze_records_delta_from_previous_manifest(self, tmp_path: Path) -> None:
+        module = _load_script_module()
+
+        gated_samples_path = tmp_path / "gated_samples.jsonl"
+        quality_report_path = tmp_path / "quality_gate_report.json"
+        output_root = tmp_path / "output"
+        tool_kg_path = tmp_path / "tool_kg.json"
+        tool_extension_path = tmp_path / "tool_ext.json"
+        config_template_path = tmp_path / "configs" / "training" / "dataset_v1.example.json"
+
+        previous_freeze_dir = output_root / "old-v1"
+        previous_freeze_dir.mkdir(parents=True, exist_ok=True)
+        previous_stats_path = previous_freeze_dir / "dataset_stats.json"
+        previous_matrix_path = previous_freeze_dir / "tool_coverage_matrix.json"
+        previous_manifest_path = previous_freeze_dir / "manifest.json"
+
+        _write_json(
+            previous_stats_path,
+            {
+                "capability_distribution": {"structure_prediction": 1},
+                "split_counts": {"train": 1},
+            },
+        )
+        _write_json(
+            previous_matrix_path,
+            {
+                "structure_prediction": {
+                    "esmfold": {"local": {"sample_count": 1, "occurrence_count": 1}}
+                }
+            },
+        )
+        _write_json(
+            previous_manifest_path,
+            {
+                "dataset_version": "old-v1",
+                "dataset_counts": {"input_total": 1, "accepted_total": 1, "blocked_total": 0},
+                "split_counts": {"train": 1},
+                "artifacts": {
+                    "dataset_stats_path": str(previous_stats_path),
+                    "tool_coverage_matrix_path": str(previous_matrix_path),
+                },
+                "requirement2": {
+                    "p0_core_minimum_coverage": {
+                        "satisfied": False,
+                        "missing_groups": ["sequence_core", "quality_qc", "objective_scoring"],
+                    }
+                },
+            },
+        )
+
+        rows = [
+            _build_sample(
+                sample_id="sample_s1",
+                split="train",
+                status="PASS",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                adapter_mode="local",
+            ),
+            _build_sample(
+                sample_id="sample_s2",
+                split="val",
+                status="PASS",
+                tool_id="objective_ranker",
+                capability_id="objective_scoring",
+                adapter_mode="local",
+            ),
+            _build_sample(
+                sample_id="sample_s3",
+                split="test",
+                status="PASS",
+                tool_id="biopython_qc",
+                capability_id="quality_qc",
+                adapter_mode="local",
+            ),
+            _build_sample(
+                sample_id="sample_s4",
+                split="train",
+                status="PASS",
+                tool_id="protein_mpnn",
+                capability_id="sequence_design",
+                adapter_mode="remote",
+                provider="nvidia_nim",
+                model_id="ipd/proteinmpnn/predict",
+            ),
+        ]
+        _write_jsonl(gated_samples_path, rows)
+        _write_json(quality_report_path, {"summary": {"counts": {"pass": 4}}})
+        _write_json(tool_kg_path, _build_tool_kg())
+        _write_json(tool_extension_path, _build_tool_extension())
+
+        manifest = module.freeze_sft_dataset_v1(
+            gated_samples_path=gated_samples_path,
+            quality_report_path=quality_report_path,
+            output_root=output_root,
+            dataset_version="new-v1-1",
+            previous_manifest_path=previous_manifest_path,
+            tool_kg_path=tool_kg_path,
+            tool_extension_kg_path=tool_extension_path,
+            config_template_path=config_template_path,
+        )
+
+        assert "delta_from_previous" in manifest
+        delta = manifest["delta_from_previous"]
+        assert delta["previous_dataset_version"] == "old-v1"
+        assert delta["dataset_counts_delta"]["accepted_total"] == 3
+        assert delta["p0_core_coverage_change"]["previous_satisfied"] is False
+        assert delta["p0_core_coverage_change"]["current_satisfied"] is True
+        assert any(
+            key.startswith("quality_qc|biopython_qc|")
+            for key in delta["tool_coverage_matrix_delta"]["added_keys"]
+        )
 
     def test_cli_runs_successfully(self, tmp_path: Path) -> None:
         gated_samples_path = tmp_path / "gated_samples.jsonl"


### PR DESCRIPTION
## 背景
本 PR 对 Issue #147 在 #177 之后遗留的 3 项补充进行闭环实现：

1. 数据覆盖补齐（`sequence_core / quality_qc / objective_scoring`）
2. 版本演进（发布 `v1.1/r02`，并记录与 v1 的差异）
3. 流程接入（将 `freeze + --fail-on-missing-p0-core` 接入发布流水线）

## 主要实现

### 1) Requirement2 覆盖补齐脚本
新增：`scripts/augment_requirement2_coverage.py`

- 输入：
  - `output/training/w11-data-1/samples.jsonl`
  - `output/training/w11-data-2/gated_samples.jsonl`
- 自动识别缺失的 P0 核心能力组：
  - `sequence_core`
  - `quality_qc`
  - `objective_scoring`
- 生成可追溯 addon 样本（保留 source sample/task），输出：
  - `output/training/w11-data-3/requirement2_addon_samples.jsonl`
  - `output/training/w11-data-3/samples_with_addons.jsonl`
  - `output/training/w11-data-3/requirement2_addon_report.json`

### 2) freeze 脚本支持版本差异追踪
增强：`scripts/freeze_sft_dataset_v1.py`

- 新增参数：`--previous-manifest-path`
- 新增 manifest 字段：`delta_from_previous`，包含：
  - `dataset_counts_delta`
  - `split_counts_delta`
  - `capability_distribution_delta`
  - `tool_coverage_matrix_delta`
  - `p0_core_coverage_change`

### 3) 数据发布流水线接入
新增：`scripts/release_sft_dataset_v1_1.py`

- 一键执行：
  1. extract
  2. base quality gate
  3. requirement2 addon 生成
  4. addon 合并后 quality gate
  5. freeze（默认启用 `--fail-on-missing-p0-core`）

新增说明：`scripts/w11-data-3-requirement2-addons-release.md`

## 本地验证

### 单测
```bash
uv run pytest tests/unit/test_augment_requirement2_coverage.py tests/unit/test_freeze_sft_dataset_v1.py tests/unit/test_quality_gate_training_data.py tests/unit/test_extract_training_samples.py
```
结果：`11 passed`

### 实际发布演练
```bash
uv run python scripts/release_sft_dataset_v1_1.py \
  --dataset-version w11-sft-dataset-v1.1-20260315-57fc60d-r02 \
  --previous-manifest-path output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/manifest.json
```
结果：
- 新版本：`w11-sft-dataset-v1.1-20260315-57fc60d-r02`
- `p0_core_coverage_satisfied = true`
- manifest 包含 `delta_from_previous`

## 遗留与后续（已明确）

1. 当前新增覆盖依赖 addon 样本（可复现、可追溯），但规模仍小。  
2. 若目标提升为“真实工具执行覆盖为主”，仍需补充 sequence/qc/objective 的真实运行样本，并逐步降低 addon 占比。  
3. 可在后续版本将 `release_sft_dataset_v1_1.py` 固化为 CI Job，形成自动发布门禁。

## 关联
- Issue: #147
- 续接 PR: #177, #178
