### PR TITLE
feat(workflow): implement issue #158 S4 structure-conditioned refinement loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,41 @@ Traceability:
 - S3 execution emits `STEP_FINISHED/STEP_FAILED` with `data.quality_gate` summary.
 - `PlanRunner` step events now include `data.failure_code` and S3 quality summary fields for downstream extraction reuse.
 
+## S4 Structure-conditioned Refinement (Issue #158)
+
+De novo planning now includes `S4` step specification:
+
+- default stage chain: `S1 -> S2 -> S4`
+- `S4` metadata:
+  - `stage_id=S4`
+  - `stage_name=structure_conditioned_refinement`
+  - `loop_path=[S4,S2,S3]`
+  - `stop_conditions`: `max_iterations`, `convergence_delta`, `max_degradation_rounds`
+
+Runtime loop entrypoint:
+
+- `ExecutorAgent.refine_sequences_from_s3(...)`
+- iterative closure: `S4 refinement -> S2 structure projection -> S3 quality gate`
+
+Loop stop reasons:
+
+- `converged`
+- `degradation_limit`
+- `refinement_failed`
+- `quality_gate_rejected`
+- `missing_source_pdb`
+- `max_iterations_reached`
+
+Traceability and persistence:
+
+- step outputs include:
+  - `refinement_iterations`
+  - `gain_metrics` (`baseline_plddt/final_plddt/delta_vs_baseline`)
+  - `stop_reason`
+  - `lineage.rollback_applied`
+- audit artifact persisted as:
+  - `output/artifacts/s4_refinement_<task_id>_<step_id>.json`
+
 ## Layered Patch/Replan Recovery (Issue #143)
 
 Recovery strategy now follows strict layered patch order before replan:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Traceability:
 
 De novo planning now includes `S4` step specification:
 
-- default stage chain: `S1 -> S2 -> S4`
+- default stage chain: `S1 -> S2 -> S4 -> S2R`
 - `S4` metadata:
   - `stage_id=S4`
   - `stage_name=structure_conditioned_refinement`
@@ -122,6 +122,8 @@ Runtime loop entrypoint:
 
 - `ExecutorAgent.refine_sequences_from_s3(...)`
 - iterative closure: `S4 refinement -> S2 structure projection -> S3 quality gate`
+- when `S3` baseline is absent, baseline candidates fallback to `S2` and are filtered by quality gate before entering S4
+- `S2R` remaps structure from `S4.sequence` to keep final sequence/structure pairing consistent
 
 Loop stop reasons:
 

--- a/src/adapters/protein_mpnn_adapter.py
+++ b/src/adapters/protein_mpnn_adapter.py
@@ -213,18 +213,35 @@ class ProteinMPNNAdapter(BaseToolAdapter):
             fallback=self.default_num_candidates,
         )
         goal = str(inputs.get("goal") or "")
+        task_id = str(inputs.get("task_id", "unknown"))
+        step_id = str(inputs.get("step_id", "unknown"))
 
         rng = _seeded_rng(pdb_path, goal, min_len, max_len, num_candidates)
         candidates = _generate_candidates(rng, min_len, max_len, num_candidates)
+        iteration = _normalize_iteration(inputs.get("iteration"))
+        source_candidate_id = (
+            str(inputs.get("source_candidate_id"))
+            if isinstance(inputs.get("source_candidate_id"), str)
+            else None
+        )
+        candidates = _annotate_candidates(
+            candidates,
+            step_id=str(step_id),
+            source_candidate_id=source_candidate_id,
+            iteration=iteration,
+        )
         selected = max(candidates, key=lambda item: item["score"])
+        lineage = _build_refinement_lineage(
+            inputs,
+            step_id=step_id,
+        )
 
-        task_id = inputs.get("task_id", "unknown")
-        step_id = inputs.get("step_id", "unknown")
         artifacts_path = self._write_artifacts(
             task_id=task_id,
             step_id=step_id,
             pdb_path=pdb_path,
             candidates=candidates,
+            lineage=lineage if lineage else None,
         )
 
         duration_ms = int((perf_counter() - t0) * 1000)
@@ -234,11 +251,22 @@ class ProteinMPNNAdapter(BaseToolAdapter):
             "candidates": candidates,
             "artifacts": {"candidates_path": str(artifacts_path)},
         }
+        stage_id = inputs.get("stage_id")
+        if isinstance(stage_id, str) and stage_id:
+            outputs["stage_id"] = stage_id
+        elif lineage:
+            outputs["stage_id"] = "S4"
+        if lineage:
+            outputs["lineage"] = lineage
         metrics = {
             "exec_type": "python",
             "duration_ms": duration_ms,
             "num_candidates": len(candidates),
         }
+        if iteration is not None:
+            metrics["iteration"] = iteration
+        if source_candidate_id:
+            metrics["source_candidate_id"] = source_candidate_id
         return outputs, metrics
 
     def _run_nvidia_nim(
@@ -283,16 +311,33 @@ class ProteinMPNNAdapter(BaseToolAdapter):
                 failure_type=FailureType.TOOL_ERROR,
                 message="NIM ProteinMPNN response contains no valid sequence candidates",
                 code=FailureCode.NIM_INVALID_RESPONSE.value,
-            )
+        )
+        task_id = str(inputs.get("task_id", "unknown"))
+        step_id = str(inputs.get("step_id", "unknown"))
+        iteration = _normalize_iteration(inputs.get("iteration"))
+        source_candidate_id = (
+            str(inputs.get("source_candidate_id"))
+            if isinstance(inputs.get("source_candidate_id"), str)
+            else None
+        )
+        candidates = _annotate_candidates(
+            candidates,
+            step_id=str(step_id),
+            source_candidate_id=source_candidate_id,
+            iteration=iteration,
+        )
+        lineage = _build_refinement_lineage(
+            inputs,
+            step_id=step_id,
+        )
 
         selected = _select_primary_candidate(candidates)
-        task_id = inputs.get("task_id", "unknown")
-        step_id = inputs.get("step_id", "unknown")
         artifacts_path = self._write_artifacts(
             task_id=task_id,
             step_id=step_id,
             pdb_path=str(pdb_path),
             candidates=candidates,
+            lineage=lineage if lineage else None,
         )
 
         duration_ms = int((perf_counter() - t0) * 1000)
@@ -302,6 +347,13 @@ class ProteinMPNNAdapter(BaseToolAdapter):
             "candidates": candidates,
             "artifacts": {"candidates_path": str(artifacts_path)},
         }
+        stage_id = inputs.get("stage_id")
+        if isinstance(stage_id, str) and stage_id:
+            outputs["stage_id"] = stage_id
+        elif lineage:
+            outputs["stage_id"] = "S4"
+        if lineage:
+            outputs["lineage"] = lineage
         metrics = {
             "exec_type": "nvidia_nim",
             "provider": "nvidia_nim",
@@ -309,6 +361,10 @@ class ProteinMPNNAdapter(BaseToolAdapter):
             "duration_ms": duration_ms,
             "num_candidates": len(candidates),
         }
+        if iteration is not None:
+            metrics["iteration"] = iteration
+        if source_candidate_id:
+            metrics["source_candidate_id"] = source_candidate_id
         return outputs, metrics
 
     def _write_artifacts(
@@ -318,6 +374,7 @@ class ProteinMPNNAdapter(BaseToolAdapter):
         step_id: str,
         pdb_path: str,
         candidates: List[Dict[str, Any]],
+        lineage: Dict[str, Any] | None = None,
     ) -> Path:
         self.artifacts_dir.mkdir(parents=True, exist_ok=True)
         path = self.artifacts_dir / f"protein_mpnn_{task_id}_{step_id}.json"
@@ -328,6 +385,8 @@ class ProteinMPNNAdapter(BaseToolAdapter):
             "pdb_path": pdb_path,
             "candidates": candidates,
         }
+        if isinstance(lineage, dict) and lineage:
+            payload["lineage"] = lineage
         path.write_text(json.dumps(payload, ensure_ascii=True, indent=2))
         return path
 
@@ -481,3 +540,54 @@ def _select_primary_candidate(candidates: List[Dict[str, Any]]) -> Dict[str, Any
     if sampled:
         return sampled[0]
     return candidates[0]
+
+
+def _normalize_iteration(value: Any) -> int | None:
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        return None
+    return normalized if normalized > 0 else None
+
+
+def _build_refinement_lineage(
+    inputs: Dict[str, Any],
+    *,
+    step_id: str,
+) -> Dict[str, Any]:
+    lineage: Dict[str, Any] = {}
+    source_candidate_id = inputs.get("source_candidate_id")
+    if isinstance(source_candidate_id, str) and source_candidate_id:
+        lineage["source_candidate_id"] = source_candidate_id
+    iteration = _normalize_iteration(inputs.get("iteration"))
+    if iteration is not None:
+        lineage["iteration"] = iteration
+    stage_id = inputs.get("stage_id")
+    if isinstance(stage_id, str) and stage_id:
+        lineage["stage_id"] = stage_id
+    if lineage:
+        lineage["step_id"] = step_id
+    return lineage
+
+
+def _annotate_candidates(
+    candidates: List[Dict[str, Any]],
+    *,
+    step_id: str,
+    source_candidate_id: str | None,
+    iteration: int | None,
+) -> List[Dict[str, Any]]:
+    annotated: List[Dict[str, Any]] = []
+    for idx, candidate in enumerate(candidates, start=1):
+        row = dict(candidate)
+        row.setdefault("candidate_id", f"{step_id}_cand_{idx}")
+        row_lineage = row.get("lineage")
+        lineage = dict(row_lineage) if isinstance(row_lineage, dict) else {}
+        if source_candidate_id:
+            lineage.setdefault("source_candidate_id", source_candidate_id)
+        if iteration is not None:
+            lineage.setdefault("iteration", iteration)
+        if lineage:
+            row["lineage"] = lineage
+        annotated.append(row)
+    return annotated

--- a/src/agents/executor.py
+++ b/src/agents/executor.py
@@ -20,9 +20,18 @@ from src.workflow.quality_gate import (
     QUALITY_GATE_ALL_REJECTED_CODE,
     evaluate_quality_gate_batch,
 )
+from src.workflow.recovery import (
+    StructureRefinementIteration,
+    build_structure_refinement_audit,
+    persist_structure_refinement_audit,
+)
 from src.workflow.step_runner import StepRunner
 from src.workflow.plan_runner import PlanRunner
 from src.workflow.status import transition_task_status
+
+_S4_DEFAULT_MAX_ITERATIONS = 3
+_S4_DEFAULT_CONVERGENCE_DELTA = 0.01
+_S4_DEFAULT_MAX_DEGRADATION_ROUNDS = 1
 
 
 class ExecutorAgent:
@@ -413,6 +422,393 @@ class ExecutorAgent:
         )
         return aggregate_result
 
+    def refine_sequences_from_s3(
+        self,
+        context: WorkflowContext,
+        *,
+        source_step_id: str = "S3",
+        refinement_step_id: str = "S4",
+        structure_step_id: str = "S2",
+        max_candidates: int = 3,
+        max_iterations: int | None = None,
+        convergence_delta: float | None = None,
+        max_degradation_rounds: int | None = None,
+    ) -> StepResult:
+        """Run S4 iterative loop: refinement -> structure projection -> quality gate."""
+        source_result = context.get_step_result(source_step_id)
+        if source_result is None:
+            raise ValueError(f"Missing source step result '{source_step_id}'")
+
+        refinement_template = _resolve_refinement_step_template(
+            plan=context.plan,
+            refinement_step_id=refinement_step_id,
+        )
+        tool_id = refinement_template.tool if refinement_template is not None else "protein_mpnn"
+
+        structure_template = _resolve_structure_step_template(
+            plan=context.plan,
+            structure_step_id=structure_step_id,
+        )
+        if structure_template is None:
+            structure_template = PlanStep(
+                id=structure_step_id,
+                tool="esmfold",
+                inputs={"sequence": "S4.sequence"},
+                metadata={"stage_id": "S2", "stage_name": "structure_projection"},
+            )
+
+        loop_config = _resolve_s4_loop_config(
+            context.task.constraints,
+            max_iterations=max_iterations,
+            convergence_delta=convergence_delta,
+            max_degradation_rounds=max_degradation_rounds,
+        )
+        candidates = _extract_s3_candidates_for_refinement(
+            source_result,
+            max_candidates=max_candidates,
+        )
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if not candidates:
+            failed = StepResult(
+                task_id=context.task.task_id,
+                step_id=refinement_step_id,
+                tool=tool_id,
+                status="failed",
+                failure_type=FailureType.NON_RETRYABLE.value,
+                error_message="S4 refinement requires at least one S3 passed sample",
+                error_details={
+                    "failure_code": "S4_NO_BASELINE_CANDIDATE",
+                    "phase": "structure_refinement",
+                    "timestamp": now_iso,
+                },
+                inputs={"source_step_id": source_step_id},
+                outputs={
+                    "stage_id": "S4",
+                    "stage_name": "structure_conditioned_refinement",
+                    "source_step_id": source_step_id,
+                    "refinement_iterations": [],
+                    "iteration_count": 0,
+                    "stop_reason": "missing_baseline",
+                },
+                metrics={
+                    "exec_type": "structure_refinement_loop",
+                    "max_iterations": loop_config["max_iterations"],
+                    "convergence_delta": loop_config["convergence_delta"],
+                    "max_degradation_rounds": loop_config["max_degradation_rounds"],
+                },
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso,
+            )
+            context.add_step_result(failed)
+            return failed
+
+        baseline = _select_best_quality_candidate(candidates) or candidates[0]
+        current_source = dict(baseline)
+        baseline_plddt = _coerce_float(baseline.get("plddt"))
+        previous_plddt = baseline_plddt
+        best_candidate = dict(baseline)
+        best_plddt = baseline_plddt
+        successful_iterations = 0
+        degraded_rounds = 0
+        rollback_applied = False
+        stop_reason = "max_iterations_reached"
+        iteration_logs: list[StructureRefinementIteration] = []
+        latest_refined_candidates: list[dict[str, Any]] = []
+
+        for iteration in range(1, loop_config["max_iterations"] + 1):
+            source_pdb_path = current_source.get("pdb_path")
+            source_candidate_id = _as_str(current_source.get("candidate_id")) or (
+                f"{source_step_id}_baseline"
+            )
+            source_plddt = previous_plddt
+            if not isinstance(source_pdb_path, str) or not source_pdb_path:
+                stop_reason = "missing_source_pdb"
+                rollback_applied = successful_iterations > 0
+                break
+
+            refine_step = _build_structure_refinement_step(
+                template=refinement_template,
+                refinement_step_id=refinement_step_id,
+                iteration=iteration,
+                pdb_path=source_pdb_path,
+                length_range=context.task.constraints.get("length_range"),
+                source_candidate_id=source_candidate_id,
+            )
+            refine_result = self.step_runner.run_step(refine_step, context)
+            context.add_step_result(refine_result)
+            if refine_result.status != "success":
+                rollback_applied = successful_iterations > 0
+                stop_reason = "refinement_failed"
+                iteration_logs.append(
+                    StructureRefinementIteration(
+                        iteration=iteration,
+                        source_candidate_id=source_candidate_id,
+                        source_pdb_path=_as_str(source_pdb_path),
+                        source_plddt=source_plddt,
+                        refined_candidate_id=None,
+                        refined_sequence=None,
+                        refined_pdb_path=None,
+                        refined_plddt=None,
+                        gain_vs_baseline=None,
+                        gain_vs_previous=None,
+                        qc_pass_count=0,
+                        qc_fail_count=0,
+                        status="failed",
+                        stop_reason=stop_reason,
+                    )
+                )
+                break
+
+            latest_refined_candidates = _extract_refinement_sequences(
+                refine_result.outputs,
+                max_candidates=max_candidates,
+                fallback_candidate_prefix=f"{refinement_step_id}_iter{iteration}",
+            )
+            if not latest_refined_candidates:
+                rollback_applied = successful_iterations > 0
+                stop_reason = "empty_refinement_candidates"
+                iteration_logs.append(
+                    StructureRefinementIteration(
+                        iteration=iteration,
+                        source_candidate_id=source_candidate_id,
+                        source_pdb_path=_as_str(source_pdb_path),
+                        source_plddt=source_plddt,
+                        refined_candidate_id=None,
+                        refined_sequence=None,
+                        refined_pdb_path=None,
+                        refined_plddt=None,
+                        gain_vs_baseline=None,
+                        gain_vs_previous=None,
+                        qc_pass_count=0,
+                        qc_fail_count=0,
+                        status="failed",
+                        stop_reason=stop_reason,
+                    )
+                )
+                break
+
+            projected_rows = []
+            for candidate_index, refined_candidate in enumerate(latest_refined_candidates, start=1):
+                projected_rows.append(
+                    _run_structure_projection_for_refinement(
+                        step_runner=self.step_runner,
+                        context=context,
+                        structure_template=structure_template,
+                        structure_step_id=structure_step_id,
+                        sequence=_as_str(refined_candidate.get("sequence")) or "",
+                        refined_candidate_id=_as_str(refined_candidate.get("candidate_id"))
+                        or f"{refinement_step_id}_iter{iteration}_cand{candidate_index}",
+                        iteration=iteration,
+                        candidate_index=candidate_index,
+                    )
+                )
+
+            qc_batch = evaluate_quality_gate_batch(
+                projected_rows,
+                constraints=context.task.constraints,
+            )
+            passed_rows = qc_batch["passed_samples"]
+            failed_rows = qc_batch["failed_samples"]
+            best_row = _select_best_quality_candidate(passed_rows)
+            if best_row is None:
+                rollback_applied = successful_iterations > 0
+                stop_reason = "quality_gate_rejected"
+                iteration_logs.append(
+                    StructureRefinementIteration(
+                        iteration=iteration,
+                        source_candidate_id=source_candidate_id,
+                        source_pdb_path=_as_str(source_pdb_path),
+                        source_plddt=source_plddt,
+                        refined_candidate_id=None,
+                        refined_sequence=None,
+                        refined_pdb_path=None,
+                        refined_plddt=None,
+                        gain_vs_baseline=None,
+                        gain_vs_previous=None,
+                        qc_pass_count=len(passed_rows),
+                        qc_fail_count=len(failed_rows),
+                        status="failed_qc",
+                        stop_reason=stop_reason,
+                    )
+                )
+                break
+
+            successful_iterations += 1
+            current_plddt = _coerce_float(best_row.get("plddt"))
+            gain_vs_baseline = _diff_or_none(current_plddt, baseline_plddt)
+            gain_vs_previous = _diff_or_none(current_plddt, previous_plddt)
+            iteration_stop_reason = None
+
+            if (
+                current_plddt is not None
+                and previous_plddt is not None
+                and current_plddt < previous_plddt
+            ):
+                degraded_rounds += 1
+            else:
+                degraded_rounds = 0
+
+            if (
+                current_plddt is not None
+                and previous_plddt is not None
+                and current_plddt < previous_plddt
+                and degraded_rounds > loop_config["max_degradation_rounds"]
+            ):
+                rollback_applied = True
+                stop_reason = "degradation_limit"
+                iteration_stop_reason = stop_reason
+            elif (
+                current_plddt is not None
+                and previous_plddt is not None
+                and current_plddt >= previous_plddt
+                and (current_plddt - previous_plddt) <= loop_config["convergence_delta"]
+            ):
+                stop_reason = "converged"
+                iteration_stop_reason = stop_reason
+
+            if current_plddt is not None and (
+                best_plddt is None or current_plddt > best_plddt
+            ):
+                best_plddt = current_plddt
+                best_candidate = dict(best_row)
+            current_source = dict(best_row)
+            if current_plddt is not None:
+                previous_plddt = current_plddt
+
+            iteration_logs.append(
+                StructureRefinementIteration(
+                    iteration=iteration,
+                    source_candidate_id=source_candidate_id,
+                    source_pdb_path=_as_str(source_pdb_path),
+                    source_plddt=source_plddt,
+                    refined_candidate_id=_as_str(best_row.get("candidate_id")),
+                    refined_sequence=_as_str(best_row.get("sequence")),
+                    refined_pdb_path=_as_str(best_row.get("pdb_path")),
+                    refined_plddt=current_plddt,
+                    gain_vs_baseline=gain_vs_baseline,
+                    gain_vs_previous=gain_vs_previous,
+                    qc_pass_count=len(passed_rows),
+                    qc_fail_count=len(failed_rows),
+                    status="success",
+                    stop_reason=iteration_stop_reason,
+                )
+            )
+
+            if iteration_stop_reason is not None:
+                break
+
+        selected_candidate = best_candidate if successful_iterations > 0 else None
+        final_plddt = _coerce_float(
+            selected_candidate.get("plddt") if isinstance(selected_candidate, dict) else None
+        )
+        audit_payload = build_structure_refinement_audit(
+            task_id=context.task.task_id,
+            step_id=refinement_step_id,
+            source_step_id=source_step_id,
+            baseline=baseline,
+            iterations=iteration_logs,
+            stop_reason=stop_reason,
+            rollback_applied=rollback_applied,
+            selected_candidate=selected_candidate,
+        )
+        audit_path = persist_structure_refinement_audit(
+            task_id=context.task.task_id,
+            step_id=refinement_step_id,
+            audit_payload=audit_payload,
+        )
+
+        result_status = "success" if successful_iterations > 0 else "failed"
+        error_message = None
+        error_details: Dict[str, Any] = {}
+        failure_type = None
+        if result_status == "failed":
+            failure_type = FailureType.NON_RETRYABLE.value
+            error_message = "S4 refinement loop produced no valid candidates"
+            error_details = {
+                "failure_code": "S4_REFINEMENT_FAILED",
+                "phase": "structure_refinement",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "stop_reason": stop_reason,
+            }
+
+        result = StepResult(
+            task_id=context.task.task_id,
+            step_id=refinement_step_id,
+            tool=tool_id,
+            status=result_status,
+            failure_type=failure_type,
+            error_message=error_message,
+            error_details=error_details,
+            inputs={
+                "source_step_id": source_step_id,
+                "max_candidates": max_candidates,
+                "max_iterations": loop_config["max_iterations"],
+                "convergence_delta": loop_config["convergence_delta"],
+                "max_degradation_rounds": loop_config["max_degradation_rounds"],
+            },
+            outputs={
+                "stage_id": "S4",
+                "stage_name": "structure_conditioned_refinement",
+                "source_step_id": source_step_id,
+                "loop_path": ["S4", "S2", "S3"],
+                "lineage": {
+                    "stage_id": "S4",
+                    "source_step_id": source_step_id,
+                    "baseline_candidate_id": baseline.get("candidate_id"),
+                    "rollback_applied": rollback_applied,
+                },
+                "sequence": selected_candidate.get("sequence")
+                if isinstance(selected_candidate, dict)
+                else None,
+                "pdb_path": selected_candidate.get("pdb_path")
+                if isinstance(selected_candidate, dict)
+                else None,
+                "plddt": final_plddt,
+                "candidates": latest_refined_candidates,
+                "refinement_iterations": [row.to_dict() for row in iteration_logs],
+                "iteration_count": len(iteration_logs),
+                "successful_iterations": successful_iterations,
+                "stop_reason": stop_reason,
+                "gain_metrics": {
+                    "baseline_plddt": baseline_plddt,
+                    "final_plddt": final_plddt,
+                    "delta_vs_baseline": _diff_or_none(final_plddt, baseline_plddt),
+                },
+            },
+            artifacts={
+                "refinement_audit_path": str(audit_path),
+            },
+            metrics={
+                "exec_type": "structure_refinement_loop",
+                "max_iterations": loop_config["max_iterations"],
+                "convergence_delta": loop_config["convergence_delta"],
+                "max_degradation_rounds": loop_config["max_degradation_rounds"],
+                "rollback_applied": rollback_applied,
+            },
+            risk_flags=[],
+            logs_path=None,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+        )
+        context.add_step_result(result)
+        append_event(
+            context.task.task_id,
+            {
+                "event": "STEP_FINISHED" if result.status == "success" else "STEP_FAILED",
+                "task_id": context.task.task_id,
+                "step_id": refinement_step_id,
+                "tool": tool_id,
+                "status": result.status,
+                "failure_type": result.failure_type,
+                "error_message": result.error_message,
+                "timestamp": result.timestamp,
+                "state": context.status.value,
+                "external_status": to_external_status(context.status).value,
+                "data": _build_structure_refinement_trace_data(result),
+            },
+        )
+        return result
+
     def summarize_and_finalize(
         self,
         context: WorkflowContext,
@@ -495,6 +891,23 @@ def _resolve_quality_gate_step_template(
         return None
     for step in plan.steps:
         if step.id == quality_step_id:
+            return step
+    return None
+
+
+def _resolve_refinement_step_template(
+    *,
+    plan: Plan | None,
+    refinement_step_id: str,
+) -> PlanStep | None:
+    if plan is None:
+        return None
+    for step in plan.steps:
+        if step.id == refinement_step_id:
+            return step
+    for step in plan.steps:
+        metadata = step.metadata if isinstance(step.metadata, dict) else {}
+        if metadata.get("stage_id") == "S4":
             return step
     return None
 
@@ -608,6 +1021,293 @@ def _extract_s2_candidates_for_quality_gate(
             f"No structure candidates found in '{source_result.step_id}' outputs"
         )
     return resolved[: max(1, max_candidates)]
+
+
+def _extract_s3_candidates_for_refinement(
+    source_result: StepResult,
+    *,
+    max_candidates: int,
+) -> List[Dict[str, Any]]:
+    outputs = source_result.outputs if isinstance(source_result.outputs, dict) else {}
+    passed_rows = outputs.get("passed_samples")
+    resolved: list[dict[str, Any]] = []
+
+    if isinstance(passed_rows, list):
+        for idx, item in enumerate(passed_rows):
+            if not isinstance(item, dict):
+                continue
+            row = dict(item)
+            row.setdefault("candidate_id", f"{source_result.step_id}_passed_{idx + 1}")
+            resolved.append(row)
+            if len(resolved) >= max(1, max_candidates):
+                break
+    if not resolved:
+        qc_rows = outputs.get("qc_results")
+        if isinstance(qc_rows, list):
+            for idx, item in enumerate(qc_rows):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("status") != "pass":
+                    continue
+                row = dict(item)
+                row.setdefault("candidate_id", f"{source_result.step_id}_qc_{idx + 1}")
+                resolved.append(row)
+                if len(resolved) >= max(1, max_candidates):
+                    break
+    if not resolved and bool(outputs.get("pass_fail")):
+        plddt = outputs.get("plddt")
+        if not isinstance(plddt, (int, float)):
+            confidence = outputs.get("confidence")
+            if isinstance(confidence, dict) and isinstance(confidence.get("plddt_mean"), (int, float)):
+                plddt = confidence.get("plddt_mean")
+        resolved.append(
+            {
+                "candidate_id": f"{source_result.step_id}_primary",
+                "sequence": outputs.get("sequence"),
+                "pdb_path": outputs.get("pdb_path"),
+                "plddt": plddt,
+                "lineage": outputs.get("lineage", {}),
+            }
+        )
+    return resolved[: max(1, max_candidates)]
+
+
+def _extract_refinement_sequences(
+    outputs: Dict[str, Any],
+    *,
+    max_candidates: int,
+    fallback_candidate_prefix: str,
+) -> List[Dict[str, Any]]:
+    resolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    primary_sequence = outputs.get("sequence")
+    primary_score = outputs.get("sequence_score")
+    if isinstance(primary_sequence, str) and primary_sequence and primary_sequence not in seen:
+        resolved.append(
+            {
+                "candidate_id": f"{fallback_candidate_prefix}_primary",
+                "sequence": primary_sequence,
+                "score": primary_score,
+                "source": "primary",
+            }
+        )
+        seen.add(primary_sequence)
+
+    raw_candidates = outputs.get("candidates")
+    if isinstance(raw_candidates, list):
+        for idx, item in enumerate(raw_candidates):
+            sequence = None
+            score = None
+            candidate_id = f"{fallback_candidate_prefix}_{idx + 1}"
+            if isinstance(item, dict):
+                raw_sequence = item.get("sequence")
+                if isinstance(raw_sequence, str):
+                    sequence = raw_sequence
+                score = item.get("score")
+                if isinstance(item.get("candidate_id"), str):
+                    candidate_id = str(item.get("candidate_id"))
+            elif isinstance(item, str):
+                sequence = item
+            if not isinstance(sequence, str) or not sequence or sequence in seen:
+                continue
+            resolved.append(
+                {
+                    "candidate_id": candidate_id,
+                    "sequence": sequence,
+                    "score": score,
+                    "source": "candidate_list",
+                }
+            )
+            seen.add(sequence)
+            if len(resolved) >= max(1, max_candidates):
+                break
+    return resolved[: max(1, max_candidates)]
+
+
+def _run_structure_projection_for_refinement(
+    *,
+    step_runner: StepRunner,
+    context: WorkflowContext,
+    structure_template: PlanStep,
+    structure_step_id: str,
+    sequence: str,
+    refined_candidate_id: str,
+    iteration: int,
+    candidate_index: int,
+) -> Dict[str, Any]:
+    row = {
+        "candidate_id": refined_candidate_id,
+        "status": "failed",
+        "sequence": sequence,
+        "lineage": {
+            "stage_id": "S2",
+            "source_stage_id": "S4",
+            "source_candidate_id": refined_candidate_id,
+            "iteration": iteration,
+        },
+    }
+    if not _is_valid_sequence_for_projection(sequence):
+        row["failure_code"] = "S2_SEQUENCE_INVALID"
+        row["failure_reason"] = "sequence must be uppercase alphabetic characters"
+        return row
+
+    attempts = []
+    for tool_id in _resolve_structure_tool_chain(structure_template.tool):
+        step = _build_structure_projection_step(
+            template=structure_template,
+            step_id=(
+                f"{structure_step_id}_s4_{iteration}_{candidate_index}_{tool_id}"
+            ),
+            tool_id=tool_id,
+            sequence=sequence,
+            source_candidate_id=refined_candidate_id,
+        )
+        result = step_runner.run_step(step, context)
+        context.add_step_result(result)
+        attempts.append(result)
+        if result.status == "success":
+            break
+
+    final_result = _pick_final_projection_result(attempts)
+    if final_result is None:
+        row["failure_code"] = "S2_TOOL_EXECUTION_FAILED"
+        row["failure_reason"] = "structure projection produced no result"
+        return row
+
+    if final_result.status == "success":
+        outputs = final_result.outputs
+        row["status"] = "success"
+        row["tool_id"] = final_result.tool
+        row["pdb_path"] = outputs.get("pdb_path")
+        row["plddt"] = outputs.get("plddt")
+        row["confidence"] = outputs.get("confidence")
+        row["failure_code"] = None
+        row["failure_reason"] = None
+    else:
+        row["status"] = "failed"
+        row["tool_id"] = final_result.tool
+        row["failure_code"] = _normalize_s2_failure_code(final_result)
+        row["failure_reason"] = final_result.error_message
+        if len(attempts) > 1:
+            row["failure_code"] = "S2_FALLBACK_EXHAUSTED"
+    return row
+
+
+def _resolve_s4_loop_config(
+    constraints: Dict[str, Any],
+    *,
+    max_iterations: int | None,
+    convergence_delta: float | None,
+    max_degradation_rounds: int | None,
+) -> Dict[str, Any]:
+    local = (
+        constraints.get("structure_refinement")
+        if isinstance(constraints.get("structure_refinement"), dict)
+        else {}
+    )
+
+    raw_max_iterations = (
+        max_iterations
+        if max_iterations is not None
+        else local.get("max_iterations", constraints.get("s4_max_iterations"))
+    )
+    raw_convergence_delta = (
+        convergence_delta
+        if convergence_delta is not None
+        else local.get("convergence_delta", constraints.get("s4_convergence_delta"))
+    )
+    raw_max_degradation = (
+        max_degradation_rounds
+        if max_degradation_rounds is not None
+        else local.get(
+            "max_degradation_rounds",
+            constraints.get("s4_max_degradation_rounds"),
+        )
+    )
+
+    try:
+        normalized_max_iterations = int(raw_max_iterations)
+    except (TypeError, ValueError):
+        normalized_max_iterations = _S4_DEFAULT_MAX_ITERATIONS
+    normalized_max_iterations = max(1, normalized_max_iterations)
+
+    try:
+        normalized_convergence_delta = float(raw_convergence_delta)
+    except (TypeError, ValueError):
+        normalized_convergence_delta = _S4_DEFAULT_CONVERGENCE_DELTA
+    normalized_convergence_delta = max(0.0, normalized_convergence_delta)
+
+    try:
+        normalized_max_degradation = int(raw_max_degradation)
+    except (TypeError, ValueError):
+        normalized_max_degradation = _S4_DEFAULT_MAX_DEGRADATION_ROUNDS
+    normalized_max_degradation = max(0, normalized_max_degradation)
+
+    return {
+        "max_iterations": normalized_max_iterations,
+        "convergence_delta": normalized_convergence_delta,
+        "max_degradation_rounds": normalized_max_degradation,
+    }
+
+
+def _build_structure_refinement_step(
+    *,
+    template: PlanStep | None,
+    refinement_step_id: str,
+    iteration: int,
+    pdb_path: str,
+    length_range: Any,
+    source_candidate_id: str,
+) -> PlanStep:
+    tool_id = template.tool if isinstance(template, PlanStep) else "protein_mpnn"
+    step_id = f"{refinement_step_id}_{iteration}"
+    inputs = {
+        "pdb_path": pdb_path,
+        "source_candidate_id": source_candidate_id,
+        "stage_id": "S4",
+        "iteration": iteration,
+    }
+    if isinstance(length_range, (list, tuple)) and len(length_range) == 2:
+        inputs["length_range"] = [int(length_range[0]), int(length_range[1])]
+    metadata = dict(template.metadata if isinstance(template, PlanStep) else {})
+    metadata.update(
+        {
+            "stage_id": "S4",
+            "stage_name": "structure_conditioned_refinement",
+            "iteration": iteration,
+            "lineage": {
+                "stage_id": "S4",
+                "source_candidate_id": source_candidate_id,
+                "source_stage_id": "S3",
+            },
+        }
+    )
+    return PlanStep(
+        id=step_id,
+        tool=tool_id,
+        inputs=inputs,
+        metadata=metadata,
+    )
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _diff_or_none(current: float | None, baseline: float | None) -> float | None:
+    if current is None or baseline is None:
+        return None
+    return round(current - baseline, 6)
+
+
+def _as_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None
 
 
 def _resolve_structure_tool_chain(primary_tool_id: str) -> List[str]:
@@ -825,4 +1525,18 @@ def _build_quality_gate_trace_data(result: StepResult) -> Dict[str, Any]:
             "reject_code_counts": reject_counts if isinstance(reject_counts, dict) else {},
             "failed_samples": failed_samples,
         },
+    }
+
+
+def _build_structure_refinement_trace_data(result: StepResult) -> Dict[str, Any]:
+    outputs = result.outputs if isinstance(result.outputs, dict) else {}
+    gain_metrics = outputs.get("gain_metrics")
+    lineage = outputs.get("lineage")
+    return {
+        "stage_id": outputs.get("stage_id"),
+        "stop_reason": outputs.get("stop_reason"),
+        "iteration_count": outputs.get("iteration_count"),
+        "successful_iterations": outputs.get("successful_iterations"),
+        "gain_metrics": gain_metrics if isinstance(gain_metrics, dict) else {},
+        "lineage": lineage if isinstance(lineage, dict) else {},
     }

--- a/src/agents/executor.py
+++ b/src/agents/executor.py
@@ -435,9 +435,11 @@ class ExecutorAgent:
         max_degradation_rounds: int | None = None,
     ) -> StepResult:
         """Run S4 iterative loop: refinement -> structure projection -> quality gate."""
-        source_result = context.get_step_result(source_step_id)
-        if source_result is None:
-            raise ValueError(f"Missing source step result '{source_step_id}'")
+        candidates, baseline_source_step_id = _resolve_refinement_baseline_candidates(
+            context,
+            source_step_id=source_step_id,
+            max_candidates=max_candidates,
+        )
 
         refinement_template = _resolve_refinement_step_template(
             plan=context.plan,
@@ -463,10 +465,6 @@ class ExecutorAgent:
             convergence_delta=convergence_delta,
             max_degradation_rounds=max_degradation_rounds,
         )
-        candidates = _extract_s3_candidates_for_refinement(
-            source_result,
-            max_candidates=max_candidates,
-        )
         now_iso = datetime.now(timezone.utc).isoformat()
         if not candidates:
             failed = StepResult(
@@ -475,17 +473,20 @@ class ExecutorAgent:
                 tool=tool_id,
                 status="failed",
                 failure_type=FailureType.NON_RETRYABLE.value,
-                error_message="S4 refinement requires at least one S3 passed sample",
+                error_message=(
+                    "S4 refinement requires at least one quality-passed baseline "
+                    f"from '{baseline_source_step_id}'"
+                ),
                 error_details={
                     "failure_code": "S4_NO_BASELINE_CANDIDATE",
                     "phase": "structure_refinement",
                     "timestamp": now_iso,
                 },
-                inputs={"source_step_id": source_step_id},
+                inputs={"source_step_id": baseline_source_step_id},
                 outputs={
                     "stage_id": "S4",
                     "stage_name": "structure_conditioned_refinement",
-                    "source_step_id": source_step_id,
+                    "source_step_id": baseline_source_step_id,
                     "refinement_iterations": [],
                     "iteration_count": 0,
                     "stop_reason": "missing_baseline",
@@ -519,7 +520,7 @@ class ExecutorAgent:
         for iteration in range(1, loop_config["max_iterations"] + 1):
             source_pdb_path = current_source.get("pdb_path")
             source_candidate_id = _as_str(current_source.get("candidate_id")) or (
-                f"{source_step_id}_baseline"
+                f"{baseline_source_step_id}_baseline"
             )
             source_plddt = previous_plddt
             if not isinstance(source_pdb_path, str) or not source_pdb_path:
@@ -705,7 +706,7 @@ class ExecutorAgent:
         audit_payload = build_structure_refinement_audit(
             task_id=context.task.task_id,
             step_id=refinement_step_id,
-            source_step_id=source_step_id,
+            source_step_id=baseline_source_step_id,
             baseline=baseline,
             iterations=iteration_logs,
             stop_reason=stop_reason,
@@ -741,7 +742,7 @@ class ExecutorAgent:
             error_message=error_message,
             error_details=error_details,
             inputs={
-                "source_step_id": source_step_id,
+                "source_step_id": baseline_source_step_id,
                 "max_candidates": max_candidates,
                 "max_iterations": loop_config["max_iterations"],
                 "convergence_delta": loop_config["convergence_delta"],
@@ -750,11 +751,11 @@ class ExecutorAgent:
             outputs={
                 "stage_id": "S4",
                 "stage_name": "structure_conditioned_refinement",
-                "source_step_id": source_step_id,
+                "source_step_id": baseline_source_step_id,
                 "loop_path": ["S4", "S2", "S3"],
                 "lineage": {
                     "stage_id": "S4",
-                    "source_step_id": source_step_id,
+                    "source_step_id": baseline_source_step_id,
                     "baseline_candidate_id": baseline.get("candidate_id"),
                     "rollback_applied": rollback_applied,
                 },
@@ -1070,6 +1071,67 @@ def _extract_s3_candidates_for_refinement(
             }
         )
     return resolved[: max(1, max_candidates)]
+
+
+def _resolve_refinement_baseline_candidates(
+    context: WorkflowContext,
+    *,
+    source_step_id: str,
+    max_candidates: int,
+) -> tuple[List[Dict[str, Any]], str]:
+    source_result = context.get_step_result(source_step_id)
+    if source_result is not None:
+        stage_id = None
+        if isinstance(source_result.outputs, dict):
+            value = source_result.outputs.get("stage_id")
+            if isinstance(value, str):
+                stage_id = value
+        if source_step_id == "S2" or stage_id == "S2":
+            return _collect_passed_baseline_from_s2(
+                source_result,
+                constraints=context.task.constraints,
+                max_candidates=max_candidates,
+            ), "S2"
+        return _extract_s3_candidates_for_refinement(
+            source_result,
+            max_candidates=max_candidates,
+        ), source_step_id
+
+    if source_step_id == "S3":
+        s2_result = context.get_step_result("S2")
+        if s2_result is not None:
+            candidates = _collect_passed_baseline_from_s2(
+                s2_result,
+                constraints=context.task.constraints,
+                max_candidates=max_candidates,
+            )
+            return candidates, "S2"
+        raise ValueError("Missing source step result 'S3' and fallback baseline 'S2'")
+    raise ValueError(f"Missing source step result '{source_step_id}'")
+
+
+def _collect_passed_baseline_from_s2(
+    source_result: StepResult,
+    *,
+    constraints: Dict[str, Any],
+    max_candidates: int,
+) -> List[Dict[str, Any]]:
+    candidates = _extract_s2_candidates_for_quality_gate(
+        source_result,
+        max_candidates=max_candidates,
+    )
+    qc_batch = evaluate_quality_gate_batch(
+        candidates,
+        constraints=constraints,
+    )
+    passed_rows = qc_batch["passed_samples"]
+    if not isinstance(passed_rows, list):
+        return []
+    return [
+        dict(row)
+        for row in passed_rows[: max(1, max_candidates)]
+        if isinstance(row, dict)
+    ]
 
 
 def _extract_refinement_sequences(

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -2393,6 +2393,16 @@ def _build_de_novo_plan(
                 },
             },
         ),
+        PlanStep(
+            id="S2R",
+            tool=structure_tool.id,
+            inputs={"sequence": "S4.sequence"},
+            metadata={
+                "stage_id": "S2",
+                "stage_name": "structure_projection",
+                "source_stage_id": "S4",
+            },
+        ),
     ]
 
     explanation = _build_de_novo_explanation(
@@ -2456,11 +2466,11 @@ def _build_de_novo_explanation(
         compat_note = f"KG compat.from={', '.join(str(item) for item in compat_from)}"
 
     parts = [
-        "de_novo_design 任务采用序列生成→结构预测→结构条件精修链路。",
+        "de_novo_design 任务采用序列生成→结构预测→结构条件精修→结构重映射链路。",
         f"ProteinToolKG 显示 {seq_name}({sequence_tool_id}) 能力={seq_caps}。{seq_desc}",
         f"ProteinToolKG 显示 {struct_name}({structure_tool_id}) 能力={struct_caps}。{struct_desc}",
         f"ProteinToolKG 显示 {refine_name}({refinement_tool_id}) 能力={refine_caps}。{refine_desc}",
-        "S4 按 max_iterations/convergence_delta/max_degradation_rounds 控制迭代停止。",
+        "S4 按 max_iterations/convergence_delta/max_degradation_rounds 控制迭代停止，并在 S4 后执行结构重映射保证序列-结构一致。",
     ]
     if compat_note:
         parts.append(compat_note)

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -1902,6 +1902,11 @@ _S1_STAGE_ID = "S1"
 _S1_STAGE_NAME = "sequence_exploration"
 _S1_SEQUENCE_SOURCE_PRIMARY = "primary"
 _S1_SEQUENCE_SOURCE_FALLBACK = "fallback"
+_S4_STAGE_ID = "S4"
+_S4_STAGE_NAME = "structure_conditioned_refinement"
+_S4_DEFAULT_MAX_ITERATIONS = 3
+_S4_DEFAULT_CONVERGENCE_DELTA = 0.01
+_S4_DEFAULT_MAX_DEGRADATION_ROUNDS = 1
 _S1_INPUT_FIELDS = ("goal", "length_range", "prompt", "template")
 _S1_OUTPUT_FIELDS = (
     "sequence",
@@ -1975,6 +1980,48 @@ def _collect_sequence_exploration_inputs(constraints: dict) -> Set[str]:
     if template:
         inputs.update({"template", "structure_template_pdb", "pdb_path"})
     return inputs
+
+
+def _extract_structure_refinement_config(constraints: dict) -> dict:
+    local = (
+        constraints.get("structure_refinement")
+        if isinstance(constraints.get("structure_refinement"), dict)
+        else {}
+    )
+
+    max_iterations_raw = local.get("max_iterations", constraints.get("s4_max_iterations"))
+    convergence_raw = local.get(
+        "convergence_delta",
+        constraints.get("s4_convergence_delta"),
+    )
+    max_degradation_raw = local.get(
+        "max_degradation_rounds",
+        constraints.get("s4_max_degradation_rounds"),
+    )
+
+    try:
+        max_iterations = int(max_iterations_raw)
+    except (TypeError, ValueError):
+        max_iterations = _S4_DEFAULT_MAX_ITERATIONS
+    max_iterations = max(1, max_iterations)
+
+    try:
+        convergence_delta = float(convergence_raw)
+    except (TypeError, ValueError):
+        convergence_delta = _S4_DEFAULT_CONVERGENCE_DELTA
+    convergence_delta = max(0.0, convergence_delta)
+
+    try:
+        max_degradation_rounds = int(max_degradation_raw)
+    except (TypeError, ValueError):
+        max_degradation_rounds = _S4_DEFAULT_MAX_DEGRADATION_ROUNDS
+    max_degradation_rounds = max(0, max_degradation_rounds)
+
+    return {
+        "max_iterations": max_iterations,
+        "convergence_delta": convergence_delta,
+        "max_degradation_rounds": max_degradation_rounds,
+    }
 
 
 def _build_s1_io_contract(task: ProteinDesignTask) -> dict:
@@ -2249,6 +2296,30 @@ def _build_de_novo_plan(
             io_hint={"inputs": ["sequence"]},
             prefer_remote=prefer_remote,
         )
+    available_inputs.update(structure_tool.outputs)
+
+    try:
+        refinement_tool = _select_tool_by_capability(
+            registry=registry,
+            capability="sequence_design",
+            available_inputs=available_inputs,
+            safety_level=safety_level,
+            io_hint={"inputs": ["pdb_path"]},
+            prefer_remote=prefer_remote,
+        )
+    except ValueError:
+        try:
+            refinement_tool = _find_tool_spec(registry, "protein_mpnn")
+        except ValueError:
+            fallback_inputs = _collect_registry_inputs(registry)
+            refinement_tool = _select_tool_by_capability(
+                registry=registry,
+                capability="sequence_design",
+                available_inputs=fallback_inputs,
+                safety_level=safety_level,
+                io_hint={"inputs": ["pdb_path"]},
+                prefer_remote=prefer_remote,
+            )
 
     step_inputs: dict = {
         "goal": task.goal,
@@ -2285,6 +2356,13 @@ def _build_de_novo_plan(
         source_tier=_S1_SEQUENCE_SOURCE_PRIMARY,
         source_reason="de_novo_template",
     )
+    refinement_config = _extract_structure_refinement_config(constraints)
+
+    s4_inputs: dict = {
+        "pdb_path": "S2.pdb_path",
+    }
+    if length_range:
+        s4_inputs["length_range"] = length_range
 
     steps = [
         s1_step,
@@ -2292,11 +2370,36 @@ def _build_de_novo_plan(
             id="S2",
             tool=structure_tool.id,
             inputs={"sequence": "S1.sequence"},
-            metadata={},
+            metadata={
+                "stage_id": "S2",
+                "stage_name": "structure_projection",
+            },
+        ),
+        PlanStep(
+            id=_S4_STAGE_ID,
+            tool=refinement_tool.id,
+            inputs=s4_inputs,
+            metadata={
+                "stage_id": _S4_STAGE_ID,
+                "stage_name": _S4_STAGE_NAME,
+                "loop_path": ["S4", "S2", "S3"],
+                "loop_control": refinement_config,
+                "stop_conditions": {
+                    "max_iterations": refinement_config["max_iterations"],
+                    "convergence_delta": refinement_config["convergence_delta"],
+                    "max_degradation_rounds": refinement_config[
+                        "max_degradation_rounds"
+                    ],
+                },
+            },
         ),
     ]
 
-    explanation = _build_de_novo_explanation(sequence_tool.id, structure_tool.id)
+    explanation = _build_de_novo_explanation(
+        sequence_tool.id,
+        structure_tool.id,
+        refinement_tool.id,
+    )
 
     return Plan(
         task_id=task.task_id,
@@ -2307,7 +2410,11 @@ def _build_de_novo_plan(
     )
 
 
-def _build_de_novo_explanation(sequence_tool_id: str, structure_tool_id: str) -> str:
+def _build_de_novo_explanation(
+    sequence_tool_id: str,
+    structure_tool_id: str,
+    refinement_tool_id: str,
+) -> str:
     kg = load_tool_kg()
     tools = {tool.get("id"): tool for tool in kg.get("tools", []) if tool.get("id")}
     capabilities = {
@@ -2318,6 +2425,7 @@ def _build_de_novo_explanation(sequence_tool_id: str, structure_tool_id: str) ->
 
     sequence_tool = tools.get(sequence_tool_id, {})
     structure_tool = tools.get(structure_tool_id, {})
+    refinement_tool = tools.get(refinement_tool_id, {})
 
     def format_caps(tool: dict) -> str:
         cap_ids = tool.get("capabilities", [])
@@ -2338,6 +2446,9 @@ def _build_de_novo_explanation(sequence_tool_id: str, structure_tool_id: str) ->
     struct_name = structure_tool.get("name") or structure_tool_id
     struct_desc = structure_tool.get("description") or ""
     struct_caps = format_caps(structure_tool)
+    refine_name = refinement_tool.get("name") or refinement_tool_id
+    refine_desc = refinement_tool.get("description") or ""
+    refine_caps = format_caps(refinement_tool)
 
     compat_from = structure_tool.get("compat", {}).get("from", [])
     compat_note = ""
@@ -2345,9 +2456,11 @@ def _build_de_novo_explanation(sequence_tool_id: str, structure_tool_id: str) ->
         compat_note = f"KG compat.from={', '.join(str(item) for item in compat_from)}"
 
     parts = [
-        "de_novo_design 任务采用序列生成→结构预测两步链路。",
+        "de_novo_design 任务采用序列生成→结构预测→结构条件精修链路。",
         f"ProteinToolKG 显示 {seq_name}({sequence_tool_id}) 能力={seq_caps}。{seq_desc}",
         f"ProteinToolKG 显示 {struct_name}({structure_tool_id}) 能力={struct_caps}。{struct_desc}",
+        f"ProteinToolKG 显示 {refine_name}({refinement_tool_id}) 能力={refine_caps}。{refine_desc}",
+        "S4 按 max_iterations/convergence_delta/max_degradation_rounds 控制迭代停止。",
     ]
     if compat_note:
         parts.append(compat_note)

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -10,6 +10,7 @@ Snapshot-based recovery logic for resuming interrupted tasks.
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,6 +37,9 @@ __all__ = [
     "extract_remote_job_context",
     "RemoteJobContext",
     "RecoveryResult",
+    "StructureRefinementIteration",
+    "build_structure_refinement_audit",
+    "persist_structure_refinement_audit",
 ]
 
 
@@ -100,6 +104,111 @@ class RecoveryResult:
     snapshot: TaskSnapshot
     applied_event_logs: Sequence[EventLog]
     resume_from_existing: bool
+
+
+@dataclass(frozen=True)
+class StructureRefinementIteration:
+    """S4 精修闭环单轮审计记录。"""
+
+    iteration: int
+    source_candidate_id: str | None
+    source_pdb_path: str | None
+    source_plddt: float | None
+    refined_candidate_id: str | None
+    refined_sequence: str | None
+    refined_pdb_path: str | None
+    refined_plddt: float | None
+    gain_vs_baseline: float | None
+    gain_vs_previous: float | None
+    qc_pass_count: int
+    qc_fail_count: int
+    status: str
+    stop_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "iteration": int(self.iteration),
+            "source_candidate_id": self.source_candidate_id,
+            "source_pdb_path": self.source_pdb_path,
+            "source_plddt": self.source_plddt,
+            "refined_candidate_id": self.refined_candidate_id,
+            "refined_sequence": self.refined_sequence,
+            "refined_pdb_path": self.refined_pdb_path,
+            "refined_plddt": self.refined_plddt,
+            "gain_vs_baseline": self.gain_vs_baseline,
+            "gain_vs_previous": self.gain_vs_previous,
+            "qc_pass_count": int(self.qc_pass_count),
+            "qc_fail_count": int(self.qc_fail_count),
+            "status": self.status,
+            "stop_reason": self.stop_reason,
+        }
+
+
+def build_structure_refinement_audit(
+    *,
+    task_id: str,
+    step_id: str,
+    source_step_id: str,
+    baseline: dict[str, Any],
+    iterations: Sequence[StructureRefinementIteration | dict[str, Any]],
+    stop_reason: str,
+    rollback_applied: bool,
+    selected_candidate: dict[str, Any] | None,
+) -> dict[str, Any]:
+    normalized_iterations: list[dict[str, Any]] = []
+    for row in iterations:
+        if isinstance(row, StructureRefinementIteration):
+            normalized_iterations.append(row.to_dict())
+        elif isinstance(row, dict):
+            normalized_iterations.append(dict(row))
+
+    baseline_plddt = baseline.get("plddt")
+    selected_plddt = (
+        selected_candidate.get("plddt")
+        if isinstance(selected_candidate, dict)
+        else None
+    )
+    gain_vs_baseline = None
+    if isinstance(baseline_plddt, (int, float)) and isinstance(selected_plddt, (int, float)):
+        gain_vs_baseline = round(float(selected_plddt) - float(baseline_plddt), 6)
+
+    return {
+        "stage_id": "S4",
+        "task_id": task_id,
+        "step_id": step_id,
+        "source_step_id": source_step_id,
+        "created_at": now_iso(),
+        "baseline": {
+            "candidate_id": baseline.get("candidate_id"),
+            "sequence": baseline.get("sequence"),
+            "pdb_path": baseline.get("pdb_path"),
+            "plddt": baseline_plddt,
+        },
+        "selected_candidate": selected_candidate if isinstance(selected_candidate, dict) else None,
+        "iterations": normalized_iterations,
+        "summary": {
+            "iteration_count": len(normalized_iterations),
+            "stop_reason": stop_reason,
+            "rollback_applied": bool(rollback_applied),
+            "gain_vs_baseline": gain_vs_baseline,
+        },
+    }
+
+
+def persist_structure_refinement_audit(
+    *,
+    task_id: str,
+    step_id: str,
+    audit_payload: dict[str, Any],
+    artifacts_dir: Path = Path("output/artifacts"),
+) -> Path:
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    path = artifacts_dir / f"s4_refinement_{task_id}_{step_id}.json"
+    path.write_text(
+        json.dumps(audit_payload, ensure_ascii=True, indent=2),
+        encoding="utf-8",
+    )
+    return path
 
 
 def restore_context_from_snapshot(

--- a/tests/integration/test_nim_esmfold.py
+++ b/tests/integration/test_nim_esmfold.py
@@ -135,11 +135,12 @@ def test_de_novo_with_nim(
     planner = PlannerAgent()
     plan = planner.plan(task)
 
-    assert len(plan.steps) >= 3
-    assert [step.id for step in plan.steps[:3]] == ["S1", "S2", "S4"]
+    assert len(plan.steps) >= 4
+    assert [step.id for step in plan.steps[:4]] == ["S1", "S2", "S4", "S2R"]
     assert plan.steps[0].tool == "protgpt2"
     assert plan.steps[1].tool == "nim_esmfold"
     assert plan.steps[1].inputs.get("sequence") == "S1.sequence"
+    assert plan.steps[3].inputs.get("sequence") == "S4.sequence"
 
     register_adapter(ProtGPT2Adapter(service=_MockPLMService(), output_dir=tmp_path / "seq"))
     register_adapter(NIMESMFoldAdapter(output_dir=tmp_path / "pdb"))

--- a/tests/integration/test_nim_esmfold.py
+++ b/tests/integration/test_nim_esmfold.py
@@ -135,7 +135,8 @@ def test_de_novo_with_nim(
     planner = PlannerAgent()
     plan = planner.plan(task)
 
-    assert len(plan.steps) == 2
+    assert len(plan.steps) >= 3
+    assert [step.id for step in plan.steps[:3]] == ["S1", "S2", "S4"]
     assert plan.steps[0].tool == "protgpt2"
     assert plan.steps[1].tool == "nim_esmfold"
     assert plan.steps[1].inputs.get("sequence") == "S1.sequence"
@@ -143,13 +144,14 @@ def test_de_novo_with_nim(
     register_adapter(ProtGPT2Adapter(service=_MockPLMService(), output_dir=tmp_path / "seq"))
     register_adapter(NIMESMFoldAdapter(output_dir=tmp_path / "pdb"))
 
+    runtime_plan = plan.model_copy(update={"steps": plan.steps[:2]}, deep=True)
     context = WorkflowContext(
         task=task,
-        plan=plan,
+        plan=runtime_plan,
         status=InternalStatus.PLANNED,
     )
     executor = ExecutorAgent()
-    executor.run_plan(plan, context, finalize_status=False)
+    executor.run_plan(runtime_plan, context, finalize_status=False)
 
     assert "S2" in context.step_results
     s1_result = context.step_results["S1"]

--- a/tests/integration/test_structure_refinement_s4.py
+++ b/tests/integration/test_structure_refinement_s4.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.agents import executor as executor_module
+from src.agents.executor import ExecutorAgent
+from src.models.contracts import Plan, PlanStep, ProteinDesignTask, StepResult, now_iso
+from src.models.db import InternalStatus
+from src.workflow import recovery as recovery_module
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType
+
+
+def _build_context_with_s3_passed(
+    *,
+    max_iterations: int = 3,
+    convergence_delta: float = 0.01,
+    max_degradation_rounds: int = 1,
+) -> WorkflowContext:
+    task = ProteinDesignTask(
+        task_id="task_s4_loop",
+        goal="de_novo_design",
+        constraints={
+            "length_range": [20, 30],
+            "plddt_threshold": 0.7,
+            "structure_refinement": {
+                "max_iterations": max_iterations,
+                "convergence_delta": convergence_delta,
+                "max_degradation_rounds": max_degradation_rounds,
+            },
+        },
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S2", tool="nim_esmfold", inputs={"sequence": "S1.sequence"}, metadata={"stage_id": "S2"}),
+            PlanStep(id="S3", tool="biopython_qc", inputs={"structure_results": "S2.structure_results"}, metadata={"stage_id": "S3"}),
+            PlanStep(id="S4", tool="protein_mpnn", inputs={"pdb_path": "S2.pdb_path"}, metadata={"stage_id": "S4"}),
+        ],
+        constraints=task.constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.RUNNING,
+    )
+    context.step_results["S3"] = StepResult(
+        task_id=task.task_id,
+        step_id="S3",
+        tool="biopython_qc",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        inputs={},
+        outputs={
+            "stage_id": "S3",
+            "pass_fail": True,
+            "pass_count": 1,
+            "fail_count": 0,
+            "passed_samples": [
+                {
+                    "candidate_id": "s3_base",
+                    "sequence": "ACDEFGHIKLMNPQRSTVWY",
+                    "pdb_path": "/tmp/base.pdb",
+                    "plddt": 0.8,
+                    "lineage": {"stage_id": "S3", "source_candidate_id": "s2_base"},
+                }
+            ],
+        },
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    return context
+
+
+def _mock_success_result(
+    *,
+    task_id: str,
+    step: PlanStep,
+    outputs: dict,
+) -> StepResult:
+    return StepResult(
+        task_id=task_id,
+        step_id=step.id,
+        tool=step.tool,
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        inputs=step.inputs,
+        outputs=outputs,
+        metrics={"exec_type": "mock"},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+
+def _mock_failed_result(
+    *,
+    task_id: str,
+    step: PlanStep,
+    code: str,
+    message: str,
+) -> StepResult:
+    return StepResult(
+        task_id=task_id,
+        step_id=step.id,
+        tool=step.tool,
+        status="failed",
+        failure_type=FailureType.TOOL_ERROR.value,
+        error_message=message,
+        error_details={"failure_code": code},
+        inputs=step.inputs,
+        outputs={},
+        metrics={"exec_type": "mock"},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+
+def _patch_audit_to_tmp(monkeypatch, tmp_path: Path) -> None:
+    def _persist(*, task_id: str, step_id: str, audit_payload: dict):
+        return recovery_module.persist_structure_refinement_audit(
+            task_id=task_id,
+            step_id=step_id,
+            audit_payload=audit_payload,
+            artifacts_dir=tmp_path,
+        )
+
+    monkeypatch.setattr(executor_module, "persist_structure_refinement_audit", _persist)
+
+
+def test_refine_sequences_from_s3_runs_multi_round_until_converged(monkeypatch, tmp_path: Path):
+    context = _build_context_with_s3_passed(max_iterations=3, convergence_delta=0.02)
+    executor = ExecutorAgent()
+    events: list[dict] = []
+    _patch_audit_to_tmp(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        executor_module,
+        "append_event",
+        lambda _task_id, payload: events.append(payload),
+    )
+
+    plddt_by_sequence = {
+        "MKTAYIAKQRQISFVKSHFS": 0.9,
+        "MTEEEREAARRARERVERAAREAE": 0.905,
+    }
+
+    def _fake_run_step(step: PlanStep, _context: WorkflowContext) -> StepResult:
+        if step.tool == "protein_mpnn":
+            iteration = int(step.inputs["iteration"])
+            if iteration == 1:
+                sequence = "MKTAYIAKQRQISFVKSHFS"
+            else:
+                sequence = "MTEEEREAARRARERVERAAREAE"
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S4",
+                    "sequence": sequence,
+                    "sequence_score": 0.9,
+                    "candidates": [{"sequence": sequence, "score": 0.9}],
+                },
+            )
+        if step.tool in {"nim_esmfold", "esmfold"}:
+            sequence = step.inputs["sequence"]
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S2",
+                    "sequence": sequence,
+                    "pdb_path": f"/tmp/{sequence}.pdb",
+                    "plddt": plddt_by_sequence[sequence],
+                },
+            )
+        raise AssertionError(f"unexpected tool: {step.tool}")
+
+    monkeypatch.setattr(executor.step_runner, "run_step", _fake_run_step)
+    result = executor.refine_sequences_from_s3(context)
+
+    assert result.status == "success"
+    assert result.outputs["stage_id"] == "S4"
+    assert result.outputs["iteration_count"] == 2
+    assert result.outputs["successful_iterations"] == 2
+    assert result.outputs["stop_reason"] == "converged"
+    assert result.outputs["gain_metrics"]["delta_vs_baseline"] == 0.105
+    assert events and events[0]["data"]["stop_reason"] == "converged"
+
+    audit_path = Path(result.artifacts["refinement_audit_path"])
+    assert audit_path.exists()
+    audit_payload = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert audit_payload["summary"]["iteration_count"] == 2
+    assert audit_payload["summary"]["stop_reason"] == "converged"
+
+
+def test_refine_sequences_from_s3_stops_on_degradation(monkeypatch, tmp_path: Path):
+    context = _build_context_with_s3_passed(
+        max_iterations=3,
+        convergence_delta=0.001,
+        max_degradation_rounds=0,
+    )
+    executor = ExecutorAgent()
+    _patch_audit_to_tmp(monkeypatch, tmp_path)
+
+    plddt_by_sequence = {
+        "ACDEFGHIKLMNPQRSTVWY": 0.86,
+        "MKTAYIAKQRQISFVKSHFS": 0.78,
+    }
+
+    def _fake_run_step(step: PlanStep, _context: WorkflowContext) -> StepResult:
+        if step.tool == "protein_mpnn":
+            iteration = int(step.inputs["iteration"])
+            sequence = (
+                "ACDEFGHIKLMNPQRSTVWY"
+                if iteration == 1
+                else "MKTAYIAKQRQISFVKSHFS"
+            )
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S4",
+                    "sequence": sequence,
+                    "sequence_score": 0.8,
+                    "candidates": [{"sequence": sequence, "score": 0.8}],
+                },
+            )
+        if step.tool in {"nim_esmfold", "esmfold"}:
+            sequence = step.inputs["sequence"]
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S2",
+                    "sequence": sequence,
+                    "pdb_path": f"/tmp/{sequence}.pdb",
+                    "plddt": plddt_by_sequence[sequence],
+                },
+            )
+        raise AssertionError(f"unexpected tool: {step.tool}")
+
+    monkeypatch.setattr(executor.step_runner, "run_step", _fake_run_step)
+    result = executor.refine_sequences_from_s3(context)
+
+    assert result.status == "success"
+    assert result.outputs["stop_reason"] == "degradation_limit"
+    assert result.outputs["lineage"]["rollback_applied"] is True
+    assert result.outputs["plddt"] == 0.86
+    assert result.outputs["iteration_count"] == 2
+
+
+def test_refine_sequences_from_s3_rolls_back_after_refinement_failure(monkeypatch, tmp_path: Path):
+    context = _build_context_with_s3_passed(max_iterations=3, convergence_delta=0.001)
+    executor = ExecutorAgent()
+    _patch_audit_to_tmp(monkeypatch, tmp_path)
+
+    def _fake_run_step(step: PlanStep, _context: WorkflowContext) -> StepResult:
+        if step.tool == "protein_mpnn":
+            iteration = int(step.inputs["iteration"])
+            if iteration == 1:
+                return _mock_success_result(
+                    task_id=_context.task.task_id,
+                    step=step,
+                    outputs={
+                        "stage_id": "S4",
+                        "sequence": "MKTAYIAKQRQISFVKSHFS",
+                        "sequence_score": 0.9,
+                        "candidates": [{"sequence": "MKTAYIAKQRQISFVKSHFS", "score": 0.9}],
+                    },
+                )
+            return _mock_failed_result(
+                task_id=_context.task.task_id,
+                step=step,
+                code="PROTEIN_MPNN_RUNTIME_ERROR",
+                message="mpnn service unavailable",
+            )
+        if step.tool in {"nim_esmfold", "esmfold"}:
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S2",
+                    "sequence": step.inputs["sequence"],
+                    "pdb_path": "/tmp/refined_ok.pdb",
+                    "plddt": 0.88,
+                },
+            )
+        raise AssertionError(f"unexpected tool: {step.tool}")
+
+    monkeypatch.setattr(executor.step_runner, "run_step", _fake_run_step)
+    result = executor.refine_sequences_from_s3(context)
+
+    assert result.status == "success"
+    assert result.outputs["stop_reason"] == "refinement_failed"
+    assert result.outputs["successful_iterations"] == 1
+    assert result.outputs["lineage"]["rollback_applied"] is True
+    assert result.outputs["plddt"] == 0.88
+
+    audit_path = Path(result.artifacts["refinement_audit_path"])
+    payload = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["rollback_applied"] is True

--- a/tests/integration/test_structure_refinement_s4.py
+++ b/tests/integration/test_structure_refinement_s4.py
@@ -82,6 +82,69 @@ def _build_context_with_s3_passed(
     return context
 
 
+def _build_context_with_s2_only() -> WorkflowContext:
+    task = ProteinDesignTask(
+        task_id="task_s4_s2_fallback",
+        goal="de_novo_design",
+        constraints={
+            "length_range": [20, 30],
+            "plddt_threshold": 0.7,
+            "structure_refinement": {
+                "max_iterations": 1,
+                "convergence_delta": 0.01,
+                "max_degradation_rounds": 1,
+            },
+        },
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S2", tool="nim_esmfold", inputs={"sequence": "S1.sequence"}, metadata={"stage_id": "S2"}),
+            PlanStep(id="S4", tool="protein_mpnn", inputs={"pdb_path": "S2.pdb_path"}, metadata={"stage_id": "S4"}),
+        ],
+        constraints=task.constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+        design_result=None,
+        status=InternalStatus.RUNNING,
+    )
+    context.step_results["S2"] = StepResult(
+        task_id=task.task_id,
+        step_id="S2",
+        tool="nim_esmfold",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        inputs={},
+        outputs={
+            "stage_id": "S2",
+            "structure_results": [
+                {
+                    "candidate_id": "s2_base",
+                    "status": "success",
+                    "sequence": "ACDEFGHIKLMNPQRSTVWY",
+                    "pdb_path": "/tmp/s2_base.pdb",
+                    "plddt": 0.82,
+                    "tool_id": "nim_esmfold",
+                    "lineage": {"stage_id": "S2", "source_candidate_id": "s1_base"},
+                }
+            ],
+        },
+        metrics={},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    return context
+
+
 def _mock_success_result(
     *,
     task_id: str,
@@ -312,3 +375,42 @@ def test_refine_sequences_from_s3_rolls_back_after_refinement_failure(monkeypatc
     audit_path = Path(result.artifacts["refinement_audit_path"])
     payload = json.loads(audit_path.read_text(encoding="utf-8"))
     assert payload["summary"]["rollback_applied"] is True
+
+
+def test_refine_sequences_from_s3_falls_back_to_s2_when_s3_missing(monkeypatch, tmp_path: Path):
+    context = _build_context_with_s2_only()
+    executor = ExecutorAgent()
+    _patch_audit_to_tmp(monkeypatch, tmp_path)
+
+    def _fake_run_step(step: PlanStep, _context: WorkflowContext) -> StepResult:
+        if step.tool == "protein_mpnn":
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S4",
+                    "sequence": "MKTAYIAKQRQISFVKSHFS",
+                    "sequence_score": 0.9,
+                    "candidates": [{"sequence": "MKTAYIAKQRQISFVKSHFS", "score": 0.9}],
+                },
+            )
+        if step.tool in {"nim_esmfold", "esmfold"}:
+            return _mock_success_result(
+                task_id=_context.task.task_id,
+                step=step,
+                outputs={
+                    "stage_id": "S2",
+                    "sequence": step.inputs["sequence"],
+                    "pdb_path": "/tmp/s4_refined.pdb",
+                    "plddt": 0.9,
+                },
+            )
+        raise AssertionError(f"unexpected tool: {step.tool}")
+
+    monkeypatch.setattr(executor.step_runner, "run_step", _fake_run_step)
+    result = executor.refine_sequences_from_s3(context)
+
+    assert result.status == "success"
+    assert result.outputs["source_step_id"] == "S2"
+    assert result.outputs["successful_iterations"] == 1
+    assert result.outputs["plddt"] == 0.9

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -353,15 +353,17 @@ class TestPlannerAgent:
         planner = PlannerAgent()
         plan = planner.plan(task)
 
-        assert len(plan.steps) == 3
-        assert [step.id for step in plan.steps] == ["S1", "S2", "S4"]
+        assert len(plan.steps) == 4
+        assert [step.id for step in plan.steps] == ["S1", "S2", "S4", "S2R"]
         assert plan.steps[0].tool == "protgpt2"
         assert plan.steps[1].tool == "esmfold"
         assert plan.steps[2].tool == "protein_mpnn"
+        assert plan.steps[3].tool == "esmfold"
         assert plan.steps[0].inputs["goal"] == "de_novo_design"
         assert plan.steps[0].inputs["length_range"] == [40, 60]
         assert plan.steps[1].inputs["sequence"] == "S1.sequence"
         assert plan.steps[2].inputs["pdb_path"] == "S2.pdb_path"
+        assert plan.steps[3].inputs["sequence"] == "S4.sequence"
         assert plan.steps[2].metadata["stage_id"] == "S4"
         assert plan.steps[2].metadata["stop_conditions"]["max_iterations"] == 3
         assert plan.explanation

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -340,7 +340,7 @@ class TestPlannerAgent:
         assert step.inputs["sequence"] == sample_task.constraints.get("sequence")
 
     def test_plan_creates_de_novo_template(self):
-        """de novo 任务应生成两步模板计划"""
+        """de novo 任务应生成包含 S4 规范的模板计划"""
         task = ProteinDesignTask(
             task_id="test_denovo",
             goal="de_novo_design",
@@ -353,13 +353,17 @@ class TestPlannerAgent:
         planner = PlannerAgent()
         plan = planner.plan(task)
 
-        assert len(plan.steps) == 2
-        assert [step.id for step in plan.steps] == ["S1", "S2"]
+        assert len(plan.steps) == 3
+        assert [step.id for step in plan.steps] == ["S1", "S2", "S4"]
         assert plan.steps[0].tool == "protgpt2"
         assert plan.steps[1].tool == "esmfold"
+        assert plan.steps[2].tool == "protein_mpnn"
         assert plan.steps[0].inputs["goal"] == "de_novo_design"
         assert plan.steps[0].inputs["length_range"] == [40, 60]
         assert plan.steps[1].inputs["sequence"] == "S1.sequence"
+        assert plan.steps[2].inputs["pdb_path"] == "S2.pdb_path"
+        assert plan.steps[2].metadata["stage_id"] == "S4"
+        assert plan.steps[2].metadata["stop_conditions"]["max_iterations"] == 3
         assert plan.explanation
         assert "ProteinToolKG" in plan.explanation
 


### PR DESCRIPTION
## 背景
实现 Issue #158（W11-Req1-S4），补齐 de novo 六阶段中的 `S4: 结构条件序列精修`，并建立 `S4 -> S2 -> S3` 的可审计闭环迭代能力。

Closes #158

## 本次实现

### 1) 执行计划增加 S4 规范
- `Planner` 的 de novo 模板由 `S1 -> S2` 扩展为 `S1 -> S2 -> S4`。
- `S4` 元数据包含：
  - `stage_id=S4`
  - `stage_name=structure_conditioned_refinement`
  - `loop_path=[S4,S2,S3]`
  - `stop_conditions`：`max_iterations/convergence_delta/max_degradation_rounds`
- 参数来源支持：`constraints.structure_refinement.*`（并兼容 `s4_*` 顶层键）。

### 2) S4 闭环执行与停止策略
- 新增入口：`ExecutorAgent.refine_sequences_from_s3(...)`
- 执行闭环：
  - 从 `S3` 合格样本取 baseline
  - 迭代执行 `S4 refinement -> S2 projection -> S3 quality gate`
- 停止条件：
  - `converged`
  - `degradation_limit`
  - `refinement_failed`
  - `quality_gate_rejected`
  - `missing_source_pdb`
  - `max_iterations_reached`
- 支持失败回退：迭代失败或退化超阈值时回退到历史最佳候选。

### 3) 可审计追溯与落盘
- 在 `src/workflow/recovery.py` 增加 S4 审计结构与持久化工具：
  - `StructureRefinementIteration`
  - `build_structure_refinement_audit(...)`
  - `persist_structure_refinement_audit(...)`
- S4 输出新增：
  - `refinement_iterations`
  - `gain_metrics`
  - `stop_reason`
  - `lineage.rollback_applied`
- 审计文件落盘：
  - `output/artifacts/s4_refinement_<task_id>_<step_id>.json`

### 4) ProteinMPNN 追溯字段增强（兼容性增量）
- `protein_mpnn` 候选补充稳定 `candidate_id`。
- 在 S4 场景输出/产物中附加 lineage（`source_candidate_id/iteration/stage_id`）。
- 保留现有字段语义，不做破坏性修改。

## 测试
新增/更新测试：
- 新增 `tests/integration/test_structure_refinement_s4.py`
  - 多轮迭代收敛
  - 退化提前终止
  - 失败回退
- 更新 `tests/unit/test_planner_agent.py`（de novo 模板含 S4 规范）
- 更新 `tests/integration/test_nim_esmfold.py`（兼容 de novo 模板新增 S4）

已执行：
```bash
uv run pytest \
  tests/unit/test_planner_agent.py \
  tests/unit/test_protein_mpnn_adapter.py \
  tests/unit/test_recovery_event_logs.py \
  tests/integration/test_structure_projection_s2.py \
  tests/integration/test_quality_gate_s3.py \
  tests/integration/test_structure_refinement_s4.py \
  tests/integration/test_nim_esmfold.py
```
结果：`48 passed`。

## 验收标准对照
- [x] S4 在结构约束下可生成可用精修候选（ProteinMPNN + S2/S3 验证闭环）。
- [x] 精修闭环可审计（轮次、增益、停止原因、lineage、落盘审计文件）。
- [x] 与 S2/S3 接口保持稳定（复用既有 S2/S3 数据契约，相关回归测试通过）。

## 与 Requirement2 的对齐
- 本次实现保持 Requirement2 既有字段契约与能力映射兼容（`quality_qc` 等接口不破坏）。
- S4 闭环输出采用增量字段扩展，不更改已有语义。

## 后续可补充项（非本 PR 范围）
- 将 `refine_sequences_from_s3(...)` 作为默认执行路径接入统一 `run_plan` 编排策略（当前保留显式入口以最小化执行语义影响）。
- 与 S5（#159）联动，在目标打分后驱动 S4 的二次回环策略。
