### PR TITLE
docs(data): update issue #147 with v1.1 addon freeze results

### DIFF
--- a/docs/algorithm-and-llm/sft-dataset-v1-freeze.md
+++ b/docs/algorithm-and-llm/sft-dataset-v1-freeze.md
@@ -2,102 +2,109 @@
 
 ## 1. 目标与范围
 
-本文档对应 Issue #147，给出 Week11 SFT 数据集 v1 的冻结结果与使用说明，作为 Week12 训练输入基线。
+本文档对应 Issue #147，记录 SFT 数据集冻结与后续补齐结果，作为 Week12 训练输入基线说明。
 
-本次冻结覆盖：
+覆盖内容：
 
-- 数据集版本与 manifest（不可变语义）。
-- 字段字典与样本统计。
-- 已知偏差与不适用场景。
-- 最小复现实验命令。
-- Requirement2：工具覆盖矩阵、P0 工具版本固化、最小覆盖门槛判定。
+- 数据集版本冻结（不可变语义）
+- 字段字典与分布统计
+- Requirement2 工具覆盖矩阵与 P0 覆盖判定
+- 增量版本（v1.1/r02）与上一版本差异
+- 复现命令与发布流程
 
-## 2. 冻结版本
+## 2. 版本总览
+
+### 2.1 v1（首版冻结）
 
 - `dataset_version`: `w11-sft-dataset-v1-20260315-0ce8eb8`
 - 冻结目录：`output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/`
-- manifest：`output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/manifest.json`
-- 冻结语义：
-  - 同版本内容不可变更；
-  - 若重新执行且输入完全一致，仅允许幂等复用（fingerprint 相同）；
-  - 输入变更必须升版本。
+- 输入/纳入/阻断：`36 / 32 / 4`
+- P0 核心覆盖：`false`
+  - 已覆盖：`structure_prediction`
+  - 缺失：`sequence_core`, `quality_qc`, `objective_scoring`
 
-## 3. 输入与筛选规则
+### 2.2 v1.1（增量补齐 / r02）
 
-### 3.1 输入来源
+- `dataset_version`: `w11-sft-dataset-v1.1-20260315-57fc60d-r02`
+- 冻结目录：`output/dataset_v1/w11-sft-dataset-v1.1-20260315-57fc60d-r02/`
+- 输入/纳入/阻断：`39 / 35 / 4`
+- P0 核心覆盖：`true`
+  - 覆盖结果：
+    - `sequence_core`（通过 `sequence_design`）
+    - `structure_prediction`
+    - `quality_qc`
+    - `objective_scoring`
 
-- 质检后样本：`output/training/w11-data-2/gated_samples.jsonl`
-- 质检报告：`output/training/w11-data-2/quality_gate_report.json`
+## 3. 冻结语义与版本演进
+
+冻结语义：
+
+- 同版本内容不可变更；
+- 仅当 fingerprint 相同允许幂等复用；
+- 输入变化必须升版本。
+
+v1.1 在 manifest 中新增：
+
+- `delta_from_previous`
+  - `dataset_counts_delta`
+  - `split_counts_delta`
+  - `capability_distribution_delta`
+  - `tool_coverage_matrix_delta`
+  - `p0_core_coverage_change`
+
+v1.1 相对 v1 的关键差异：
+
+- `accepted_total`: `+3`
+- capability 新增：`sequence_design`, `quality_qc`, `objective_scoring`
+- tool coverage 新增键：
+  - `sequence_design|protein_mpnn|remote`
+  - `quality_qc|biopython_qc|local`
+  - `objective_scoring|objective_ranker|local`
+- `p0_core_minimum_coverage`: `false -> true`
+
+## 4. 输入与产物
+
+### 4.1 输入来源
+
+- 基础样本：`output/training/w11-data-1/samples.jsonl`
+- 基础门禁：`output/training/w11-data-2/gated_samples.jsonl`
+- Addon 补齐样本：`output/training/w11-data-3/requirement2_addon_samples.jsonl`
+- Addon 合并门禁：`output/training/w11-data-3/gated_samples.jsonl`
 - 工具目录：
   - `src/kg/protein_tool_kg.json`
   - `src/kg/protein_tool_kg/extension_draft_v0.1.json`
 
-### 3.2 样本纳入规则
+### 4.2 冻结产物
 
-- 仅纳入 `quality_gate.status in {PASS, WARN}` 的样本。
-- `BLOCK` 样本不进入训练集。
-- split 直接继承门禁结果（`train/val/test`）。
+每个冻结版本目录下包含：
 
-## 4. 数据产物
+- `accepted_samples.jsonl`
+- `train.jsonl` / `val.jsonl` / `test.jsonl`
+- `dataset_stats.json`
+- `field_dictionary.json`
+- `tool_coverage_matrix.json`
+- `training_reader_config.json`
+- `manifest.json`
 
-冻结目录下产物：
-
-- `accepted_samples.jsonl`：纳入训练的全量样本。
-- `train.jsonl` / `val.jsonl` / `test.jsonl`：按 split 拆分。
-- `dataset_stats.json`：分布统计。
-- `field_dictionary.json`：字段字典（路径、类型、覆盖率、非空率）。
-- `tool_coverage_matrix.json`：`capability x tool x adapter_mode` 覆盖矩阵。
-- `training_reader_config.json`：本版本训练读取配置。
-- `manifest.json`：冻结元数据、追溯信息、Requirement2 检查结果。
-
-同时在代码仓维护模板：
+代码仓同步提供配置模板：
 
 - `configs/training/sft_dataset_v1.example.json`
 
-## 5. 统计摘要（本次冻结）
+## 5. Requirement2 并入结果
 
-来自 `manifest.json` / `dataset_stats.json`：
+### 5.1 工具覆盖矩阵
 
-- 输入样本：36
-- 纳入样本：32
-- 阻断样本：4
-- split：
-  - train: 25
-  - val: 5
-  - test: 2
-- capability 分布：
-  - structure_prediction: 32
-- 工具分布：
-  - tool_id: esmfold (32)
-  - adapter_mode: local (32)
+矩阵维度固定为：`capability x tool x adapter_mode`。
 
-## 6. 字段字典说明
+v1.1 新增覆盖：
 
-字段字典产物：
+- `sequence_design -> protein_mpnn -> remote`
+- `quality_qc -> biopython_qc -> local`
+- `objective_scoring -> objective_ranker -> local`
 
-- `output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/field_dictionary.json`
+### 5.2 P0 工具版本/模型标识固化
 
-说明：
-
-- 每个字段按路径记录（例如 `sample.context.task_id`）。
-- 提供字段类型分布、行覆盖率、非空率、示例值（若可提取）。
-- 可直接用于 Week12 训练前 schema 对账。
-
-## 7. Requirement2 并入结果
-
-### 7.1 工具覆盖矩阵
-
-产物：
-
-- `output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/tool_coverage_matrix.json`
-
-当前矩阵结果：
-
-- `structure_prediction -> esmfold -> local`（sample_count=32）
-
-### 7.2 P0 工具版本/模型标识固化
-
-manifest 中 `requirement2.p0_tool_registry` 固化了 P0 工具的：
+manifest `requirement2.p0_tool_registry` 固化字段：
 
 - `tool_id`
 - `capability_id`
@@ -106,96 +113,62 @@ manifest 中 `requirement2.p0_tool_registry` 固化了 P0 工具的：
 - `provider`
 - `model_id`
 
-示例（含 provider/model_id）：
+### 5.3 最小覆盖门槛判定
 
-- `nim_esmfold` -> `provider=nvidia_nim`, `model_id=nvidia/esmfold`
-- `protein_mpnn` -> `provider=nvidia_nim`, `model_id=ipd/proteinmpnn/predict`
-- `protgpt2` -> `provider=plm_rest`, `model_id=nferruz/ProtGPT2`
+P0 核心能力要求：
 
-### 7.3 P0 核心能力最小覆盖要求
-
-冻结脚本内置最小覆盖检查：
-
-- `sequence_core`：`sequence_generation` 或 `sequence_design`
+- `sequence_core`（`sequence_generation` 或 `sequence_design`）
 - `structure_prediction`
 - `quality_qc`
 - `objective_scoring`
 
-本版本结果：
+v1.1 判定结果：`satisfied = true`。
 
-- 满足：`structure_prediction`
-- 缺失：`sequence_core`, `quality_qc`, `objective_scoring`
-- 结论：`p0_core_minimum_coverage.satisfied = false`
+## 6. 发布流水线接入
 
-该结论已写入 manifest，供 Week12 训练策略决定是否仅用于结构子任务或先补齐数据再进入全能力训练。
+Issue #147 的后续补充已纳入发布流程：
 
-## 8. 工具偏差与已知限制（按工具族）
+1. `extract_training_samples.py`
+2. `quality_gate_training_data.py`（base）
+3. `augment_requirement2_coverage.py`
+4. `quality_gate_training_data.py`（addons 合并后）
+5. `freeze_sft_dataset_v1.py --fail-on-missing-p0-core`
 
-### 8.1 结构预测工具族（esmfold）
-
-- 当前 v1 样本几乎完全由 `esmfold/local` 族构成。
-- 偏差风险：模型可能过拟合到单一工具输出风格，跨工具迁移能力有限。
-
-### 8.2 序列生成/设计工具族
-
-- 当前 v1 未覆盖 `protgpt2` / `protein_mpnn` 训练样本。
-- 限制：不适合评估或训练 sequence 相关能力。
-
-### 8.3 质量控制与目标评分工具族
-
-- 当前 v1 未覆盖 `biopython_qc` 与 `objective_ranker` 的训练样本。
-- 限制：不适合用于 QC gate 学习或 objective score 学习。
-
-## 9. 不适用场景
-
-当前 v1 不建议直接用于：
-
-- 全能力 Planner 训练（尤其包含 sequence/qc/objective 的联合训练）；
-- 需要跨工具鲁棒性的评估；
-- 用于 Requirement2 中 P0 核心能力“全覆盖”验收。
-
-当前 v1 适合：
-
-- Week12 结构能力相关流程联调；
-- 训练链路打通与最小可复现验证。
-
-## 10. 最小复现实验命令
-
-按顺序执行：
+推荐一键命令：
 
 ```bash
-uv run python scripts/extract_training_samples.py \
-  --logs-dir data/logs \
-  --snapshots-dir data/snapshots \
-  --reports-dir output/reports \
-  --metrics-dir output/metrics \
-  --tool-kg-path src/kg/protein_tool_kg.json \
-  --tool-extension-kg-path src/kg/protein_tool_kg/extension_draft_v0.1.json \
-  --output-dir output/training/w11-data-1
-
-uv run python scripts/quality_gate_training_data.py \
-  --samples-path output/training/w11-data-1/samples.jsonl \
-  --output-dir output/training/w11-data-2 \
-  --split-strategy time \
-  --plddt-min 0.70 \
-  --score-completeness-min 0.80
-
-uv run python scripts/freeze_sft_dataset_v1.py \
-  --gated-samples-path output/training/w11-data-2/gated_samples.jsonl \
-  --quality-report-path output/training/w11-data-2/quality_gate_report.json \
-  --tool-kg-path src/kg/protein_tool_kg.json \
-  --tool-extension-kg-path src/kg/protein_tool_kg/extension_draft_v0.1.json \
-  --dataset-version w11-sft-dataset-v1-20260315-0ce8eb8
+uv run python scripts/release_sft_dataset_v1_1.py \
+  --dataset-version w11-sft-dataset-v1.1-20260315-57fc60d-r02 \
+  --previous-manifest-path output/dataset_v1/w11-sft-dataset-v1-20260315-0ce8eb8/manifest.json
 ```
 
-## 11. 验收对照（Issue #147）
+说明文档：`scripts/w11-data-3-requirement2-addons-release.md`
 
-- [x] 生成并固化数据集版本号（tag/manifest）。
+## 7. 偏差、限制与后续补充
+
+### 7.1 当前可用性
+
+- v1.1 已满足 Requirement2 的 P0 核心覆盖门槛，可作为 Week12 训练输入版本。
+
+### 7.2 当前限制
+
+- 新增覆盖来自 addon 补齐样本（可复现、可追溯），但规模仍小；
+- 总体工具分布仍偏向结构预测任务；
+- 样本规模对泛化评估仍偏保守。
+
+### 7.3 后续建议
+
+- 增加真实运行任务中的 `sequence/qc/objective` 原生样本比例；
+- 若目标是“真实工具执行覆盖”而非“最小门槛覆盖”，需补充对应工具在生产链路中的实际执行数据。
+
+## 8. 验收对照（Issue #147）
+
+- [x] 生成并固化数据集版本号（manifest + 不可变语义）。
 - [x] 输出字段字典与分布统计。
-- [x] 文档化已知偏差与不适用场景。
-- [x] 产出最小复现实验说明。
+- [x] 文档化偏差与不适用边界。
+- [x] 产出最小复现实验与发布命令。
 - [x] Requirement2：
-  - [x] manifest 增加 `tool_coverage_matrix`
-  - [x] 固化 P0 工具版本/模型标识（provider/model_id）
-  - [x] 文档化工具偏差与已知限制
-  - [x] 明确 v1 最小覆盖要求并给出判定结果
+  - [x] `tool_coverage_matrix`
+  - [x] P0 工具版本/模型标识固化
+  - [x] 工具偏差与限制说明
+  - [x] P0 核心覆盖要求与判定（v1.1 达标）


### PR DESCRIPTION
## 背景
本 PR 对 #178 的文档结论进行增量更新，补齐 Issue #147 后续项：

- 记录 `v1.1/r02` 版本发布结果；
- 从“覆盖不足”更新为“P0 核心覆盖达标”；
- 明确与 v1 的 manifest 差异字段；
- 补充发布流水线与 addon 样本边界说明。

## 文档更新点
更新文件：`docs/algorithm-and-llm/sft-dataset-v1-freeze.md`

新增/调整内容：
1. 版本总览（v1 + v1.1）
2. 版本演进语义与 `delta_from_previous` 结构
3. Requirement2 覆盖矩阵在 v1.1 的新增键
4. 发布流水线：`extract -> quality gate -> addon -> quality gate -> freeze --fail-on-missing-p0-core`
5. 结论更新：
- v1.1 已满足 P0 核心能力最小覆盖
- 仍保留 addon 样本规模与真实性边界说明

## 与实现 PR 的关系
- 对应实现 PR（dev）：#179
- 本 PR负责 design 侧口径同步与可追溯文档化。

## 后续建议（文档中已写明）
1. 扩充真实 sequence/qc/objective 运行样本；
2. 逐步降低 addon 占比；
3. 固化发布流水线为持续门禁。

## 关联
- Issue: #147
- 前置文档 PR: #178
