### PR TITLE
feat(runtime): dual-route planner fallback and threshold routing (#150)

### DIFF
--- a/configs/runtime/w12_issue150_dual_route_fallback.json
+++ b/configs/runtime/w12_issue150_dual_route_fallback.json
@@ -1,0 +1,30 @@
+{
+  "runtime_fallback": {
+    "enable_dual_route": true,
+    "force_external_only": false,
+    "schema_fail_threshold": 2,
+    "executable_rate_threshold": 0.95,
+    "executable_drop_threshold": 0.05,
+    "consecutive_failure_threshold": 2,
+    "sustained_high_risk_threshold": 2,
+    "fallback_capability": "planner_generation"
+  },
+  "release_defaults": {
+    "external_fallback_enabled_by_default": true,
+    "circuit_breaker_env": "PLANNER_FORCE_EXTERNAL_FALLBACK"
+  },
+  "threshold_recommendations": {
+    "schema_fail_threshold": "2",
+    "executable_rate_threshold": "0.95",
+    "executable_drop_threshold": "0.05",
+    "consecutive_failure_threshold": "2",
+    "sustained_high_risk_threshold": "2"
+  },
+  "change_log": [
+    {
+      "date": "2026-03-16",
+      "change": "Initial RC Gate-C baseline for dual-route runtime fallback",
+      "author": "codex"
+    }
+  ]
+}

--- a/scripts/w12-issue-150-dual-route-fallback.md
+++ b/scripts/w12-issue-150-dual-route-fallback.md
@@ -1,0 +1,66 @@
+# W12 Issue #150: Dual-Route Planner Runtime Fallback
+
+## Goal
+
+Introduce a runtime-safe dual-route planner policy (`local default + external fallback`) without changing FSM/HITL ownership.
+
+## Delivered Scope
+
+- Planner dual-route routing and threshold triggers in provider layer.
+- External fallback remains enabled by default.
+- One-click circuit breaker via:
+  - runtime config: `runtime_fallback.force_external_only=true`
+  - env switch: `PLANNER_FORCE_EXTERNAL_FALLBACK=1`
+- Route decision audit events with required fields:
+  - `from_tool`, `to_tool`, `capability_id`, `trigger_threshold`
+- Integration tests covering trigger and recovery.
+
+## Trigger Conditions
+
+The router can switch to external provider when any trigger hits:
+
+1. `schema_fail_streak >= schema_fail_threshold`
+2. `candidate_executable_rate < executable_rate_threshold`
+3. `candidate_executable_drop >= executable_drop_threshold`
+4. `consecutive_execution_failures >= consecutive_failure_threshold`
+5. `sustained_high_risk >= sustained_high_risk_threshold`
+
+## Config
+
+Reference config:
+
+- `configs/runtime/w12_issue150_dual_route_fallback.json`
+
+Task-level override example (`task.constraints.runtime_fallback`):
+
+```json
+{
+  "runtime_fallback": {
+    "enable_dual_route": true,
+    "force_external_only": false,
+    "schema_fail_threshold": 2,
+    "executable_rate_threshold": 0.95,
+    "executable_drop_threshold": 0.05,
+    "consecutive_failure_threshold": 2,
+    "sustained_high_risk_threshold": 2,
+    "fallback_capability": "planner_generation"
+  }
+}
+```
+
+## Observability
+
+Route decisions emit `PLANNER_ROUTE_DECISION` with:
+
+- top-level: `from_tool`, `to_tool`, `capability_id`
+- `data.trigger_reason`
+- `data.trigger_threshold`
+
+## Validation
+
+```bash
+uv run pytest \
+  tests/integration/test_planner_dual_route_fallback.py \
+  tests/unit/test_log_store_timeline.py \
+  tests/unit/test_planner_with_provider.py -q
+```

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from typing import Any, Iterable, List, Literal, Optional, Sequence, Set, Tuple
 
 from src.kg.kg_client import ToolKGError, load_tool_kg
-from src.llm.base_llm_provider import BaseProvider
+from src.llm.base_llm_provider import BaseProvider, ProviderConfig
+from src.llm.baseline_provider import BaselineProvider
 from src.models.contracts import (
     PatchRequest,
     PendingActionType,
@@ -19,9 +21,20 @@ from src.models.contracts import (
     ProteinDesignTask,
     ReplanRequest,
     StepResult,
+    now_iso,
 )
-from src.models.validation import validate_candidate_set_output
-from src.models.db import InternalStatus, TaskRecord, TERMINAL_INTERNAL_STATUSES
+from src.models.validation import (
+    CandidateExecutionValidationError,
+    validate_candidate_set_output,
+    validate_plan_executability,
+)
+from src.models.db import (
+    InternalStatus,
+    TaskRecord,
+    TERMINAL_INTERNAL_STATUSES,
+    to_external_status,
+)
+from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
 from src.workflow.status import transition_task_status
@@ -72,6 +85,28 @@ class _CandidatePayload:
     recovery_reason: str | None = None
 
 
+@dataclass(frozen=True)
+class RuntimeFallbackConfig:
+    """Planner 双路推理回退配置。"""
+
+    enable_dual_route: bool = True
+    force_external_only: bool = False
+    schema_fail_threshold: int = 2
+    executable_rate_threshold: float = 0.95
+    executable_drop_threshold: float = 0.05
+    consecutive_failure_threshold: int = 2
+    sustained_high_risk_threshold: int = 2
+    fallback_capability: str = "planner_generation"
+
+
+@dataclass(frozen=True)
+class RouteTrigger:
+    """触发外部回退的原因与阈值描述。"""
+
+    reason: str
+    threshold: str
+
+
 _PATCH_LAYER_PRIORITY = {
     "parameter_level": 0,
     "tool_level": 1,
@@ -110,6 +145,8 @@ _P0_CAPABILITY_REPLACEMENT_MATRIX: dict[str, tuple[str, ...]] = {
     "objective_scoring": ("objective_ranker",),
 }
 
+_DEFAULT_EXTERNAL_PROVIDER_NAME = "external_baseline"
+
 
 class PlannerAgent:
     """最小可用 PlannerAgent: 根据任务目标生成一个单步 Plan
@@ -122,12 +159,14 @@ class PlannerAgent:
         self,
         tool_registry: Iterable[ToolSpec] | None = None,
         llm_provider: Optional[BaseProvider] = None,
+        fallback_llm_provider: Optional[BaseProvider] = None,
     ) -> None:
         """初始化 PlannerAgent
 
         Args:
             tool_registry: 可用工具注册表，默认从 ProteinToolKG 读取
             llm_provider: 可选的 LLM Provider，用于生成计划
+            fallback_llm_provider: 外部兜底 Provider（默认 baseline）
         """
         if tool_registry is None:
             tool_registry = _load_default_tool_registry()
@@ -137,50 +176,54 @@ class PlannerAgent:
                 "Tool registry is empty; ensure ProteinToolKG provides tools."
             )
         self._llm_provider = llm_provider
+        self._fallback_llm_provider = (
+            fallback_llm_provider
+            if fallback_llm_provider is not None
+            else BaselineProvider(ProviderConfig(model_name=_DEFAULT_EXTERNAL_PROVIDER_NAME))
+        )
+        self._runtime_fallback_state: dict[str, dict[str, Any]] = {}
 
-    def plan(self, task: ProteinDesignTask) -> Plan:
+    def plan(
+        self,
+        task: ProteinDesignTask,
+        *,
+        use_external: bool = False,
+    ) -> Plan:
         """生成执行计划
 
         Args:
             task: 蛋白质设计任务
+            use_external: 是否使用 external fallback provider
 
         Returns:
             Plan: 包含步骤列表的执行计划
         """
-        # 如果未提供 Provider，回退到默认行为（向后兼容）
-        if self._llm_provider is None:
-            return self._default_plan(task)
-
-        # 调用 LLM Provider 生成计划
-        plan_dict = self._llm_provider.call_planner(
-            task=task, tool_registry=self._tool_registry
-        )
-
-        # 验证并返回 Plan 对象
-        plan = Plan.model_validate(plan_dict)
-        plan = _resolve_plan_tools(
-            plan,
-            self._tool_registry,
-            task.constraints,
-        )
-        _ensure_plan_tools_in_registry(plan, self._tool_registry)
-        plan = _attach_kg_explanation(plan)
-        return plan
+        return self._plan_from_route(task, use_external=use_external)
 
     def plan_top_k(self, task: ProteinDesignTask, *, k: int = 3) -> TopKResult:
         """生成 Plan Top-K 候选（默认 K=3）。"""
         base_plan = self.plan(task)
+        return self._build_plan_top_k(task, base_plan, k=_normalize_top_k(k))
+
+    def _build_plan_top_k(
+        self,
+        task: ProteinDesignTask,
+        base_plan: Plan,
+        *,
+        k: int,
+    ) -> TopKResult:
+        """基于 base_plan 组装 plan top-k 结果。"""
         payloads = _build_plan_candidate_payloads(
             task=task,
             base_plan=base_plan,
             registry=self._tool_registry,
-            top_k=_normalize_top_k(k),
+            top_k=k,
         )
         return _build_top_k_result(
             payloads=payloads,
             registry=self._tool_registry,
             candidate_kind="plan",
-            top_k=_normalize_top_k(k),
+            top_k=k,
             task_constraints=task.constraints,
         )
 
@@ -278,6 +321,91 @@ class PlannerAgent:
         )
         return _attach_kg_explanation(plan)
 
+    def _plan_from_route(
+        self,
+        task: ProteinDesignTask,
+        *,
+        use_external: bool,
+    ) -> Plan:
+        if use_external:
+            plan = self._plan_from_provider(task, provider=self._fallback_llm_provider)
+            provider_name = _provider_name(self._fallback_llm_provider)
+            return self._attach_route_metadata(
+                plan,
+                provider_tier="external",
+                provider_name=provider_name,
+            )
+
+        # local path keeps backward-compatible default behavior
+        if self._llm_provider is None:
+            plan = self._default_plan(task)
+            return self._attach_route_metadata(
+                plan,
+                provider_tier="local",
+                provider_name="planner_default",
+            )
+
+        plan = self._plan_from_provider(task, provider=self._llm_provider)
+        provider_name = _provider_name(self._llm_provider)
+        return self._attach_route_metadata(
+            plan,
+            provider_tier="local",
+            provider_name=provider_name,
+        )
+
+    def _plan_from_provider(
+        self,
+        task: ProteinDesignTask,
+        *,
+        provider: BaseProvider,
+    ) -> Plan:
+        plan_dict = provider.call_planner(task=task, tool_registry=self._tool_registry)
+        plan = Plan.model_validate(plan_dict)
+        plan = _resolve_plan_tools(
+            plan,
+            self._tool_registry,
+            task.constraints,
+        )
+        _ensure_plan_tools_in_registry(plan, self._tool_registry)
+        return _attach_kg_explanation(plan)
+
+    def _attach_route_metadata(
+        self,
+        plan: Plan,
+        *,
+        provider_tier: Literal["local", "external"],
+        provider_name: str,
+    ) -> Plan:
+        metadata = dict(plan.metadata or {})
+        route_meta = dict(metadata.get("planner_route", {}))
+        route_meta["provider_tier"] = provider_tier
+        route_meta["provider_name"] = provider_name
+        metadata["planner_route"] = route_meta
+        return plan.model_copy(update={"metadata": metadata})
+
+    def _estimate_executable_rate(
+        self,
+        top_k_result: TopKResult,
+        task: ProteinDesignTask,
+    ) -> float:
+        total = 0
+        executable = 0
+        for candidate in top_k_result.candidates:
+            payload = candidate.structured_payload
+            if not isinstance(payload, Plan):
+                continue
+            total += 1
+            try:
+                validate_plan_executability(payload, task)
+                executable += 1
+            except CandidateExecutionValidationError:
+                continue
+            except Exception:
+                continue
+        if total == 0:
+            return 0.0
+        return executable / total
+
     def plan_with_status(
         self,
         task: ProteinDesignTask,
@@ -292,13 +420,89 @@ class PlannerAgent:
             InternalStatus.PLANNING,
             reason="task_created",
         )
+        runtime_cfg = _resolve_runtime_fallback_config(task.constraints)
+        runtime_state = dict(self._runtime_fallback_state.get(task.task_id, {}))
+        route_trigger: RouteTrigger | None = _resolve_pre_route_trigger(
+            context=context,
+            cfg=runtime_cfg,
+        )
+
         try:
             top_k_value = _resolve_top_k_value(
                 task.constraints,
                 key="plan_top_k",
                 default=3,
             )
-            top_k = self.plan_top_k(task, k=top_k_value)
+            use_external = route_trigger is not None
+            if use_external:
+                base_plan = self.plan(task, use_external=True)
+            else:
+                try:
+                    base_plan = self.plan(task, use_external=False)
+                    runtime_state["schema_fail_streak"] = 0
+                except Exception:
+                    streak = _safe_int(runtime_state.get("schema_fail_streak"), default=0) + 1
+                    runtime_state["schema_fail_streak"] = streak
+                    if runtime_cfg.enable_dual_route and streak >= runtime_cfg.schema_fail_threshold:
+                        route_trigger = RouteTrigger(
+                            reason="schema_fail_streak",
+                            threshold=(
+                                f"schema_fail_streak={streak}"
+                                f">={runtime_cfg.schema_fail_threshold}"
+                            ),
+                        )
+                        use_external = True
+                        base_plan = self.plan(task, use_external=True)
+                    else:
+                        self._runtime_fallback_state[task.task_id] = dict(runtime_state)
+                        raise
+
+            top_k = self._build_plan_top_k(
+                task,
+                base_plan,
+                k=_normalize_top_k(top_k_value),
+            )
+            executable_rate = self._estimate_executable_rate(top_k, task)
+            previous_rate = _safe_optional_float(runtime_state.get("last_executable_rate"))
+
+            if (
+                runtime_cfg.enable_dual_route
+                and not use_external
+                and self._fallback_llm_provider is not None
+            ):
+                drop = (
+                    previous_rate - executable_rate
+                    if previous_rate is not None
+                    else 0.0
+                )
+                trigger: RouteTrigger | None = None
+                if executable_rate < runtime_cfg.executable_rate_threshold:
+                    trigger = RouteTrigger(
+                        reason="candidate_executable_rate_low",
+                        threshold=(
+                            f"candidate_executable_rate={executable_rate:.3f}"
+                            f"<{runtime_cfg.executable_rate_threshold:.3f}"
+                        ),
+                    )
+                elif drop >= runtime_cfg.executable_drop_threshold:
+                    trigger = RouteTrigger(
+                        reason="candidate_executable_rate_drop",
+                        threshold=(
+                            f"candidate_executable_drop={drop:.3f}"
+                            f">={runtime_cfg.executable_drop_threshold:.3f}"
+                        ),
+                    )
+                if trigger is not None:
+                    route_trigger = trigger
+                    use_external = True
+                    base_plan = self.plan(task, use_external=True)
+                    top_k = self._build_plan_top_k(
+                        task,
+                        base_plan,
+                        k=_normalize_top_k(top_k_value),
+                    )
+                    executable_rate = self._estimate_executable_rate(top_k, task)
+
             gate = self.evaluate_top_k_gate(
                 candidate_kind="plan",
                 top_k_result=top_k,
@@ -312,6 +516,37 @@ class PlannerAgent:
         except Exception:
             self._mark_failed(context, record, reason="planning_failed")
             raise
+
+        route_meta = plan.metadata.get("planner_route", {}) if isinstance(plan.metadata, dict) else {}
+        to_provider = str(route_meta.get("provider_name") or "planner_default")
+        from_provider = str(runtime_state.get("last_provider_name") or to_provider)
+        if route_trigger is not None or from_provider != to_provider:
+            append_event(
+                task.task_id,
+                {
+                    "event": "PLANNER_ROUTE_DECISION",
+                    "task_id": task.task_id,
+                    "timestamp": now_iso(),
+                    "tool": to_provider,
+                    "from_tool": from_provider,
+                    "to_tool": to_provider,
+                    "capability_id": runtime_cfg.fallback_capability,
+                    "state": context.status.value,
+                    "external_status": to_external_status(context.status).value,
+                    "data": {
+                        "from_tool": from_provider,
+                        "to_tool": to_provider,
+                        "capability_id": runtime_cfg.fallback_capability,
+                        "trigger_reason": route_trigger.reason if route_trigger else "route_stable",
+                        "trigger_threshold": route_trigger.threshold if route_trigger else "",
+                        "enable_dual_route": runtime_cfg.enable_dual_route,
+                    },
+                },
+            )
+
+        runtime_state["last_provider_name"] = to_provider
+        runtime_state["last_executable_rate"] = round(executable_rate, 6)
+        self._runtime_fallback_state[task.task_id] = dict(runtime_state)
 
         context.plan = plan
         if record is not None:
@@ -398,6 +633,148 @@ class PlannerAgent:
 
 
 # --- helpers ---
+
+
+def _provider_name(provider: BaseProvider) -> str:
+    config = getattr(provider, "config", None)
+    model_name = getattr(config, "model_name", None)
+    if isinstance(model_name, str) and model_name.strip():
+        return model_name.strip()
+    return provider.__class__.__name__
+
+
+def _safe_int(value: object, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_optional_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _resolve_runtime_fallback_config(constraints: dict[str, Any]) -> RuntimeFallbackConfig:
+    runtime_cfg = constraints.get("runtime_fallback")
+    payload = runtime_cfg if isinstance(runtime_cfg, dict) else {}
+
+    return RuntimeFallbackConfig(
+        enable_dual_route=_safe_bool(payload.get("enable_dual_route"), default=True),
+        force_external_only=(
+            _safe_bool(payload.get("force_external_only"), default=False)
+            or _safe_bool(os.getenv("PLANNER_FORCE_EXTERNAL_FALLBACK"), default=False)
+        ),
+        schema_fail_threshold=max(1, _safe_int(payload.get("schema_fail_threshold"), default=2)),
+        executable_rate_threshold=min(
+            1.0,
+            max(0.0, _safe_float(payload.get("executable_rate_threshold"), default=0.95)),
+        ),
+        executable_drop_threshold=max(
+            0.0,
+            _safe_float(payload.get("executable_drop_threshold"), default=0.05),
+        ),
+        consecutive_failure_threshold=max(
+            1,
+            _safe_int(payload.get("consecutive_failure_threshold"), default=2),
+        ),
+        sustained_high_risk_threshold=max(
+            1,
+            _safe_int(payload.get("sustained_high_risk_threshold"), default=2),
+        ),
+        fallback_capability=_safe_text(
+            payload.get("fallback_capability"),
+            default="planner_generation",
+        ),
+    )
+
+
+def _resolve_pre_route_trigger(
+    *,
+    context: WorkflowContext,
+    cfg: RuntimeFallbackConfig,
+) -> RouteTrigger | None:
+    if cfg.force_external_only:
+        return RouteTrigger(
+            reason="force_external_only",
+            threshold="force_external_only=true",
+        )
+    if not cfg.enable_dual_route:
+        return None
+
+    consecutive_failures = _count_consecutive_execution_failures(context)
+    if consecutive_failures >= cfg.consecutive_failure_threshold:
+        return RouteTrigger(
+            reason="consecutive_execution_failures",
+            threshold=(
+                f"consecutive_execution_failures={consecutive_failures}"
+                f">={cfg.consecutive_failure_threshold}"
+            ),
+        )
+
+    sustained_high_risk = _count_sustained_high_risk_events(context)
+    if sustained_high_risk >= cfg.sustained_high_risk_threshold:
+        return RouteTrigger(
+            reason="sustained_high_risk",
+            threshold=(
+                f"sustained_high_risk={sustained_high_risk}"
+                f">={cfg.sustained_high_risk_threshold}"
+            ),
+        )
+    return None
+
+
+def _count_consecutive_execution_failures(context: WorkflowContext) -> int:
+    results = list(context.step_results.values())
+    results.sort(key=lambda item: item.timestamp)
+    count = 0
+    for result in reversed(results):
+        if result.status != "failed":
+            break
+        count += 1
+    return count
+
+
+def _count_sustained_high_risk_events(context: WorkflowContext) -> int:
+    events = list(context.safety_events)
+    events.sort(key=lambda item: item.timestamp)
+    count = 0
+    for event in reversed(events):
+        if event.action == "block":
+            count += 1
+            continue
+        if event.action == "warn":
+            count += 1
+            continue
+        has_high_flag = any(flag.level in {"warn", "block"} for flag in event.risk_flags)
+        if not has_high_flag:
+            break
+        count += 1
+    return count
+
+
+def _safe_bool(value: object, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _safe_text(value: object, *, default: str) -> str:
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized:
+            return normalized
+    return default
 
 
 def _ensure_task_match(request: PatchRequest) -> None:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -502,6 +502,7 @@ async def get_task_events(
         "REPLACE_TOOL",
         "PARAM_TWEAK",
         "STRUCTURE_PATCH",
+        "PLANNER_ROUTE_DECISION",
         "RECOVERY_ESCALATED",
         "CANDIDATE_VALIDATION_FAILED",
     }

--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -317,7 +317,9 @@ def _extract_observability_fields(
         or _string_field(recovery, "from_tool")
     )
     capability_id = (
-        _string_field(data, "capability_id")
+        _string_field(payload, "capability_id")
+        or _string_field(data, "capability_id")
+        or _string_field(data, "capability")
         or _string_field(patch, "capability_id")
         or _string_field(recovery, "capability_id")
     )
@@ -334,8 +336,18 @@ def _extract_observability_fields(
         or _string_field(recovery, "adapter_mode")
     )
 
-    from_tool = _string_field(recovery, "from_tool") or _string_field(patch, "from_tool")
-    to_tool = _string_field(recovery, "to_tool") or _string_field(patch, "to_tool")
+    from_tool = (
+        _string_field(payload, "from_tool")
+        or _string_field(data, "from_tool")
+        or _string_field(recovery, "from_tool")
+        or _string_field(patch, "from_tool")
+    )
+    to_tool = (
+        _string_field(payload, "to_tool")
+        or _string_field(data, "to_tool")
+        or _string_field(recovery, "to_tool")
+        or _string_field(patch, "to_tool")
+    )
     failure_type = (
         _string_field(payload, "failure_type")
         or _string_field(data, "failure_type")

--- a/tests/integration/test_planner_dual_route_fallback.py
+++ b/tests/integration/test_planner_dual_route_fallback.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import pytest
+
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.llm.base_llm_provider import BaseProvider, ProviderConfig
+from src.models.contracts import ProteinDesignTask, StepResult
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.workflow.context import WorkflowContext
+
+
+class _FixedPlanProvider(BaseProvider):
+    def __init__(self, model_name: str):
+        self.config = ProviderConfig(model_name=model_name)
+        self.call_count = 0
+
+    def call_planner(self, task: ProteinDesignTask, tool_registry: List[ToolSpec]) -> Dict:
+        self.call_count += 1
+        tool_id = tool_registry[0].id if tool_registry else "dummy_tool"
+        return {
+            "task_id": task.task_id,
+            "steps": [
+                {
+                    "id": "S1",
+                    "tool": tool_id,
+                    "inputs": {"sequence": task.constraints.get("sequence", "MKTAYIAK")},
+                    "metadata": {},
+                }
+            ],
+            "constraints": task.constraints,
+            "metadata": {"provider": self.config.model_name},
+        }
+
+
+def _task_record(task: ProteinDesignTask) -> TaskRecord:
+    return TaskRecord(
+        id=task.task_id,
+        status=ExternalStatus.CREATED,
+        internal_status=InternalStatus.CREATED,
+        goal=task.goal,
+        constraints=task.constraints,
+        metadata={},
+    )
+
+
+@pytest.mark.integration
+def test_dual_route_triggers_external_on_consecutive_failures(monkeypatch):
+    events: list[dict] = []
+    monkeypatch.setattr("src.agents.planner.append_event", lambda _task_id, payload: events.append(dict(payload)))
+
+    local_provider = _FixedPlanProvider("planner_local")
+    external_provider = _FixedPlanProvider("planner_external")
+    planner = PlannerAgent(llm_provider=local_provider, fallback_llm_provider=external_provider)
+
+    task = ProteinDesignTask(
+        task_id="dual_route_failures_001",
+        goal="test dual route fallback",
+        constraints={
+            "sequence": "MKTAYIAKQRQISFVKSHFSRQLE",
+            "plan_top_k": 1,
+            "runtime_fallback": {
+                "enable_dual_route": True,
+                "consecutive_failure_threshold": 2,
+                "sustained_high_risk_threshold": 2,
+            },
+        },
+        metadata={},
+    )
+    context = WorkflowContext(task=task)
+    context.step_results["S1"] = StepResult(
+        task_id=task.task_id,
+        step_id="S1",
+        tool="dummy_tool",
+        status="failed",
+        timestamp="2026-03-16T00:00:01+00:00",
+    )
+    context.step_results["S2"] = StepResult(
+        task_id=task.task_id,
+        step_id="S2",
+        tool="dummy_tool",
+        status="failed",
+        timestamp="2026-03-16T00:00:02+00:00",
+    )
+
+    plan = planner.plan_with_status(task, context, record=_task_record(task))
+
+    route_meta = plan.metadata.get("planner_route", {})
+    assert route_meta.get("provider_tier") == "external"
+    assert route_meta.get("provider_name") == "planner_external"
+    assert local_provider.call_count == 0
+    assert external_provider.call_count >= 1
+
+    route_events = [event for event in events if event.get("event") == "PLANNER_ROUTE_DECISION"]
+    assert route_events
+    latest = route_events[-1]
+    assert latest.get("from_tool")
+    assert latest.get("to_tool") == "planner_external"
+    assert latest.get("capability_id") == "planner_generation"
+    data = latest.get("data") or {}
+    assert data.get("trigger_reason") == "consecutive_execution_failures"
+    assert "consecutive_execution_failures" in data.get("trigger_threshold", "")
+
+
+@pytest.mark.integration
+def test_dual_route_recovers_back_to_local_after_trigger_cleared(monkeypatch):
+    events: list[dict] = []
+    monkeypatch.setattr("src.agents.planner.append_event", lambda _task_id, payload: events.append(dict(payload)))
+
+    local_provider = _FixedPlanProvider("planner_local")
+    external_provider = _FixedPlanProvider("planner_external")
+    planner = PlannerAgent(llm_provider=local_provider, fallback_llm_provider=external_provider)
+
+    first_task = ProteinDesignTask(
+        task_id="dual_route_recover_001",
+        goal="test dual route recovery",
+        constraints={
+            "sequence": "MKTAYIAKQRQISFVKSHFSRQLE",
+            "plan_top_k": 1,
+            "runtime_fallback": {
+                "enable_dual_route": True,
+                "force_external_only": True,
+            },
+        },
+        metadata={},
+    )
+    first_context = WorkflowContext(task=first_task)
+    first_plan = planner.plan_with_status(first_task, first_context, record=_task_record(first_task))
+    assert first_plan.metadata.get("planner_route", {}).get("provider_tier") == "external"
+
+    second_task = ProteinDesignTask(
+        task_id="dual_route_recover_001",
+        goal="test dual route recovery",
+        constraints={
+            "sequence": "MKTAYIAKQRQISFVKSHFSRQLE",
+            "plan_top_k": 1,
+            "runtime_fallback": {
+                "enable_dual_route": True,
+                "force_external_only": False,
+                "consecutive_failure_threshold": 2,
+                "sustained_high_risk_threshold": 2,
+                "executable_rate_threshold": 0.0,
+                "executable_drop_threshold": 1.0,
+            },
+        },
+        metadata={},
+    )
+    second_context = WorkflowContext(task=second_task)
+    second_plan = planner.plan_with_status(second_task, second_context, record=_task_record(second_task))
+
+    route_meta = second_plan.metadata.get("planner_route", {})
+    assert route_meta.get("provider_tier") == "local"
+    assert route_meta.get("provider_name") == "planner_local"
+    assert local_provider.call_count >= 1
+
+    route_events = [event for event in events if event.get("event") == "PLANNER_ROUTE_DECISION"]
+    assert len(route_events) >= 2
+    last = route_events[-1]
+    assert last.get("from_tool") == "planner_external"
+    assert last.get("to_tool") == "planner_local"
+
+
+@pytest.mark.integration
+def test_dual_route_switches_to_external_when_executable_rate_is_low(monkeypatch):
+    events: list[dict] = []
+    monkeypatch.setattr("src.agents.planner.append_event", lambda _task_id, payload: events.append(dict(payload)))
+
+    local_provider = _FixedPlanProvider("planner_local")
+    external_provider = _FixedPlanProvider("planner_external")
+    planner = PlannerAgent(llm_provider=local_provider, fallback_llm_provider=external_provider)
+
+    rates = iter([0.2, 1.0])
+    monkeypatch.setattr(planner, "_estimate_executable_rate", lambda _top_k, _task: next(rates))
+
+    task = ProteinDesignTask(
+        task_id="dual_route_exec_rate_001",
+        goal="test executable rate fallback",
+        constraints={
+            "sequence": "MKTAYIAKQRQISFVKSHFSRQLE",
+            "plan_top_k": 1,
+            "runtime_fallback": {
+                "enable_dual_route": True,
+                "executable_rate_threshold": 0.9,
+            },
+        },
+        metadata={},
+    )
+
+    plan = planner.plan_with_status(task, WorkflowContext(task=task), record=_task_record(task))
+    route_meta = plan.metadata.get("planner_route", {})
+    assert route_meta.get("provider_tier") == "external"
+    assert local_provider.call_count >= 1
+    assert external_provider.call_count >= 1
+
+    route_events = [event for event in events if event.get("event") == "PLANNER_ROUTE_DECISION"]
+    assert route_events
+    latest = route_events[-1]
+    data = latest.get("data") or {}
+    assert data.get("trigger_reason") == "candidate_executable_rate_low"
+    assert "candidate_executable_rate" in data.get("trigger_threshold", "")

--- a/tests/unit/test_log_store_timeline.py
+++ b/tests/unit/test_log_store_timeline.py
@@ -98,3 +98,33 @@ def test_read_timeline_events_keeps_legacy_entries_compatible(tmp_path: Path) ->
     finished = timeline[1]
     assert finished["event_type"] == "STEP_FINISHED"
     assert finished["step_id"] == "S1"
+
+
+@pytest.mark.unit
+def test_read_timeline_events_extracts_planner_route_fields(tmp_path: Path) -> None:
+    task_id = "timeline_route_001"
+    log_file = tmp_path / f"{task_id}.jsonl"
+    event = {
+        "event": "PLANNER_ROUTE_DECISION",
+        "task_id": task_id,
+        "tool": "external_baseline",
+        "timestamp": "2026-03-16T03:00:00+00:00",
+        "data": {
+            "from_tool": "planner_default",
+            "to_tool": "external_baseline",
+            "capability": "planner_generation",
+            "trigger_threshold": "consecutive_execution_failures=2>=2",
+        },
+    }
+
+    with log_file.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=True) + "\n")
+
+    timeline = read_timeline_events(task_id, log_dir=tmp_path)
+    assert len(timeline) == 1
+    route = timeline[0]
+    assert route["event_type"] == "PLANNER_ROUTE_DECISION"
+    assert route["tool_id"] == "external_baseline"
+    assert route["from_tool"] == "planner_default"
+    assert route["to_tool"] == "external_baseline"
+    assert route["capability_id"] == "planner_generation"


### PR DESCRIPTION
## Summary
Implement W12 Runtime dual-route planner fallback for issue #150 with deterministic threshold triggers, audit events, and integration coverage, while preserving existing FSM/HITL control flow.

## What Changed

### 1. Planner dual-route routing (local default + external fallback)
- File: `src/agents/planner.py`
- Added runtime fallback policy support in `plan_with_status`:
  - `schema_fail_streak >= schema_fail_threshold`
  - `candidate_executable_rate < executable_rate_threshold`
  - `candidate_executable_drop >= executable_drop_threshold`
  - `consecutive_execution_failures >= consecutive_failure_threshold`
  - `sustained_high_risk >= sustained_high_risk_threshold`
- Added emergency one-click degradation switch:
  - `runtime_fallback.force_external_only=true`
  - env override: `PLANNER_FORCE_EXTERNAL_FALLBACK=1`
- Added explicit route metadata to planned output (`metadata.planner_route`).

### 2. Route observability events
- File: `src/agents/planner.py`
- Added `PLANNER_ROUTE_DECISION` timeline event with required route fields:
  - `from_tool`
  - `to_tool`
  - `capability_id`
  - `data.trigger_threshold`

### 3. Timeline/API compatibility for route events
- Files:
  - `src/storage/log_store.py`
  - `src/api/main.py`
- Timeline extractor now reads route `from_tool/to_tool` fields directly from event payload/data.
- Added `PLANNER_ROUTE_DECISION` to events endpoint highlight set for replay visibility.

### 4. Config + runbook
- `configs/runtime/w12_issue150_dual_route_fallback.json`
- `scripts/w12-issue-150-dual-route-fallback.md`
- Includes default-safe release baseline and threshold recommendations + change log.

### 5. Tests
- New integration tests:
  - `tests/integration/test_planner_dual_route_fallback.py`
  - Covers trigger, recovery back to local, and executable-rate fallback path.
- Updated unit tests:
  - `tests/unit/test_log_store_timeline.py`
  - Verifies planner route event field extraction in timeline.

## Acceptance Criteria Mapping (#150)
- [x] 回退触发条件可测且结果确定
  - Trigger logic is deterministic and covered by integration tests.
- [x] 触发回退后系统仍满足 FSM/HITL 契约
  - Change is provider-layer routing only; existing `PLANNING -> PLANNED/WAITING_PLAN_CONFIRM` flow remains unchanged.
- [x] 关键路由事件可追溯
  - `PLANNER_ROUTE_DECISION` includes route fields and threshold reason.

## RC Gate-C Alignment
- [x] 默认安全配置（默认保留 external fallback）
- [x] 一键降级/熔断开关（config + env）
- [x] 门槛建议值与变更记录（runtime config + runbook）

## Validation
```bash
uv run pytest \
  tests/integration/test_planner_dual_route_fallback.py \
  tests/unit/test_planner_with_provider.py \
  tests/unit/test_planner_agent.py \
  tests/unit/test_log_store_timeline.py \
  tests/integration/test_workflow.py \
  tests/api/test_api_endpoints.py -q
```

Closes #150
