### PR TITLE
feat(workflow): stage-aware S6 control-layer recovery matrix (#160)

### DIFF
--- a/scripts/w12-issue-160-s6-control-layer-runbook.md
+++ b/scripts/w12-issue-160-s6-control-layer-runbook.md
@@ -1,0 +1,38 @@
+# W12 Issue #160：S6 控制层触发矩阵与操作指南
+
+## 1. 目标
+
+将 S6（Patch/Replan 控制层）规则显式化为“阶段感知触发矩阵”，并给出 WAITING 决策后的恢复操作路径。
+
+## 2. 阶段触发矩阵（v2026-03-16.v1）
+
+- `S1`：默认 `patch`；`SAFETY_*` 前缀失败码直接 `replan`
+- `S2`：默认 `patch`；`S2_ALL_*` / `S2_IO_*` 失败码直接 `replan`
+- `S3`：默认 `replan`（质量门禁失败属于全局策略调整）
+- `S4`：默认 `patch`；`S4_LOOP_EXHAUSTED` 直接 `replan`
+- `S5`：默认 `patch`；`S5_OBJECTIVE_NOT_MET` / `S5_SCORE_INVALID` 直接 `replan`
+
+说明：`Safety block` 永远优先 `replan`。
+
+## 3. WAITING 决策回流
+
+- `WAITING_PATCH_CONFIRM` + `accept`：`WAITING_PATCH -> PATCHING -> RUNNING`
+- `WAITING_PATCH_CONFIRM` + `replan`：进入 `WAITING_REPLAN`
+- `WAITING_REPLAN_CONFIRM` + `accept`：进入 `PLANNING`（使用确认后的 replan 候选）
+- `WAITING_REPLAN_CONFIRM` + `continue`：回到 `RUNNING`
+
+## 4. 失败升级顺序
+
+- 必须遵循 `retry -> patch -> replan`
+- 当命中矩阵“直接 replan”规则时，跳过 patch，直接等待 replan 决策
+- 仅在恢复路径耗尽或安全永久阻断时进入 `FAILED`
+
+## 5. 审计链要求
+
+每次进入控制层都必须保留：
+
+- `WAITING_ENTER`
+- `DECISION_APPLIED`
+- `WAITING_EXIT`
+- 失败上下文（`step_id/tool/failure_code/stage_id`）
+

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -19,6 +19,7 @@ from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
 from src.workflow.patch import apply_patch, build_patch_request
+from src.workflow.recovery import resolve_s6_recovery_action
 from src.workflow.step_runner import StepRunner
 from src.workflow.status import transition_task_status
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
@@ -360,15 +361,21 @@ class PatchRunner:
     def _should_patch(self, result: StepResult) -> bool:
         if result.status != "failed":
             return False
-        if result.failure_type == FailureType.SAFETY_BLOCK:
-            return False
 
         retry_exhausted = result.metrics.get("retry_exhausted", False)
-        patchable_nonretryable = result.failure_type in (
-            FailureType.TOOL_ERROR,
-            FailureType.NON_RETRYABLE,
+        stage_id = _extract_stage_id(result)
+        failure_code = _extract_failure_code(result)
+        action = resolve_s6_recovery_action(
+            stage_id=stage_id,
+            failure_code=failure_code,
+            failure_type=result.failure_type,
+            retry_exhausted=bool(retry_exhausted),
+            safety_blocked=result.failure_type == FailureType.SAFETY_BLOCK,
         )
-        return bool(retry_exhausted or patchable_nonretryable)
+        result.metrics.setdefault("s6_trigger_stage_id", stage_id)
+        result.metrics.setdefault("s6_trigger_failure_code", failure_code)
+        result.metrics.setdefault("s6_recovery_action", action)
+        return action == "patch"
 
     def _attach_patch_meta(
         self,
@@ -591,6 +598,22 @@ def _extract_patch_candidates(
             )
         )
     return pairs
+
+
+def _extract_stage_id(result: StepResult) -> str | None:
+    outputs = result.outputs if isinstance(result.outputs, dict) else {}
+    stage_id = outputs.get("stage_id")
+    if isinstance(stage_id, str) and stage_id:
+        return stage_id
+    return None
+
+
+def _extract_failure_code(result: StepResult) -> str | None:
+    details = result.error_details if isinstance(result.error_details, dict) else {}
+    failure_code = details.get("failure_code")
+    if isinstance(failure_code, str) and failure_code:
+        return failure_code
+    return None
 
 
 def _recovery_layer_rank(patch: PlanPatch) -> int:

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -813,6 +813,14 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
             "upgrade_reason": recovery_meta.get("upgrade_reason"),
         }
 
+    s6_action = step_result.metrics.get("s6_recovery_action")
+    if isinstance(s6_action, str) and s6_action:
+        data["s6"] = {
+            "action": s6_action,
+            "trigger_stage_id": step_result.metrics.get("s6_trigger_stage_id"),
+            "trigger_failure_code": step_result.metrics.get("s6_trigger_failure_code"),
+        }
+
     if stage_id == "S3":
         reject_counts = outputs.get("reject_code_counts")
         failed_rows = outputs.get("failed_samples")

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -30,6 +30,7 @@ from src.models.event_log import EventLog, EventType
 from src.storage.log_store import DEFAULT_LOG_DIR, read_event_logs
 from src.storage.snapshot_store import read_latest_snapshot, DEFAULT_SNAPSHOT_DIR
 from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType
 
 __all__ = [
     "restore_context_from_snapshot",
@@ -40,7 +41,91 @@ __all__ = [
     "StructureRefinementIteration",
     "build_structure_refinement_audit",
     "persist_structure_refinement_audit",
+    "S6_TRIGGER_MATRIX_VERSION",
+    "get_s6_trigger_matrix",
+    "resolve_s6_recovery_action",
 ]
+
+S6_TRIGGER_MATRIX_VERSION = "2026-03-16.v1"
+_S6_STAGE_TRIGGER_MATRIX: dict[str, dict[str, Any]] = {
+    "S1": {
+        "default_action": "patch",
+        "replan_failure_prefixes": ["SAFETY_"],
+    },
+    "S2": {
+        "default_action": "patch",
+        "replan_failure_prefixes": ["S2_ALL_", "S2_IO_"],
+    },
+    "S3": {
+        "default_action": "replan",
+        "replan_failure_prefixes": ["S3_"],
+    },
+    "S4": {
+        "default_action": "patch",
+        "replan_failure_prefixes": ["S4_LOOP_EXHAUSTED"],
+    },
+    "S5": {
+        "default_action": "patch",
+        "replan_failure_prefixes": ["S5_OBJECTIVE_NOT_MET", "S5_SCORE_INVALID"],
+    },
+}
+
+
+def get_s6_trigger_matrix() -> dict[str, Any]:
+    """返回 S6 阶段感知触发矩阵（用于审计与文档）。"""
+    return {
+        "version": S6_TRIGGER_MATRIX_VERSION,
+        "stages": json.loads(json.dumps(_S6_STAGE_TRIGGER_MATRIX, ensure_ascii=True)),
+    }
+
+
+def resolve_s6_recovery_action(
+    *,
+    stage_id: str | None,
+    failure_code: str | None,
+    failure_type: FailureType | str | None,
+    retry_exhausted: bool,
+    safety_blocked: bool = False,
+) -> str:
+    """根据阶段与失败上下文决定优先恢复动作：patch 或 replan。"""
+    if safety_blocked:
+        return "replan"
+
+    normalized_type = _normalize_failure_type(failure_type)
+    if normalized_type == FailureType.SAFETY_BLOCK:
+        return "replan"
+
+    normalized_stage = (stage_id or "").strip().upper()
+    stage_rule = _S6_STAGE_TRIGGER_MATRIX.get(normalized_stage)
+    normalized_code = (failure_code or "").strip().upper()
+    if stage_rule and normalized_code:
+        for prefix in stage_rule.get("replan_failure_prefixes", []):
+            if isinstance(prefix, str) and normalized_code.startswith(prefix.upper()):
+                return "replan"
+
+    if stage_rule:
+        return str(stage_rule.get("default_action") or "patch")
+
+    if normalized_type in {
+        FailureType.RETRYABLE,
+        FailureType.TOOL_ERROR,
+        FailureType.NON_RETRYABLE,
+    }:
+        return "patch"
+    if retry_exhausted:
+        return "patch"
+    return "replan"
+
+
+def _normalize_failure_type(value: FailureType | str | None) -> FailureType | None:
+    if isinstance(value, FailureType):
+        return value
+    if isinstance(value, str):
+        try:
+            return FailureType(value)
+        except ValueError:
+            return None
+    return None
 
 
 class RemoteJobContext:

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -11,6 +11,9 @@ from src.agents.planner import PlannerAgent
 from src.agents.executor import ExecutorAgent
 from src.agents.summarizer import SummarizerAgent
 from src.workflow.context import WorkflowContext
+from src.workflow.recovery import S6_TRIGGER_MATRIX_VERSION
+
+S6_CONTROL_LAYER_MATRIX_VERSION = S6_TRIGGER_MATRIX_VERSION
 
 _WAITING_INTERNAL_STATUSES = {
     InternalStatus.WAITING_PLAN_CONFIRM,

--- a/tests/integration/test_s6_control_layer_e2e.py
+++ b/tests/integration/test_s6_control_layer_e2e.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+import src.agents.planner as planner_module
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.models.contracts import (
+    Decision,
+    DecisionChoice,
+    PendingActionType,
+    Plan,
+    PlanStep,
+    ProteinDesignTask,
+    StepResult,
+    now_iso,
+)
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.models.event_log import EventType
+from src.storage.log_store import DEFAULT_LOG_DIR, read_timeline_events
+from src.workflow.context import WorkflowContext
+from src.workflow.decision_apply import apply_patch_confirm_decision
+from src.workflow.errors import FailureType
+from src.workflow.errors import PlanRunError
+from src.workflow.plan_runner import PlanRunner
+
+
+def _cleanup_task_log(task_id: str) -> None:
+    path = Path(DEFAULT_LOG_DIR) / f"{task_id}.jsonl"
+    if path.exists():
+        path.unlink()
+
+
+def _s6_runtime_kg() -> dict:
+    return {
+        "capabilities": [
+            {"capability_id": "sequence_generation", "name": "Sequence", "domain": "protein/design"},
+            {"capability_id": "structure_prediction", "name": "Structure", "domain": "protein/structure"},
+            {"capability_id": "quality_qc", "name": "QC", "domain": "protein/qc"},
+            {"capability_id": "sequence_design", "name": "Refinement", "domain": "protein/design"},
+            {"capability_id": "objective_scoring", "name": "Objective", "domain": "protein/score"},
+        ],
+        "io_types": [
+            {
+                "io_type_id": "goal_to_sequence_candidates",
+                "input_types": ["goal"],
+                "output_types": ["sequence"],
+                "combinable": True,
+            },
+            {
+                "io_type_id": "sequence_to_structure",
+                "input_types": ["sequence"],
+                "output_types": ["pdb_path", "plddt"],
+                "combinable": True,
+            },
+            {
+                "io_type_id": "sequence_structure_to_qc_metrics",
+                "input_types": ["sequence", "pdb_path"],
+                "output_types": ["qc_metrics"],
+                "combinable": True,
+            },
+            {
+                "io_type_id": "structure_to_sequence",
+                "input_types": ["pdb_path"],
+                "output_types": ["sequence"],
+                "combinable": True,
+            },
+            {
+                "io_type_id": "candidates_to_objective_scores_topk",
+                "input_types": ["candidates"],
+                "output_types": ["score_table", "top_k"],
+                "combinable": True,
+            },
+        ],
+        "tools": [
+            {
+                "id": "seqgen_local",
+                "capabilities": ["sequence_generation"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "goal_to_sequence_candidates",
+                    "inputs": {"goal": "str"},
+                    "outputs": {"sequence": "str"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "esmfold",
+                "capabilities": ["structure_prediction"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_to_structure",
+                    "inputs": {"sequence": "str"},
+                    "outputs": {"pdb_path": "path", "plddt": "float"},
+                },
+                "execution": "nextflow",
+                "constraints": {},
+            },
+            {
+                "id": "biopython_qc",
+                "capabilities": ["quality_qc"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "sequence_structure_to_qc_metrics",
+                    "inputs": {"sequence": "str", "pdb_path": "path"},
+                    "outputs": {"qc_metrics": "list"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "protein_mpnn",
+                "capabilities": ["sequence_design"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "structure_to_sequence",
+                    "inputs": {"pdb_path": "path"},
+                    "outputs": {"sequence": "str"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "objective_ranker_v2",
+                "capabilities": ["objective_scoring"],
+                "priority": "P1",
+                "io": {
+                    "io_type_id": "candidates_to_objective_scores_topk",
+                    "inputs": {"candidates": "list"},
+                    "outputs": {"score_table": "dict", "top_k": "list"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "objective_ranker",
+                "capabilities": ["objective_scoring"],
+                "priority": "P0",
+                "io": {
+                    "io_type_id": "candidates_to_objective_scores_topk",
+                    "inputs": {"candidates": "list"},
+                    "outputs": {"score_table": "dict", "top_k": "list"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+        ],
+    }
+
+
+def _s6_registry() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            id="seqgen_local",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence",),
+            cost=0.2,
+            safety_level=1,
+            io_type="goal_to_sequence_candidates",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="esmfold",
+            capabilities=("structure_prediction",),
+            inputs=("sequence",),
+            outputs=("pdb_path", "plddt"),
+            cost=0.5,
+            safety_level=1,
+            io_type="sequence_to_structure",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="biopython_qc",
+            capabilities=("quality_qc",),
+            inputs=("sequence", "pdb_path"),
+            outputs=("qc_metrics",),
+            cost=0.2,
+            safety_level=1,
+            io_type="sequence_structure_to_qc_metrics",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="protein_mpnn",
+            capabilities=("sequence_design",),
+            inputs=("pdb_path",),
+            outputs=("sequence",),
+            cost=0.3,
+            safety_level=1,
+            io_type="structure_to_sequence",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="objective_ranker_v2",
+            capabilities=("objective_scoring",),
+            inputs=("candidates",),
+            outputs=("score_table", "top_k"),
+            cost=0.35,
+            safety_level=1,
+            io_type="candidates_to_objective_scores_topk",
+            adapter_mode="local",
+            priority="P1",
+        ),
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("objective_scoring",),
+            inputs=("candidates",),
+            outputs=("score_table", "top_k"),
+            cost=0.25,
+            safety_level=1,
+            io_type="candidates_to_objective_scores_topk",
+            adapter_mode="local",
+            priority="P0",
+        ),
+    ]
+
+
+class _SixStageStepRunner:
+    def __init__(self, *, fail_stage: str | None = None):
+        self._fail_stage = fail_stage
+        self._calls = defaultdict(int)
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self._calls[step.id] += 1
+
+        if self._fail_stage == "S3" and step.id == "S3":
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.NON_RETRYABLE,
+                error_message="quality gate rejected all candidates",
+                error_details={"failure_code": "S3_ALL_CANDIDATES_REJECTED"},
+                outputs={"stage_id": "S3"},
+                metrics={"retry_exhausted": True},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+
+        if self._fail_stage == "S5_once" and step.id == "S5" and self._calls[step.id] == 1:
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="failed",
+                failure_type=FailureType.RETRYABLE,
+                error_message="objective scoring transient failure",
+                error_details={"failure_code": "S5_SCORE_TEMP_UNAVAILABLE"},
+                outputs={"stage_id": "S5"},
+                metrics={"retry_exhausted": True},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+
+        outputs = _success_outputs(step.id)
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs=outputs,
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+def _success_outputs(step_id: str) -> dict:
+    if step_id == "S1":
+        return {"stage_id": "S1", "sequence": "MKTAYIAK"}
+    if step_id == "S2":
+        return {"stage_id": "S2", "pdb_path": "/tmp/s2.pdb", "plddt": 0.82}
+    if step_id == "S3":
+        return {
+            "stage_id": "S3",
+            "qc_metrics": [{"candidate_id": "c1", "status": "PASS"}],
+            "pass_count": 1,
+            "fail_count": 0,
+        }
+    if step_id == "S4":
+        return {"stage_id": "S4", "sequence": "MKTAYIAKGG"}
+    if step_id == "S5":
+        return {
+            "stage_id": "S5",
+            "score_table": {"c1": 0.88},
+            "top_k": ["c1"],
+        }
+    return {"stage_id": step_id}
+
+
+def _build_plan(task_id: str, constraints: dict) -> tuple[Plan, WorkflowContext, TaskRecord]:
+    task = ProteinDesignTask(
+        task_id=task_id,
+        goal="six-stage-e2e",
+        constraints=constraints,
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S1", tool="seqgen_local", inputs={"goal": "de_novo_design"}, metadata={"stage_id": "S1"}),
+            PlanStep(id="S2", tool="esmfold", inputs={"sequence": "S1.sequence"}, metadata={"stage_id": "S2"}),
+            PlanStep(
+                id="S3",
+                tool="biopython_qc",
+                inputs={"sequence": "S1.sequence", "pdb_path": "S2.pdb_path"},
+                metadata={"stage_id": "S3"},
+            ),
+            PlanStep(id="S4", tool="protein_mpnn", inputs={"pdb_path": "S2.pdb_path"}, metadata={"stage_id": "S4"}),
+            PlanStep(
+                id="S5",
+                tool="objective_ranker_v2",
+                inputs={"candidates": "S3.qc_metrics"},
+                metadata={"stage_id": "S5"},
+            ),
+        ],
+        constraints=constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        status=InternalStatus.PLANNED,
+        plan=None,
+        step_results={},
+        design_result=None,
+        safety_events=[],
+        pending_action=None,
+    )
+    record = TaskRecord(
+        id=task.task_id,
+        status=ExternalStatus.PLANNED,
+        internal_status=InternalStatus.PLANNED,
+        goal=task.goal,
+        constraints=task.constraints,
+        metadata=task.metadata,
+        plan=None,
+    )
+    return plan, context, record
+
+
+@pytest.mark.integration
+def test_six_stage_waiting_patch_decision_replay_to_done(monkeypatch):
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _s6_runtime_kg())
+    planner = PlannerAgent(tool_registry=_s6_registry())
+    runner = PlanRunner(
+        step_runner=_SixStageStepRunner(fail_stage="S5_once"),
+        planner_agent=planner,
+    )
+
+    task_id = "int_s6_patch_decision_replay_done"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_plan(
+        task_id,
+        constraints={
+            "require_patch_confirm": True,
+            "require_replan_confirm": True,
+            "min_candidate_confidence": 0.0,
+            "high_cost_min_overall": 0.0,
+        },
+    )
+
+    runner.run_plan(plan, context, record=record, finalize_status=False)
+    assert context.status == InternalStatus.WAITING_PATCH
+    assert record.status == ExternalStatus.WAITING_PATCH_CONFIRM
+    assert context.pending_action is not None
+    assert context.pending_action.action_type == PendingActionType.PATCH_CONFIRM
+
+    decision = Decision(
+        decision_id=f"decision_{task_id}",
+        task_id=task_id,
+        pending_action_id=context.pending_action.pending_action_id,
+        choice=DecisionChoice.ACCEPT,
+        selected_candidate_id=context.pending_action.default_recommendation,
+        decided_by="integration-test",
+    )
+    apply_patch_confirm_decision(context, record, decision)
+    assert context.status == InternalStatus.RUNNING
+
+    runner.run_plan(
+        context.plan or plan,
+        context,
+        record=record,
+        finalize_status=True,
+        resume_from_existing=True,
+    )
+    assert context.status == InternalStatus.DONE
+    assert record.status == ExternalStatus.DONE
+
+    events = read_timeline_events(task_id)
+    event_types = [entry.get("event_type") for entry in events]
+    assert EventType.WAITING_ENTER.value in event_types
+    assert EventType.DECISION_APPLIED.value in event_types
+    assert EventType.WAITING_EXIT.value in event_types
+
+
+@pytest.mark.integration
+def test_s6_trigger_matrix_routes_s3_failure_to_replan(monkeypatch):
+    monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _s6_runtime_kg())
+    planner = PlannerAgent(tool_registry=_s6_registry())
+    runner = PlanRunner(
+        step_runner=_SixStageStepRunner(fail_stage="S3"),
+        planner_agent=planner,
+    )
+
+    task_id = "int_s6_trigger_matrix_s3_replan"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_plan(
+        task_id,
+        constraints={
+            "require_replan_confirm": True,
+            "min_candidate_confidence": 0.0,
+            "high_cost_min_overall": 0.0,
+        },
+    )
+
+    try:
+        runner.run_plan(plan, context, record=record, finalize_status=False)
+    except PlanRunError:
+        pass
+
+    assert context.status in {InternalStatus.WAITING_REPLAN, InternalStatus.FAILED}
+    if context.status == InternalStatus.WAITING_REPLAN:
+        assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+        assert context.pending_action is not None
+        assert context.pending_action.action_type == PendingActionType.REPLAN_CONFIRM
+
+    failed_s3 = context.step_results["S3"]
+    assert failed_s3.metrics.get("s6_recovery_action") == "replan"
+    assert failed_s3.metrics.get("s6_trigger_stage_id") == "S3"
+    assert failed_s3.metrics.get("s6_trigger_failure_code") == "S3_ALL_CANDIDATES_REJECTED"
+
+    events = read_timeline_events(task_id)
+    assert any(
+        entry.get("event_type") == "STEP_FAILED"
+        and isinstance(entry.get("data"), dict)
+        and entry["data"].get("s6", {}).get("action") == "replan"
+        for entry in events
+    )


### PR DESCRIPTION
## Summary

Implements Issue #160 (S6 control layer) with minimal contract-safe changes:

- Adds an explicit stage-aware S6 trigger matrix (`failure_code -> patch/replan`) in `src/workflow/recovery.py`.
- Routes PatchRunner trigger decisions through the matrix and records decision metadata into step metrics.
- Extends step trace event payloads with `data.s6` for audit/replay (`action`, `trigger_stage_id`, `trigger_failure_code`).
- Keeps FSM semantics and agent boundaries unchanged.
- Adds six-stage integration tests for:
  - `WAITING_PATCH_CONFIRM -> decision apply -> RUNNING -> DONE` replay path
  - S3 failure routing to replan path based on S6 trigger matrix
- Adds runbook documentation for trigger matrix and operator guidance.

## Why base `dev`

Issue #160 is in W12 workflow track and depends on completed W11/W12 recovery/HITL work already integrated on `dev`, so this branch is cut from and targets `dev`.

## Files

- `src/workflow/recovery.py`
- `src/workflow/patch_runner.py`
- `src/workflow/plan_runner.py`
- `src/workflow/workflow.py`
- `tests/integration/test_s6_control_layer_e2e.py`
- `scripts/w12-issue-160-s6-control-layer-runbook.md`

## Acceptance Criteria Mapping

1. **S6 可在任一阶段失败时给出可审计恢复决策**
- S6 matrix resolver added and used by PatchRunner.
- Decision fields are emitted into step trace (`data.s6`) for replay/audit.

2. **不突破 FSM 合法迁移与 WAITING_* 语义**
- No new states introduced.
- Existing transition paths preserved; tests cover WAITING_PATCH / WAITING_REPLAN behavior.

3. **六阶段覆盖链路至少 1 条端到端稳定通过**
- Added integration test covering six-stage path with patch-confirm decision replay to DONE.

## Validation

Executed:

```bash
uv run pytest tests/integration/test_workflow.py tests/integration/test_event_log_integration.py tests/unit/test_patch_runner.py tests/unit/test_plan_runner.py tests/integration/test_recovery_layered_patch.py tests/integration/test_s6_control_layer_e2e.py -q
```

Result: passed.

## Link

Closes #160
