### PR TITLE
feat(workflow): implement issue #143 layered patch/replan strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,29 @@ Traceability:
 
 - S3 execution emits `STEP_FINISHED/STEP_FAILED` with `data.quality_gate` summary.
 - `PlanRunner` step events now include `data.failure_code` and S3 quality summary fields for downstream extraction reuse.
+
+## Layered Patch/Replan Recovery (Issue #143)
+
+Recovery strategy now follows strict layered patch order before replan:
+
+- `parameter_level -> tool_level -> structure_level`
+
+Runtime behavior:
+
+- `PatchRunner` attempts patch candidates layer-by-layer in one recovery cycle.
+- replan upgrade triggers on:
+  - patch generation/apply failure (`patch_failed`)
+  - all patch layers failed (`patch_failed`)
+  - high-risk patch gate (`patch_high_risk`)
+- `replan` remains `suffix_replan` by default in planner metadata.
+
+Requirement-2 replacement matrix (P0):
+
+- `structure_prediction`: `nim_esmfold/esmfold/alphafold/openfold`
+- `quality_qc`: `biopython_qc/dssp`
+- `objective_scoring`: `objective_ranker`
+
+Traceability:
+
+- replacement decisions write `from_tool/to_tool/capability_id/reason/recovery_layer` to EventLog.
+- step trace includes `data.patch` and `data.recovery`.

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -68,6 +68,24 @@ class _CandidatePayload:
     primary_tool_id: str
     capability_bucket: str
     note: str
+    recovery_layer: str | None = None
+    recovery_reason: str | None = None
+
+
+_PATCH_LAYER_PRIORITY = {
+    "parameter_level": 0,
+    "tool_level": 1,
+    "structure_level": 2,
+}
+
+_P0_CAPABILITY_REPLACEMENT_MATRIX: dict[str, tuple[str, ...]] = {
+    # Requirement-2: P0 capability swap matrix (structure prediction core path)
+    "structure_prediction": ("nim_esmfold", "esmfold", "alphafold", "openfold"),
+    # Requirement-2: minimal fallback path for quality_qc
+    "quality_qc": ("biopython_qc", "dssp"),
+    # Requirement-2: minimal fallback path for objective_scoring
+    "objective_scoring": ("objective_ranker",),
+}
 
 
 class PlannerAgent:
@@ -660,11 +678,15 @@ def _build_patch_candidate_payloads(
     target_step = _locate_target_step(request)
     target_spec = _find_tool_spec(registry, target_step.tool)
     capability = _primary_capability(target_spec)
+    failed_result = _latest_failed_step_result(
+        request.context_step_results,
+        target_step.id,
+    )
 
     available_inputs = _collect_available_inputs(
         request.context_step_results, target_step
     )
-    alternatives = _rank_candidate_tools(
+    alternatives = _rank_patch_alternatives(
         registry=registry,
         capability=capability,
         available_inputs=available_inputs,
@@ -672,19 +694,32 @@ def _build_patch_candidate_payloads(
     )
     if not alternatives:
         fallback_inputs = _collect_registry_inputs(registry)
-        alternatives = _rank_candidate_tools(
+        alternatives = _rank_patch_alternatives(
             registry=registry,
             capability=capability,
             available_inputs=fallback_inputs,
             exclude_tool=target_step.tool,
         )
-    if not alternatives:
-        raise ValueError(
-            f"No alternative tool found for capability '{capability}' "
-            f"with inputs {sorted(available_inputs)}"
-        )
 
     payloads: List[_CandidatePayload] = []
+    parameter_patch = _build_parameter_level_patch(
+        request=request,
+        target_step=target_step,
+        target_capability=capability,
+        failed_result=failed_result,
+    )
+    if parameter_patch is not None:
+        payloads.append(
+            _CandidatePayload(
+                payload=parameter_patch,
+                primary_tool_id=target_step.tool,
+                capability_bucket=capability,
+                note=f"target:{target_step.id}:param_tweak:{target_step.tool}",
+                recovery_layer="parameter_level",
+                recovery_reason="parameter_tweak",
+            )
+        )
+
     max_candidates = max(1, top_k * 2)
     for alternative in alternatives[:max_candidates]:
         patched_step = target_step.model_copy(
@@ -705,7 +740,14 @@ def _build_patch_candidate_payloads(
         patch = PlanPatch(
             task_id=request.task_id,
             operations=[op],
-            metadata={"strategy": "cost_first"},
+            metadata=_build_patch_metadata(
+                target_capability=capability,
+                source_tool=target_step.tool,
+                selected_tool=alternative.id,
+                recovery_layer="tool_level",
+                reason="tool_swap_replacement_matrix",
+                request_reason=request.reason,
+            ),
         )
         patch.metadata["kg_explanation"] = _build_kg_explanation_for_steps(
             [patched_step]
@@ -716,9 +758,244 @@ def _build_patch_candidate_payloads(
                 primary_tool_id=alternative.id,
                 capability_bucket=_primary_capability(alternative),
                 note=f"target:{target_step.id}:{target_step.tool}->{alternative.id}",
+                recovery_layer="tool_level",
+                recovery_reason="tool_swap_replacement_matrix",
             )
         )
+
+    structure_patch = _build_structure_level_patch(
+        request=request,
+        registry=registry,
+        target_step=target_step,
+        target_capability=capability,
+    )
+    if structure_patch is not None:
+        payloads.append(
+            _CandidatePayload(
+                payload=structure_patch,
+                primary_tool_id=target_step.tool,
+                capability_bucket=capability,
+                note=f"target:{target_step.id}:structure_guard",
+                recovery_layer="structure_level",
+                recovery_reason="insert_guard_step",
+            )
+        )
+
+    if not payloads:
+        raise ValueError(
+            f"No patch candidate found for capability '{capability}' "
+            f"with inputs {sorted(available_inputs)}"
+        )
     return payloads
+
+
+def _latest_failed_step_result(
+    results: Sequence[StepResult],
+    step_id: str,
+) -> StepResult | None:
+    for result in reversed(list(results)):
+        if result.step_id == step_id and result.status == "failed":
+            return result
+    return None
+
+
+def _build_parameter_level_patch(
+    *,
+    request: PatchRequest,
+    target_step: PlanStep,
+    target_capability: str,
+    failed_result: StepResult | None,
+) -> PlanPatch | None:
+    param_updates = _derive_param_updates(failed_result, target_step)
+    if not param_updates:
+        return None
+
+    patched_step = target_step.model_copy(
+        update={
+            "metadata": {
+                **(target_step.metadata or {}),
+                "patched_from": target_step.tool,
+                "patch_param_updates": param_updates,
+            }
+        },
+        deep=True,
+    )
+    op = PlanPatchOp(
+        op="replace_step",
+        target=target_step.id,
+        step=patched_step,
+    )
+    return PlanPatch(
+        task_id=request.task_id,
+        operations=[op],
+        metadata=_build_patch_metadata(
+            target_capability=target_capability,
+            source_tool=target_step.tool,
+            selected_tool=target_step.tool,
+            recovery_layer="parameter_level",
+            reason="parameter_tweak",
+            request_reason=request.reason,
+            param_updates=param_updates,
+        ),
+    )
+
+
+def _derive_param_updates(
+    failed_result: StepResult | None,
+    target_step: PlanStep,
+) -> dict:
+    updates: dict[str, object] = {}
+    failure_type = failed_result.failure_type if failed_result is not None else None
+    if failure_type in {"RETRYABLE", "TOOL_ERROR"}:
+        updates["retry_profile"] = "conservative"
+    error_message = (failed_result.error_message or "").lower() if failed_result else ""
+    if "timeout" in error_message:
+        updates["timeout_multiplier"] = 1.5
+    if "memory" in error_message or "oom" in error_message:
+        updates["batch_size"] = 1
+
+    metadata = target_step.metadata if isinstance(target_step.metadata, dict) else {}
+    if "temperature" in metadata:
+        try:
+            current = float(metadata["temperature"])
+            updates["temperature"] = max(0.0, min(1.0, round(current * 0.8, 3)))
+        except (TypeError, ValueError):
+            pass
+
+    if not updates:
+        updates["patch_mode"] = "safe_default_retry"
+    return updates
+
+
+def _build_structure_level_patch(
+    *,
+    request: PatchRequest,
+    registry: Sequence[ToolSpec],
+    target_step: PlanStep,
+    target_capability: str,
+) -> PlanPatch | None:
+    available_inputs = _collect_available_inputs(request.context_step_results, target_step)
+    guard_tools = _rank_structure_guard_tools(
+        registry=registry,
+        available_inputs=available_inputs,
+        exclude_tool=target_step.tool,
+    )
+    for guard_tool in guard_tools:
+        guard_inputs = _materialize_structure_guard_inputs(
+            target_step=target_step,
+            guard_tool=guard_tool,
+        )
+        if guard_inputs is None:
+            continue
+        guard_step = PlanStep(
+            id=f"{target_step.id}_guard",
+            tool=guard_tool.id,
+            inputs=guard_inputs,
+            metadata={
+                "stage_id": "S6",
+                "stage_name": "patch_replan_control",
+                "recovery_guard_for": target_step.id,
+                "recovery_layer": "structure_level",
+                "capability_id": _primary_capability(guard_tool),
+            },
+        )
+        op = PlanPatchOp(
+            op="insert_step_after",
+            target=target_step.id,
+            step=guard_step,
+        )
+        return PlanPatch(
+            task_id=request.task_id,
+            operations=[op],
+            metadata=_build_patch_metadata(
+                target_capability=target_capability,
+                source_tool=target_step.tool,
+                selected_tool=guard_tool.id,
+                recovery_layer="structure_level",
+                reason="insert_guard_step",
+                request_reason=request.reason,
+            ),
+        )
+    return None
+
+
+def _rank_structure_guard_tools(
+    *,
+    registry: Sequence[ToolSpec],
+    available_inputs: Set[str],
+    exclude_tool: str,
+) -> List[ToolSpec]:
+    ranked: List[ToolSpec] = []
+    seen: Set[str] = set()
+    for capability in ("quality_qc", "objective_scoring"):
+        candidates = _rank_patch_alternatives(
+            registry=registry,
+            capability=capability,
+            available_inputs=available_inputs | {"sequence", "pdb_path", "plddt", "candidates"},
+            exclude_tool=exclude_tool,
+        )
+        for candidate in candidates:
+            if candidate.id in seen:
+                continue
+            seen.add(candidate.id)
+            ranked.append(candidate)
+    return ranked
+
+
+def _materialize_structure_guard_inputs(
+    *,
+    target_step: PlanStep,
+    guard_tool: ToolSpec,
+) -> dict | None:
+    resolved: dict[str, object] = {}
+    source_inputs = target_step.inputs if isinstance(target_step.inputs, dict) else {}
+    output_ref_aliases = {
+        "sequence": "sequence",
+        "pdb_path": "pdb_path",
+        "structure_pdb": "pdb_path",
+        "plddt": "plddt",
+        "candidates": "candidates",
+        "qc_metrics": "qc_metrics",
+        "structure_metrics": "structure_metrics",
+    }
+    for required in guard_tool.inputs:
+        if required in source_inputs:
+            resolved[required] = source_inputs[required]
+            continue
+        alias = output_ref_aliases.get(required)
+        if alias is not None:
+            resolved[required] = f"{target_step.id}.{alias}"
+            continue
+        return None
+    return resolved
+
+
+def _build_patch_metadata(
+    *,
+    target_capability: str,
+    source_tool: str,
+    selected_tool: str,
+    recovery_layer: str,
+    reason: str,
+    request_reason: str,
+    param_updates: dict | None = None,
+) -> dict:
+    metadata: dict[str, object] = {
+        "strategy": "layered_patch_v1",
+        "recovery_layer": recovery_layer,
+        "recovery_layer_rank": _PATCH_LAYER_PRIORITY.get(recovery_layer, 99),
+        "reason": reason,
+        "request_reason": request_reason,
+        "capability_id": target_capability,
+        "from_tool": source_tool,
+        "to_tool": selected_tool,
+        "replacement_matrix": list(
+            _P0_CAPABILITY_REPLACEMENT_MATRIX.get(target_capability, ())
+        ),
+    }
+    if param_updates:
+        metadata["param_updates"] = param_updates
+    return metadata
 
 
 def _build_replan_candidate_payloads(
@@ -846,6 +1123,14 @@ def _build_top_k_result(
             "adapter_mode": adapter_mode,
             "generation_note": payload.note,
         }
+        if payload.recovery_layer:
+            metadata["recovery_layer"] = payload.recovery_layer
+        if payload.recovery_reason:
+            metadata["recovery_reason"] = payload.recovery_reason
+        if isinstance(payload.payload, PlanPatch):
+            patch_meta = _extract_patch_candidate_metadata(payload.payload)
+            if patch_meta:
+                metadata.update(patch_meta)
         if isinstance(payload.payload, Plan):
             s1_metadata = _extract_s1_candidate_metadata(payload.payload)
             if s1_metadata:
@@ -869,13 +1154,24 @@ def _build_top_k_result(
             metadata=metadata,
         )
         priority_rank = _priority_rank(primary_tool.priority if primary_tool else None)
-        sort_key = (
-            -score_breakdown["overall"],
-            priority_rank,
-            capability_id,
-            tool_id,
-            candidate_id,
-        )
+        patch_layer_rank = _patch_layer_rank(payload.payload)
+        if candidate_kind == "patch":
+            sort_key = (
+                patch_layer_rank,
+                -score_breakdown["overall"],
+                priority_rank,
+                capability_id,
+                tool_id,
+                candidate_id,
+            )
+        else:
+            sort_key = (
+                -score_breakdown["overall"],
+                priority_rank,
+                capability_id,
+                tool_id,
+                candidate_id,
+            )
         ranked_rows.append((candidate, sort_key, capability_id))
 
     ranked_rows.sort(key=lambda row: row[1])
@@ -938,7 +1234,49 @@ def _build_candidate_summary(payload: Plan | PlanPatch) -> str:
         tools = [step.tool for step in payload.steps]
         return f"plan_steps={len(payload.steps)} tools={','.join(tools)}"
     ops = [op.op for op in payload.operations]
-    return f"patch_ops={len(payload.operations)} ops={','.join(ops)}"
+    layer = ""
+    if isinstance(payload.metadata, dict):
+        raw_layer = payload.metadata.get("recovery_layer")
+        if isinstance(raw_layer, str) and raw_layer:
+            layer = f" layer={raw_layer}"
+    return f"patch_ops={len(payload.operations)} ops={','.join(ops)}{layer}"
+
+
+def _extract_patch_candidate_metadata(payload: PlanPatch) -> dict:
+    metadata = payload.metadata if isinstance(payload.metadata, dict) else {}
+    extracted: dict[str, object] = {}
+    for key in (
+        "strategy",
+        "recovery_layer",
+        "recovery_layer_rank",
+        "reason",
+        "capability_id",
+        "from_tool",
+        "to_tool",
+        "request_reason",
+    ):
+        value = metadata.get(key)
+        if value is not None:
+            extracted[key] = value
+    replacement_matrix = metadata.get("replacement_matrix")
+    if isinstance(replacement_matrix, (tuple, list)):
+        extracted["replacement_matrix"] = list(replacement_matrix)
+    return extracted
+
+
+def _patch_layer_rank(payload: Plan | PlanPatch) -> int:
+    if isinstance(payload, Plan):
+        return 999
+    metadata = payload.metadata if isinstance(payload.metadata, dict) else {}
+    raw_rank = metadata.get("recovery_layer_rank")
+    try:
+        return int(raw_rank)
+    except (TypeError, ValueError):
+        pass
+    raw_layer = metadata.get("recovery_layer")
+    if isinstance(raw_layer, str):
+        return _PATCH_LAYER_PRIORITY.get(raw_layer, 999)
+    return 999
 
 
 def _score_payload(payload: Plan | PlanPatch, registry: Sequence[ToolSpec]) -> dict[str, float]:
@@ -1212,6 +1550,40 @@ def _rank_candidate_tools(
         )
     )
     return candidates
+
+
+def _rank_patch_alternatives(
+    *,
+    registry: Sequence[ToolSpec],
+    capability: str,
+    available_inputs: Set[str],
+    exclude_tool: str,
+) -> List[ToolSpec]:
+    ranked = _rank_candidate_tools(
+        registry=registry,
+        capability=capability,
+        available_inputs=available_inputs,
+        exclude_tool=exclude_tool,
+    )
+    indexed = {tool.id: idx for idx, tool in enumerate(ranked)}
+    ranked.sort(
+        key=lambda tool: (
+            _replacement_matrix_rank(capability, tool.id),
+            indexed.get(tool.id, 999),
+            tool.id,
+        )
+    )
+    return ranked
+
+
+def _replacement_matrix_rank(capability: str, tool_id: str) -> int:
+    order = _P0_CAPABILITY_REPLACEMENT_MATRIX.get(capability, ())
+    if not order:
+        return 999
+    try:
+        return order.index(tool_id)
+    except ValueError:
+        return len(order) + 1
 
 
 def _priority_rank(priority: str | None) -> int:

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from src.agents.planner import PlannerAgent, TopKResult
 from src.models.contracts import (
@@ -11,9 +11,11 @@ from src.models.contracts import (
     PlanPatch,
     PlanStep,
     StepResult,
+    now_iso,
 )
 from src.models.validation import validate_candidate_set_output
-from src.models.db import TaskRecord, InternalStatus
+from src.models.db import TaskRecord, InternalStatus, to_external_status
+from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
 from src.workflow.patch import apply_patch, build_patch_request
@@ -93,6 +95,7 @@ class PatchRunner:
             if result.metrics.get("retry_exhausted")
             else "patch_required"
         )
+        selected_candidate: PendingActionCandidate | None = None
         try:
             patch_request = build_patch_request(
                 plan=plan,
@@ -126,9 +129,16 @@ class PatchRunner:
                 patch_candidate = PendingActionCandidate(
                     candidate_id=f"patch_{step.id.lower()}",
                     payload=plan_patch,
+                    structured_payload=plan_patch,
                     summary="fallback patch candidate",
-                    metadata={"reason": patch_reason},
+                    tool_id=step.tool,
+                    capability_id=_extract_capability_from_step(step),
+                    metadata={
+                        "reason": patch_reason,
+                        "recovery_layer": "tool_level",
+                    },
                 )
+                selected_candidate = patch_candidate
                 patch_top_k = TopKResult(
                     candidates=[patch_candidate],
                     default_recommendation=patch_candidate.candidate_id,
@@ -140,11 +150,47 @@ class PatchRunner:
                 top_k_result=patch_top_k,
                 task_constraints=context.task.constraints,
             )
-        except Exception:
+        except Exception as exc:
+            _emit_recovery_escalation_event(
+                context,
+                step_id=step.id,
+                reason="patch_failed",
+                detail=f"patch candidate generation failed: {exc}",
+                recovery=_extract_recovery_metadata(
+                    plan_patch=None,
+                    selected_candidate=selected_candidate,
+                    source_step=step,
+                ),
+            )
             _enter_replan_waiting(context, record, reason="patch_failed")
             raise
 
         if gate.requires_hitl:
+            recovery_meta = _extract_recovery_metadata(
+                plan_patch=plan_patch,
+                selected_candidate=selected_candidate,
+                source_step=step,
+            )
+            if gate.reason == "patch_high_risk":
+                _attach_recovery_upgrade_meta(
+                    result,
+                    recovery_meta,
+                    upgrade_reason="patch_high_risk",
+                )
+                _emit_recovery_escalation_event(
+                    context,
+                    step_id=step.id,
+                    reason="patch_high_risk",
+                    detail="patch candidate blocked by high risk gate; escalate to replan",
+                    recovery=recovery_meta,
+                )
+                _enter_replan_waiting(context, record, reason="patch_high_risk")
+                return PatchRunOutcome(
+                    plan=plan,
+                    step_results=[result],
+                    next_step_index=step_index + 1,
+                )
+
             pending_action = build_pending_action(
                 task_id=context.task.task_id,
                 action_type=PendingActionType.PATCH_CONFIRM,
@@ -187,52 +233,127 @@ class PatchRunner:
             InternalStatus.PATCHING,
             reason="patch_start_auto",
         )
-        try:
-            patched_plan = apply_patch(plan, plan_patch)
-        except Exception:
-            _enter_replan_waiting(context, record, reason="patch_failed")
-            raise
+        candidate_pairs = _extract_patch_candidates(patch_top_k)
+        if not candidate_pairs:
+            candidate_pairs = [(selected_candidate, plan_patch)]
 
-        # 将最新的 plan 写回 context（如果 task_id 匹配）
-        if context.plan is None or context.plan.task_id == patched_plan.task_id:
-            context.plan = patched_plan
-        if record is not None and (
-            record.plan is None or record.plan.task_id == patched_plan.task_id
-        ):
-            record.plan = patched_plan
+        last_failed_result: StepResult | None = None
+        recovery_attempts: list[dict[str, Any]] = []
+        for index, (candidate, patch_payload) in enumerate(candidate_pairs, start=1):
+            recovery = _extract_recovery_metadata(
+                plan_patch=patch_payload,
+                selected_candidate=candidate,
+                source_step=step,
+            )
+            _emit_replacement_decision_event(
+                context,
+                step_id=step.id,
+                decision="patch_apply_start",
+                recovery=recovery,
+            )
+            try:
+                patched_plan = apply_patch(plan, patch_payload)
+            except Exception as exc:
+                recovery_attempts.append(
+                    {
+                        "attempt": index,
+                        "status": "apply_failed",
+                        "error": str(exc),
+                        "recovery": recovery,
+                    }
+                )
+                continue
 
-        if _has_insert_before_target(plan_patch, step.id):
-            pending_patch = PendingPatch(
-                target_step_id=step.id,
+            if _has_insert_before_target(patch_payload, step.id):
+                _commit_patched_plan(context, record, patched_plan)
+                pending_patch = PendingPatch(
+                    target_step_id=step.id,
+                    original_step=step,
+                    previous_result=result,
+                    plan_patch=patch_payload,
+                )
+                return PatchRunOutcome(
+                    plan=patched_plan,
+                    step_results=[],
+                    next_step_index=step_index,
+                    pending_patch=pending_patch,
+                )
+
+            target_id = step.id
+            patched_step = next(s for s in patched_plan.steps if s.id == target_id)
+            patched_index = next(
+                idx for idx, s in enumerate(patched_plan.steps) if s.id == target_id
+            )
+            patched_result = self._step_runner.run_step(patched_step, context)
+            self._attach_patch_meta(
+                patched_result,
                 original_step=step,
                 previous_result=result,
-                plan_patch=plan_patch,
+                plan_patch=patch_payload,
             )
-            return PatchRunOutcome(
-                plan=patched_plan,
-                step_results=[],
-                next_step_index=step_index,
-                pending_patch=pending_patch,
+            recovery_attempts.append(
+                {
+                    "attempt": index,
+                    "status": patched_result.status,
+                    "tool": patched_result.tool,
+                    "recovery": recovery,
+                }
             )
+            if patched_result.status != "failed":
+                _commit_patched_plan(context, record, patched_plan)
+                return PatchRunOutcome(
+                    plan=patched_plan,
+                    step_results=[patched_result],
+                    next_step_index=patched_index + 1,
+                )
+            last_failed_result = patched_result
 
-        # 优先使用原 step id 定位（避免插入操作改变索引）
-        target_id = step.id
-        patched_step = next(s for s in patched_plan.steps if s.id == target_id)
-        patched_index = next(
-            idx for idx, s in enumerate(patched_plan.steps) if s.id == target_id
-        )
-
-        patched_result = self._step_runner.run_step(patched_step, context)
-        self._attach_patch_meta(
-            patched_result,
-            original_step=step,
-            previous_result=result,
+        escalation_recovery = _extract_recovery_metadata(
             plan_patch=plan_patch,
+            selected_candidate=selected_candidate,
+            source_step=step,
         )
+        if last_failed_result is not None:
+            _attach_recovery_upgrade_meta(
+                last_failed_result,
+                escalation_recovery,
+                upgrade_reason="patch_failed",
+            )
+            metrics = dict(last_failed_result.metrics)
+            recovery = metrics.get("recovery", {})
+            if isinstance(recovery, dict):
+                recovery["attempts"] = recovery_attempts
+                metrics["recovery"] = recovery
+            last_failed_result.metrics = metrics
+        _emit_recovery_escalation_event(
+            context,
+            step_id=step.id,
+            reason="patch_failed",
+            detail="all patch layers failed; escalate to replan",
+            recovery=escalation_recovery,
+        )
+        _enter_replan_waiting(context, record, reason="patch_failed")
+        if last_failed_result is None:
+            _attach_recovery_upgrade_meta(
+                result,
+                escalation_recovery,
+                upgrade_reason="patch_failed",
+            )
+            metrics = dict(result.metrics)
+            recovery = metrics.get("recovery", {})
+            if isinstance(recovery, dict):
+                recovery["attempts"] = recovery_attempts
+                metrics["recovery"] = recovery
+            result.metrics = metrics
+            return PatchRunOutcome(
+                plan=plan,
+                step_results=[result],
+                next_step_index=step_index + 1,
+            )
         return PatchRunOutcome(
-            plan=patched_plan,
-            step_results=[patched_result],
-            next_step_index=patched_index + 1,
+            plan=plan,
+            step_results=[last_failed_result],
+            next_step_index=step_index + 1,
         )
 
     def _should_patch(self, result: StepResult) -> bool:
@@ -257,6 +378,12 @@ class PatchRunner:
         plan_patch: PlanPatch,
     ) -> None:
         """将 patch 关键信息写入 patched_result.metrics"""
+        recovery = _extract_recovery_metadata(
+            plan_patch=plan_patch,
+            selected_candidate=None,
+            source_step=original_step,
+            patched_step=patched_result,
+        )
         patch_info = {
             "applied": True,
             "ops": [op.op for op in plan_patch.operations],
@@ -266,9 +393,20 @@ class PatchRunner:
             "patched_step_id": patched_result.step_id,
             "patched_status": patched_result.status,
             "previous_attempt": _summarize_result(previous_result),
+            "layer": recovery.get("recovery_layer"),
+            "capability_id": recovery.get("capability_id"),
+            "reason": recovery.get("reason"),
         }
         metrics = dict(patched_result.metrics)
         metrics["patch"] = patch_info
+        metrics["recovery"] = {
+            **recovery,
+            "upgrade_reason": (
+                "patch_failed"
+                if patched_result.status == "failed"
+                else None
+            ),
+        }
         patched_result.metrics = metrics
 
     def attach_patch_meta(
@@ -285,6 +423,197 @@ class PatchRunner:
         )
 
 
+def _extract_recovery_metadata(
+    *,
+    plan_patch: PlanPatch | None,
+    selected_candidate: PendingActionCandidate | None,
+    source_step: PlanStep,
+    patched_step: StepResult | None = None,
+) -> dict[str, Any]:
+    metadata = (
+        plan_patch.metadata
+        if plan_patch is not None and isinstance(plan_patch.metadata, dict)
+        else {}
+    )
+    candidate_meta = (
+        selected_candidate.metadata
+        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        else {}
+    )
+    capability_id = metadata.get("capability_id")
+    if not isinstance(capability_id, str) or not capability_id:
+        capability_id = selected_candidate.capability_id if selected_candidate else None
+    if not isinstance(capability_id, str) or not capability_id:
+        capability_id = _extract_capability_from_step(source_step)
+
+    from_tool = metadata.get("from_tool")
+    if not isinstance(from_tool, str) or not from_tool:
+        from_tool = source_step.tool
+    to_tool = metadata.get("to_tool")
+    if not isinstance(to_tool, str) or not to_tool:
+        to_tool = (
+            patched_step.tool
+            if patched_step is not None
+            else (selected_candidate.tool_id if selected_candidate else source_step.tool)
+        )
+    recovery_layer = metadata.get("recovery_layer")
+    if not isinstance(recovery_layer, str) or not recovery_layer:
+        recovery_layer = str(candidate_meta.get("recovery_layer") or "tool_level")
+    reason = metadata.get("reason")
+    if not isinstance(reason, str) or not reason:
+        reason = str(candidate_meta.get("reason") or candidate_meta.get("recovery_reason") or "patch_required")
+
+    payload: dict[str, Any] = {
+        "recovery_layer": recovery_layer,
+        "capability_id": capability_id,
+        "from_tool": from_tool,
+        "to_tool": to_tool,
+        "reason": reason,
+    }
+    if isinstance(metadata.get("strategy"), str):
+        payload["strategy"] = metadata.get("strategy")
+    return payload
+
+
+def _attach_recovery_upgrade_meta(
+    result: StepResult,
+    recovery_meta: dict[str, Any],
+    *,
+    upgrade_reason: str,
+) -> None:
+    metrics = dict(result.metrics)
+    recovery = dict(recovery_meta)
+    recovery["upgrade_reason"] = upgrade_reason
+    metrics["recovery"] = recovery
+    result.metrics = metrics
+    error_details = dict(result.error_details)
+    error_details["recovery"] = recovery
+    normalized_code = upgrade_reason.upper()
+    if not normalized_code.startswith("PATCH_"):
+        normalized_code = f"PATCH_{normalized_code}"
+    error_details["failure_code"] = normalized_code
+    result.error_details = error_details
+
+
+def _emit_replacement_decision_event(
+    context: WorkflowContext,
+    *,
+    step_id: str,
+    decision: str,
+    recovery: dict[str, Any],
+) -> None:
+    layer = str(recovery.get("recovery_layer") or "tool_level")
+    event_name = {
+        "parameter_level": "PARAM_TWEAK",
+        "tool_level": "REPLACE_TOOL",
+        "structure_level": "STRUCTURE_PATCH",
+    }.get(layer, "REPLACE_TOOL")
+    append_event(
+        context.task.task_id,
+        {
+            "event": event_name,
+            "task_id": context.task.task_id,
+            "step_id": step_id,
+            "timestamp": now_iso(),
+            "state": context.status.value,
+            "external_status": to_external_status(context.status).value,
+            "data": {
+                "decision": decision,
+                "recovery": recovery,
+            },
+        },
+    )
+
+
+def _emit_recovery_escalation_event(
+    context: WorkflowContext,
+    *,
+    step_id: str,
+    reason: str,
+    detail: str,
+    recovery: dict[str, Any],
+) -> None:
+    append_event(
+        context.task.task_id,
+        {
+            "event": "RECOVERY_ESCALATED",
+            "task_id": context.task.task_id,
+            "step_id": step_id,
+            "timestamp": now_iso(),
+            "state": context.status.value,
+            "external_status": to_external_status(context.status).value,
+            "data": {
+                "reason": reason,
+                "detail": detail,
+                "recovery": recovery,
+            },
+        },
+    )
+
+
+def _extract_capability_from_step(step: PlanStep) -> str:
+    metadata = step.metadata if isinstance(step.metadata, dict) else {}
+    raw = metadata.get("capability")
+    if isinstance(raw, str) and raw:
+        return raw
+    values = metadata.get("capabilities")
+    if isinstance(values, list):
+        for item in values:
+            if isinstance(item, str) and item:
+                return item
+    return "unknown"
+
+
+def _extract_patch_candidates(
+    top_k: TopKResult,
+) -> list[tuple[PendingActionCandidate, PlanPatch]]:
+    pairs: list[tuple[PendingActionCandidate, PlanPatch]] = []
+    for candidate in top_k.candidates:
+        payload = candidate.structured_payload or candidate.payload
+        if isinstance(payload, PlanPatch):
+            pairs.append((candidate, payload))
+    if not pairs:
+        return []
+    if top_k.default_recommendation:
+        pairs.sort(
+            key=lambda pair: (
+                0 if pair[0].candidate_id == top_k.default_recommendation else 1,
+                _recovery_layer_rank(pair[1]),
+                pair[0].candidate_id,
+            )
+        )
+    else:
+        pairs.sort(
+            key=lambda pair: (
+                _recovery_layer_rank(pair[1]),
+                pair[0].candidate_id,
+            )
+        )
+    return pairs
+
+
+def _recovery_layer_rank(patch: PlanPatch) -> int:
+    metadata = patch.metadata if isinstance(patch.metadata, dict) else {}
+    raw_rank = metadata.get("recovery_layer_rank")
+    try:
+        return int(raw_rank)
+    except (TypeError, ValueError):
+        return 99
+
+
+def _commit_patched_plan(
+    context: WorkflowContext,
+    record: TaskRecord | None,
+    patched_plan: Plan,
+) -> None:
+    if context.plan is None or context.plan.task_id == patched_plan.task_id:
+        context.plan = patched_plan
+    if record is not None and (
+        record.plan is None or record.plan.task_id == patched_plan.task_id
+    ):
+        record.plan = patched_plan
+
+
 def _enter_replan_waiting(
     context: WorkflowContext,
     record: TaskRecord | None,
@@ -296,7 +625,7 @@ def _enter_replan_waiting(
         action_type=PendingActionType.REPLAN_CONFIRM,
         candidates=[],
         default_suggestion=None,
-        explanation="patch failed; replan confirmation required",
+        explanation=f"patch escalation ({reason}); replan confirmation required",
     )
     enter_waiting_state(
         context,

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -284,8 +284,16 @@ class PlanRunner:
 
                 if failed_result is not None:
                     failure_reason = "step_failed"
-                    if failed_result.metrics.get("retry_exhausted"):
+                    patch_meta = failed_result.metrics.get("patch")
+                    recovery_meta = failed_result.metrics.get("recovery")
+                    if isinstance(patch_meta, dict) and patch_meta.get("applied") is True:
+                        failure_reason = "patch_failed"
+                    elif failed_result.metrics.get("retry_exhausted"):
                         failure_reason = "retry_exhausted"
+                    if isinstance(recovery_meta, dict):
+                        upgrade_reason = recovery_meta.get("upgrade_reason")
+                        if isinstance(upgrade_reason, str) and upgrade_reason:
+                            failure_reason = upgrade_reason
                     request_failure_type = self._coerce_failure_type(
                         failed_result.failure_type
                     )
@@ -485,6 +493,8 @@ class PlanRunner:
         options = ["replan", "cancel"]
         if isinstance(failure_code, str) and failure_code.startswith("NIM_"):
             options.append("switch_to_local_esmfold")
+        if isinstance(failure_code, str) and failure_code.startswith("S3_"):
+            options.append("suffix_replan")
         return options
 
     def _summarize_failure_result(self, result: StepResult) -> dict:
@@ -496,6 +506,8 @@ class PlanRunner:
                 failure_reason = result.risk_flags[0].message
         if not failure_code and isinstance(result.error_details, dict):
             failure_code = result.error_details.get("failure_code")
+        patch_meta = result.metrics.get("patch")
+        recovery_meta = result.metrics.get("recovery")
         return {
             "step_id": result.step_id,
             "tool": result.tool,
@@ -503,6 +515,8 @@ class PlanRunner:
             "failure_code": failure_code,
             "failure_reason": failure_reason,
             "risk_flags": [flag.model_dump() for flag in result.risk_flags],
+            "patch": patch_meta if isinstance(patch_meta, dict) else {},
+            "recovery": recovery_meta if isinstance(recovery_meta, dict) else {},
         }
 
     def _coerce_failure_type(self, value) -> FailureType:
@@ -775,6 +789,29 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
     stage_id = outputs.get("stage_id")
     if isinstance(stage_id, str) and stage_id:
         data["stage_id"] = stage_id
+
+    patch_meta = step_result.metrics.get("patch")
+    if isinstance(patch_meta, dict) and patch_meta:
+        data["patch"] = {
+            "layer": patch_meta.get("layer"),
+            "from_tool": patch_meta.get("from_tool"),
+            "to_tool": patch_meta.get("to_tool"),
+            "capability_id": patch_meta.get("capability_id"),
+            "reason": patch_meta.get("reason"),
+            "ops": patch_meta.get("ops"),
+            "patched_status": patch_meta.get("patched_status"),
+        }
+
+    recovery_meta = step_result.metrics.get("recovery")
+    if isinstance(recovery_meta, dict) and recovery_meta:
+        data["recovery"] = {
+            "layer": recovery_meta.get("recovery_layer"),
+            "from_tool": recovery_meta.get("from_tool"),
+            "to_tool": recovery_meta.get("to_tool"),
+            "capability_id": recovery_meta.get("capability_id"),
+            "reason": recovery_meta.get("reason"),
+            "upgrade_reason": recovery_meta.get("upgrade_reason"),
+        }
 
     if stage_id == "S3":
         reject_counts = outputs.get("reject_code_counts")

--- a/tests/integration/test_recovery_layered_patch.py
+++ b/tests/integration/test_recovery_layered_patch.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import src.agents.planner as planner_module
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.models.contracts import Plan, PlanStep, ProteinDesignTask, StepResult, now_iso
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.storage.log_store import DEFAULT_LOG_DIR, read_timeline_events
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType
+from src.workflow.patch_runner import PatchRunner
+
+
+def _cleanup_task_log(task_id: str) -> None:
+    path = Path(DEFAULT_LOG_DIR) / f"{task_id}.jsonl"
+    if path.exists():
+        path.unlink()
+
+
+def _patch_runtime_kg() -> dict:
+    return {
+        "capabilities": [
+            {"capability_id": "structure_prediction", "name": "Structure", "domain": "protein/structure"},
+            {"capability_id": "quality_qc", "name": "QC", "domain": "protein/qc"},
+        ],
+        "io_types": [
+            {
+                "io_type_id": "sequence_to_structure",
+                "input_types": ["sequence"],
+                "output_types": ["structure_pdb", "plddt"],
+                "combinable": True,
+            },
+            {
+                "io_type_id": "sequence_structure_to_qc_metrics",
+                "input_types": ["sequence", "pdb_path"],
+                "output_types": ["qc_metrics"],
+                "combinable": True,
+            },
+        ],
+        "tools": [
+            {
+                "id": "failing_tool",
+                "capabilities": ["structure_prediction"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {"sequence": "str"},
+                    "outputs": {"pdb_path": "path", "plddt": "float"},
+                },
+                "execution": {"backend": "remote_model_service", "provider": "nim"},
+                "constraints": {},
+            },
+            {
+                "id": "esmfold",
+                "capabilities": ["structure_prediction"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {"sequence": "str"},
+                    "outputs": {"pdb_path": "path", "plddt": "float"},
+                },
+                "execution": "nextflow",
+                "constraints": {},
+            },
+            {
+                "id": "biopython_qc",
+                "capabilities": ["quality_qc"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_structure_to_qc_metrics",
+                    "inputs": {"sequence": "str", "pdb_path": "path"},
+                    "outputs": {"qc_metrics": "dict"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+        ],
+    }
+
+
+def _build_runtime_objects(
+    *,
+    task_id: str,
+    constraints: dict,
+    step_tool: str,
+) -> tuple[Plan, WorkflowContext, TaskRecord]:
+    task = ProteinDesignTask(
+        task_id=task_id,
+        goal="layered-patch-test",
+        constraints=constraints,
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[PlanStep(id="S1", tool=step_tool, inputs={"sequence": "MKTAYIAK"}, metadata={})],
+        constraints=constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.RUNNING,
+    )
+    record = TaskRecord(
+        id=task.task_id,
+        status=ExternalStatus.RUNNING,
+        internal_status=InternalStatus.RUNNING,
+        goal=task.goal,
+        constraints=task.constraints,
+        metadata=task.metadata,
+        plan=plan,
+    )
+    return plan, context, record
+
+
+class _LayeredFallbackStepRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self.calls.append(step.tool)
+        if len(self.calls) == 1:
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.RETRYABLE,
+                error_message="first attempt failed",
+                error_details={},
+                outputs={},
+                metrics={"retry_exhausted": True},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        if step.tool == "failing_tool":
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.TOOL_ERROR,
+                error_message="parameter-level patch failed",
+                error_details={},
+                outputs={},
+                metrics={},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={"pdb_path": "/tmp/a.pdb", "plddt": 0.9},
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+class _AlwaysFailStepRunner:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self.calls.append(step.tool)
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="failed",
+            failure_type=FailureType.TOOL_ERROR,
+            error_message="all patch attempts failed",
+            error_details={},
+            outputs={},
+            metrics={"retry_exhausted": True} if len(self.calls) == 1 else {},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+class _SingleFailStepRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self.calls += 1
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="failed",
+            failure_type=FailureType.RETRYABLE,
+            error_message="retry exhausted",
+            error_details={},
+            outputs={},
+            metrics={"retry_exhausted": True},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+@pytest.mark.integration
+def test_layered_patch_promotes_from_parameter_to_tool_level(monkeypatch):
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _patch_runtime_kg())
+    planner = PlannerAgent(
+        tool_registry=[
+            ToolSpec(
+                id="failing_tool",
+                capabilities=("structure_prediction",),
+                inputs=("sequence",),
+                outputs=("pdb_path", "plddt"),
+                cost=0.6,
+                safety_level=1,
+                io_type="sequence_to_structure",
+                adapter_mode="local",
+                priority="P0",
+            ),
+            ToolSpec(
+                id="esmfold",
+                capabilities=("structure_prediction",),
+                inputs=("sequence",),
+                outputs=("pdb_path", "plddt"),
+                cost=0.5,
+                safety_level=1,
+                io_type="sequence_to_structure",
+                adapter_mode="local",
+                priority="P0",
+            ),
+            ToolSpec(
+                id="biopython_qc",
+                capabilities=("quality_qc",),
+                inputs=("sequence", "pdb_path"),
+                outputs=("qc_metrics",),
+                cost=0.2,
+                safety_level=1,
+                io_type="sequence_structure_to_qc_metrics",
+                adapter_mode="local",
+                priority="P0",
+            ),
+        ]
+    )
+    task_id = "int_layered_patch_tool_success"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={
+            "require_patch_confirm": False,
+            "min_candidate_confidence": 0.0,
+            "high_cost_min_overall": 0.0,
+        },
+        step_tool="failing_tool",
+    )
+    step_runner = _LayeredFallbackStepRunner()
+    patch_runner = PatchRunner(step_runner=step_runner, planner_agent=planner)
+
+    outcome = patch_runner.run_step_with_patch(plan, 0, context, record=record)
+
+    assert step_runner.calls == ["failing_tool", "failing_tool", "esmfold"]
+    assert context.status == InternalStatus.PATCHING
+    assert record.status == ExternalStatus.WAITING_PATCH_CONFIRM
+    assert outcome.step_results[0].status == "success"
+    patch_meta = outcome.step_results[0].metrics.get("patch")
+    assert patch_meta["layer"] == "tool_level"
+    assert patch_meta["from_tool"] == "failing_tool"
+    assert patch_meta["to_tool"] == "esmfold"
+    assert patch_meta["capability_id"] == "structure_prediction"
+    assert patch_meta["reason"] == "tool_swap_replacement_matrix"
+
+    events = read_timeline_events(task_id)
+    replace_events = [e for e in events if e.get("event_type") == "REPLACE_TOOL"]
+    assert replace_events
+    recovery = replace_events[-1]["data"]["recovery"]
+    assert recovery["from_tool"] == "failing_tool"
+    assert recovery["to_tool"] == "esmfold"
+    assert recovery["capability_id"] == "structure_prediction"
+
+
+@pytest.mark.integration
+def test_layered_patch_failure_escalates_to_replan_with_trace(monkeypatch):
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _patch_runtime_kg())
+    planner = PlannerAgent(
+        tool_registry=[
+            ToolSpec(
+                id="failing_tool",
+                capabilities=("structure_prediction",),
+                inputs=("sequence",),
+                outputs=("pdb_path", "plddt"),
+                cost=0.6,
+                safety_level=1,
+                io_type="sequence_to_structure",
+                adapter_mode="local",
+                priority="P0",
+            ),
+            ToolSpec(
+                id="esmfold",
+                capabilities=("structure_prediction",),
+                inputs=("sequence",),
+                outputs=("pdb_path", "plddt"),
+                cost=0.5,
+                safety_level=1,
+                io_type="sequence_to_structure",
+                adapter_mode="local",
+                priority="P0",
+            ),
+        ]
+    )
+    task_id = "int_layered_patch_all_failed"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={
+            "require_patch_confirm": False,
+            "min_candidate_confidence": 0.0,
+            "high_cost_min_overall": 0.0,
+        },
+        step_tool="failing_tool",
+    )
+    patch_runner = PatchRunner(step_runner=_AlwaysFailStepRunner(), planner_agent=planner)
+
+    outcome = patch_runner.run_step_with_patch(plan, 0, context, record=record)
+
+    assert context.status == InternalStatus.WAITING_REPLAN
+    assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+    assert outcome.step_results
+    failed = outcome.step_results[0]
+    recovery = failed.metrics.get("recovery")
+    assert recovery["upgrade_reason"] == "patch_failed"
+    assert isinstance(recovery.get("attempts"), list)
+    assert len(recovery["attempts"]) >= 2
+
+    events = read_timeline_events(task_id)
+    escalated = [e for e in events if e.get("event_type") == "RECOVERY_ESCALATED"]
+    assert escalated
+    assert escalated[-1]["data"]["reason"] == "patch_failed"
+
+
+@pytest.mark.integration
+def test_high_risk_patch_escalates_to_replan(monkeypatch):
+    kg = {
+        "capabilities": [
+            {"capability_id": "structure_prediction", "name": "Structure", "domain": "protein/structure"}
+        ],
+        "io_types": [
+            {
+                "io_type_id": "sequence_to_structure",
+                "input_types": ["sequence"],
+                "output_types": ["structure_pdb", "plddt"],
+                "combinable": True,
+            }
+        ],
+        "tools": [
+            {
+                "id": "risky_tool",
+                "capabilities": ["structure_prediction"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {"sequence": "str"},
+                    "outputs": {"pdb_path": "path", "plddt": "float"},
+                },
+                "execution": {"backend": "remote_model_service", "provider": "nim"},
+                "constraints": {},
+            }
+        ],
+    }
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: kg)
+    planner = PlannerAgent(
+        tool_registry=[
+            ToolSpec(
+                id="risky_tool",
+                capabilities=("structure_prediction",),
+                inputs=("sequence",),
+                outputs=("pdb_path", "plddt"),
+                cost=0.6,
+                safety_level=5,
+                io_type="sequence_to_structure",
+                adapter_mode="remote",
+                priority="P0",
+            )
+        ]
+    )
+    task_id = "int_layered_patch_high_risk"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={
+            "require_patch_confirm": False,
+            "min_candidate_confidence": 0.0,
+            "high_cost_min_overall": 0.0,
+        },
+        step_tool="risky_tool",
+    )
+    patch_runner = PatchRunner(step_runner=_SingleFailStepRunner(), planner_agent=planner)
+
+    outcome = patch_runner.run_step_with_patch(plan, 0, context, record=record)
+
+    assert context.status == InternalStatus.WAITING_REPLAN
+    assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+    recovery = outcome.step_results[0].metrics.get("recovery")
+    assert recovery["upgrade_reason"] == "patch_high_risk"
+
+    events = read_timeline_events(task_id)
+    escalated = [e for e in events if e.get("event_type") == "RECOVERY_ESCALATED"]
+    assert escalated
+    assert escalated[-1]["data"]["reason"] == "patch_high_risk"

--- a/tests/unit/test_patch_runner.py
+++ b/tests/unit/test_patch_runner.py
@@ -193,10 +193,10 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task, monkeypatch):
     patched_result = outcome.step_results[0]
 
     # patch 应被触发并自动应用
-    assert step_runner.calls == ["failing_tool", "patched_tool"]
+    assert step_runner.calls == ["failing_tool", "failing_tool"]
 
     # plan 应被替换为 patched 版本
-    assert patched_plan.steps[0].tool == "patched_tool"
+    assert patched_plan.steps[0].tool == "failing_tool"
     assert context.plan is patched_plan
     assert record.plan is patched_plan
     assert outcome.next_step_index == 1
@@ -204,12 +204,14 @@ def test_patch_runner_triggers_patch_and_records_meta(sample_task, monkeypatch):
 
     # patched step 应执行成功并返回
     assert patched_result.status == "success"
-    assert patched_result.tool == "patched_tool"
+    assert patched_result.tool == "failing_tool"
 
     patch_meta = patched_result.metrics.get("patch")
     assert patch_meta and patch_meta["applied"] is True
     assert patch_meta["from_tool"] == "failing_tool"
-    assert patch_meta["to_tool"] == "patched_tool"
+    assert patch_meta["to_tool"] == "failing_tool"
+    assert patch_meta["layer"] == "parameter_level"
+    assert patch_meta["reason"] == "parameter_tweak"
     assert patch_meta["patched_status"] == "success"
     prev_attempt = patch_meta["previous_attempt"]
     assert prev_attempt["attempt_history"][0]["failure_type"] == "RETRYABLE"

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -259,6 +259,56 @@ def _patch_request_for_topk() -> PatchRequest:
     )
 
 
+def _patch_request_for_tool(
+    *,
+    task_id: str,
+    tool_id: str,
+    inputs: dict,
+    previous_outputs: dict,
+) -> PatchRequest:
+    plan = Plan(
+        task_id=task_id,
+        steps=[PlanStep(id="S1", tool=tool_id, inputs=inputs, metadata={})],
+        constraints={},
+        metadata={},
+    )
+    previous = StepResult(
+        task_id=task_id,
+        step_id="S0",
+        tool="seed",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        outputs=previous_outputs,
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    failed = StepResult(
+        task_id=task_id,
+        step_id="S1",
+        tool=tool_id,
+        status="failed",
+        failure_type="TOOL_ERROR",
+        error_message="boom",
+        error_details={},
+        outputs={},
+        metrics={"retry_exhausted": True},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    return PatchRequest(
+        task_id=task_id,
+        original_plan=plan,
+        context_step_results=[previous, failed],
+        safety_events=[],
+        reason="unit-test",
+    )
+
+
 @pytest.mark.unit
 class TestPlannerAgent:
     """PlannerAgent测试类"""
@@ -526,6 +576,180 @@ class TestPlannerAgent:
             assert candidate.io_type is not None
             assert candidate.adapter_mode is not None
             json.dumps(candidate.model_dump(mode="json"), ensure_ascii=True)
+
+    def test_patch_top_k_uses_layered_priority_and_matrix_metadata(self, monkeypatch):
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        planner = PlannerAgent(tool_registry=_topk_registry())
+        topk = planner.patch_top_k(_patch_request_for_topk(), k=6)
+
+        assert topk.candidates
+        first = topk.candidates[0]
+        assert first.metadata.get("recovery_layer") == "parameter_level"
+        assert first.metadata.get("capability_id") == "structure_prediction"
+
+        tool_level = [
+            candidate
+            for candidate in topk.candidates
+            if candidate.metadata.get("recovery_layer") == "tool_level"
+        ]
+        assert tool_level, "expected at least one tool-level fallback candidate"
+        assert any(candidate.metadata.get("to_tool") == "nim_esmfold" for candidate in tool_level)
+        assert any(
+            candidate.metadata.get("from_tool") == "esmfold"
+            and candidate.metadata.get("to_tool") == "nim_esmfold"
+            for candidate in tool_level
+        )
+
+    def test_patch_top_k_supports_requirement2_qc_and_objective_replacements(self, monkeypatch):
+        kg = {
+            "capabilities": [
+                {"capability_id": "quality_qc", "name": "Quality QC", "domain": "protein/qc"},
+                {"capability_id": "objective_scoring", "name": "Objective", "domain": "protein/score"},
+            ],
+            "io_types": [
+                {
+                    "io_type_id": "sequence_structure_to_qc_metrics",
+                    "input_types": ["sequence", "pdb_path"],
+                    "output_types": ["qc_metrics"],
+                    "combinable": True,
+                },
+                {
+                    "io_type_id": "candidates_to_objective_scores_topk",
+                    "input_types": ["candidates"],
+                    "output_types": ["score_table", "top_k"],
+                    "combinable": True,
+                },
+            ],
+            "tools": [
+                {
+                    "id": "biopython_qc",
+                    "capabilities": ["quality_qc"],
+                    "priority": "P0",
+                    "io": {
+                        "io_type_id": "sequence_structure_to_qc_metrics",
+                        "inputs": {"sequence": "str", "pdb_path": "path"},
+                        "outputs": {"qc_metrics": "dict"},
+                    },
+                    "execution": "python",
+                    "constraints": {},
+                },
+                {
+                    "id": "dssp",
+                    "capabilities": ["quality_qc"],
+                    "priority": "P1",
+                    "io": {
+                        "io_type_id": "sequence_structure_to_qc_metrics",
+                        "inputs": {"sequence": "str", "pdb_path": "path"},
+                        "outputs": {"qc_metrics": "dict"},
+                    },
+                    "execution": "python",
+                    "constraints": {},
+                },
+                {
+                    "id": "objective_ranker",
+                    "capabilities": ["objective_scoring"],
+                    "priority": "P0",
+                    "io": {
+                        "io_type_id": "candidates_to_objective_scores_topk",
+                        "inputs": {"candidates": "list"},
+                        "outputs": {"score_table": "dict", "top_k": "list"},
+                    },
+                    "execution": "python",
+                    "constraints": {},
+                },
+                {
+                    "id": "objective_ranker_v2",
+                    "capabilities": ["objective_scoring"],
+                    "priority": "P1",
+                    "io": {
+                        "io_type_id": "candidates_to_objective_scores_topk",
+                        "inputs": {"candidates": "list"},
+                        "outputs": {"score_table": "dict", "top_k": "list"},
+                    },
+                    "execution": "python",
+                    "constraints": {},
+                },
+            ],
+        }
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: kg)
+        planner = PlannerAgent(
+            tool_registry=[
+                ToolSpec(
+                    id="biopython_qc",
+                    capabilities=("quality_qc",),
+                    inputs=("sequence", "pdb_path"),
+                    outputs=("qc_metrics",),
+                    cost=0.2,
+                    safety_level=1,
+                    io_type="sequence_structure_to_qc_metrics",
+                    adapter_mode="local",
+                    priority="P0",
+                ),
+                ToolSpec(
+                    id="dssp",
+                    capabilities=("quality_qc",),
+                    inputs=("sequence", "pdb_path"),
+                    outputs=("qc_metrics",),
+                    cost=0.3,
+                    safety_level=1,
+                    io_type="sequence_structure_to_qc_metrics",
+                    adapter_mode="local",
+                    priority="P1",
+                ),
+                ToolSpec(
+                    id="objective_ranker",
+                    capabilities=("objective_scoring",),
+                    inputs=("candidates",),
+                    outputs=("score_table", "top_k"),
+                    cost=0.25,
+                    safety_level=1,
+                    io_type="candidates_to_objective_scores_topk",
+                    adapter_mode="local",
+                    priority="P0",
+                ),
+                ToolSpec(
+                    id="objective_ranker_v2",
+                    capabilities=("objective_scoring",),
+                    inputs=("candidates",),
+                    outputs=("score_table", "top_k"),
+                    cost=0.35,
+                    safety_level=1,
+                    io_type="candidates_to_objective_scores_topk",
+                    adapter_mode="local",
+                    priority="P1",
+                ),
+            ]
+        )
+
+        qc_topk = planner.patch_top_k(
+            _patch_request_for_tool(
+                task_id="task_patch_qc",
+                tool_id="biopython_qc",
+                inputs={"sequence": "S0.sequence", "pdb_path": "S0.pdb_path"},
+                previous_outputs={"sequence": "MKT", "pdb_path": "/tmp/a.pdb"},
+            ),
+            k=4,
+        )
+        assert any(
+            candidate.metadata.get("to_tool") == "dssp"
+            and candidate.metadata.get("recovery_layer") == "tool_level"
+            for candidate in qc_topk.candidates
+        )
+
+        objective_topk = planner.patch_top_k(
+            _patch_request_for_tool(
+                task_id="task_patch_objective",
+                tool_id="objective_ranker_v2",
+                inputs={"candidates": "S0.candidates"},
+                previous_outputs={"candidates": [{"id": "c1"}]},
+            ),
+            k=4,
+        )
+        assert any(
+            candidate.metadata.get("to_tool") == "objective_ranker"
+            and candidate.metadata.get("recovery_layer") == "tool_level"
+            for candidate in objective_topk.candidates
+        )
 
     def test_replan_top_k_order_is_deterministic(self, monkeypatch):
         monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())


### PR DESCRIPTION
## Summary

This PR implements **Issue #143 (W11-Workflow-1)** with strict layered recovery behavior and Requirement-2 tool integration in the existing workflow architecture.

Core delivery:

- Layered patch generation and execution path:
  - `parameter_level -> tool_level -> structure_level`
- Replan escalation conditions are explicit and traceable:
  - `patch_failed` (generation/apply/all layered attempts failed)
  - `patch_high_risk` (gate blocks patch due to risk)
- Replan remains default **`suffix_replan`** in planner metadata.
- Recovery trace fields are now included in runtime events and step traces.

## What Changed

### 1) Planner layered patch strategy

Files:
- `src/agents/planner.py`

Implemented:
- Layered patch candidate generation in `patch_top_k` path:
  - parameter-level candidate (same tool with safe param updates)
  - tool-level candidate (capability-compatible tool swap)
  - structure-level candidate (guard/insert step)
- Candidate ordering prioritizes recovery layer before score for patch candidates.
- Patch metadata now carries recovery trace payload:
  - `recovery_layer`, `recovery_layer_rank`, `reason`, `request_reason`
  - `capability_id`, `from_tool`, `to_tool`, `replacement_matrix`

Requirement-2 replacement matrix integrated:
- `structure_prediction`: `nim_esmfold <-> esmfold <-> alphafold/openfold`
- `quality_qc`: `biopython_qc/dssp` minimal fallback path
- `objective_scoring`: `objective_ranker` minimal fallback path

### 2) Runtime layered execution and escalation

Files:
- `src/workflow/patch_runner.py`
- `src/workflow/plan_runner.py`

Implemented:
- Patch auto-path now attempts layered candidates sequentially in one recovery cycle.
- If earlier layer fails, automatically promotes to next layer.
- On full patch failure or high-risk gate, transitions to `WAITING_REPLAN` with explicit reason.
- Adds structured recovery metadata into `StepResult.metrics` and `error_details`.
- Emits recovery decision/escalation events:
  - `PARAM_TWEAK`
  - `REPLACE_TOOL`
  - `STRUCTURE_PATCH`
  - `RECOVERY_ESCALATED`
- `PlanRunner` step trace payload now includes `data.patch` and `data.recovery` to support replay/audit.

### 3) Tests and docs

Files:
- `tests/unit/test_planner_agent.py`
- `tests/unit/test_patch_runner.py`
- `tests/integration/test_recovery_layered_patch.py` (new)
- `README.md`

Added coverage:
- Layered patch priority and metadata correctness.
- Requirement-2 replacement paths for `quality_qc` and `objective_scoring`.
- Runtime promotion `parameter -> tool` and success case.
- Patch all-failed escalation to replan with trace assertions.
- High-risk patch gate escalation to replan.

## Acceptance Criteria Mapping (Issue #143)

- [x] 实现分层 patch 候选生成与选择
- [x] 为升级 replan 定义明确触发条件
- [x] 在日志中记录恢复层级与升级原因
- [x] 增加恢复路径集成测试（含 FSM 合法性行为）
- [x] 始终满足 `retry -> patch -> replan` 顺序约束
- [x] 默认优先 `suffix_replan`

## Test Commands

Executed:

```bash
uv run pytest \
  tests/unit/test_planner_agent.py \
  tests/unit/test_patch_runner.py \
  tests/unit/test_plan_runner.py \
  tests/unit/test_plan_runner_step_trace.py \
  tests/integration/test_candidate_score_gate.py \
  tests/integration/test_recovery_layered_patch.py
```

Result: all passed.

## Future Follow-ups (non-blocking)

- Expand structure-level patch operators beyond minimal guard insertion for richer subplan rewrites.
- Align event schema/API query surface with #144 observability scope for dedicated recovery replay endpoints.
- Add longer-chain recovery stress tests across multi-step plans and mixed capability failures.

Closes #143
