### PR TITLE
feat(executor): complete issue #156 s2 structure projection flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,28 @@ Fallback policy:
 - Primary source uses the best-ranked S1 sequence tool from ToolKG.
 - Fallback source uses deterministic alternative tools (same capability first, then compatible alternatives when available).
 - Top-K ordering remains deterministic.
+
+## S2 Structure Projection Contract (Issue #156)
+
+S2 output contract (adapter-normalized):
+
+- `stage_id`: `S2`
+- `pdb_path`: projected structure file path
+- `plddt`: normalized confidence score
+- `confidence`: `{plddt_mean, level}`
+- `lineage`: `{stage_id, tool_id, io_type}`
+
+Batch mapping entrypoint:
+
+- `ExecutorAgent.project_structures_from_s1(...)` maps S1 candidates to S2 structures in batch mode.
+- Keeps partial success: failed candidates are retained with failure code while successful candidates continue.
+- Preserves lineage per candidate (`source_step_id`, `source_candidate_id`, upstream lineage).
+
+S2 normalized failure codes:
+
+- `S2_SEQUENCE_INVALID`
+- `S2_OUTPUT_INVALID`
+- `S2_TOOL_UNAVAILABLE`
+- `S2_TOOL_EXECUTION_FAILED`
+- `S2_FALLBACK_EXHAUSTED`
+- `S2_ALL_CANDIDATES_FAILED`

--- a/src/adapters/esmfold_adapter.py
+++ b/src/adapters/esmfold_adapter.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple
 
 from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.adapters.structure_projection import normalize_structure_projection_outputs
 from src.engines.nextflow_adapter import WorkflowEngineAdapter
 from src.models.contracts import PlanStep
 from src.workflow.context import WorkflowContext
@@ -130,12 +131,12 @@ class ESMFoldAdapter(BaseToolAdapter):
         # 验证输入
         sequence = inputs.get("sequence")
         if not sequence:
-            from src.workflow.errors import FailureType, StepRunError
+            from src.workflow.errors import FailureCode, FailureType, StepRunError
 
             raise StepRunError(
                 failure_type=FailureType.NON_RETRYABLE,
                 message="Missing required input 'sequence'",
-                code="ESMFOLD_MISSING_SEQUENCE",
+                code=FailureCode.INPUT_RESOLUTION_FAILED.value,
             )
 
         # 获取上下文信息（如果有）
@@ -156,4 +157,8 @@ class ESMFoldAdapter(BaseToolAdapter):
             tool_name=self.tool_id,
         )
 
-        return outputs, metrics
+        normalized_outputs = normalize_structure_projection_outputs(
+            outputs,
+            tool_id=self.tool_id,
+        )
+        return normalized_outputs, metrics

--- a/src/adapters/nim_adapter.py
+++ b/src/adapters/nim_adapter.py
@@ -8,6 +8,7 @@ from time import perf_counter
 from typing import Any, Dict, Optional, Tuple
 
 from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.adapters.structure_projection import normalize_structure_projection_outputs
 from src.engines.nim_client import NvidiaNIMClient
 from src.models.contracts import PlanStep
 from src.workflow.context import WorkflowContext
@@ -126,6 +127,10 @@ class NIMESMFoldAdapter(BaseToolAdapter):
             "plddt": plddt,
             "metrics": {"plddt_mean": plddt},
         }
+        outputs = normalize_structure_projection_outputs(
+            outputs,
+            tool_id=self.tool_id,
+        )
         duration_ms = int((perf_counter() - t0) * 1000)
         metrics = {
             "exec_type": "nvidia_nim",

--- a/src/adapters/structure_projection.py
+++ b/src/adapters/structure_projection.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from src.workflow.errors import FailureCode, FailureType, StepRunError
+
+__all__ = ["normalize_structure_projection_outputs"]
+
+
+def normalize_structure_projection_outputs(
+    outputs: Dict[str, Any],
+    *,
+    tool_id: str,
+) -> Dict[str, Any]:
+    """Normalize structure projection adapter outputs to S2 contract."""
+    if not isinstance(outputs, dict):
+        raise StepRunError(
+            failure_type=FailureType.NON_RETRYABLE,
+            message="Structure projection outputs must be a dict",
+            code=FailureCode.OUTPUT_NOT_DICT.value,
+        )
+
+    normalized = dict(outputs)
+    pdb_path = normalized.get("pdb_path")
+    if not isinstance(pdb_path, str) or not pdb_path:
+        raise StepRunError(
+            failure_type=FailureType.NON_RETRYABLE,
+            message="Structure projection output missing 'pdb_path'",
+            code=FailureCode.OUTPUT_MISSING.value,
+        )
+
+    metrics = normalized.get("metrics")
+    if not isinstance(metrics, dict):
+        metrics = {}
+
+    plddt_value = _extract_plddt_value(normalized, metrics)
+    if plddt_value is None:
+        raise StepRunError(
+            failure_type=FailureType.NON_RETRYABLE,
+            message="Structure projection output missing confidence 'plddt'",
+            code=FailureCode.OUTPUT_MISSING.value,
+        )
+
+    confidence_level = _derive_confidence_level(plddt_value)
+    metrics.setdefault("plddt_mean", plddt_value)
+    metrics.setdefault("confidence", confidence_level)
+    normalized["metrics"] = metrics
+    normalized["plddt"] = plddt_value
+    normalized["confidence"] = {
+        "plddt_mean": plddt_value,
+        "level": confidence_level,
+    }
+    normalized["stage_id"] = "S2"
+    normalized["lineage"] = {
+        "stage_id": "S2",
+        "tool_id": tool_id,
+        "io_type": "sequence_to_structure",
+    }
+    return normalized
+
+
+def _extract_plddt_value(outputs: Dict[str, Any], metrics: Dict[str, Any]) -> float | None:
+    for key in ("plddt", "pLDDT", "plddt_mean", "mean_plddt", "mean_pLDDT"):
+        value = outputs.get(key)
+        parsed = _to_float(value)
+        if parsed is not None:
+            return parsed
+
+    for key in ("plddt", "pLDDT", "plddt_mean", "mean_plddt", "mean_pLDDT"):
+        value = metrics.get(key)
+        parsed = _to_float(value)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, list):
+        parsed = [float(item) for item in value if isinstance(item, (int, float))]
+        if parsed:
+            return sum(parsed) / len(parsed)
+    return None
+
+
+def _derive_confidence_level(plddt: float) -> str:
+    if plddt <= 1.0:
+        if plddt >= 0.85:
+            return "high"
+        if plddt >= 0.65:
+            return "medium"
+        return "low"
+    if plddt >= 85:
+        return "high"
+    if plddt >= 65:
+        return "medium"
+    return "low"

--- a/src/agents/executor.py
+++ b/src/agents/executor.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from src.models.contracts import DesignResult, Plan, StepResult
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Sequence
+
+from src.kg.kg_client import ToolKGError, load_tool_kg
+from src.models.contracts import DesignResult, Plan, PlanStep, StepResult
 from src.models.db import (
     InternalStatus,
     TaskRecord,
@@ -9,6 +13,7 @@ from src.models.db import (
 )
 from src.agents.summarizer import SummarizerAgent
 from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureCode, FailureType
 from src.workflow.step_runner import StepRunner
 from src.workflow.plan_runner import PlanRunner
 from src.workflow.status import transition_task_status
@@ -100,6 +105,163 @@ class ExecutorAgent:
             resume_from_existing=resume_from_existing,
         )
 
+    def project_structures_from_s1(
+        self,
+        context: WorkflowContext,
+        *,
+        source_step_id: str = "S1",
+        structure_step_id: str = "S2",
+        max_candidates: int = 3,
+    ) -> StepResult:
+        """Batch map S1 sequence candidates into S2 structure results.
+
+        Returns an aggregated S2 StepResult that preserves partial success.
+        """
+        source_result = context.get_step_result(source_step_id)
+        if source_result is None:
+            raise ValueError(f"Missing source step result '{source_step_id}'")
+
+        candidates = _extract_sequence_candidates(source_result, max_candidates=max_candidates)
+        template_step = _resolve_structure_step_template(
+            plan=context.plan,
+            structure_step_id=structure_step_id,
+        )
+        if template_step is None:
+            raise ValueError(
+                f"Missing structure projection step '{structure_step_id}' in current plan"
+            )
+
+        tool_chain = _resolve_structure_tool_chain(template_step.tool)
+        structure_rows: List[Dict[str, Any]] = []
+        fallback_hits = 0
+        for index, candidate in enumerate(candidates):
+            sequence = candidate["sequence"]
+            candidate_row = {
+                "candidate_index": index,
+                "candidate_id": candidate["candidate_id"],
+                "sequence": sequence,
+                "source_score": candidate.get("score"),
+                "source_metadata": candidate.get("metadata", {}),
+                "stage_id": "S2",
+                "status": "failed",
+                "lineage": {
+                    "stage_id": "S2",
+                    "source_step_id": source_step_id,
+                    "source_candidate_id": candidate["candidate_id"],
+                    "source_candidate_index": index,
+                    "upstream_lineage": candidate.get("upstream_lineage", {}),
+                },
+                "attempts": [],
+            }
+            if not _is_valid_sequence_for_projection(sequence):
+                candidate_row["failure_code"] = "S2_SEQUENCE_INVALID"
+                candidate_row["failure_reason"] = "sequence must be uppercase alphabetic characters"
+                structure_rows.append(candidate_row)
+                continue
+
+            attempt_results: List[StepResult] = []
+            for tool_id in tool_chain:
+                step = _build_structure_projection_step(
+                    template=template_step,
+                    step_id=f"{structure_step_id}_{index + 1}_{tool_id}",
+                    tool_id=tool_id,
+                    sequence=sequence,
+                    source_candidate_id=candidate["candidate_id"],
+                )
+                result = self.step_runner.run_step(step, context)
+                context.add_step_result(result)
+                attempt_results.append(result)
+                candidate_row["attempts"].append(_build_structure_attempt_row(result))
+                if result.status == "success":
+                    break
+
+            final_result = _pick_final_projection_result(attempt_results)
+            if final_result is None:
+                candidate_row["failure_code"] = "S2_TOOL_EXECUTION_FAILED"
+                candidate_row["failure_reason"] = "structure projection produced no result"
+                structure_rows.append(candidate_row)
+                continue
+
+            normalized_code = _normalize_s2_failure_code(final_result)
+            if final_result.status == "success":
+                outputs = final_result.outputs
+                candidate_row["status"] = "success"
+                candidate_row["tool_id"] = final_result.tool
+                candidate_row["pdb_path"] = outputs.get("pdb_path")
+                candidate_row["plddt"] = outputs.get("plddt")
+                candidate_row["confidence"] = outputs.get("confidence") or outputs.get("metrics", {}).get("confidence")
+                candidate_row["failure_code"] = None
+                candidate_row["failure_reason"] = None
+                if len(attempt_results) > 1:
+                    fallback_hits += 1
+                    candidate_row["fallback_used"] = True
+                    candidate_row["lineage"]["fallback_from"] = attempt_results[0].tool
+            else:
+                candidate_row["status"] = "failed"
+                candidate_row["tool_id"] = final_result.tool
+                candidate_row["failure_code"] = normalized_code
+                candidate_row["failure_reason"] = final_result.error_message
+                if len(attempt_results) > 1:
+                    candidate_row["failure_code"] = "S2_FALLBACK_EXHAUSTED"
+            structure_rows.append(candidate_row)
+
+        successful_rows = [row for row in structure_rows if row.get("status") == "success"]
+        best_row = _select_best_structure_result(successful_rows)
+        aggregate_status = "success" if successful_rows else "failed"
+        now_iso = datetime.now(timezone.utc).isoformat()
+        aggregate_outputs: Dict[str, Any] = {
+            "stage_id": "S2",
+            "source_step_id": source_step_id,
+            "structure_results": structure_rows,
+            "success_count": len(successful_rows),
+            "failure_count": len(structure_rows) - len(successful_rows),
+        }
+        if best_row is not None:
+            aggregate_outputs["pdb_path"] = best_row.get("pdb_path")
+            aggregate_outputs["plddt"] = best_row.get("plddt")
+            aggregate_outputs["confidence"] = best_row.get("confidence")
+            aggregate_outputs["best_candidate_id"] = best_row.get("candidate_id")
+
+        aggregate_error_details: Dict[str, Any] = {}
+        aggregate_error_message = None
+        aggregate_failure_type = None
+        if aggregate_status == "failed":
+            aggregate_failure_type = FailureType.TOOL_ERROR.value
+            aggregate_error_message = "All S2 structure projections failed"
+            aggregate_error_details = {
+                "failure_code": "S2_ALL_CANDIDATES_FAILED",
+                "phase": "structure_projection",
+                "timestamp": now_iso,
+            }
+
+        aggregate_result = StepResult(
+            task_id=context.task.task_id,
+            step_id=structure_step_id,
+            tool=template_step.tool,
+            status=aggregate_status,
+            failure_type=aggregate_failure_type,
+            error_message=aggregate_error_message,
+            error_details=aggregate_error_details,
+            inputs={
+                "source_step_id": source_step_id,
+                "candidate_count": len(candidates),
+            },
+            outputs=aggregate_outputs,
+            artifacts=_collect_projection_artifacts(successful_rows),
+            metrics={
+                "exec_type": "structure_projection_batch",
+                "mapped_candidates": len(structure_rows),
+                "successful_candidates": len(successful_rows),
+                "fallback_hits": fallback_hits,
+                "partial_success": bool(successful_rows) and len(successful_rows) < len(structure_rows),
+            },
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso,
+        )
+        context.add_step_result(aggregate_result)
+        return aggregate_result
+
     def summarize_and_finalize(
         self,
         context: WorkflowContext,
@@ -158,3 +320,243 @@ class ExecutorAgent:
             InternalStatus.FAILED,
             reason=reason,
         )
+
+
+def _resolve_structure_step_template(
+    *,
+    plan: Plan | None,
+    structure_step_id: str,
+) -> PlanStep | None:
+    if plan is None:
+        return None
+    for step in plan.steps:
+        if step.id == structure_step_id:
+            return step
+    return None
+
+
+def _extract_sequence_candidates(
+    source_result: StepResult,
+    *,
+    max_candidates: int,
+) -> List[Dict[str, Any]]:
+    outputs = source_result.outputs if isinstance(source_result.outputs, dict) else {}
+    candidates_raw = outputs.get("candidates")
+    upstream_lineage = (
+        source_result.outputs.get("lineage", {})
+        if isinstance(source_result.outputs, dict)
+        else {}
+    )
+
+    resolved: List[Dict[str, Any]] = []
+    seen_sequences: set[str] = set()
+    primary_sequence = outputs.get("sequence")
+    if isinstance(primary_sequence, str) and primary_sequence and primary_sequence not in seen_sequences:
+        resolved.append(
+            {
+                "candidate_id": f"{source_result.step_id}_candidate_primary",
+                "sequence": primary_sequence,
+                "score": None,
+                "metadata": {"source": "primary"},
+                "upstream_lineage": upstream_lineage,
+            }
+        )
+        seen_sequences.add(primary_sequence)
+
+    if isinstance(candidates_raw, list):
+        for idx, item in enumerate(candidates_raw):
+            sequence = None
+            score = None
+            metadata: Dict[str, Any] = {"source": "fallback"}
+            if isinstance(item, dict):
+                raw_seq = item.get("sequence")
+                if isinstance(raw_seq, str):
+                    sequence = raw_seq
+                score = item.get("score")
+                metadata.update({k: v for k, v in item.items() if k != "sequence"})
+            elif isinstance(item, str):
+                sequence = item
+            if not isinstance(sequence, str) or not sequence or sequence in seen_sequences:
+                continue
+            resolved.append(
+                {
+                    "candidate_id": f"{source_result.step_id}_candidate_{idx}",
+                    "sequence": sequence,
+                    "score": score,
+                    "metadata": metadata,
+                    "upstream_lineage": upstream_lineage,
+                }
+            )
+            seen_sequences.add(sequence)
+            if len(resolved) >= max(1, max_candidates):
+                break
+
+    if not resolved:
+        raise ValueError(
+            f"No sequence candidates found in '{source_result.step_id}' outputs"
+        )
+    return resolved[: max(1, max_candidates)]
+
+
+def _resolve_structure_tool_chain(primary_tool_id: str) -> List[str]:
+    candidates = [primary_tool_id]
+    fallback = _find_structure_fallback_tool(primary_tool_id)
+    if fallback and fallback not in candidates:
+        candidates.append(fallback)
+    return candidates
+
+
+def _find_structure_fallback_tool(primary_tool_id: str) -> str | None:
+    try:
+        kg = load_tool_kg()
+    except ToolKGError:
+        if primary_tool_id == "nim_esmfold":
+            return "esmfold"
+        if primary_tool_id == "esmfold":
+            return "nim_esmfold"
+        return None
+
+    tools = kg.get("tools", [])
+    if not isinstance(tools, list):
+        return None
+
+    primary_entry = None
+    for tool in tools:
+        if isinstance(tool, dict) and tool.get("id") == primary_tool_id:
+            primary_entry = tool
+            break
+    if not isinstance(primary_entry, dict):
+        return None
+
+    capabilities = primary_entry.get("capabilities", [])
+    if not isinstance(capabilities, list):
+        capabilities = []
+    primary_caps = set(capabilities)
+    if not primary_caps:
+        return None
+
+    fallback_candidates: List[tuple[int, str]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        tool_id = tool.get("id")
+        if not isinstance(tool_id, str) or tool_id == primary_tool_id:
+            continue
+        caps = tool.get("capabilities", [])
+        if not isinstance(caps, list) or not primary_caps.intersection(caps):
+            continue
+        execution = tool.get("execution")
+        is_remote = isinstance(execution, dict) and execution.get("backend") == "remote_model_service"
+        fallback_candidates.append((1 if is_remote else 0, tool_id))
+
+    if not fallback_candidates:
+        return None
+    fallback_candidates.sort(key=lambda row: (row[0], row[1]))
+    return fallback_candidates[0][1]
+
+
+def _build_structure_projection_step(
+    *,
+    template: PlanStep,
+    step_id: str,
+    tool_id: str,
+    sequence: str,
+    source_candidate_id: str,
+) -> PlanStep:
+    metadata = dict(template.metadata or {})
+    metadata.update(
+        {
+            "stage_id": "S2",
+            "stage_name": "structure_projection",
+            "lineage": {
+                "stage_id": "S2",
+                "source_candidate_id": source_candidate_id,
+            },
+        }
+    )
+    return PlanStep(
+        id=step_id,
+        tool=tool_id,
+        inputs={"sequence": sequence},
+        metadata=metadata,
+    )
+
+
+def _is_valid_sequence_for_projection(sequence: str) -> bool:
+    if not isinstance(sequence, str) or not sequence:
+        return False
+    return all(char.isalpha() and char.isupper() for char in sequence)
+
+
+def _build_structure_attempt_row(result: StepResult) -> Dict[str, Any]:
+    error_code = None
+    if isinstance(result.error_details, dict):
+        error_code = result.error_details.get("failure_code")
+    return {
+        "step_id": result.step_id,
+        "tool_id": result.tool,
+        "status": result.status,
+        "failure_code": error_code,
+        "error_message": result.error_message,
+    }
+
+
+def _pick_final_projection_result(results: Sequence[StepResult]) -> StepResult | None:
+    if not results:
+        return None
+    for result in results:
+        if result.status == "success":
+            return result
+    return results[-1]
+
+
+def _normalize_s2_failure_code(result: StepResult) -> str:
+    failure_code = None
+    if isinstance(result.error_details, dict):
+        failure_code = result.error_details.get("failure_code")
+
+    if failure_code in {
+        FailureCode.INPUT_RESOLUTION_FAILED.value,
+        FailureCode.NIM_INVALID_INPUT.value,
+    }:
+        return "S2_SEQUENCE_INVALID"
+    if failure_code in {
+        FailureCode.OUTPUT_MISSING.value,
+        FailureCode.OUTPUT_TYPE_MISMATCH.value,
+        FailureCode.NIM_INVALID_RESPONSE.value,
+    }:
+        return "S2_OUTPUT_INVALID"
+    if failure_code in {
+        FailureCode.NIM_TIMEOUT.value,
+        FailureCode.NIM_NETWORK_ERROR.value,
+        FailureCode.NIM_AUTH_FAILED.value,
+        FailureCode.REMOTE_POLL_TIMEOUT.value,
+        FailureCode.REMOTE_JOB_FAILED.value,
+        FailureCode.ADAPTER_NOT_FOUND.value,
+    }:
+        return "S2_TOOL_UNAVAILABLE"
+    return "S2_TOOL_EXECUTION_FAILED"
+
+
+def _select_best_structure_result(rows: Sequence[Dict[str, Any]]) -> Dict[str, Any] | None:
+    if not rows:
+        return None
+    ranked = sorted(
+        rows,
+        key=lambda row: (
+            -(float(row.get("plddt")) if isinstance(row.get("plddt"), (int, float)) else -1.0),
+            str(row.get("candidate_id", "")),
+        ),
+    )
+    return ranked[0]
+
+
+def _collect_projection_artifacts(rows: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    pdb_paths = [
+        row.get("pdb_path")
+        for row in rows
+        if isinstance(row.get("pdb_path"), str) and row.get("pdb_path")
+    ]
+    if not pdb_paths:
+        return {}
+    return {"pdb_paths": pdb_paths}

--- a/tests/integration/test_structure_projection_s2.py
+++ b/tests/integration/test_structure_projection_s2.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from src.agents.executor import ExecutorAgent
+from src.models.contracts import Plan, PlanStep, ProteinDesignTask, StepResult, now_iso
+from src.models.db import InternalStatus
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType
+
+
+def _build_context_with_s1_candidates() -> WorkflowContext:
+    task = ProteinDesignTask(
+        task_id="task_s2_batch",
+        goal="de_novo_design",
+        constraints={"length_range": [20, 30]},
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="protgpt2",
+                inputs={"goal": "de_novo_design"},
+                metadata={
+                    "stage_id": "S1",
+                    "lineage": {
+                        "stage_id": "S1",
+                        "primary_tool_id": "protgpt2",
+                        "fallback_tool_ids": ["seqgen_local"],
+                    },
+                },
+            ),
+            PlanStep(
+                id="S2",
+                tool="nim_esmfold",
+                inputs={"sequence": "S1.sequence"},
+                metadata={"stage_id": "S2"},
+            ),
+        ],
+        constraints=task.constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.PLANNED,
+    )
+    context.step_results["S1"] = StepResult(
+        task_id=task.task_id,
+        step_id="S1",
+        tool="protgpt2",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        inputs={},
+        outputs={
+            "sequence": "ACDEFGHIKLMNPQRSTVWY",
+            "candidates": [
+                {"sequence": "MKTAYIAKQRQISFVKSHFS", "score": 0.82},
+                {"sequence": "INVALID*", "score": 0.10},
+            ],
+            "lineage": plan.steps[0].metadata.get("lineage"),
+        },
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    return context
+
+
+def test_project_structures_from_s1_keeps_partial_success_and_lineage(monkeypatch):
+    context = _build_context_with_s1_candidates()
+    executor = ExecutorAgent()
+
+    def _fake_run_step(step: PlanStep, _context: WorkflowContext) -> StepResult:
+        seq = step.inputs["sequence"]
+        if step.tool == "nim_esmfold" and seq == "ACDEFGHIKLMNPQRSTVWY":
+            return StepResult(
+                task_id=_context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.TOOL_ERROR.value,
+                error_message="nim timeout",
+                error_details={"failure_code": "NIM_TIMEOUT"},
+                inputs=step.inputs,
+                outputs={},
+                metrics={},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        if step.tool == "esmfold" and seq == "ACDEFGHIKLMNPQRSTVWY":
+            return StepResult(
+                task_id=_context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="success",
+                failure_type=None,
+                error_message=None,
+                error_details={},
+                inputs=step.inputs,
+                outputs={
+                    "pdb_path": "/tmp/primary_fb.pdb",
+                    "plddt": 0.88,
+                    "confidence": {"plddt_mean": 0.88, "level": "high"},
+                    "stage_id": "S2",
+                },
+                metrics={"provider": "nextflow"},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        return StepResult(
+            task_id=_context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            inputs=step.inputs,
+            outputs={
+                "pdb_path": "/tmp/candidate_ok.pdb",
+                "plddt": 0.91,
+                "confidence": {"plddt_mean": 0.91, "level": "high"},
+                "stage_id": "S2",
+            },
+            metrics={"provider": "nvidia_nim"},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+    monkeypatch.setattr(executor.step_runner, "run_step", _fake_run_step)
+
+    result = executor.project_structures_from_s1(
+        context,
+        source_step_id="S1",
+        structure_step_id="S2",
+        max_candidates=3,
+    )
+
+    assert result.status == "success"
+    assert result.outputs["stage_id"] == "S2"
+    assert result.outputs["success_count"] == 2
+    assert result.outputs["failure_count"] == 1
+    assert result.outputs["best_candidate_id"] is not None
+    rows = result.outputs["structure_results"]
+    assert len(rows) == 3
+    assert any(row.get("fallback_used") for row in rows if row.get("status") == "success")
+    assert any(row.get("failure_code") == "S2_SEQUENCE_INVALID" for row in rows)
+    for row in rows:
+        assert row["lineage"]["stage_id"] == "S2"
+        assert row["lineage"]["source_step_id"] == "S1"
+
+
+def test_project_structures_from_s1_returns_failed_when_all_candidates_fail(monkeypatch):
+    context = _build_context_with_s1_candidates()
+    executor = ExecutorAgent()
+
+    def _always_fail(step: PlanStep, _context: WorkflowContext) -> StepResult:
+        return StepResult(
+            task_id=_context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="failed",
+            failure_type=FailureType.TOOL_ERROR.value,
+            error_message="projection failed",
+            error_details={"failure_code": "NIM_INVALID_RESPONSE"},
+            inputs=step.inputs,
+            outputs={},
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+    monkeypatch.setattr(executor.step_runner, "run_step", _always_fail)
+
+    result = executor.project_structures_from_s1(
+        context,
+        source_step_id="S1",
+        structure_step_id="S2",
+        max_candidates=2,
+    )
+
+    assert result.status == "failed"
+    assert result.error_details["failure_code"] == "S2_ALL_CANDIDATES_FAILED"
+    assert result.outputs["success_count"] == 0

--- a/tests/unit/test_esmfold_adapter.py
+++ b/tests/unit/test_esmfold_adapter.py
@@ -158,6 +158,9 @@ def test_run_local_success(mock_execute: MagicMock, adapter: ESMFoldAdapter) -> 
     # 验证返回值
     assert "pdb_path" in outputs
     assert "metrics" in outputs
+    assert outputs["stage_id"] == "S2"
+    assert outputs["plddt"] == 0.85
+    assert outputs["confidence"]["level"] in {"high", "medium", "low"}
     assert metrics["exec_type"] == "nextflow"
 
 
@@ -180,14 +183,15 @@ def test_run_local_missing_sequence_raises_error(adapter: ESMFoldAdapter) -> Non
 def test_run_local_with_default_context(mock_execute: MagicMock, adapter: ESMFoldAdapter) -> None:
     """测试没有提供 task_id/step_id 时使用默认值"""
     mock_execute.return_value = (
-        {"pdb_path": "/path/to/output.pdb"},
+        {"pdb_path": "/path/to/output.pdb", "metrics": {"plddt_mean": 0.81}},
         {"exec_type": "nextflow", "duration_ms": 1000},
     )
 
     inputs = {"sequence": "ACDEFGHIKLMNPQRSTVWY"}
 
-    adapter.run_local(inputs)
+    outputs, _metrics = adapter.run_local(inputs)
 
     call_kwargs = mock_execute.call_args[1]
     assert call_kwargs["task_id"] == "unknown"
     assert call_kwargs["step_id"] == "unknown"
+    assert outputs["plddt"] == 0.81

--- a/tests/unit/test_nim_adapter.py
+++ b/tests/unit/test_nim_adapter.py
@@ -104,6 +104,8 @@ def test_run_local_success(tmp_path: Path) -> None:
 
     assert Path(outputs["pdb_path"]).exists()
     assert outputs["plddt"] == 85.0
+    assert outputs["stage_id"] == "S2"
+    assert outputs["confidence"]["level"] in {"high", "medium", "low"}
     assert metrics["provider"] == "nvidia_nim"
 
 

--- a/tests/unit/test_structure_projection_adapter.py
+++ b/tests/unit/test_structure_projection_adapter.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from src.adapters.structure_projection import normalize_structure_projection_outputs
+from src.workflow.errors import StepRunError
+
+
+def test_normalize_structure_projection_outputs_with_metrics_only() -> None:
+    outputs = normalize_structure_projection_outputs(
+        {
+            "pdb_path": "/tmp/a.pdb",
+            "metrics": {"plddt_mean": 0.87},
+        },
+        tool_id="esmfold",
+    )
+    assert outputs["stage_id"] == "S2"
+    assert outputs["plddt"] == 0.87
+    assert outputs["confidence"]["level"] == "high"
+    assert outputs["lineage"]["tool_id"] == "esmfold"
+
+
+def test_normalize_structure_projection_outputs_requires_pdb_and_plddt() -> None:
+    with pytest.raises(StepRunError):
+        normalize_structure_projection_outputs(
+            {"metrics": {"plddt_mean": 0.2}},
+            tool_id="esmfold",
+        )
+
+    with pytest.raises(StepRunError):
+        normalize_structure_projection_outputs(
+            {"pdb_path": "/tmp/a.pdb"},
+            tool_id="esmfold",
+        )


### PR DESCRIPTION
## 关联
- Closes #156
- Hard dependency satisfied: #155, #141
- Soft sync: #157, #158, #170

## 背景
本 PR 在 `w10-req1-s2/structure-projection` 分支完成 Requirement-1 的 S2（Structure Projection）最小闭环：
- 将 S1 多候选序列稳定映射为结构结果；
- 建立主路径 + fallback 路径（NIM ESMFold -> local ESMFold）；
- 统一 S2 输出字段与失败码；
- 保留每条结构结果与上游候选的 lineage；
- 保持部分成功可继续（不因单候选失败而整体中断）。

## 本次实现

### 1) Executor: S1 -> S2 批量结构映射入口
文件：`src/agents/executor.py`

新增 `ExecutorAgent.project_structures_from_s1(...)`：
- 从 `S1` StepResult 读取 `sequence + candidates`；
- 批量执行结构映射，按候选逐条处理；
- 每条候选输出统一结构：`pdb_path/plddt/confidence/stage_id/lineage`；
- 保留 `source_step_id/source_candidate_id/upstream_lineage`；
- 主工具失败时自动尝试 fallback 工具；
- 允许 partial success：成功候选继续保留，失败候选写入标准失败码；
- 汇总为聚合 `S2` StepResult，可被 S3 直接消费（含 `structure_results` 列表与 best candidate）。

### 2) Adapters: 主/备结构工具输出格式统一
文件：
- `src/adapters/structure_projection.py`（新增）
- `src/adapters/esmfold_adapter.py`
- `src/adapters/nim_adapter.py`

新增标准化函数 `normalize_structure_projection_outputs(...)`：
- 统一输出字段：
  - `stage_id=S2`
  - `pdb_path`
  - `plddt`
  - `confidence={plddt_mean, level}`
  - `lineage={stage_id, tool_id, io_type}`
- 统一缺失字段报错（`OUTPUT_MISSING`/`OUTPUT_NOT_DICT`）。

`esmfold` 与 `nim_esmfold` 现在都返回同一 S2 口径结构。

### 3) S2 失败码统一（聚合层）
文件：`src/agents/executor.py`

在 S2 聚合输出中，统一映射失败码：
- `S2_SEQUENCE_INVALID`
- `S2_OUTPUT_INVALID`
- `S2_TOOL_UNAVAILABLE`
- `S2_TOOL_EXECUTION_FAILED`
- `S2_FALLBACK_EXHAUSTED`
- `S2_ALL_CANDIDATES_FAILED`

## 测试

新增/更新测试：
- `tests/integration/test_structure_projection_s2.py`
  - 多候选结构映射
  - fallback 链路
  - partial success 保留
  - lineage 完整性
- `tests/unit/test_structure_projection_adapter.py`
  - S2 适配器输出标准化与缺失字段报错
- 更新：
  - `tests/unit/test_esmfold_adapter.py`
  - `tests/unit/test_nim_adapter.py`

本地验证通过：
- `uv run pytest tests/unit/test_esmfold_adapter.py tests/unit/test_nim_adapter.py tests/unit/test_structure_projection_adapter.py tests/integration/test_structure_projection_s2.py`
- `uv run pytest tests/unit/test_executor_agent.py`

## 验收映射（Issue #156）
- [x] 增加 `stage_id=S2` 输出约束与序列->结构映射校验
- [x] 统一主/备结构工具返回格式与错误码
- [x] 增加失败回退与部分成功处理策略（保留可用候选）
- [x] 增补集成测试：多候选结构映射、回退链路、lineage 完整性
- [x] S2 可批量输出结构结果与置信度
- [x] 工具异常可回退并输出统一失败码
- [x] 结构结果可被 S3 质量门禁直接消费（`structure_results`）

## Requirement-2 对齐
- S2 lineage 中保留 `tool_id/io_type`，并在候选级保留工具执行轨迹。
- 主备工具路径（NIM/local）统一到同一输出 schema，便于后续训练抽取与审计复用。

## 未来仍需补充（不在本 PR 范围）
1. 与 #157 联调：将 `S2_*` 失败码与 S3 质量门禁拒绝码做统一映射和统计口径。
2. 与 #158 联调：把 S2 `best_candidate` 与迭代精修回环（S4）建立轮次级 lineage。
3. 扩展真实工具集成测试：覆盖真实 NIM/Nextflow 混合环境下的端到端批量映射基准。
4. 文档沉淀：将 README 中 S2 字段字典迁移到 design 仓库长期规范文档。
