### PR TITLE
feat(evaluation): add W12 issue #149 offline benchmark and RC gate

### DIFF
--- a/scripts/evaluate_w12_issue149_offline_benchmark.py
+++ b/scripts/evaluate_w12_issue149_offline_benchmark.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SUMMARY_CSV = Path(
+    "output/experiment/w12-expr-2/issue171-remote-batch2-r1/vertical_metrics_summary.csv"
+)
+DEFAULT_SLICE_CSV = Path(
+    "output/experiment/w12-expr-2/issue171-remote-batch2-r1/requirement2_tool_capability_slices.csv"
+)
+DEFAULT_OUTPUT_DIR = Path("output/experiment/w12-expr-2/issue149-offline-benchmark")
+DEFAULT_CANDIDATE_VERSION = "v0.3.0-rc1"
+DEFAULT_BASELINE_VERSION = "external-baseline-a0"
+DEFAULT_SELF_GROUP = "A2"
+DEFAULT_BASELINE_GROUP = "A0"
+
+OFFLINE_THRESHOLDS: dict[str, float] = {
+    "schema_valid_rate": 0.995,
+    "executable_plan_rate": 0.95,
+    "patch_minimality_hit_rate": 0.8,
+    "suffix_replan_prefix_preservation_rate": 1.0,
+}
+
+METRIC_LABELS: dict[str, str] = {
+    "schema_valid_rate": "Schema legal rate",
+    "executable_plan_rate": "Executable plan rate",
+    "patch_minimality_hit_rate": "Patch minimality hit rate",
+    "suffix_replan_prefix_preservation_rate": "Suffix replan prefix retention rate",
+}
+
+
+@dataclass(frozen=True)
+class GateCheck:
+    metric: str
+    threshold: float
+    value: float | None
+    passed: bool
+
+
+@dataclass(frozen=True)
+class BenchmarkComparison:
+    metric: str
+    self_value: float | None
+    baseline_value: float | None
+    delta: float | None
+
+
+def _json_dump(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2)
+
+
+def _str_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _to_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+    return None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_dump(payload) + "\n", encoding="utf-8")
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key) for key in fieldnames})
+
+
+def _git_short_sha() -> str:
+    try:
+        return (
+            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True)
+            .strip()
+            .lower()
+        )
+    except Exception:
+        return "nogit"
+
+
+def load_group_metric_rows(path: Path) -> dict[str, dict[str, Any]]:
+    rows = _read_csv(path)
+    grouped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        group_id = _str_value(row.get("group_id"))
+        if not group_id:
+            continue
+        grouped[group_id] = {**row}
+    return grouped
+
+
+def build_comparisons(
+    *,
+    self_row: dict[str, Any],
+    baseline_row: dict[str, Any],
+) -> list[BenchmarkComparison]:
+    rows: list[BenchmarkComparison] = []
+    for metric in OFFLINE_THRESHOLDS:
+        self_value = _to_float(self_row.get(metric))
+        baseline_value = _to_float(baseline_row.get(metric))
+        delta = None
+        if self_value is not None and baseline_value is not None:
+            delta = self_value - baseline_value
+        rows.append(
+            BenchmarkComparison(
+                metric=metric,
+                self_value=self_value,
+                baseline_value=baseline_value,
+                delta=delta,
+            )
+        )
+    return rows
+
+
+def build_gate_checks(self_row: dict[str, Any]) -> list[GateCheck]:
+    checks: list[GateCheck] = []
+    for metric, threshold in OFFLINE_THRESHOLDS.items():
+        value = _to_float(self_row.get(metric))
+        passed = value is not None and value >= threshold
+        checks.append(
+            GateCheck(
+                metric=metric,
+                threshold=threshold,
+                value=value,
+                passed=passed,
+            )
+        )
+    return checks
+
+
+def build_slice_comparison(
+    *,
+    slice_rows: list[dict[str, str]],
+    self_group: str,
+    baseline_group: str,
+) -> list[dict[str, Any]]:
+    index: dict[tuple[str, str, str], dict[str, str]] = {}
+    for row in slice_rows:
+        group_id = _str_value(row.get("group_id"))
+        slice_type = _str_value(row.get("slice_type"))
+        name = _str_value(row.get("name"))
+        if not group_id or not slice_type or not name:
+            continue
+        index[(group_id, slice_type, name)] = row
+
+    keys = sorted(
+        {
+            (slice_type, name)
+            for group_id, slice_type, name in index
+            if group_id in {self_group, baseline_group}
+        }
+    )
+
+    rows: list[dict[str, Any]] = []
+    for slice_type, name in keys:
+        self_row = index.get((self_group, slice_type, name), {})
+        baseline_row = index.get((baseline_group, slice_type, name), {})
+        self_usage = _to_float(self_row.get("usage_count")) or 0.0
+        baseline_usage = _to_float(baseline_row.get("usage_count")) or 0.0
+        rows.append(
+            {
+                "slice_type": slice_type,
+                "name": name,
+                "self_covered": _to_bool(self_row.get("covered")),
+                "baseline_covered": _to_bool(baseline_row.get("covered")),
+                "self_usage_count": int(self_usage),
+                "baseline_usage_count": int(baseline_usage),
+                "usage_delta": int(self_usage - baseline_usage),
+            }
+        )
+    return rows
+
+
+def render_release_markdown(
+    *,
+    candidate_version: str,
+    baseline_version: str,
+    self_group: str,
+    baseline_group: str,
+    comparisons: list[BenchmarkComparison],
+    gate_checks: list[GateCheck],
+    slice_rows: list[dict[str, Any]],
+    generated_at: str,
+    summary_csv: Path,
+    slice_csv: Path,
+) -> str:
+    overall_pass = all(item.passed for item in gate_checks)
+
+    lines = [
+        "# release-benchmark",
+        "",
+        "## Benchmark Target",
+        f"- Candidate: `{candidate_version}` (group `{self_group}`)",
+        f"- Baseline: `{baseline_version}` (group `{baseline_group}`)",
+        f"- Generated at: `{generated_at}`",
+        "",
+        "## Reproducibility",
+        f"- Summary input: `{summary_csv}`",
+        f"- Slice input: `{slice_csv}`",
+        f"- Command: `python scripts/evaluate_w12_issue149_offline_benchmark.py --summary-csv {summary_csv} --slice-csv {slice_csv} --self-group {self_group} --baseline-group {baseline_group}`",
+        "",
+        "## Metric Definitions",
+        "- Schema legal rate: valid schema runs / total runs in group.",
+        "- Executable plan rate: runs without step execution failure / total runs in group.",
+        "- Patch minimality hit rate: parameter-level patch events / all patch events (null when patch events are zero).",
+        "- Suffix replan prefix retention rate: suffix-replan runs preserving successful prefix / suffix-replan runs (null when no suffix-replan samples).",
+        "- Missing value handling: if metric is null, gate check fails and release is blocked.",
+        "",
+        "## Candidate vs Baseline",
+        "| metric | candidate | baseline | delta |",
+        "|---|---:|---:|---:|",
+    ]
+
+    for item in comparisons:
+        lines.append(
+            "| {label} | {self_v} | {base_v} | {delta} |".format(
+                label=METRIC_LABELS[item.metric],
+                self_v="-" if item.self_value is None else f"{item.self_value:.6f}",
+                base_v="-" if item.baseline_value is None else f"{item.baseline_value:.6f}",
+                delta="-" if item.delta is None else f"{item.delta:+.6f}",
+            )
+        )
+
+    lines.extend([
+        "",
+        "## RC Gate-B",
+        "| metric | threshold | candidate | pass |",
+        "|---|---:|---:|---:|",
+    ])
+
+    blocked_reasons: list[str] = []
+    for item in gate_checks:
+        value_text = "-" if item.value is None else f"{item.value:.6f}"
+        pass_text = "yes" if item.passed else "no"
+        lines.append(
+            f"| {METRIC_LABELS[item.metric]} | {item.threshold:.6f} | {value_text} | {pass_text} |"
+        )
+        if not item.passed:
+            blocked_reasons.append(
+                f"{METRIC_LABELS[item.metric]} below threshold ({value_text} < {item.threshold:.6f})"
+            )
+
+    lines.extend(["", "## Tool Coverage vs Metrics", "| slice_type | name | candidate covered | baseline covered | candidate usage | baseline usage | usage delta |", "|---|---|---:|---:|---:|---:|---:|"])
+    for row in slice_rows:
+        lines.append(
+            "| {slice_type} | {name} | {self_cov} | {base_cov} | {self_use} | {base_use} | {delta:+d} |".format(
+                slice_type=row["slice_type"],
+                name=row["name"],
+                self_cov="yes" if row.get("self_covered") else "no",
+                base_cov="yes" if row.get("baseline_covered") else "no",
+                self_use=int(row.get("self_usage_count", 0)),
+                base_use=int(row.get("baseline_usage_count", 0)),
+                delta=int(row.get("usage_delta", 0)),
+            )
+        )
+
+    lines.extend(["", "## Release Decision"]) 
+    if overall_pass:
+        lines.append("- Decision: pass RC Gate-B; release is not blocked by offline thresholds.")
+    else:
+        lines.append("- Decision: block release due to unmet offline thresholds.")
+        for reason in blocked_reasons:
+            lines.append(f"- Blocker: {reason}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate Issue #149 offline benchmark (candidate vs external baseline)."
+    )
+    parser.add_argument("--summary-csv", type=Path, default=DEFAULT_SUMMARY_CSV)
+    parser.add_argument("--slice-csv", type=Path, default=DEFAULT_SLICE_CSV)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--self-group", type=str, default=DEFAULT_SELF_GROUP)
+    parser.add_argument("--baseline-group", type=str, default=DEFAULT_BASELINE_GROUP)
+    parser.add_argument("--candidate-version", type=str, default=DEFAULT_CANDIDATE_VERSION)
+    parser.add_argument("--baseline-version", type=str, default=DEFAULT_BASELINE_VERSION)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+
+    group_rows = load_group_metric_rows(args.summary_csv)
+    self_row = group_rows.get(args.self_group)
+    baseline_row = group_rows.get(args.baseline_group)
+    if self_row is None:
+        raise ValueError(f"self group not found in summary csv: {args.self_group}")
+    if baseline_row is None:
+        raise ValueError(f"baseline group not found in summary csv: {args.baseline_group}")
+
+    comparisons = build_comparisons(self_row=self_row, baseline_row=baseline_row)
+    gate_checks = build_gate_checks(self_row)
+    slice_rows = build_slice_comparison(
+        slice_rows=_read_csv(args.slice_csv),
+        self_group=args.self_group,
+        baseline_group=args.baseline_group,
+    )
+
+    generated_at = _now_iso()
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    comparison_rows = [
+        {
+            "metric": item.metric,
+            "metric_label": METRIC_LABELS[item.metric],
+            "candidate_value": item.self_value,
+            "baseline_value": item.baseline_value,
+            "delta": item.delta,
+        }
+        for item in comparisons
+    ]
+    gate_rows = [
+        {
+            "metric": item.metric,
+            "metric_label": METRIC_LABELS[item.metric],
+            "threshold": item.threshold,
+            "candidate_value": item.value,
+            "passed": item.passed,
+        }
+        for item in gate_checks
+    ]
+
+    _write_csv(
+        output_dir / "release_benchmark_comparison.csv",
+        comparison_rows,
+        ["metric", "metric_label", "candidate_value", "baseline_value", "delta"],
+    )
+    _write_csv(
+        output_dir / "release_benchmark_gate_checks.csv",
+        gate_rows,
+        ["metric", "metric_label", "threshold", "candidate_value", "passed"],
+    )
+    _write_csv(
+        output_dir / "tool_coverage_vs_metrics.csv",
+        slice_rows,
+        [
+            "slice_type",
+            "name",
+            "self_covered",
+            "baseline_covered",
+            "self_usage_count",
+            "baseline_usage_count",
+            "usage_delta",
+        ],
+    )
+
+    payload = {
+        "issue": 149,
+        "generated_at": generated_at,
+        "candidate_version": args.candidate_version,
+        "baseline_version": args.baseline_version,
+        "self_group": args.self_group,
+        "baseline_group": args.baseline_group,
+        "summary_csv": str(args.summary_csv),
+        "slice_csv": str(args.slice_csv),
+        "thresholds": OFFLINE_THRESHOLDS,
+        "comparisons": comparison_rows,
+        "gate_checks": gate_rows,
+        "tool_slice_rows": slice_rows,
+        "release_blocked": not all(item.passed for item in gate_checks),
+        "reproducibility": {
+            "command": " ".join(sys.argv),
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "git_short_sha": _git_short_sha(),
+        },
+    }
+    _write_json(output_dir / "release_benchmark.json", payload)
+
+    markdown = render_release_markdown(
+        candidate_version=args.candidate_version,
+        baseline_version=args.baseline_version,
+        self_group=args.self_group,
+        baseline_group=args.baseline_group,
+        comparisons=comparisons,
+        gate_checks=gate_checks,
+        slice_rows=slice_rows,
+        generated_at=generated_at,
+        summary_csv=args.summary_csv,
+        slice_csv=args.slice_csv,
+    )
+    (output_dir / "release-benchmark.md").write_text(markdown, encoding="utf-8")
+
+    print(_json_dump({"output_dir": str(output_dir), "release_blocked": payload["release_blocked"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/w12-issue-149-offline-benchmark.md
+++ b/scripts/w12-issue-149-offline-benchmark.md
@@ -1,0 +1,60 @@
+# W12 Issue #149: Offline Benchmark vs External Baseline
+
+## Goal
+
+Generate a reproducible offline benchmark report for candidate model `v0.3.0-rc1` against an external baseline reference, with RC Gate-B pass/fail decision.
+
+## Input Baseline
+
+This script reuses Week12 vertical experiment outputs:
+
+- Summary metrics: `output/experiment/w12-expr-2/issue171-remote-batch2-r1/vertical_metrics_summary.csv`
+- Tool/capability slices: `output/experiment/w12-expr-2/issue171-remote-batch2-r1/requirement2_tool_capability_slices.csv`
+
+Default comparison mapping:
+
+- Candidate group: `A2`
+- Baseline group: `A0`
+
+## Run Command
+
+```bash
+uv run python scripts/evaluate_w12_issue149_offline_benchmark.py \
+  --summary-csv output/experiment/w12-expr-2/issue171-remote-batch2-r1/vertical_metrics_summary.csv \
+  --slice-csv output/experiment/w12-expr-2/issue171-remote-batch2-r1/requirement2_tool_capability_slices.csv \
+  --self-group A2 \
+  --baseline-group A0 \
+  --candidate-version v0.3.0-rc1 \
+  --baseline-version external-baseline-a0 \
+  --output-dir output/experiment/w12-expr-2/issue149-offline-benchmark
+```
+
+## Output
+
+- `release_benchmark.json`
+- `release_benchmark_comparison.csv`
+- `release_benchmark_gate_checks.csv`
+- `tool_coverage_vs_metrics.csv`
+- `release-benchmark.md`
+
+## Metric Formula and Denominator
+
+- Schema legal rate: valid schema runs / total runs in group.
+- Executable plan rate: runs without step failure / total runs in group.
+- Patch minimality hit rate: parameter-level patch events / all patch events.
+  - If patch events are 0, value is null and gate check fails.
+- `suffix_replan` prefix retention rate: runs preserving successful prefix / suffix-replan runs.
+  - If suffix-replan sample count is 0, value is null and gate check fails.
+
+## RC Gate-B Thresholds
+
+- Schema legal rate >= 99.5%
+- Executable plan rate >= 95%
+- Patch minimality hit rate >= 80%
+- `suffix_replan` prefix retention rate = 100%
+
+## Requirement-2 Merge Checks
+
+- Per-tool / per-capability slices are exported in `tool_coverage_vs_metrics.csv`.
+- Report explicitly maps coverage to candidate/baseline usage deltas.
+- `release-benchmark.md` includes gate blockers when thresholds are not met.

--- a/tests/unit/test_evaluate_w12_issue149_offline_benchmark.py
+++ b/tests/unit/test_evaluate_w12_issue149_offline_benchmark.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path("scripts/evaluate_w12_issue149_offline_benchmark.py")
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("evaluate_w12_issue149_offline_benchmark", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+@pytest.mark.unit
+def test_build_comparisons_and_gate_checks() -> None:
+    module = _load_script_module()
+    self_row = {
+        "schema_valid_rate": "0.996",
+        "executable_plan_rate": "0.960",
+        "patch_minimality_hit_rate": "0.750",
+        "suffix_replan_prefix_preservation_rate": "1.0",
+    }
+    baseline_row = {
+        "schema_valid_rate": "0.990",
+        "executable_plan_rate": "0.940",
+        "patch_minimality_hit_rate": "0.700",
+        "suffix_replan_prefix_preservation_rate": "0.950",
+    }
+
+    comparisons = module.build_comparisons(self_row=self_row, baseline_row=baseline_row)
+    checks = module.build_gate_checks(self_row)
+
+    by_metric = {item.metric: item for item in comparisons}
+    assert by_metric["schema_valid_rate"].delta == pytest.approx(0.006)
+    assert by_metric["patch_minimality_hit_rate"].delta == pytest.approx(0.05)
+
+    checks_by_metric = {item.metric: item for item in checks}
+    assert checks_by_metric["schema_valid_rate"].passed is True
+    assert checks_by_metric["patch_minimality_hit_rate"].passed is False
+
+
+@pytest.mark.unit
+def test_build_slice_comparison_aligns_groups() -> None:
+    module = _load_script_module()
+    rows = [
+        {
+            "group_id": "A2",
+            "slice_type": "capability_bucket",
+            "name": "sequence_core",
+            "covered": "True",
+            "usage_count": "12",
+        },
+        {
+            "group_id": "A0",
+            "slice_type": "capability_bucket",
+            "name": "sequence_core",
+            "covered": "False",
+            "usage_count": "3",
+        },
+    ]
+
+    compared = module.build_slice_comparison(
+        slice_rows=rows,
+        self_group="A2",
+        baseline_group="A0",
+    )
+
+    assert len(compared) == 1
+    row = compared[0]
+    assert row["self_covered"] is True
+    assert row["baseline_covered"] is False
+    assert row["usage_delta"] == 9
+
+
+@pytest.mark.unit
+def test_load_group_metric_rows_reads_by_group(tmp_path: Path) -> None:
+    module = _load_script_module()
+    csv_path = tmp_path / "summary.csv"
+    _write_csv(
+        csv_path,
+        ["group_id", "schema_valid_rate"],
+        [
+            {"group_id": "A0", "schema_valid_rate": 1.0},
+            {"group_id": "A2", "schema_valid_rate": 0.99},
+        ],
+    )
+
+    grouped = module.load_group_metric_rows(csv_path)
+
+    assert set(grouped) == {"A0", "A2"}
+    assert grouped["A0"]["schema_valid_rate"] == "1.0"
+
+
+@pytest.mark.unit
+def test_render_release_markdown_reports_blockers() -> None:
+    module = _load_script_module()
+    comparisons = [
+        module.BenchmarkComparison(
+            metric="schema_valid_rate",
+            self_value=0.99,
+            baseline_value=0.98,
+            delta=0.01,
+        )
+    ]
+    checks = [
+        module.GateCheck(
+            metric="schema_valid_rate",
+            threshold=0.995,
+            value=0.99,
+            passed=False,
+        )
+    ]
+    markdown = module.render_release_markdown(
+        candidate_version="v0.3.0-rc1",
+        baseline_version="baseline-a0",
+        self_group="A2",
+        baseline_group="A0",
+        comparisons=comparisons,
+        gate_checks=checks,
+        slice_rows=[],
+        generated_at="2026-03-16T00:00:00+00:00",
+        summary_csv=Path("summary.csv"),
+        slice_csv=Path("slice.csv"),
+    )
+
+    assert "block release" in markdown
+    assert "below threshold" in markdown


### PR DESCRIPTION
## Summary
This PR implements W12-Evaluation-1 (#149) by adding a reproducible offline benchmark generator and RC Gate-B decision output.

Closes #149

## Changes
- Added `scripts/evaluate_w12_issue149_offline_benchmark.py`
  - Reads offline summary metrics and Requirement-2 tool/capability slices
  - Compares candidate group vs external baseline group
  - Computes RC Gate-B checks for:
    - schema legal rate
    - executable plan rate
    - patch minimality hit rate
    - suffix replan prefix retention rate
  - Writes:
    - `release_benchmark.json`
    - `release_benchmark_comparison.csv`
    - `release_benchmark_gate_checks.csv`
    - `tool_coverage_vs_metrics.csv`
    - `release-benchmark.md`
- Added tests:
  - `tests/unit/test_evaluate_w12_issue149_offline_benchmark.py`
- Added runbook:
  - `scripts/w12-issue-149-offline-benchmark.md`

## Validation
- Unit tests:
  - `uv run pytest tests/unit/test_evaluate_w12_issue149_offline_benchmark.py -q`
- End-to-end benchmark generation:
  - `uv run python scripts/evaluate_w12_issue149_offline_benchmark.py --summary-csv output/experiment/w12-expr-2/issue171-remote-batch2-r1/vertical_metrics_summary.csv --slice-csv output/experiment/w12-expr-2/issue171-remote-batch2-r1/requirement2_tool_capability_slices.csv --self-group A2 --baseline-group A0 --candidate-version v0.3.0-rc1 --baseline-version external-baseline-a0 --output-dir output/experiment/w12-expr-2/issue149-offline-benchmark`

## Acceptance Criteria Check (#149)
- [x] Reproducible report with fixed input versions and command
- [x] Metrics script is deterministic and rerunnable
- [x] Conclusions are traceable to summary/slice inputs and explicit thresholds
- [x] `release-benchmark.md` generated for RC Gate-B
- [x] RC Gate-B unmet items are explicitly listed as release blockers
- [x] Requirement-2 merge coverage:
  - per-tool/per-capability slices
  - tool coverage vs metric impact table

## Notes
- Current input data yields missing values for `patch_minimality_hit_rate` and `suffix_replan_prefix_preservation_rate`, so RC Gate-B is marked `blocked` by design.
- This result is surfaced as an explicit release decision and blocker list in output artifacts.
