### PR TITLE
feat(workflow): complete issue #157 s3 runtime quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,35 @@ S2 normalized failure codes:
 - `S2_TOOL_EXECUTION_FAILED`
 - `S2_FALLBACK_EXHAUSTED`
 - `S2_ALL_CANDIDATES_FAILED`
+
+## S3 Quality Gate Contract (Issue #157)
+
+S3 runtime hard gate now supports batch evaluation from S2 outputs:
+
+- Entry: `ExecutorAgent.quality_gate_from_s2(...)`
+- Input: `S2.structure_results` (or single S2 structure output)
+- Output:
+  - `stage_id`: `S3`
+  - `qc_results`: per-candidate `pass_fail + reject_codes + reject_reasons + qc_metrics`
+  - `failed_samples` / `passed_samples`
+  - `pass_count` / `fail_count` / `pass_fail`
+  - `reject_code_counts`
+  - Requirement2-aligned metadata: `capability_id=quality_qc`, `io_type=sequence_structure_to_qc_metrics`
+
+S3 reject code enum:
+
+- `S3_SOURCE_STRUCTURE_FAILED`
+- `S3_SEQUENCE_MISSING`
+- `S3_SEQUENCE_LENGTH_OUT_OF_RANGE`
+- `S3_SEQUENCE_INVALID_CHAR`
+- `S3_STRUCTURE_MISSING`
+- `S3_PLDDT_MISSING`
+- `S3_PLDDT_BELOW_THRESHOLD`
+- `S3_LOW_COMPLEXITY_COMPOSITION`
+- `S3_LOW_COMPLEXITY_REPEAT`
+- Stage fail code: `S3_ALL_CANDIDATES_REJECTED`
+
+Traceability:
+
+- S3 execution emits `STEP_FINISHED/STEP_FAILED` with `data.quality_gate` summary.
+- `PlanRunner` step events now include `data.failure_code` and S3 quality summary fields for downstream extraction reuse.

--- a/src/agents/executor.py
+++ b/src/agents/executor.py
@@ -10,10 +10,16 @@ from src.models.db import (
     TaskRecord,
     TERMINAL_INTERNAL_STATUSES,
     derive_task_status,
+    to_external_status,
 )
 from src.agents.summarizer import SummarizerAgent
+from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureCode, FailureType
+from src.workflow.quality_gate import (
+    QUALITY_GATE_ALL_REJECTED_CODE,
+    evaluate_quality_gate_batch,
+)
 from src.workflow.step_runner import StepRunner
 from src.workflow.plan_runner import PlanRunner
 from src.workflow.status import transition_task_status
@@ -262,6 +268,151 @@ class ExecutorAgent:
         context.add_step_result(aggregate_result)
         return aggregate_result
 
+    def quality_gate_from_s2(
+        self,
+        context: WorkflowContext,
+        *,
+        source_step_id: str = "S2",
+        quality_step_id: str = "S3",
+        max_candidates: int = 3,
+    ) -> StepResult:
+        """Run S3 quality gate against S2 batch outputs."""
+        source_result = context.get_step_result(source_step_id)
+        if source_result is None:
+            raise ValueError(f"Missing source step result '{source_step_id}'")
+
+        candidates = _extract_s2_candidates_for_quality_gate(
+            source_result,
+            max_candidates=max_candidates,
+        )
+        qc_batch = evaluate_quality_gate_batch(
+            candidates,
+            constraints=context.task.constraints,
+        )
+        template_step = _resolve_quality_gate_step_template(
+            plan=context.plan,
+            quality_step_id=quality_step_id,
+        )
+        tool_id = template_step.tool if template_step is not None else "biopython_qc"
+
+        passed_rows = qc_batch["passed_samples"]
+        failed_rows = qc_batch["failed_samples"]
+        pass_count = int(qc_batch["pass_count"])
+        fail_count = int(qc_batch["fail_count"])
+        pass_fail = bool(qc_batch["pass_fail"])
+        now_iso = datetime.now(timezone.utc).isoformat()
+        aggregate_status = "success" if pass_fail else "failed"
+        best_row = _select_best_quality_candidate(passed_rows)
+        tool_lineage = sorted(
+            {
+                str(row["tool_id"])
+                for row in qc_batch["qc_results"]
+                if isinstance(row, dict) and row.get("tool_id")
+            }
+        )
+
+        aggregate_outputs: Dict[str, Any] = {
+            "stage_id": "S3",
+            "stage_name": "quality_gate",
+            "source_step_id": source_step_id,
+            "qc_results": qc_batch["qc_results"],
+            "passed_samples": passed_rows,
+            "failed_samples": failed_rows,
+            "pass_count": pass_count,
+            "fail_count": fail_count,
+            "pass_fail": pass_fail,
+            "reject_code_counts": qc_batch["reject_code_counts"],
+            "qc_metrics": qc_batch["qc_metrics"],
+            "capability_id": "quality_qc",
+            "io_type": "sequence_structure_to_qc_metrics",
+            "quality_gate": {
+                "status": "PASS" if pass_fail else "BLOCK",
+                "reject_codes": sorted(qc_batch["reject_code_counts"].keys()),
+                "capability_ids": ["quality_qc"],
+                "tool_lineage": tool_lineage,
+                "qc_pass": pass_fail,
+            },
+        }
+        if best_row is not None:
+            aggregate_outputs["best_candidate_id"] = best_row.get("candidate_id")
+            aggregate_outputs["sequence"] = best_row.get("sequence")
+            aggregate_outputs["pdb_path"] = best_row.get("pdb_path")
+            aggregate_outputs["plddt"] = best_row.get("plddt")
+
+        aggregate_error_message = None
+        aggregate_error_details: Dict[str, Any] = {}
+        aggregate_failure_type = None
+        if aggregate_status == "failed":
+            aggregate_failure_type = FailureType.NON_RETRYABLE.value
+            aggregate_error_message = "All candidates rejected by S3 quality gate"
+            aggregate_error_details = {
+                "failure_code": QUALITY_GATE_ALL_REJECTED_CODE,
+                "phase": "quality_gate",
+                "timestamp": now_iso,
+                "context": {
+                    "reject_code_counts": qc_batch["reject_code_counts"],
+                    "failed_candidate_ids": [
+                        row.get("candidate_id")
+                        for row in failed_rows
+                        if isinstance(row, dict)
+                    ],
+                },
+            }
+
+        aggregate_result = StepResult(
+            task_id=context.task.task_id,
+            step_id=quality_step_id,
+            tool=tool_id,
+            status=aggregate_status,
+            failure_type=aggregate_failure_type,
+            error_message=aggregate_error_message,
+            error_details=aggregate_error_details,
+            inputs={
+                "source_step_id": source_step_id,
+                "candidate_count": len(candidates),
+            },
+            outputs=aggregate_outputs,
+            artifacts={},
+            metrics={
+                "exec_type": "quality_gate_batch",
+                "evaluated_candidates": len(candidates),
+                "pass_count": pass_count,
+                "fail_count": fail_count,
+                "partial_success": pass_count > 0 and fail_count > 0,
+                "reject_code_counts": qc_batch["reject_code_counts"],
+                "requirement2": {
+                    "capability_id": "quality_qc",
+                    "io_type": "sequence_structure_to_qc_metrics",
+                    "qc_pass": pass_fail,
+                },
+            },
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso,
+        )
+        context.add_step_result(aggregate_result)
+        append_event(
+            context.task.task_id,
+            {
+                "event": (
+                    "STEP_FINISHED"
+                    if aggregate_result.status != "failed"
+                    else "STEP_FAILED"
+                ),
+                "task_id": context.task.task_id,
+                "step_id": quality_step_id,
+                "tool": tool_id,
+                "status": aggregate_result.status,
+                "failure_type": aggregate_result.failure_type,
+                "error_message": aggregate_result.error_message,
+                "timestamp": aggregate_result.timestamp,
+                "state": context.status.value,
+                "external_status": to_external_status(context.status).value,
+                "data": _build_quality_gate_trace_data(aggregate_result),
+            },
+        )
+        return aggregate_result
+
     def summarize_and_finalize(
         self,
         context: WorkflowContext,
@@ -335,6 +486,19 @@ def _resolve_structure_step_template(
     return None
 
 
+def _resolve_quality_gate_step_template(
+    *,
+    plan: Plan | None,
+    quality_step_id: str,
+) -> PlanStep | None:
+    if plan is None:
+        return None
+    for step in plan.steps:
+        if step.id == quality_step_id:
+            return step
+    return None
+
+
 def _extract_sequence_candidates(
     source_result: StepResult,
     *,
@@ -394,6 +558,54 @@ def _extract_sequence_candidates(
     if not resolved:
         raise ValueError(
             f"No sequence candidates found in '{source_result.step_id}' outputs"
+        )
+    return resolved[: max(1, max_candidates)]
+
+
+def _extract_s2_candidates_for_quality_gate(
+    source_result: StepResult,
+    *,
+    max_candidates: int,
+) -> List[Dict[str, Any]]:
+    outputs = source_result.outputs if isinstance(source_result.outputs, dict) else {}
+    structure_results = outputs.get("structure_results")
+    resolved: List[Dict[str, Any]] = []
+
+    if isinstance(structure_results, list):
+        for idx, item in enumerate(structure_results):
+            if not isinstance(item, dict):
+                continue
+            row = dict(item)
+            row.setdefault("candidate_id", f"{source_result.step_id}_structure_{idx + 1}")
+            row.setdefault("lineage", outputs.get("lineage", {}))
+            row.setdefault("tool_id", row.get("tool_id") or source_result.tool)
+            resolved.append(row)
+            if len(resolved) >= max(1, max_candidates):
+                break
+    else:
+        plddt = outputs.get("plddt")
+        if not isinstance(plddt, (int, float)):
+            confidence = outputs.get("confidence")
+            if isinstance(confidence, dict) and isinstance(
+                confidence.get("plddt_mean"), (int, float)
+            ):
+                plddt = confidence["plddt_mean"]
+        row = {
+            "candidate_id": f"{source_result.step_id}_primary",
+            "status": source_result.status,
+            "sequence": outputs.get("sequence"),
+            "pdb_path": outputs.get("pdb_path"),
+            "plddt": plddt,
+            "tool_id": source_result.tool,
+            "lineage": outputs.get("lineage", {}),
+            "failure_code": _extract_failure_code(source_result),
+            "failure_reason": source_result.error_message,
+        }
+        resolved.append(row)
+
+    if not resolved:
+        raise ValueError(
+            f"No structure candidates found in '{source_result.step_id}' outputs"
         )
     return resolved[: max(1, max_candidates)]
 
@@ -560,3 +772,57 @@ def _collect_projection_artifacts(rows: Sequence[Dict[str, Any]]) -> Dict[str, A
     if not pdb_paths:
         return {}
     return {"pdb_paths": pdb_paths}
+
+
+def _select_best_quality_candidate(rows: Sequence[Dict[str, Any]]) -> Dict[str, Any] | None:
+    if not rows:
+        return None
+    ranked = sorted(
+        rows,
+        key=lambda row: (
+            -(float(row.get("plddt")) if isinstance(row.get("plddt"), (int, float)) else -1.0),
+            str(row.get("candidate_id", "")),
+        ),
+    )
+    return ranked[0]
+
+
+def _extract_failure_code(result: StepResult) -> str | None:
+    if not isinstance(result.error_details, dict):
+        return None
+    value = result.error_details.get("failure_code")
+    if isinstance(value, FailureCode):
+        return value.value
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _build_quality_gate_trace_data(result: StepResult) -> Dict[str, Any]:
+    outputs = result.outputs if isinstance(result.outputs, dict) else {}
+    reject_counts = outputs.get("reject_code_counts")
+    failure_code = _extract_failure_code(result)
+    failed_rows = outputs.get("failed_samples")
+    failed_samples: list[dict[str, Any]] = []
+    if isinstance(failed_rows, list):
+        for item in failed_rows:
+            if not isinstance(item, dict):
+                continue
+            failed_samples.append(
+                {
+                    "candidate_id": item.get("candidate_id"),
+                    "reject_codes": item.get("reject_codes"),
+                    "reason": item.get("reason"),
+                }
+            )
+    return {
+        "stage_id": outputs.get("stage_id"),
+        "failure_code": failure_code,
+        "quality_gate": {
+            "pass_count": outputs.get("pass_count"),
+            "fail_count": outputs.get("fail_count"),
+            "pass_fail": outputs.get("pass_fail"),
+            "reject_code_counts": reject_counts if isinstance(reject_counts, dict) else {},
+            "failed_samples": failed_samples,
+        },
+    }

--- a/src/agents/safety.py
+++ b/src/agents/safety.py
@@ -13,7 +13,7 @@ A4 阶段：实现接口框架和伪实现，返回 SafetyResult 占位。
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from src.models.contracts import (
     ProteinDesignTask,
@@ -148,6 +148,32 @@ class SafetyAgent:
                 )
             )
             action = "block"
+        elif self._is_s3_quality_gate_step(step, step_result):
+            pass_count, fail_count = self._extract_s3_counts(step_result)
+            if pass_count <= 0:
+                risk_flags.append(
+                    self._build_failure_flag(
+                        step,
+                        step_result,
+                        failure_code="S3_ALL_CANDIDATES_REJECTED",
+                        failure_reason="S3 quality gate rejected all candidates",
+                    )
+                )
+                action = "block"
+            elif fail_count > 0:
+                risk_flags.append(
+                    self._build_failure_flag(
+                        step,
+                        step_result,
+                        failure_code="S3_PARTIAL_QUALITY_GATE_FAIL",
+                        failure_reason=(
+                            f"S3 quality gate partially rejected candidates "
+                            f"(pass={pass_count}, fail={fail_count})"
+                        ),
+                        level="warn",
+                    )
+                )
+                action = "warn"
         elif step.tool == "protein_mpnn":
             sequence = step_result.outputs.get("sequence")
             if not self._is_valid_sequence(sequence):
@@ -254,6 +280,27 @@ class SafetyAgent:
             return threshold * 100
         return threshold
 
+    def _is_s3_quality_gate_step(self, step: PlanStep, step_result: StepResult) -> bool:
+        metadata = step.metadata if isinstance(step.metadata, dict) else {}
+        if metadata.get("stage_id") == "S3":
+            return True
+        outputs = step_result.outputs if isinstance(step_result.outputs, dict) else {}
+        return outputs.get("stage_id") == "S3"
+
+    def _extract_s3_counts(self, step_result: StepResult) -> tuple[int, int]:
+        outputs = step_result.outputs if isinstance(step_result.outputs, dict) else {}
+        pass_count = outputs.get("pass_count")
+        fail_count = outputs.get("fail_count")
+        if isinstance(pass_count, bool) or not isinstance(pass_count, (int, float)):
+            pass_count = 0
+        if isinstance(fail_count, bool) or not isinstance(fail_count, (int, float)):
+            failed_rows = outputs.get("failed_samples")
+            if isinstance(failed_rows, list):
+                fail_count = len(failed_rows)
+            else:
+                fail_count = 0
+        return int(pass_count), int(fail_count)
+
     def _extract_failure_code(self, step_result: StepResult) -> str:
         failure_code = ""
         if isinstance(step_result.error_details, dict):
@@ -272,6 +319,7 @@ class SafetyAgent:
         failure_code: str,
         failure_reason: str,
         extra_details: Optional[dict] = None,
+        level: Literal["warn", "block"] = "block",
     ) -> RiskFlag:
         details = {
             "failure_code": failure_code,
@@ -283,7 +331,7 @@ class SafetyAgent:
         if extra_details:
             details.update(extra_details)
         return RiskFlag(
-            level="block",
+            level=level,
             code=failure_code,
             message=failure_reason,
             scope="step",

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json
-from typing import Protocol
+from typing import Any, Protocol
 from src.agents.planner import PlannerAgent
 from src.infra.event_log_factory import make_candidate_validation_failed
 from src.models.contracts import (
@@ -735,20 +735,24 @@ class PlanRunner:
         step_result: StepResult,
     ) -> None:
         event_name = "STEP_FINISHED" if step_result.status != "failed" else "STEP_FAILED"
+        event_payload = {
+            "event": event_name,
+            "task_id": context.task.task_id,
+            "step_id": step_result.step_id,
+            "tool": step_result.tool,
+            "status": step_result.status,
+            "failure_type": step_result.failure_type,
+            "error_message": step_result.error_message,
+            "timestamp": step_result.timestamp,
+            "state": context.status.value,
+            "external_status": to_external_status(context.status).value,
+        }
+        event_data = _build_step_trace_data(step_result)
+        if event_data:
+            event_payload["data"] = event_data
         append_event(
             context.task.task_id,
-            {
-                "event": event_name,
-                "task_id": context.task.task_id,
-                "step_id": step_result.step_id,
-                "tool": step_result.tool,
-                "status": step_result.status,
-                "failure_type": step_result.failure_type,
-                "error_message": step_result.error_message,
-                "timestamp": step_result.timestamp,
-                "state": context.status.value,
-                "external_status": to_external_status(context.status).value,
-            },
+            event_payload,
         )
 
 
@@ -758,6 +762,43 @@ def _should_require_replan_confirm(error: PlanRunError) -> bool:
         error.failure_type == FailureType.SAFETY_BLOCK
         or error.code in {"SAFETY_TASK_INPUT_BLOCK", "SAFETY_FINAL_BLOCK", "SAFETY_POST_BLOCK"}
     )
+
+
+def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    if isinstance(step_result.error_details, dict):
+        failure_code = step_result.error_details.get("failure_code")
+        if isinstance(failure_code, str) and failure_code:
+            data["failure_code"] = failure_code
+
+    outputs = step_result.outputs if isinstance(step_result.outputs, dict) else {}
+    stage_id = outputs.get("stage_id")
+    if isinstance(stage_id, str) and stage_id:
+        data["stage_id"] = stage_id
+
+    if stage_id == "S3":
+        reject_counts = outputs.get("reject_code_counts")
+        failed_rows = outputs.get("failed_samples")
+        failed_samples: list[dict[str, Any]] = []
+        if isinstance(failed_rows, list):
+            for item in failed_rows:
+                if not isinstance(item, dict):
+                    continue
+                failed_samples.append(
+                    {
+                        "candidate_id": item.get("candidate_id"),
+                        "reject_codes": item.get("reject_codes"),
+                        "reason": item.get("reason"),
+                    }
+                )
+        data["quality_gate"] = {
+            "pass_count": outputs.get("pass_count"),
+            "fail_count": outputs.get("fail_count"),
+            "pass_fail": outputs.get("pass_fail"),
+            "reject_code_counts": reject_counts if isinstance(reject_counts, dict) else {},
+            "failed_samples": failed_samples,
+        }
+    return data
 
 
 def _resolve_top_k(value: object, *, default: int) -> int:

--- a/src/workflow/quality_gate.py
+++ b/src/workflow/quality_gate.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from enum import Enum
+from itertools import groupby
+from typing import Any, Mapping, Sequence
+
+__all__ = [
+    "QualityGateRejectCode",
+    "QUALITY_GATE_ALL_REJECTED_CODE",
+    "evaluate_quality_gate_batch",
+]
+
+
+class QualityGateRejectCode(str, Enum):
+    """S3 quality gate reject code enum."""
+
+    SOURCE_STRUCTURE_FAILED = "S3_SOURCE_STRUCTURE_FAILED"
+    SEQUENCE_MISSING = "S3_SEQUENCE_MISSING"
+    SEQUENCE_LENGTH_OUT_OF_RANGE = "S3_SEQUENCE_LENGTH_OUT_OF_RANGE"
+    SEQUENCE_INVALID_CHAR = "S3_SEQUENCE_INVALID_CHAR"
+    STRUCTURE_MISSING = "S3_STRUCTURE_MISSING"
+    PLDDT_MISSING = "S3_PLDDT_MISSING"
+    PLDDT_BELOW_THRESHOLD = "S3_PLDDT_BELOW_THRESHOLD"
+    LOW_COMPLEXITY_COMPOSITION = "S3_LOW_COMPLEXITY_COMPOSITION"
+    LOW_COMPLEXITY_REPEAT = "S3_LOW_COMPLEXITY_REPEAT"
+
+
+QUALITY_GATE_ALL_REJECTED_CODE = "S3_ALL_CANDIDATES_REJECTED"
+
+_AMINO_ACIDS = set("ACDEFGHIKLMNPQRSTVWY")
+_DEFAULT_MIN_LENGTH = 20
+_DEFAULT_MAX_LENGTH = 400
+_DEFAULT_MIN_PLDDT = 0.7
+_DEFAULT_MAX_RESIDUE_FRACTION = 0.7
+_DEFAULT_MAX_REPEAT_RUN = 6
+
+
+@dataclass(frozen=True)
+class _QualityGateConfig:
+    min_length: int
+    max_length: int
+    min_plddt: float
+    max_residue_fraction: float
+    max_repeat_run: int
+
+
+def evaluate_quality_gate_batch(
+    candidates: Sequence[Mapping[str, Any]],
+    *,
+    constraints: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Evaluate S3 quality gate for a batch of S2 candidates."""
+    cfg = _resolve_config(constraints or {})
+    qc_rows: list[dict[str, Any]] = []
+    reject_counter: Counter[str] = Counter()
+
+    for index, candidate in enumerate(candidates):
+        qc_row = _evaluate_candidate(candidate, index=index, cfg=cfg)
+        qc_rows.append(qc_row)
+        for code in qc_row["reject_codes"]:
+            reject_counter[code] += 1
+
+    passed_rows = [row for row in qc_rows if row["status"] == "pass"]
+    failed_rows = [row for row in qc_rows if row["status"] == "fail"]
+    pass_count = len(passed_rows)
+    fail_count = len(failed_rows)
+    total = len(qc_rows)
+    pass_rate = round(pass_count / total, 6) if total else 0.0
+
+    qc_metrics = {
+        "rule_config": {
+            "min_length": cfg.min_length,
+            "max_length": cfg.max_length,
+            "min_plddt": cfg.min_plddt,
+            "max_residue_fraction": cfg.max_residue_fraction,
+            "max_repeat_run": cfg.max_repeat_run,
+        },
+        "total_candidates": total,
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "pass_rate": pass_rate,
+        "reject_code_counts": dict(sorted(reject_counter.items())),
+    }
+    return {
+        "qc_results": qc_rows,
+        "passed_samples": passed_rows,
+        "failed_samples": failed_rows,
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "pass_fail": pass_count > 0,
+        "qc_metrics": qc_metrics,
+        "reject_code_counts": qc_metrics["reject_code_counts"],
+    }
+
+
+def _resolve_config(constraints: Mapping[str, Any]) -> _QualityGateConfig:
+    local = constraints.get("quality_gate")
+    gate_constraints = local if isinstance(local, dict) else {}
+
+    min_length = _to_int(
+        _pick_value(
+            gate_constraints,
+            constraints,
+            keys=("min_length",),
+        ),
+        default=_DEFAULT_MIN_LENGTH,
+        minimum=1,
+    )
+    max_length = _to_int(
+        _pick_value(
+            gate_constraints,
+            constraints,
+            keys=("max_length",),
+        ),
+        default=_DEFAULT_MAX_LENGTH,
+        minimum=min_length,
+    )
+
+    length_range = _pick_value(gate_constraints, constraints, keys=("length_range",))
+    if isinstance(length_range, (list, tuple)) and len(length_range) == 2:
+        min_from_range = _to_int(length_range[0], default=min_length, minimum=1)
+        max_from_range = _to_int(length_range[1], default=max_length, minimum=min_from_range)
+        min_length = min_from_range
+        max_length = max_from_range
+
+    min_plddt = _to_float(
+        _pick_value(
+            gate_constraints,
+            constraints,
+            keys=("min_plddt", "plddt_threshold"),
+        ),
+        default=_DEFAULT_MIN_PLDDT,
+    )
+    max_residue_fraction = _to_float(
+        _pick_value(
+            gate_constraints,
+            constraints,
+            keys=(
+                "max_residue_fraction",
+                "low_complexity_max_residue_fraction",
+            ),
+        ),
+        default=_DEFAULT_MAX_RESIDUE_FRACTION,
+    )
+    max_repeat_run = _to_int(
+        _pick_value(
+            gate_constraints,
+            constraints,
+            keys=("max_repeat_run", "low_complexity_max_repeat_run"),
+        ),
+        default=_DEFAULT_MAX_REPEAT_RUN,
+        minimum=1,
+    )
+
+    if min_length > max_length:
+        min_length, max_length = max_length, min_length
+    if max_residue_fraction <= 0:
+        max_residue_fraction = _DEFAULT_MAX_RESIDUE_FRACTION
+
+    return _QualityGateConfig(
+        min_length=min_length,
+        max_length=max_length,
+        min_plddt=min_plddt,
+        max_residue_fraction=max_residue_fraction,
+        max_repeat_run=max_repeat_run,
+    )
+
+
+def _evaluate_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    index: int,
+    cfg: _QualityGateConfig,
+) -> dict[str, Any]:
+    candidate_id = _as_string(candidate.get("candidate_id")) or f"s2_candidate_{index + 1}"
+    source_status = _as_string(candidate.get("status"))
+    sequence = _as_string(candidate.get("sequence"))
+    pdb_path = _as_string(candidate.get("pdb_path"))
+    source_failure_code = _as_string(candidate.get("failure_code"))
+    source_failure_reason = _as_string(candidate.get("failure_reason")) or _as_string(
+        candidate.get("error_message")
+    )
+    plddt = _extract_plddt(candidate)
+    reject_codes: list[str] = []
+    reject_reasons: list[str] = []
+
+    length_value = len(sequence) if sequence else 0
+    max_residue_fraction = _max_residue_fraction(sequence)
+    longest_repeat_run = _longest_repeat_run(sequence)
+    unique_residue_count = len(set(sequence)) if sequence else 0
+
+    if source_status and source_status not in {"success", "pass"}:
+        _append_reject(
+            reject_codes,
+            reject_reasons,
+            code=QualityGateRejectCode.SOURCE_STRUCTURE_FAILED.value,
+            reason=(
+                f"S2 source candidate failed before quality gate"
+                f" (source_code={source_failure_code or 'unknown'})"
+            ),
+        )
+    else:
+        if not sequence:
+            _append_reject(
+                reject_codes,
+                reject_reasons,
+                code=QualityGateRejectCode.SEQUENCE_MISSING.value,
+                reason="sequence is required for quality gate",
+            )
+        else:
+            if length_value < cfg.min_length or length_value > cfg.max_length:
+                _append_reject(
+                    reject_codes,
+                    reject_reasons,
+                    code=QualityGateRejectCode.SEQUENCE_LENGTH_OUT_OF_RANGE.value,
+                    reason=(
+                        f"sequence length {length_value} is outside "
+                        f"[{cfg.min_length}, {cfg.max_length}]"
+                    ),
+                )
+            if not _is_valid_sequence(sequence):
+                _append_reject(
+                    reject_codes,
+                    reject_reasons,
+                    code=QualityGateRejectCode.SEQUENCE_INVALID_CHAR.value,
+                    reason="sequence contains invalid residues",
+                )
+            if max_residue_fraction > cfg.max_residue_fraction:
+                _append_reject(
+                    reject_codes,
+                    reject_reasons,
+                    code=QualityGateRejectCode.LOW_COMPLEXITY_COMPOSITION.value,
+                    reason=(
+                        f"max residue fraction {max_residue_fraction:.3f} exceeds "
+                        f"{cfg.max_residue_fraction:.3f}"
+                    ),
+                )
+            if longest_repeat_run > cfg.max_repeat_run:
+                _append_reject(
+                    reject_codes,
+                    reject_reasons,
+                    code=QualityGateRejectCode.LOW_COMPLEXITY_REPEAT.value,
+                    reason=(
+                        f"longest repeat run {longest_repeat_run} exceeds "
+                        f"{cfg.max_repeat_run}"
+                    ),
+                )
+
+        if not pdb_path:
+            _append_reject(
+                reject_codes,
+                reject_reasons,
+                code=QualityGateRejectCode.STRUCTURE_MISSING.value,
+                reason="pdb_path is required for quality gate",
+            )
+        if plddt is None:
+            _append_reject(
+                reject_codes,
+                reject_reasons,
+                code=QualityGateRejectCode.PLDDT_MISSING.value,
+                reason="plddt is required for quality gate",
+            )
+        else:
+            threshold = _resolve_plddt_threshold(plddt, cfg.min_plddt)
+            if plddt < threshold:
+                _append_reject(
+                    reject_codes,
+                    reject_reasons,
+                    code=QualityGateRejectCode.PLDDT_BELOW_THRESHOLD.value,
+                    reason=f"plddt {plddt:.3f} is below threshold {threshold:.3f}",
+                )
+
+    status = "pass" if not reject_codes else "fail"
+    qc_flags = {
+        "length_ok": cfg.min_length <= length_value <= cfg.max_length if sequence else False,
+        "valid_sequence_chars": _is_valid_sequence(sequence) if sequence else False,
+        "has_structure": bool(pdb_path),
+        "has_plddt": plddt is not None,
+        "low_complexity_ok": (
+            bool(sequence)
+            and max_residue_fraction <= cfg.max_residue_fraction
+            and longest_repeat_run <= cfg.max_repeat_run
+        ),
+    }
+    qc_metrics = {
+        "length": length_value,
+        "unique_residue_count": unique_residue_count,
+        "max_residue_fraction": max_residue_fraction,
+        "longest_repeat_run": longest_repeat_run,
+        "plddt": plddt,
+    }
+
+    row = {
+        "candidate_id": candidate_id,
+        "status": status,
+        "pass_fail": status == "pass",
+        "reason": "; ".join(reject_reasons),
+        "reject_codes": sorted(set(reject_codes)),
+        "reject_reasons": reject_reasons,
+        "qc_flags": qc_flags,
+        "qc_metrics": qc_metrics,
+        "sequence": sequence,
+        "pdb_path": pdb_path,
+        "plddt": plddt,
+        "tool_id": _as_string(candidate.get("tool_id")),
+        "source_failure_code": source_failure_code,
+        "source_failure_reason": source_failure_reason,
+        "lineage": candidate.get("lineage")
+        if isinstance(candidate.get("lineage"), dict)
+        else {},
+    }
+    return row
+
+
+def _append_reject(
+    reject_codes: list[str],
+    reject_reasons: list[str],
+    *,
+    code: str,
+    reason: str,
+) -> None:
+    reject_codes.append(code)
+    reject_reasons.append(reason)
+
+
+def _pick_value(
+    local: Mapping[str, Any],
+    global_constraints: Mapping[str, Any],
+    *,
+    keys: Sequence[str],
+) -> Any:
+    for key in keys:
+        if key in local:
+            return local.get(key)
+    for key in keys:
+        if key in global_constraints:
+            return global_constraints.get(key)
+    return None
+
+
+def _to_int(
+    value: Any,
+    *,
+    default: int,
+    minimum: int,
+) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        parsed = int(value)
+    else:
+        parsed = default
+    return max(parsed, minimum)
+
+
+def _to_float(
+    value: Any,
+    *,
+    default: float,
+) -> float:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    return default
+
+
+def _as_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _is_valid_sequence(sequence: str) -> bool:
+    return bool(sequence) and all(char in _AMINO_ACIDS for char in sequence)
+
+
+def _extract_plddt(candidate: Mapping[str, Any]) -> float | None:
+    direct = _to_numeric(candidate.get("plddt"))
+    if direct is not None:
+        return direct
+    confidence = candidate.get("confidence")
+    if isinstance(confidence, dict):
+        conf_value = _to_numeric(confidence.get("plddt_mean"))
+        if conf_value is not None:
+            return conf_value
+    metrics = candidate.get("metrics")
+    if isinstance(metrics, dict):
+        metric_value = _to_numeric(metrics.get("plddt_mean"))
+        if metric_value is not None:
+            return metric_value
+    return None
+
+
+def _to_numeric(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _resolve_plddt_threshold(plddt: float, threshold: float) -> float:
+    if plddt > 1.0 and threshold <= 1.0:
+        return threshold * 100.0
+    if plddt <= 1.0 and threshold > 1.0:
+        return threshold / 100.0
+    return threshold
+
+
+def _max_residue_fraction(sequence: str | None) -> float:
+    if not sequence:
+        return 0.0
+    counts = Counter(sequence)
+    return max(counts.values()) / len(sequence)
+
+
+def _longest_repeat_run(sequence: str | None) -> int:
+    if not sequence:
+        return 0
+    return max(sum(1 for _ in group) for _, group in groupby(sequence))

--- a/tests/integration/test_quality_gate_s3.py
+++ b/tests/integration/test_quality_gate_s3.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from src.agents import executor as executor_module
+from src.agents.executor import ExecutorAgent
+from src.models.contracts import Plan, PlanStep, ProteinDesignTask, StepResult, now_iso
+from src.models.db import InternalStatus
+from src.workflow.context import WorkflowContext
+from src.workflow.quality_gate import QUALITY_GATE_ALL_REJECTED_CODE
+
+
+def _build_context_with_s2_results() -> WorkflowContext:
+    task = ProteinDesignTask(
+        task_id="task_s3_gate",
+        goal="de_novo_design",
+        constraints={
+            "length_range": [20, 30],
+            "plddt_threshold": 0.7,
+            "quality_gate": {
+                "max_residue_fraction": 0.75,
+                "max_repeat_run": 7,
+            },
+        },
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S1", tool="protgpt2", inputs={}, metadata={"stage_id": "S1"}),
+            PlanStep(id="S2", tool="nim_esmfold", inputs={}, metadata={"stage_id": "S2"}),
+            PlanStep(
+                id="S3",
+                tool="biopython_qc",
+                inputs={"structure_results": "S2.structure_results"},
+                metadata={"stage_id": "S3"},
+            ),
+        ],
+        constraints=task.constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.RUNNING,
+    )
+    context.step_results["S2"] = StepResult(
+        task_id=task.task_id,
+        step_id="S2",
+        tool="nim_esmfold",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        inputs={},
+        outputs={
+            "stage_id": "S2",
+            "structure_results": [
+                {
+                    "candidate_id": "cand_pass",
+                    "status": "success",
+                    "sequence": "ACDEFGHIKLMNPQRSTVWY",
+                    "pdb_path": "/tmp/pass.pdb",
+                    "plddt": 0.86,
+                    "tool_id": "esmfold",
+                    "lineage": {"stage_id": "S2", "source_candidate_id": "S1_primary"},
+                },
+                {
+                    "candidate_id": "cand_invalid_seq",
+                    "status": "success",
+                    "sequence": "ACDEFGHIKLMNPQRSTV*Y",
+                    "pdb_path": "/tmp/invalid_seq.pdb",
+                    "plddt": 0.93,
+                    "tool_id": "nim_esmfold",
+                    "lineage": {"stage_id": "S2", "source_candidate_id": "S1_bad"},
+                },
+                {
+                    "candidate_id": "cand_s2_failed",
+                    "status": "failed",
+                    "sequence": "MKTAYIAKQRQISFVKSHFS",
+                    "failure_code": "S2_TOOL_UNAVAILABLE",
+                    "failure_reason": "upstream failed",
+                    "tool_id": "nim_esmfold",
+                    "lineage": {"stage_id": "S2", "source_candidate_id": "S1_timeout"},
+                },
+            ],
+        },
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    return context
+
+
+def test_quality_gate_from_s2_keeps_failed_samples_and_emits_trace(monkeypatch):
+    context = _build_context_with_s2_results()
+    executor = ExecutorAgent()
+    events: list[dict] = []
+
+    monkeypatch.setattr(
+        executor_module,
+        "append_event",
+        lambda _task_id, payload: events.append(payload),
+    )
+
+    result = executor.quality_gate_from_s2(
+        context,
+        source_step_id="S2",
+        quality_step_id="S3",
+        max_candidates=3,
+    )
+
+    assert result.status == "success"
+    assert result.outputs["stage_id"] == "S3"
+    assert result.outputs["pass_count"] == 1
+    assert result.outputs["fail_count"] == 2
+    assert result.outputs["pass_fail"] is True
+    assert len(result.outputs["failed_samples"]) == 2
+    assert result.outputs["quality_gate"]["status"] == "PASS"
+    assert result.metrics["requirement2"]["capability_id"] == "quality_qc"
+    assert result.metrics["requirement2"]["io_type"] == "sequence_structure_to_qc_metrics"
+    assert result.outputs["best_candidate_id"] == "cand_pass"
+
+    assert len(events) == 1
+    assert events[0]["event"] == "STEP_FINISHED"
+    assert events[0]["data"]["stage_id"] == "S3"
+    assert events[0]["data"]["quality_gate"]["fail_count"] == 2
+
+
+def test_quality_gate_from_s2_fails_when_all_candidates_rejected(monkeypatch):
+    context = _build_context_with_s2_results()
+    s2_result = context.step_results["S2"]
+    s2_result.outputs["structure_results"] = [
+        {
+            "candidate_id": "cand_1",
+            "status": "failed",
+            "failure_code": "S2_OUTPUT_INVALID",
+            "failure_reason": "missing pdb",
+            "sequence": "AAAAAAAAAAAAAAAAAAAA",
+        },
+        {
+            "candidate_id": "cand_2",
+            "status": "success",
+            "sequence": "AAAAAAAAAAAAAAAAAAAA",
+            "pdb_path": "/tmp/aa.pdb",
+            "plddt": 0.2,
+        },
+    ]
+    executor = ExecutorAgent()
+    events: list[dict] = []
+    monkeypatch.setattr(
+        executor_module,
+        "append_event",
+        lambda _task_id, payload: events.append(payload),
+    )
+
+    result = executor.quality_gate_from_s2(
+        context,
+        source_step_id="S2",
+        quality_step_id="S3",
+        max_candidates=2,
+    )
+
+    assert result.status == "failed"
+    assert result.error_details["failure_code"] == QUALITY_GATE_ALL_REJECTED_CODE
+    assert result.outputs["pass_count"] == 0
+    assert result.outputs["quality_gate"]["status"] == "BLOCK"
+    assert events[0]["event"] == "STEP_FAILED"

--- a/tests/unit/test_plan_runner_step_trace.py
+++ b/tests/unit/test_plan_runner_step_trace.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from src.models.contracts import StepResult, now_iso
+from src.workflow.plan_runner import _build_step_trace_data
+
+
+def test_build_step_trace_data_contains_quality_gate_summary() -> None:
+    step_result = StepResult(
+        task_id="task_trace",
+        step_id="S3",
+        tool="biopython_qc",
+        status="failed",
+        failure_type="non_retryable",
+        error_message="all rejected",
+        error_details={"failure_code": "S3_ALL_CANDIDATES_REJECTED"},
+        inputs={},
+        outputs={
+            "stage_id": "S3",
+            "pass_count": 0,
+            "fail_count": 2,
+            "pass_fail": False,
+            "reject_code_counts": {"S3_PLDDT_BELOW_THRESHOLD": 2},
+            "failed_samples": [
+                {
+                    "candidate_id": "cand_1",
+                    "reject_codes": ["S3_PLDDT_BELOW_THRESHOLD"],
+                    "reason": "plddt too low",
+                }
+            ],
+        },
+        artifacts={},
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+    data = _build_step_trace_data(step_result)
+    assert data["failure_code"] == "S3_ALL_CANDIDATES_REJECTED"
+    assert data["stage_id"] == "S3"
+    assert data["quality_gate"]["fail_count"] == 2
+    assert data["quality_gate"]["failed_samples"][0]["candidate_id"] == "cand_1"

--- a/tests/unit/test_quality_gate_runtime.py
+++ b/tests/unit/test_quality_gate_runtime.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from src.workflow.quality_gate import (
+    QUALITY_GATE_ALL_REJECTED_CODE,
+    QualityGateRejectCode,
+    evaluate_quality_gate_batch,
+)
+
+
+def test_quality_gate_boundary_inputs_and_reject_codes_are_stable() -> None:
+    candidates = [
+        {
+            "candidate_id": "source_failed",
+            "status": "failed",
+            "failure_code": "S2_TOOL_UNAVAILABLE",
+            "failure_reason": "upstream timeout",
+        },
+        {
+            "candidate_id": "missing_fields",
+            "status": "success",
+            "sequence": "",
+            "pdb_path": "",
+            "plddt": None,
+        },
+        {
+            "candidate_id": "low_complex",
+            "status": "success",
+            "sequence": "AAAAAAAAAAAAAAAAAAAA",
+            "pdb_path": "/tmp/low_complex.pdb",
+            "plddt": 0.95,
+        },
+    ]
+
+    report = evaluate_quality_gate_batch(candidates)
+    rows = {row["candidate_id"]: row for row in report["qc_results"]}
+
+    assert rows["source_failed"]["reject_codes"] == [
+        QualityGateRejectCode.SOURCE_STRUCTURE_FAILED.value
+    ]
+    assert rows["missing_fields"]["reject_codes"] == [
+        QualityGateRejectCode.PLDDT_MISSING.value,
+        QualityGateRejectCode.SEQUENCE_MISSING.value,
+        QualityGateRejectCode.STRUCTURE_MISSING.value,
+    ]
+    assert rows["low_complex"]["reject_codes"] == [
+        QualityGateRejectCode.LOW_COMPLEXITY_COMPOSITION.value,
+        QualityGateRejectCode.LOW_COMPLEXITY_REPEAT.value,
+    ]
+    assert report["pass_fail"] is False
+    assert report["pass_count"] == 0
+    assert report["fail_count"] == 3
+    assert QUALITY_GATE_ALL_REJECTED_CODE == "S3_ALL_CANDIDATES_REJECTED"
+
+
+def test_quality_gate_cross_tool_consistency_for_same_candidate_inputs() -> None:
+    candidates = [
+        {
+            "candidate_id": "nim_row",
+            "status": "success",
+            "tool_id": "nim_esmfold",
+            "sequence": "AAAAABBBBB",
+            "pdb_path": "/tmp/nim.pdb",
+            "plddt": 0.6,
+        },
+        {
+            "candidate_id": "local_row",
+            "status": "success",
+            "tool_id": "esmfold",
+            "sequence": "AAAAABBBBB",
+            "pdb_path": "/tmp/local.pdb",
+            "plddt": 0.6,
+        },
+    ]
+
+    report = evaluate_quality_gate_batch(
+        candidates,
+        constraints={"min_length": 8, "max_length": 20, "plddt_threshold": 0.8},
+    )
+    rows = {row["candidate_id"]: row for row in report["qc_results"]}
+    nim_codes = rows["nim_row"]["reject_codes"]
+    local_codes = rows["local_row"]["reject_codes"]
+
+    assert nim_codes == local_codes
+    assert QualityGateRejectCode.PLDDT_BELOW_THRESHOLD.value in nim_codes
+    assert QualityGateRejectCode.SEQUENCE_INVALID_CHAR.value in nim_codes

--- a/tests/unit/test_safety_agent.py
+++ b/tests/unit/test_safety_agent.py
@@ -167,3 +167,82 @@ class TestSafetyAgent:
         
         assert isinstance(result, SafetyResult)
         assert result.phase == "output"
+
+    def test_check_post_step_s3_partial_reject_returns_warn(
+        self,
+        safety_agent: SafetyAgent,
+        dummy_context: WorkflowContext,
+    ):
+        step = PlanStep(
+            id="S3",
+            tool="biopython_qc",
+            inputs={},
+            metadata={"stage_id": "S3"},
+        )
+        step_result = StepResult(
+            task_id=dummy_context.task.task_id,
+            step_id="S3",
+            tool="biopython_qc",
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={
+                "stage_id": "S3",
+                "pass_count": 1,
+                "fail_count": 2,
+                "failed_samples": [
+                    {"candidate_id": "bad_1", "reject_codes": ["S3_SEQUENCE_INVALID_CHAR"]}
+                ],
+            },
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+        result = safety_agent.check_post_step(step, step_result, dummy_context)
+
+        assert result.action == "warn"
+        assert len(result.risk_flags) == 1
+        assert result.risk_flags[0].code == "S3_PARTIAL_QUALITY_GATE_FAIL"
+        assert result.risk_flags[0].level == "warn"
+
+    def test_check_post_step_s3_all_rejected_returns_block(
+        self,
+        safety_agent: SafetyAgent,
+        dummy_context: WorkflowContext,
+    ):
+        step = PlanStep(
+            id="S3",
+            tool="biopython_qc",
+            inputs={},
+            metadata={"stage_id": "S3"},
+        )
+        step_result = StepResult(
+            task_id=dummy_context.task.task_id,
+            step_id="S3",
+            tool="biopython_qc",
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={
+                "stage_id": "S3",
+                "pass_count": 0,
+                "fail_count": 3,
+                "failed_samples": [
+                    {"candidate_id": "bad_1", "reject_codes": ["S3_PLDDT_BELOW_THRESHOLD"]}
+                ],
+            },
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+        result = safety_agent.check_post_step(step, step_result, dummy_context)
+
+        assert result.action == "block"
+        assert len(result.risk_flags) == 1
+        assert result.risk_flags[0].code == "S3_ALL_CANDIDATES_REJECTED"


### PR DESCRIPTION
## 关联 Issue
- Closes #157

## 实现摘要
本 PR 实现 W11-Req1-S3「运行期质量门禁」的最小闭环，覆盖 S2 -> S3 批处理门禁、机读拒绝原因、Safety 语义对齐与可追溯日志字段。

### 1) S3 规则内核（runtime hard gate）
- 新增 `src/workflow/quality_gate.py`
- 提供 `evaluate_quality_gate_batch(...)`，对 S2 候选执行硬门禁：
  - 长度范围
  - 序列字符合法性
  - 结构完整性（`pdb_path`）
  - 置信度完整性与阈值（`plddt`）
  - 低复杂度（组成占比 + 重复串）
- 稳定拒绝码枚举：
  - `S3_SOURCE_STRUCTURE_FAILED`
  - `S3_SEQUENCE_MISSING`
  - `S3_SEQUENCE_LENGTH_OUT_OF_RANGE`
  - `S3_SEQUENCE_INVALID_CHAR`
  - `S3_STRUCTURE_MISSING`
  - `S3_PLDDT_MISSING`
  - `S3_PLDDT_BELOW_THRESHOLD`
  - `S3_LOW_COMPLEXITY_COMPOSITION`
  - `S3_LOW_COMPLEXITY_REPEAT`
  - 聚合失败码：`S3_ALL_CANDIDATES_REJECTED`

### 2) S2 -> S3 批处理打通
- `src/agents/executor.py` 新增 `ExecutorAgent.quality_gate_from_s2(...)`
- 消费 `S2.outputs.structure_results`（或单候选退化输入），输出 `stage_id=S3` 聚合 `StepResult`：
  - `qc_results`
  - `passed_samples` / `failed_samples`
  - `pass_count` / `fail_count` / `pass_fail`
  - `reject_code_counts`
  - `qc_metrics`
- 当所有候选被拒绝时，返回 `status=failed` + `failure_code=S3_ALL_CANDIDATES_REJECTED`，可直接驱动 S6 patch/replan 触发。

### 3) Safety 语义对齐（Executor 执行评估，Safety 只判定风险）
- `src/agents/safety.py`
  - 增加 S3 后置判定：
    - 全拒绝 -> `action=block`
    - 部分拒绝 -> `action=warn`
  - 不在 Safety 中执行任何 QC 工具，仅消费 S3 输出做风险判断。

### 4) 可追溯日志字段（供 #145/#146 复用）
- `src/workflow/plan_runner.py`
  - `STEP_FINISHED/STEP_FAILED` 新增 `data` 追踪字段：
    - 通用：`failure_code`、`stage_id`
    - S3：`data.quality_gate`（pass/fail 计数、reject 统计、failed_samples 摘要）
- `quality_gate_from_s2(...)` 同步写入同结构事件，便于直接抽取。

### 5) Requirement2 对齐
S3 输出显式携带：
- `capability_id=quality_qc`
- `io_type=sequence_structure_to_qc_metrics`
- `quality_gate.qc_pass`（可机读）

## 验收标准对照
- [x] 非法/低质量候选可稳定拦截并给出机读原因。
- [x] QC 输出可直接驱动 S4/S6 的 patch/replan 触发（全拒绝返回 failed + 机读失败码）。
- [x] 质量门禁指标可复用于训练数据抽取（统一事件 `data` 字段 + S3 结构化摘要）。

## 测试
### 新增
- `tests/unit/test_quality_gate_runtime.py`
  - 边界输入
  - 拒绝码稳定性
  - 跨工具一致性
- `tests/integration/test_quality_gate_s3.py`
  - S2 -> S3 批处理
  - 失败样本列表
  - 全拒绝失败路径
  - 事件追踪字段
- `tests/unit/test_plan_runner_step_trace.py`
  - S3 日志追踪字段结构

### 更新
- `tests/unit/test_safety_agent.py`
  - S3 partial reject -> warn
  - S3 all rejected -> block

### 已执行
- `uv run pytest tests/unit/test_quality_gate_runtime.py tests/integration/test_quality_gate_s3.py tests/unit/test_safety_agent.py tests/unit/test_plan_runner_step_trace.py`
- `uv run pytest tests/unit/test_executor_agent.py tests/unit/test_plan_runner.py tests/integration/test_structure_projection_s2.py`

## 文档
- `README.md` 新增 “S3 Quality Gate Contract (Issue #157)”

## 后续建议补充（不阻塞本 PR）
- 将 S3 batch gate 显式接入六阶段主执行编排入口（当前提供 `ExecutorAgent.quality_gate_from_s2(...)` 能力入口）。
- 补充与 S4 精修闭环的端到端联动测试（S3 fail -> refine/replan 策略回路）。
- 按后续实验窗口同步扩展到 `D-recovery` 样本模板（与 #170 对齐）。
