### PR TITLE
feat(observability): enhance recovery timeline replay fields (#144)

### DIFF
--- a/scripts/w11-issue-144-recovery-observability.md
+++ b/scripts/w11-issue-144-recovery-observability.md
@@ -1,0 +1,63 @@
+# W11 Issue #144: Recovery Observability Upgrade
+
+## Goal
+
+Enhance recovery/audit observability so training extraction, audit reconciliation, and failure diagnosis can replay key decisions and recovery nodes by task and by tool dimension.
+
+## Scope Delivered
+
+- Storage timeline normalization extended with recovery observability fields.
+- API timeline endpoint supports filter query params for replay views.
+- Recovery/decision event writes now include richer tool and decision source context.
+- Legacy logs remain readable when new fields are missing.
+
+## New Timeline Fields
+
+Event-level normalized fields (when available):
+
+- `tool_id`, `capability_id`, `io_type`, `adapter_mode`
+- `from_tool`, `to_tool`
+- `failure_type`, `failure_code`
+- `candidate_id`, `decision_source`
+- `recovery_layer`, `recovery_reason`
+
+## API Query Extensions
+
+`GET /tasks/{task_id}/events`
+
+Optional query params:
+
+- `event_type`
+- `tool_id`
+- `capability_id`
+- `adapter_mode`
+
+Example:
+
+```bash
+curl "http://127.0.0.1:8000/tasks/<task_id>/events?tool_id=esmfold&adapter_mode=remote"
+```
+
+## Event Dictionary (Recovery-Critical)
+
+- Failure tracing:
+  - `failure_type`, `failure_code`
+- Candidate and decision tracing:
+  - `candidate_id`, `decision_source`
+- Recovery layer tracing:
+  - `recovery_layer`, `recovery_reason`
+- Tool-chain tracing:
+  - `tool_id`, `capability_id`, `io_type`, `adapter_mode`, `from_tool`, `to_tool`
+
+## Compatibility Note
+
+Legacy logs without these fields are still parsed and returned with `null` values for missing observability fields. Invalid JSON lines are skipped in non-strict mode.
+
+## Validation
+
+- Unit tests:
+  - `tests/unit/test_log_store_timeline.py`
+- API behavior tests:
+  - `tests/api/test_api_endpoints.py::TestTaskEndpoints::test_get_task_events_timeline_mapping_and_order`
+- Integration safety net:
+  - `tests/integration/test_event_log_integration.py`

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -115,6 +115,18 @@ class TaskTimelineEvent(BaseModel):
     decision_id: Optional[str] = None
     step_id: Optional[str] = None
     tool: Optional[str] = None
+    tool_id: Optional[str] = None
+    capability_id: Optional[str] = None
+    io_type: Optional[str] = None
+    adapter_mode: Optional[str] = None
+    from_tool: Optional[str] = None
+    to_tool: Optional[str] = None
+    failure_type: Optional[str] = None
+    failure_code: Optional[str] = None
+    candidate_id: Optional[str] = None
+    decision_source: Optional[str] = None
+    recovery_layer: Optional[str] = None
+    recovery_reason: Optional[str] = None
     status: Optional[str] = None
     from_status: Optional[str] = None
     to_status: Optional[str] = None
@@ -434,8 +446,45 @@ async def get_task(task_id: str):
     return record
 
 
+def _event_matches_filters(
+    event: dict[str, Any],
+    *,
+    event_type: Optional[str],
+    tool_id: Optional[str],
+    capability_id: Optional[str],
+    adapter_mode: Optional[str],
+) -> bool:
+    if event_type and event.get("event_type") != event_type:
+        return False
+
+    if tool_id:
+        related_tools = {
+            _normalize_text(event.get("tool")),
+            _normalize_text(event.get("tool_id")),
+            _normalize_text(event.get("from_tool")),
+            _normalize_text(event.get("to_tool")),
+        }
+        related_tools.discard(None)
+        if tool_id not in related_tools:
+            return False
+
+    if capability_id and event.get("capability_id") != capability_id:
+        return False
+
+    if adapter_mode and event.get("adapter_mode") != adapter_mode:
+        return False
+
+    return True
+
+
 @app.get("/tasks/{task_id}/events", response_model=list[TaskTimelineEvent])
-async def get_task_events(task_id: str) -> list[TaskTimelineEvent]:
+async def get_task_events(
+    task_id: str,
+    event_type: Optional[str] = Query(default=None),
+    tool_id: Optional[str] = Query(default=None),
+    capability_id: Optional[str] = Query(default=None),
+    adapter_mode: Optional[str] = Query(default=None),
+) -> list[TaskTimelineEvent]:
     runtime = _ensure_runtime_initialized()
     timeline = read_timeline_events(task_id, log_dir=runtime.paths.log_dir)
 
@@ -448,6 +497,13 @@ async def get_task_events(task_id: str) -> list[TaskTimelineEvent]:
         "DECISION_APPLIED",
         "STEP_FINISHED",
         "STEP_FAILED",
+        "WAITING_ENTER",
+        "WAITING_EXIT",
+        "REPLACE_TOOL",
+        "PARAM_TWEAK",
+        "STRUCTURE_PATCH",
+        "RECOVERY_ESCALATED",
+        "CANDIDATE_VALIDATION_FAILED",
     }
     return [
         TaskTimelineEvent(
@@ -455,6 +511,13 @@ async def get_task_events(task_id: str) -> list[TaskTimelineEvent]:
             highlight=event["event_type"] in highlighted,
         )
         for event in timeline
+        if _event_matches_filters(
+            event,
+            event_type=_normalize_text(event_type),
+            tool_id=_normalize_text(tool_id),
+            capability_id=_normalize_text(capability_id),
+            adapter_mode=_normalize_text(adapter_mode),
+        )
     ]
 
 

--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -165,6 +165,7 @@ def _normalize_timeline_event(
     )
     event_data = payload.get("data")
     data = event_data if isinstance(event_data, dict) else {}
+    observability = _extract_observability_fields(payload=payload, data=data)
 
     return {
         "seq": seq,
@@ -177,6 +178,18 @@ def _normalize_timeline_event(
         "decision_id": _string_field(payload, "decision_id"),
         "step_id": _string_field(payload, "step_id"),
         "tool": _string_field(payload, "tool"),
+        "tool_id": observability["tool_id"],
+        "capability_id": observability["capability_id"],
+        "io_type": observability["io_type"],
+        "adapter_mode": observability["adapter_mode"],
+        "from_tool": observability["from_tool"],
+        "to_tool": observability["to_tool"],
+        "failure_type": observability["failure_type"],
+        "failure_code": observability["failure_code"],
+        "candidate_id": observability["candidate_id"],
+        "decision_source": observability["decision_source"],
+        "recovery_layer": observability["recovery_layer"],
+        "recovery_reason": observability["recovery_reason"],
         "status": _string_field(payload, "status"),
         "from_status": from_status,
         "to_status": to_status,
@@ -283,3 +296,101 @@ def _build_event_summary(
         return f"Step finished ({step_id})"
 
     return event_type
+
+
+def _extract_observability_fields(
+    *,
+    payload: dict[str, Any],
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    recovery = data.get("recovery") if isinstance(data.get("recovery"), dict) else {}
+    patch = data.get("patch") if isinstance(data.get("patch"), dict) else {}
+
+    tool_id = (
+        _string_field(payload, "tool_id")
+        or _string_field(payload, "tool")
+        or _string_field(data, "tool_id")
+        or _string_field(data, "tool")
+        or _string_field(patch, "to_tool")
+        or _string_field(recovery, "to_tool")
+        or _string_field(patch, "from_tool")
+        or _string_field(recovery, "from_tool")
+    )
+    capability_id = (
+        _string_field(data, "capability_id")
+        or _string_field(patch, "capability_id")
+        or _string_field(recovery, "capability_id")
+    )
+    io_type = (
+        _string_field(payload, "io_type")
+        or _string_field(data, "io_type")
+        or _string_field(patch, "io_type")
+        or _string_field(recovery, "io_type")
+    )
+    adapter_mode = (
+        _string_field(payload, "adapter_mode")
+        or _string_field(data, "adapter_mode")
+        or _string_field(patch, "adapter_mode")
+        or _string_field(recovery, "adapter_mode")
+    )
+
+    from_tool = _string_field(recovery, "from_tool") or _string_field(patch, "from_tool")
+    to_tool = _string_field(recovery, "to_tool") or _string_field(patch, "to_tool")
+    failure_type = (
+        _string_field(payload, "failure_type")
+        or _string_field(data, "failure_type")
+        or _string_field(recovery, "failure_type")
+    )
+    failure_code = (
+        _string_field(payload, "failure_code")
+        or _string_field(data, "failure_code")
+        or _string_field(recovery, "failure_code")
+    )
+    if failure_code is None:
+        error_details = payload.get("error_details")
+        if isinstance(error_details, dict):
+            failure_code = _string_field(error_details, "failure_code")
+    if failure_code is None:
+        s6 = data.get("s6")
+        if isinstance(s6, dict):
+            failure_code = _string_field(s6, "trigger_failure_code")
+
+    candidate_id = (
+        _string_field(payload, "selected_candidate_id")
+        or _string_field(data, "selected_candidate_id")
+        or _string_field(data, "candidate_id")
+        or _string_field(recovery, "candidate_id")
+    )
+    decision_source = (
+        _string_field(payload, "decided_by")
+        or _string_field(data, "decided_by")
+        or _string_field(data, "decision_source")
+        or _string_field(payload, "actor_id")
+        or _string_field(payload, "actor_type")
+    )
+    recovery_layer = (
+        _string_field(recovery, "layer")
+        or _string_field(recovery, "recovery_layer")
+        or _string_field(patch, "layer")
+        or _string_field(patch, "recovery_layer")
+    )
+    recovery_reason = (
+        _string_field(recovery, "reason")
+        or _string_field(recovery, "upgrade_reason")
+        or _string_field(data, "reason")
+    )
+
+    return {
+        "tool_id": tool_id,
+        "capability_id": capability_id,
+        "io_type": io_type,
+        "adapter_mode": adapter_mode,
+        "from_tool": from_tool,
+        "to_tool": to_tool,
+        "failure_type": failure_type,
+        "failure_code": failure_code,
+        "candidate_id": candidate_id,
+        "decision_source": decision_source,
+        "recovery_layer": recovery_layer,
+        "recovery_reason": recovery_reason,
+    }

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -128,6 +128,7 @@ def apply_plan_confirm_decision(
     _emit_waiting_exit_event(
         context,
         action,
+        decision,
         prev_status,
         waiting_state=InternalStatus.WAITING_PLAN_CONFIRM.value,
     )
@@ -199,6 +200,7 @@ def apply_patch_confirm_decision(
         _emit_waiting_exit_event(
             context,
             action,
+            decision,
             prev_status,
             waiting_state=InternalStatus.WAITING_PATCH.value,
         )
@@ -261,6 +263,7 @@ def apply_patch_confirm_decision(
     _emit_waiting_exit_event(
         context,
         action,
+        decision,
         prev_status,
         waiting_state=InternalStatus.WAITING_PATCH.value,
     )
@@ -344,6 +347,7 @@ def apply_replan_confirm_decision(
     _emit_waiting_exit_event(
         context,
         action,
+        decision,
         prev_status,
         waiting_state=InternalStatus.WAITING_REPLAN.value,
     )
@@ -552,6 +556,17 @@ def _emit_decision_applied_event(
         prev_status: Previous external status (must be WAITING_*).
     """
     current_status = to_external_status(context.status)
+    selected_candidate = None
+    if decision.selected_candidate_id:
+        selected_candidate = find_pending_action_candidate(
+            action,
+            decision.selected_candidate_id,
+        )
+    candidate_meta = (
+        selected_candidate.metadata
+        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        else {}
+    )
     decision_event = make_decision_applied(
         task_id=context.task.task_id,
         decision_id=decision.decision_id,
@@ -564,6 +579,25 @@ def _emit_decision_applied_event(
         data={
             "selected_candidate_id": decision.selected_candidate_id,
             "action_type": action.action_type.value,
+            "decided_by": decision.decided_by,
+            "decision_source": "human",
+            "comment": decision.comment,
+            "tool_id": (
+                selected_candidate.tool_id if selected_candidate else candidate_meta.get("tool_id")
+            ),
+            "capability_id": (
+                selected_candidate.capability_id
+                if selected_candidate
+                else candidate_meta.get("capability_id")
+            ),
+            "io_type": (
+                selected_candidate.io_type if selected_candidate else candidate_meta.get("io_type")
+            ),
+            "adapter_mode": (
+                selected_candidate.adapter_mode
+                if selected_candidate
+                else candidate_meta.get("adapter_mode")
+            ),
         },
     )
     write_event_log(decision_event)
@@ -572,6 +606,7 @@ def _emit_decision_applied_event(
 def _emit_waiting_exit_event(
     context: WorkflowContext,
     action: PendingAction,
+    decision: Decision,
     prev_status: ExternalStatus,
     waiting_state: str,
 ) -> None:
@@ -595,6 +630,8 @@ def _emit_waiting_exit_event(
         data={
             "action_type": action.action_type.value,
             "action_status": action.status.value,
+            "decided_by": decision.decided_by,
+            "decision_source": "human",
         },
     )
     write_event_log(exit_event)

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -477,6 +477,9 @@ def _extract_recovery_metadata(
         "from_tool": from_tool,
         "to_tool": to_tool,
         "reason": reason,
+        "candidate_id": selected_candidate.candidate_id if selected_candidate else None,
+        "io_type": selected_candidate.io_type if selected_candidate else None,
+        "adapter_mode": selected_candidate.adapter_mode if selected_candidate else None,
     }
     if isinstance(metadata.get("strategy"), str):
         payload["strategy"] = metadata.get("strategy")

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -128,6 +128,22 @@ def enter_waiting_state(
     )
 
     # 写入结构化 WAITING_ENTER EventLog
+    selected_candidate = None
+    default_candidate_id = (
+        pending_action.default_recommendation or pending_action.default_suggestion
+    )
+    if default_candidate_id:
+        for candidate in pending_action.candidates:
+            if candidate.candidate_id == default_candidate_id:
+                selected_candidate = candidate
+                break
+    if selected_candidate is None and pending_action.candidates:
+        selected_candidate = pending_action.candidates[0]
+    selected_meta = (
+        selected_candidate.metadata
+        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        else {}
+    )
     waiting_enter_event = make_waiting_enter(
         task_id=context.task.task_id,
         pending_action_id=pending_action.pending_action_id,
@@ -141,6 +157,23 @@ def enter_waiting_state(
             "reason": reason or "entering_waiting_state",
             "candidate_count": len(pending_action.candidates),
             "explanation": pending_action.explanation,
+            "candidate_id": selected_candidate.candidate_id if selected_candidate else None,
+            "tool_id": (
+                selected_candidate.tool_id if selected_candidate else selected_meta.get("tool_id")
+            ),
+            "capability_id": (
+                selected_candidate.capability_id
+                if selected_candidate
+                else selected_meta.get("capability_id")
+            ),
+            "io_type": (
+                selected_candidate.io_type if selected_candidate else selected_meta.get("io_type")
+            ),
+            "adapter_mode": (
+                selected_candidate.adapter_mode
+                if selected_candidate
+                else selected_meta.get("adapter_mode")
+            ),
         },
     )
     write_event_log(waiting_enter_event)

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -797,6 +797,8 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
             "from_tool": patch_meta.get("from_tool"),
             "to_tool": patch_meta.get("to_tool"),
             "capability_id": patch_meta.get("capability_id"),
+            "io_type": patch_meta.get("io_type"),
+            "adapter_mode": patch_meta.get("adapter_mode"),
             "reason": patch_meta.get("reason"),
             "ops": patch_meta.get("ops"),
             "patched_status": patch_meta.get("patched_status"),
@@ -809,6 +811,9 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
             "from_tool": recovery_meta.get("from_tool"),
             "to_tool": recovery_meta.get("to_tool"),
             "capability_id": recovery_meta.get("capability_id"),
+            "io_type": recovery_meta.get("io_type"),
+            "adapter_mode": recovery_meta.get("adapter_mode"),
+            "candidate_id": recovery_meta.get("candidate_id"),
             "reason": recovery_meta.get("reason"),
             "upgrade_reason": recovery_meta.get("upgrade_reason"),
         }

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -528,7 +528,21 @@ class TestAPIEndpoints:
                 "step_id": "S5",
                 "tool": "dummy_tool",
                 "status": "failed",
+                "failure_type": "tool_error",
                 "timestamp": "2026-03-08T01:00:03+00:00",
+                "error_details": {"failure_code": "S3_QUALITY_GATE_FAIL"},
+                "data": {
+                    "failure_code": "S3_QUALITY_GATE_FAIL",
+                    "recovery": {
+                        "recovery_layer": "tool_level",
+                        "from_tool": "dummy_tool",
+                        "to_tool": "esmfold",
+                        "capability_id": "structure_prediction",
+                        "adapter_mode": "remote",
+                        "io_type": "sequence_to_structure",
+                        "reason": "quality_gate_blocked",
+                    },
+                },
             },
             {
                 "event_type": "DECISION_APPLIED",
@@ -536,7 +550,14 @@ class TestAPIEndpoints:
                 "decision_id": "decision_001",
                 "pending_action_id": "pa_001",
                 "ts": "2026-03-08T01:00:04+00:00",
-                "data": {"choice": "accept"},
+                "data": {
+                    "choice": "accept",
+                    "selected_candidate_id": "cand_001",
+                    "decision_source": "human_reviewer",
+                    "tool_id": "esmfold",
+                    "capability_id": "structure_prediction",
+                    "adapter_mode": "remote",
+                },
             },
             {
                 "event": "STEP_FINISHED",
@@ -562,6 +583,39 @@ class TestAPIEndpoints:
             "STEP_FINISHED",
         ]
         assert all(entry["highlight"] for entry in data)
+        step_failed = data[2]
+        assert step_failed["failure_type"] == "tool_error"
+        assert step_failed["failure_code"] == "S3_QUALITY_GATE_FAIL"
+        assert step_failed["from_tool"] == "dummy_tool"
+        assert step_failed["to_tool"] == "esmfold"
+        assert step_failed["capability_id"] == "structure_prediction"
+        assert step_failed["adapter_mode"] == "remote"
+
+        decision_applied = data[3]
+        assert decision_applied["candidate_id"] == "cand_001"
+        assert decision_applied["decision_source"] == "human_reviewer"
+        assert decision_applied["tool_id"] == "esmfold"
+
+        filtered = await client.get(
+            f"/tasks/{task_id}/events",
+            params={"tool_id": "esmfold", "adapter_mode": "remote"},
+        )
+        assert filtered.status_code == 200
+        filtered_data = filtered.json()
+        assert len(filtered_data) == 2
+        assert {item["event_type"] for item in filtered_data} == {
+            "STEP_FAILED",
+            "DECISION_APPLIED",
+        }
+
+        event_filtered = await client.get(
+            f"/tasks/{task_id}/events",
+            params={"event_type": "STEP_FAILED"},
+        )
+        assert event_filtered.status_code == 200
+        event_data = event_filtered.json()
+        assert len(event_data) == 1
+        assert event_data[0]["event_type"] == "STEP_FAILED"
 
     async def test_get_task_events_not_found(self, client: httpx.AsyncClient):
         """task 不存在且无日志时，events 接口返回 404。"""

--- a/tests/unit/test_log_store_timeline.py
+++ b/tests/unit/test_log_store_timeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.storage.log_store import read_timeline_events
+
+
+@pytest.mark.unit
+def test_read_timeline_events_extracts_recovery_observability_fields(tmp_path: Path) -> None:
+    task_id = "timeline_obs_001"
+    log_file = tmp_path / f"{task_id}.jsonl"
+    events = [
+        {
+            "event": "STEP_FAILED",
+            "task_id": task_id,
+            "step_id": "S3",
+            "tool": "dummy_tool",
+            "failure_type": "tool_error",
+            "error_details": {"failure_code": "S3_TIMEOUT"},
+            "timestamp": "2026-03-16T01:00:00+00:00",
+            "data": {
+                "recovery": {
+                    "recovery_layer": "tool_level",
+                    "from_tool": "dummy_tool",
+                    "to_tool": "esmfold",
+                    "capability_id": "structure_prediction",
+                    "adapter_mode": "remote",
+                    "io_type": "sequence_to_structure",
+                    "reason": "retry_exhausted",
+                    "candidate_id": "cand_patch_1",
+                }
+            },
+        },
+        {
+            "event_type": "DECISION_APPLIED",
+            "task_id": task_id,
+            "decision_id": "d_001",
+            "ts": "2026-03-16T01:00:01+00:00",
+            "data": {
+                "choice": "accept",
+                "selected_candidate_id": "cand_001",
+                "decision_source": "human_reviewer",
+                "tool_id": "esmfold",
+                "capability_id": "structure_prediction",
+                "adapter_mode": "remote",
+            },
+        },
+    ]
+
+    with log_file.open("w", encoding="utf-8") as handle:
+        for item in events:
+            handle.write(json.dumps(item, ensure_ascii=True) + "\n")
+
+    timeline = read_timeline_events(task_id, log_dir=tmp_path)
+
+    assert len(timeline) == 2
+
+    failed = timeline[0]
+    assert failed["event_type"] == "STEP_FAILED"
+    assert failed["failure_type"] == "tool_error"
+    assert failed["failure_code"] == "S3_TIMEOUT"
+    assert failed["from_tool"] == "dummy_tool"
+    assert failed["to_tool"] == "esmfold"
+    assert failed["capability_id"] == "structure_prediction"
+    assert failed["adapter_mode"] == "remote"
+    assert failed["io_type"] == "sequence_to_structure"
+    assert failed["candidate_id"] == "cand_patch_1"
+    assert failed["recovery_layer"] == "tool_level"
+    assert failed["recovery_reason"] == "retry_exhausted"
+
+    decision = timeline[1]
+    assert decision["event_type"] == "DECISION_APPLIED"
+    assert decision["candidate_id"] == "cand_001"
+    assert decision["decision_source"] == "human_reviewer"
+    assert decision["tool_id"] == "esmfold"
+    assert decision["capability_id"] == "structure_prediction"
+
+
+@pytest.mark.unit
+def test_read_timeline_events_keeps_legacy_entries_compatible(tmp_path: Path) -> None:
+    task_id = "timeline_legacy_001"
+    log_file = tmp_path / f"{task_id}.jsonl"
+    with log_file.open("w", encoding="utf-8") as handle:
+        handle.write("{not-json}\n")
+        handle.write(json.dumps({"event": "TASK_STATUS_CHANGED", "task_id": task_id}) + "\n")
+        handle.write(json.dumps({"event": "STEP_FINISHED", "task_id": task_id, "step_id": "S1"}) + "\n")
+
+    timeline = read_timeline_events(task_id, log_dir=tmp_path)
+
+    assert len(timeline) == 2
+    transition = timeline[0]
+    assert transition["event_type"] == "STATE_TRANSITION"
+    assert transition["tool_id"] is None
+    assert transition["failure_code"] is None
+    finished = timeline[1]
+    assert finished["event_type"] == "STEP_FINISHED"
+    assert finished["step_id"] == "S1"


### PR DESCRIPTION
## Summary
- Extend timeline normalization with recovery observability fields required by replay/audit/training extraction.
- Enrich recovery/decision/waiting events with tool-chain and decision-source context.
- Add task events API filters (`event_type`, `tool_id`, `capability_id`, `adapter_mode`) for task replay by tool dimension.
- Add compatibility and replay tests plus runbook documentation.

## Changes
- Storage
  - `src/storage/log_store.py`
  - Add normalized fields: `tool_id`, `capability_id`, `io_type`, `adapter_mode`, `from_tool`, `to_tool`, `failure_type`, `failure_code`, `candidate_id`, `decision_source`, `recovery_layer`, `recovery_reason`.
  - Keep legacy logs backward compatible when fields are absent.
- Workflow Event Write Path
  - `src/workflow/pending_action.py`
  - `src/workflow/decision_apply.py`
  - `src/workflow/patch_runner.py`
  - `src/workflow/plan_runner.py`
  - Populate observability metadata in `WAITING_ENTER`, `WAITING_EXIT`, `DECISION_APPLIED`, patch/recovery trace payloads.
- API
  - `src/api/main.py`
  - Extend `TaskTimelineEvent` schema and add query filters for replay.
- Tests and docs
  - `tests/unit/test_log_store_timeline.py`
  - `tests/api/test_api_endpoints.py`
  - `scripts/w11-issue-144-recovery-observability.md`

## Acceptance Criteria Mapping (#144)
- Recovery critical fields complete for extraction:
  - Added/normalized failure/candidate/decision/recovery/tool context fields in timeline.
- Replay by task with key decisions/recovery nodes:
  - `/tasks/{task_id}/events` supports event/tool/capability/adapter filters.
- Compatibility preserved:
  - Legacy lines without new fields parse to nullable values; invalid JSON skipped in non-strict mode.
- Integration path (`PendingAction -> Decision -> EventLog`):
  - Covered by updated API/integration tests and unit compatibility tests.

## Validation
- `uv run pytest tests/unit/test_log_store_timeline.py tests/api/test_api_endpoints.py tests/integration/test_event_log_integration.py -q`

Closes #144
