### PR TITLE
feat(requirement2): 完成 MMseqs2 / BLASTP / DSSP 工具接入与本地验证

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,11 @@ nf/.nextflow/
 
 # 13. 不需要上传到master的文件
 docs/
+!docs/
+docs/*
+!docs/algorithm-and-llm/
+docs/algorithm-and-llm/*
+!docs/algorithm-and-llm/requirement2-similarity-secondary-structure-tools.md
 plan/
 shared/
 drafts/

--- a/docs/algorithm-and-llm/requirement2-similarity-secondary-structure-tools.md
+++ b/docs/algorithm-and-llm/requirement2-similarity-secondary-structure-tools.md
@@ -1,0 +1,103 @@
+# Requirement-2 Similarity And Secondary Structure Tools
+
+本说明覆盖 `mmseqs2`、`blastp`、`dssp` 三个本地工具的最小接入方式，以及仓库内统一输出字段。
+
+## 1. 本地依赖
+
+- `mmseqs2`: 需要 `mmseqs`
+- `blastp`: 需要 NCBI BLAST+ 的 `blastp`
+- `dssp`: 需要 `mkdssp`
+
+当前仓库实现为 Python Adapter 调用本地 CLI。
+如果二进制缺失，Adapter 会抛出 `CANDIDATE_TOOL_UNAVAILABLE`。
+
+## 2. 最小输入
+
+### MMseqs2 / BLASTP
+
+- `sequence`: 查询序列
+- `database_path`: 本地数据库路径
+- 可选:
+  - `query_id`
+  - `max_seqs` / `max_target_seqs`
+  - `evalue`
+  - `sensitivity`
+
+### DSSP
+
+- `pdb_path`: 输入结构文件路径
+- 可选:
+  - `sequence`
+
+## 3. 统一输出字段
+
+### 相似性检索
+
+- `capability_id = sequence_similarity_search`
+- `io_type = sequence_to_similarity_hits`
+- `similarity_hits`: 归一化 hits 列表
+- `top_hit`: 第一条 hit
+- `hit_count`
+
+每条 hit 至少包含：
+
+- `query_id`
+- `target_id`
+- `identity`
+- `coverage`
+- `query_coverage`
+- `target_coverage`
+- `evalue`
+- `bitscore`
+- `alignment_length`
+- `query_start`
+- `query_end`
+- `target_start`
+- `target_end`
+- `query_length`
+- `target_length`
+
+说明：
+
+- `coverage` 当前定义为 `query_coverage`
+- `query_coverage = alignment_length / query_length`
+- `target_coverage = alignment_length / target_length`
+
+### DSSP
+
+- `capability_id = secondary_structure_annotation`
+- `capabilities = [secondary_structure_annotation, quality_qc]`
+- `io_type = sequence_structure_to_qc_metrics`
+- `secondary_structure`: residue-level rows
+- `secondary_structure_summary`
+- `qc_metrics.secondary_structure_summary`
+
+每个 residue row 至少包含：
+
+- `index`
+- `residue_number`
+- `chain_id`
+- `amino_acid`
+- `q8`
+- `q3`
+
+## 4. Requirement-2 统计对齐
+
+新增 capability bucket：
+
+- `similarity_search -> sequence_similarity_search`
+- `secondary_structure -> secondary_structure_annotation`
+
+因此 `requirement2_tool_capability_slices.csv` 会新增：
+
+- 工具切片：`mmseqs2` / `blastp` / `dssp`
+- capability bucket 切片：`similarity_search` / `secondary_structure`
+
+## 5. 运行提示
+
+- 这三个 Adapter 默认不自动安装数据库
+- 真实本地实验前，需要先准备对应数据库
+- 当前测试主要覆盖：
+  - 命令封装
+  - 输出解析
+  - Requirement-2 统计对齐

--- a/src/adapters/blastp_adapter.py
+++ b/src/adapters/blastp_adapter.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Callable, Dict, Tuple
+
+from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.adapters.tool_schema_utils import (
+    build_similarity_metrics,
+    build_similarity_outputs,
+    resolve_step_inputs,
+)
+from src.models.contracts import PlanStep
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureCode, FailureType, StepRunError
+
+__all__ = ["BlastPAdapter", "parse_blastp_tabular"]
+
+BLASTP_OUTFMT = (
+    "6 qseqid sseqid pident length mismatch gapopen qstart qend "
+    "sstart send evalue bitscore qlen slen"
+)
+
+
+class BlastPAdapter(BaseToolAdapter):
+    tool_id = "blastp"
+    adapter_id = "blastp"
+
+    def __init__(
+        self,
+        *,
+        binary: str = "blastp",
+        runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    ) -> None:
+        self.binary = binary
+        self.runner = runner or subprocess.run
+
+    def resolve_inputs(self, step: PlanStep, context: WorkflowContext) -> Dict[str, Any]:
+        return resolve_step_inputs(step, context, required_keys=("sequence", "database_path"))
+
+    def run_local(self, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        if shutil.which(self.binary) is None:
+            raise StepRunError(
+                failure_type=FailureType.NON_RETRYABLE,
+                message=f"BLASTP binary '{self.binary}' is not installed",
+                code=FailureCode.CANDIDATE_TOOL_UNAVAILABLE.value,
+            )
+
+        t0 = perf_counter()
+        with tempfile.TemporaryDirectory(prefix="blastp_") as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            query_path = tmp_path / "query.fasta"
+            result_path = tmp_path / "result.tsv"
+            query_path.write_text(
+                f">{inputs.get('query_id', 'query_1')}\n{str(inputs['sequence']).strip()}\n",
+                encoding="utf-8",
+            )
+
+            cmd = [
+                self.binary,
+                "-query",
+                str(query_path),
+                "-db",
+                str(inputs["database_path"]),
+                "-out",
+                str(result_path),
+                "-outfmt",
+                BLASTP_OUTFMT,
+            ]
+            max_target_seqs = inputs.get("max_target_seqs")
+            if max_target_seqs is not None:
+                cmd.extend(["-max_target_seqs", str(max_target_seqs)])
+            evalue = inputs.get("evalue")
+            if evalue is not None:
+                cmd.extend(["-evalue", str(evalue)])
+
+            try:
+                self.runner(cmd, capture_output=True, text=True, check=True)
+            except subprocess.CalledProcessError as exc:
+                raise StepRunError(
+                    failure_type=FailureType.TOOL_ERROR,
+                    message=f"BLASTP command failed: {exc.stderr or exc.stdout or exc}",
+                    code=FailureCode.TOOL_EXECUTION_ERROR.value,
+                ) from exc
+
+            hits = parse_blastp_tabular(result_path.read_text(encoding="utf-8"))
+            outputs = build_similarity_outputs(self.tool_id, inputs, hits)
+            metrics = build_similarity_metrics(
+                exec_type="local_cli",
+                hit_count=len(hits),
+                command=cmd,
+            )
+            metrics["duration_ms"] = int((perf_counter() - t0) * 1000)
+            return outputs, metrics
+
+
+def parse_blastp_tabular(text: str) -> list[Dict[str, Any]]:
+    hits: list[Dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 14:
+            continue
+        hits.append(
+            {
+                "query_id": parts[0],
+                "target_id": parts[1],
+                "identity": parts[2],
+                "alignment_length": parts[3],
+                "query_start": parts[6],
+                "query_end": parts[7],
+                "target_start": parts[8],
+                "target_end": parts[9],
+                "evalue": parts[10],
+                "bitscore": parts[11],
+                "query_length": parts[12],
+                "target_length": parts[13],
+            }
+        )
+    return hits

--- a/src/adapters/builtins.py
+++ b/src/adapters/builtins.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import os
 
 from src.adapters.alphafold_adapter import AlphaFold2Adapter
+from src.adapters.blastp_adapter import BlastPAdapter
 from src.adapters.biopython_qc_adapter import BioPythonQCAdapter
+from src.adapters.dssp_adapter import DSSPAdapter
 from src.adapters.dummy_adapter import DummyToolAdapter
 from src.adapters.esmfold_adapter import ESMFoldAdapter
+from src.adapters.mmseqs2_adapter import MMseqs2Adapter
 from src.adapters.nim_adapter import NIMESMFoldAdapter
 from src.adapters.openfold_adapter import OpenFold3Adapter
 from src.adapters.protein_mpnn_adapter import ProteinMPNNAdapter
@@ -73,3 +76,15 @@ def ensure_builtin_adapters() -> None:
         get_adapter(BioPythonQCAdapter.tool_id)
     except KeyError:
         register_adapter(BioPythonQCAdapter())
+    try:
+        get_adapter(MMseqs2Adapter.tool_id)
+    except KeyError:
+        register_adapter(MMseqs2Adapter())
+    try:
+        get_adapter(BlastPAdapter.tool_id)
+    except KeyError:
+        register_adapter(BlastPAdapter())
+    try:
+        get_adapter(DSSPAdapter.tool_id)
+    except KeyError:
+        register_adapter(DSSPAdapter())

--- a/src/adapters/dssp_adapter.py
+++ b/src/adapters/dssp_adapter.py
@@ -50,9 +50,9 @@ class DSSPAdapter(BaseToolAdapter):
             output_path = Path(tmp_dir) / "result.dssp"
             cmd = [
                 self.binary,
-                "-i",
+                "--output-format",
+                "dssp",
                 str(inputs["pdb_path"]),
-                "-o",
                 str(output_path),
             ]
             try:

--- a/src/adapters/dssp_adapter.py
+++ b/src/adapters/dssp_adapter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Callable, Dict, Tuple
+
+from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.adapters.tool_schema_utils import (
+    build_secondary_structure_metrics,
+    build_secondary_structure_outputs,
+    q3_bucket,
+    resolve_step_inputs,
+)
+from src.models.contracts import PlanStep
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureCode, FailureType, StepRunError
+
+__all__ = ["DSSPAdapter", "parse_dssp_output"]
+
+
+class DSSPAdapter(BaseToolAdapter):
+    tool_id = "dssp"
+    adapter_id = "dssp"
+
+    def __init__(
+        self,
+        *,
+        binary: str = "mkdssp",
+        runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    ) -> None:
+        self.binary = binary
+        self.runner = runner or subprocess.run
+
+    def resolve_inputs(self, step: PlanStep, context: WorkflowContext) -> Dict[str, Any]:
+        return resolve_step_inputs(step, context, required_keys=("pdb_path",))
+
+    def run_local(self, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        if shutil.which(self.binary) is None:
+            raise StepRunError(
+                failure_type=FailureType.NON_RETRYABLE,
+                message=f"DSSP binary '{self.binary}' is not installed",
+                code=FailureCode.CANDIDATE_TOOL_UNAVAILABLE.value,
+            )
+
+        t0 = perf_counter()
+        with tempfile.TemporaryDirectory(prefix="dssp_") as tmp_dir:
+            output_path = Path(tmp_dir) / "result.dssp"
+            cmd = [
+                self.binary,
+                "-i",
+                str(inputs["pdb_path"]),
+                "-o",
+                str(output_path),
+            ]
+            try:
+                self.runner(cmd, capture_output=True, text=True, check=True)
+            except subprocess.CalledProcessError as exc:
+                raise StepRunError(
+                    failure_type=FailureType.TOOL_ERROR,
+                    message=f"DSSP command failed: {exc.stderr or exc.stdout or exc}",
+                    code=FailureCode.TOOL_EXECUTION_ERROR.value,
+                ) from exc
+
+            rows = parse_dssp_output(output_path.read_text(encoding="utf-8"))
+            outputs = build_secondary_structure_outputs(self.tool_id, inputs, rows)
+            metrics = build_secondary_structure_metrics(
+                exec_type="local_cli",
+                residue_count=len(rows),
+                command=cmd,
+            )
+            metrics["duration_ms"] = int((perf_counter() - t0) * 1000)
+            return outputs, metrics
+
+
+def parse_dssp_output(text: str) -> list[Dict[str, Any]]:
+    rows: list[Dict[str, Any]] = []
+    in_table = False
+    for raw_line in text.splitlines():
+        if raw_line.startswith("  #  RESIDUE AA STRUCTURE"):
+            in_table = True
+            continue
+        if not in_table or len(raw_line) < 17:
+            continue
+        residue_no = raw_line[5:10].strip()
+        insertion_code = raw_line[10:11].strip()
+        chain_id = raw_line[11:12].strip() or "_"
+        aa = raw_line[13:14].strip() or "X"
+        q8 = raw_line[16:17].strip() or "C"
+        rows.append(
+            {
+                "index": _safe_int(raw_line[0:5].strip()),
+                "residue_number": residue_no,
+                "insertion_code": insertion_code or None,
+                "chain_id": chain_id,
+                "amino_acid": aa,
+                "q8": q8,
+                "q3": q3_bucket(q8),
+            }
+        )
+    return rows
+
+
+def _safe_int(value: str) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None

--- a/src/adapters/mmseqs2_adapter.py
+++ b/src/adapters/mmseqs2_adapter.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Callable, Dict, Tuple
+
+from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.adapters.tool_schema_utils import (
+    build_similarity_metrics,
+    build_similarity_outputs,
+    resolve_step_inputs,
+)
+from src.models.contracts import PlanStep
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureCode, FailureType, StepRunError
+
+__all__ = ["MMseqs2Adapter", "parse_mmseqs_tabular"]
+
+MMSEQS_FIELDS = (
+    "query",
+    "target",
+    "pident",
+    "alnlen",
+    "mismatch",
+    "gapopen",
+    "qstart",
+    "qend",
+    "tstart",
+    "tend",
+    "evalue",
+    "bits",
+    "qlen",
+    "tlen",
+)
+
+
+class MMseqs2Adapter(BaseToolAdapter):
+    tool_id = "mmseqs2"
+    adapter_id = "mmseqs2"
+
+    def __init__(
+        self,
+        *,
+        binary: str = "mmseqs",
+        runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+    ) -> None:
+        self.binary = binary
+        self.runner = runner or subprocess.run
+
+    def resolve_inputs(self, step: PlanStep, context: WorkflowContext) -> Dict[str, Any]:
+        return resolve_step_inputs(step, context, required_keys=("sequence", "database_path"))
+
+    def run_local(self, inputs: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        if shutil.which(self.binary) is None:
+            raise StepRunError(
+                failure_type=FailureType.NON_RETRYABLE,
+                message=f"MMseqs2 binary '{self.binary}' is not installed",
+                code=FailureCode.CANDIDATE_TOOL_UNAVAILABLE.value,
+            )
+
+        t0 = perf_counter()
+        with tempfile.TemporaryDirectory(prefix="mmseqs2_") as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            query_path = tmp_path / "query.fasta"
+            result_path = tmp_path / "result.m8"
+            work_path = tmp_path / "work"
+            query_path.write_text(
+                f">{inputs.get('query_id', 'query_1')}\n{str(inputs['sequence']).strip()}\n",
+                encoding="utf-8",
+            )
+
+            cmd = [
+                self.binary,
+                "easy-search",
+                str(query_path),
+                str(inputs["database_path"]),
+                str(result_path),
+                str(work_path),
+                "--format-output",
+                ",".join(MMSEQS_FIELDS),
+            ]
+            max_seqs = inputs.get("max_seqs")
+            if max_seqs is not None:
+                cmd.extend(["--max-seqs", str(max_seqs)])
+            sensitivity = inputs.get("sensitivity")
+            if sensitivity is not None:
+                cmd.extend(["-s", str(sensitivity)])
+
+            try:
+                self.runner(cmd, capture_output=True, text=True, check=True)
+            except subprocess.CalledProcessError as exc:
+                raise StepRunError(
+                    failure_type=FailureType.TOOL_ERROR,
+                    message=f"MMseqs2 command failed: {exc.stderr or exc.stdout or exc}",
+                    code=FailureCode.TOOL_EXECUTION_ERROR.value,
+                ) from exc
+
+            hits = parse_mmseqs_tabular(result_path.read_text(encoding="utf-8"))
+            outputs = build_similarity_outputs(self.tool_id, inputs, hits)
+            metrics = build_similarity_metrics(
+                exec_type="local_cli",
+                hit_count=len(hits),
+                command=cmd,
+            )
+            metrics["duration_ms"] = int((perf_counter() - t0) * 1000)
+            return outputs, metrics
+
+
+def parse_mmseqs_tabular(text: str) -> list[Dict[str, Any]]:
+    hits: list[Dict[str, Any]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < len(MMSEQS_FIELDS):
+            continue
+        hits.append(
+            {
+                "query_id": parts[0],
+                "target_id": parts[1],
+                "identity": parts[2],
+                "alignment_length": parts[3],
+                "query_start": parts[6],
+                "query_end": parts[7],
+                "target_start": parts[8],
+                "target_end": parts[9],
+                "evalue": parts[10],
+                "bitscore": parts[11],
+                "query_length": parts[12],
+                "target_length": parts[13],
+            }
+        )
+    return hits

--- a/src/adapters/tool_schema_utils.py
+++ b/src/adapters/tool_schema_utils.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Dict, Iterable
+
+from src.models.contracts import PlanStep
+from src.workflow.context import WorkflowContext
+
+__all__ = [
+    "build_similarity_outputs",
+    "build_similarity_metrics",
+    "build_secondary_structure_outputs",
+    "build_secondary_structure_metrics",
+    "normalize_similarity_hit",
+    "q3_bucket",
+    "resolve_step_inputs",
+    "summarize_secondary_structure",
+]
+
+_HELIX_Q8 = {"H", "G", "I"}
+_SHEET_Q8 = {"E", "B"}
+
+
+def resolve_step_inputs(
+    step: PlanStep,
+    context: WorkflowContext,
+    *,
+    required_keys: Iterable[str] = (),
+) -> Dict[str, Any]:
+    resolved: Dict[str, Any] = {}
+
+    for key, val in step.inputs.items():
+        if isinstance(val, str) and "." in val:
+            step_id, field = val.split(".", 1)
+            if step_id and step_id.startswith("S"):
+                if not context.has_step_result(step_id):
+                    raise ValueError(
+                        f"Failed to resolve input reference '{val}' "
+                        f"for step '{step.id}': step '{step_id}' not found in context"
+                    )
+                try:
+                    resolved[key] = context.get_step_output(step_id, field)
+                except KeyError as exc:
+                    raise ValueError(
+                        f"Failed to resolve input reference '{val}' "
+                        f"for step '{step.id}': field '{field}' not found in step '{step_id}' outputs"
+                    ) from exc
+                continue
+        resolved[key] = val
+
+    for key in required_keys:
+        if key not in resolved:
+            raise ValueError(f"Missing required input '{key}' for step '{step.id}'")
+
+    resolved["task_id"] = context.task.task_id
+    resolved["step_id"] = step.id
+    return resolved
+
+
+def normalize_similarity_hit(raw: Dict[str, Any], *, rank: int) -> Dict[str, Any]:
+    alignment_length = _to_int(raw.get("alignment_length"))
+    query_length = _to_int(raw.get("query_length"))
+    target_length = _to_int(raw.get("target_length"))
+    query_coverage = _bounded_fraction(alignment_length, query_length)
+    target_coverage = _bounded_fraction(alignment_length, target_length)
+    coverage = query_coverage
+
+    return {
+        "rank": rank,
+        "query_id": _to_str(raw.get("query_id")) or "query_1",
+        "target_id": _to_str(raw.get("target_id")) or f"target_{rank}",
+        "identity": _to_float(raw.get("identity")),
+        "coverage": coverage,
+        "query_coverage": query_coverage,
+        "target_coverage": target_coverage,
+        "evalue": _to_float(raw.get("evalue")),
+        "bitscore": _to_float(raw.get("bitscore")),
+        "alignment_length": alignment_length,
+        "query_start": _to_int(raw.get("query_start")),
+        "query_end": _to_int(raw.get("query_end")),
+        "target_start": _to_int(raw.get("target_start")),
+        "target_end": _to_int(raw.get("target_end")),
+        "query_length": query_length,
+        "target_length": target_length,
+    }
+
+
+def build_similarity_outputs(
+    tool_id: str,
+    inputs: Dict[str, Any],
+    hits: list[Dict[str, Any]],
+) -> Dict[str, Any]:
+    normalized_hits = [
+        normalize_similarity_hit(hit, rank=index)
+        for index, hit in enumerate(hits, start=1)
+    ]
+    top_hit = normalized_hits[0] if normalized_hits else None
+    return {
+        "tool_id": tool_id,
+        "capability_id": "sequence_similarity_search",
+        "io_type": "sequence_to_similarity_hits",
+        "sequence": _to_str(inputs.get("sequence")),
+        "query_id": _to_str(inputs.get("query_id")) or "query_1",
+        "database_path": _to_str(inputs.get("database_path")),
+        "similarity_hits": normalized_hits,
+        "hit_count": len(normalized_hits),
+        "top_hit": top_hit,
+    }
+
+
+def build_similarity_metrics(
+    *,
+    exec_type: str,
+    hit_count: int,
+    command: list[str] | None = None,
+) -> Dict[str, Any]:
+    metrics: Dict[str, Any] = {
+        "exec_type": exec_type,
+        "hit_count": hit_count,
+        "requirement2": {
+            "capability_id": "sequence_similarity_search",
+            "io_type": "sequence_to_similarity_hits",
+        },
+    }
+    if command:
+        metrics["command"] = list(command)
+    return metrics
+
+
+def q3_bucket(q8_code: str) -> str:
+    if q8_code in _HELIX_Q8:
+        return "H"
+    if q8_code in _SHEET_Q8:
+        return "E"
+    return "C"
+
+
+def summarize_secondary_structure(rows: list[Dict[str, Any]]) -> Dict[str, Any]:
+    q8_codes = [str(row.get("q8") or "C") for row in rows]
+    q8_counts = Counter(q8_codes)
+    q3_counts = Counter(q3_bucket(code) for code in q8_codes)
+    residue_count = len(rows)
+    return {
+        "residue_count": residue_count,
+        "q8_counts": dict(q8_counts),
+        "q8_fraction": {
+            code: round(count / residue_count, 6)
+            for code, count in sorted(q8_counts.items())
+        } if residue_count else {},
+        "q3_counts": dict(q3_counts),
+        "q3_fraction": {
+            code: round(count / residue_count, 6)
+            for code, count in sorted(q3_counts.items())
+        } if residue_count else {},
+    }
+
+
+def build_secondary_structure_outputs(
+    tool_id: str,
+    inputs: Dict[str, Any],
+    rows: list[Dict[str, Any]],
+) -> Dict[str, Any]:
+    summary = summarize_secondary_structure(rows)
+    return {
+        "tool_id": tool_id,
+        "capability_id": "secondary_structure_annotation",
+        "capabilities": ["secondary_structure_annotation", "quality_qc"],
+        "io_type": "sequence_structure_to_qc_metrics",
+        "sequence": _to_str(inputs.get("sequence")),
+        "pdb_path": _to_str(inputs.get("pdb_path")),
+        "secondary_structure": rows,
+        "secondary_structure_summary": summary,
+        "qc_metrics": {
+            "secondary_structure_summary": summary,
+        },
+    }
+
+
+def build_secondary_structure_metrics(
+    *,
+    exec_type: str,
+    residue_count: int,
+    command: list[str] | None = None,
+) -> Dict[str, Any]:
+    metrics: Dict[str, Any] = {
+        "exec_type": exec_type,
+        "residue_count": residue_count,
+        "requirement2": {
+            "capability_id": "quality_qc",
+            "io_type": "sequence_structure_to_qc_metrics",
+            "additional_capabilities": ["secondary_structure_annotation"],
+        },
+    }
+    if command:
+        metrics["command"] = list(command)
+    return metrics
+
+
+def _to_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _to_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _bounded_fraction(numerator: int | None, denominator: int | None) -> float | None:
+    if numerator is None or denominator is None or denominator <= 0:
+        return None
+    return round(min(max(numerator / denominator, 0.0), 1.0), 6)

--- a/src/infra/w12_vertical_experiment.py
+++ b/src/infra/w12_vertical_experiment.py
@@ -16,6 +16,8 @@ DEFAULT_REQUIREMENT2_CAPABILITY_MAP: dict[str, list[str]] = {
     "quality_qc": ["quality_qc"],
     "objective_scoring": ["objective_scoring"],
     "structure_prediction": ["structure_prediction"],
+    "similarity_search": ["sequence_similarity_search"],
+    "secondary_structure": ["secondary_structure_annotation"],
 }
 
 DEFAULT_OFFLINE_THRESHOLDS: dict[str, float] = {
@@ -556,6 +558,8 @@ def aggregate_group_metrics(
             "requirement2_objective_scoring": requirement2_bucket_status.get("objective_scoring", False),
             "requirement2_structure_prediction": requirement2_bucket_status.get("structure_prediction", False),
         }
+        for bucket, covered in requirement2_bucket_status.items():
+            summary_row[f"requirement2_{bucket}"] = covered
         summary_rows.append(summary_row)
 
         patch_rows.append(

--- a/src/kg/protein_tool_kg.json
+++ b/src/kg/protein_tool_kg.json
@@ -1,6 +1,6 @@
 {
   "kg_id": "protein_tool_kg",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "capabilities": [
     {
       "capability_id": "structure_prediction",
@@ -25,55 +25,127 @@
       "name": "Quality QC",
       "domain": "protein/qc",
       "description": "Evaluate sequence/structure quality metrics and gate low-quality candidates."
+    },
+    {
+      "capability_id": "objective_scoring",
+      "name": "Objective Scoring",
+      "domain": "protein/score",
+      "description": "Aggregate multi-tool evidence into comparable objective scores."
+    },
+    {
+      "capability_id": "sequence_similarity_search",
+      "name": "Sequence Similarity Search",
+      "domain": "protein/similarity",
+      "description": "Search local protein databases for homologous or near-neighbor sequences."
+    },
+    {
+      "capability_id": "secondary_structure_annotation",
+      "name": "Secondary Structure Annotation",
+      "domain": "protein/annotation",
+      "description": "Annotate residue-level secondary structure and summarize Q3/Q8 composition."
     }
   ],
   "io_types": [
     {
       "io_type_id": "sequence_to_structure",
-      "input_types": ["sequence"],
-      "output_types": ["structure_pdb", "plddt"],
+      "input_types": [
+        "sequence"
+      ],
+      "output_types": [
+        "structure_pdb",
+        "plddt"
+      ],
       "combinable": true,
       "description": "Single sequence to structure prediction outputs."
     },
     {
       "io_type_id": "structure_to_sequence",
-      "input_types": ["structure_pdb"],
-      "output_types": ["sequence"],
+      "input_types": [
+        "structure_pdb"
+      ],
+      "output_types": [
+        "sequence"
+      ],
       "combinable": true,
       "description": "Design sequences from structural backbone inputs."
     },
     {
       "io_type_id": "goal_to_sequence_candidates",
-      "input_types": ["goal"],
-      "output_types": ["sequence", "sequence_candidates"],
+      "input_types": [
+        "goal"
+      ],
+      "output_types": [
+        "sequence",
+        "sequence_candidates"
+      ],
       "combinable": true,
       "description": "Generate candidate protein sequences from goal and optional prompt constraints."
     },
     {
       "io_type_id": "sequence_msa_to_structure",
-      "input_types": ["sequence", "msa"],
-      "output_types": ["structure_pdb", "plddt"],
+      "input_types": [
+        "sequence",
+        "msa"
+      ],
+      "output_types": [
+        "structure_pdb",
+        "plddt"
+      ],
       "combinable": true,
       "description": "Sequence + MSA to structure prediction outputs."
     },
     {
       "io_type_id": "sequence_structure_to_qc_metrics",
-      "input_types": ["sequence", "structure_pdb"],
-      "output_types": ["qc_metrics"],
+      "input_types": [
+        "sequence",
+        "structure_pdb"
+      ],
+      "output_types": [
+        "qc_metrics"
+      ],
       "combinable": true,
       "description": "Sequence and structure quality evaluation outputs."
+    },
+    {
+      "io_type_id": "sequence_to_similarity_hits",
+      "input_types": [
+        "sequence"
+      ],
+      "output_types": [
+        "similarity_hits",
+        "coverage",
+        "identity"
+      ],
+      "combinable": true,
+      "description": "Sequence search outputs normalized to comparable hit fields."
+    },
+    {
+      "io_type_id": "structure_to_secondary_structure",
+      "input_types": [
+        "structure_pdb"
+      ],
+      "output_types": [
+        "secondary_structure",
+        "ss_summary"
+      ],
+      "combinable": true,
+      "description": "Structure-to-secondary-structure annotation outputs."
     }
   ],
   "constraints": [
     {
       "constraint_id": "esmfold_runtime",
-      "preconditions": ["sequence_provided"],
+      "preconditions": [
+        "sequence_provided"
+      ],
       "resource_assumptions": [
         "nextflow_installed",
         "container_engine_available",
         "gpu_available"
       ],
-      "model_assumptions": ["single_chain_only"],
+      "model_assumptions": [
+        "single_chain_only"
+      ],
       "limits": {
         "max_length": 2000
       },
@@ -81,9 +153,16 @@
     },
     {
       "constraint_id": "nim_structure_runtime",
-      "preconditions": ["sequence_provided"],
-      "resource_assumptions": ["network_available", "nim_api_key_configured"],
-      "model_assumptions": ["single_chain_only"],
+      "preconditions": [
+        "sequence_provided"
+      ],
+      "resource_assumptions": [
+        "network_available",
+        "nim_api_key_configured"
+      ],
+      "model_assumptions": [
+        "single_chain_only"
+      ],
       "limits": {
         "max_length": 4096
       },
@@ -91,12 +170,16 @@
     },
     {
       "constraint_id": "protein_mpnn_runtime",
-      "preconditions": ["structure_template_provided"],
+      "preconditions": [
+        "structure_template_provided"
+      ],
       "resource_assumptions": [
         "gpu_available",
         "python_environment_ready"
       ],
-      "model_assumptions": ["backbone_required"],
+      "model_assumptions": [
+        "backbone_required"
+      ],
       "limits": {
         "max_length": 2000
       },
@@ -104,11 +187,62 @@
     },
     {
       "constraint_id": "biopython_qc_runtime",
-      "preconditions": ["sequence_or_structure_results_provided"],
-      "resource_assumptions": ["python_environment_ready"],
-      "model_assumptions": ["single_candidate_or_batch"],
+      "preconditions": [
+        "sequence_or_structure_results_provided"
+      ],
+      "resource_assumptions": [
+        "python_environment_ready"
+      ],
+      "model_assumptions": [
+        "single_candidate_or_batch"
+      ],
       "limits": {},
       "description": "BioPython QC runtime requirements for quality-gate checks."
+    },
+    {
+      "constraint_id": "mmseqs2_runtime",
+      "preconditions": [
+        "input_provided"
+      ],
+      "resource_assumptions": [
+        "python_environment_ready",
+        "local_sequence_database_ready"
+      ],
+      "model_assumptions": [
+        "single_candidate_or_batch"
+      ],
+      "limits": {},
+      "description": "MMseqs2 local similarity-search runtime requirements."
+    },
+    {
+      "constraint_id": "blastp_runtime",
+      "preconditions": [
+        "input_provided"
+      ],
+      "resource_assumptions": [
+        "python_environment_ready",
+        "local_blast_database_ready"
+      ],
+      "model_assumptions": [
+        "single_candidate_or_batch"
+      ],
+      "limits": {},
+      "description": "BLASTP local similarity-search runtime requirements."
+    },
+    {
+      "constraint_id": "dssp_runtime",
+      "preconditions": [
+        "input_provided"
+      ],
+      "resource_assumptions": [
+        "python_environment_ready",
+        "structure_file_available"
+      ],
+      "model_assumptions": [
+        "single_candidate_or_batch"
+      ],
+      "limits": {},
+      "description": "DSSP runtime requirements for local secondary-structure annotation."
     }
   ],
   "tools": [
@@ -118,7 +252,9 @@
       "name": "ESMFold",
       "domain": "protein/structure",
       "description": "Fast single-sequence structure prediction without MSA.",
-      "capabilities": ["structure_prediction"],
+      "capabilities": [
+        "structure_prediction"
+      ],
       "io": {
         "io_type_id": "sequence_to_structure",
         "inputs": {
@@ -128,18 +264,27 @@
           "pdb_path": "path",
           "plddt": "float"
         },
-        "input_types": ["sequence"],
-        "output_types": ["structure_pdb", "plddt"],
+        "input_types": [
+          "sequence"
+        ],
+        "output_types": [
+          "structure_pdb",
+          "plddt"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["sequence_provided"],
+        "preconditions": [
+          "sequence_provided"
+        ],
         "resource_assumptions": [
           "nextflow_installed",
           "container_engine_available",
           "gpu_available"
         ],
-        "model_assumptions": ["single_chain_only"],
+        "model_assumptions": [
+          "single_chain_only"
+        ],
         "limits": {
           "max_length": 2000
         }
@@ -148,12 +293,22 @@
       "cost_score": 0.6,
       "safety_level": 1,
       "priority": "P0",
-      "official_links": ["https://github.com/facebookresearch/esm"],
+      "official_links": [
+        "https://github.com/facebookresearch/esm"
+      ],
       "compat": {
-        "from": ["protein_mpnn.sequence", "protgpt2.sequence"]
+        "from": [
+          "protein_mpnn.sequence",
+          "protgpt2.sequence"
+        ]
       },
-      "failure_modes": ["timeout", "nan_output"],
-      "preferred_next": ["biopython_qc"],
+      "failure_modes": [
+        "timeout",
+        "nan_output"
+      ],
+      "preferred_next": [
+        "biopython_qc"
+      ],
       "version": "1.0.0"
     },
     {
@@ -162,7 +317,9 @@
       "name": "NIM ESMFold",
       "domain": "protein/structure",
       "description": "Remote ESMFold via NVIDIA NIM.",
-      "capabilities": ["structure_prediction"],
+      "capabilities": [
+        "structure_prediction"
+      ],
       "io": {
         "io_type_id": "sequence_to_structure",
         "inputs": {
@@ -173,14 +330,26 @@
           "plddt": "float",
           "pdb_string": "str"
         },
-        "input_types": ["sequence"],
-        "output_types": ["structure_pdb", "plddt"],
+        "input_types": [
+          "sequence"
+        ],
+        "output_types": [
+          "structure_pdb",
+          "plddt"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["sequence_provided"],
-        "resource_assumptions": ["network_available", "nim_api_key_configured"],
-        "model_assumptions": ["single_chain_only"],
+        "preconditions": [
+          "sequence_provided"
+        ],
+        "resource_assumptions": [
+          "network_available",
+          "nim_api_key_configured"
+        ],
+        "model_assumptions": [
+          "single_chain_only"
+        ],
         "limits": {
           "max_length": 400
         }
@@ -194,11 +363,18 @@
       "cost_score": 0.3,
       "safety_level": 1,
       "priority": "P0",
-      "official_links": ["https://build.nvidia.com/nvidia/esmfold"],
+      "official_links": [
+        "https://build.nvidia.com/nvidia/esmfold"
+      ],
       "compat": {
-        "from": ["protein_mpnn.sequence", "protgpt2.sequence"]
+        "from": [
+          "protein_mpnn.sequence",
+          "protgpt2.sequence"
+        ]
       },
-      "preferred_next": ["biopython_qc"],
+      "preferred_next": [
+        "biopython_qc"
+      ],
       "version": "1.0.0"
     },
     {
@@ -207,7 +383,9 @@
       "name": "AlphaFold2 (NIM)",
       "domain": "protein/structure",
       "description": "AlphaFold2 structure prediction via NVIDIA NIM.",
-      "capabilities": ["structure_prediction"],
+      "capabilities": [
+        "structure_prediction"
+      ],
       "io": {
         "io_type_id": "sequence_to_structure",
         "inputs": {
@@ -217,14 +395,26 @@
           "pdb_path": "path",
           "plddt": "float"
         },
-        "input_types": ["sequence"],
-        "output_types": ["structure_pdb", "plddt"],
+        "input_types": [
+          "sequence"
+        ],
+        "output_types": [
+          "structure_pdb",
+          "plddt"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["sequence_provided"],
-        "resource_assumptions": ["network_available", "nim_api_key_configured"],
-        "model_assumptions": ["single_chain_only"],
+        "preconditions": [
+          "sequence_provided"
+        ],
+        "resource_assumptions": [
+          "network_available",
+          "nim_api_key_configured"
+        ],
+        "model_assumptions": [
+          "single_chain_only"
+        ],
         "limits": {
           "max_length": 4096
         }
@@ -243,10 +433,18 @@
         "https://github.com/google-deepmind/alphafold"
       ],
       "compat": {
-        "from": ["protein_mpnn.sequence", "protgpt2.sequence"]
+        "from": [
+          "protein_mpnn.sequence",
+          "protgpt2.sequence"
+        ]
       },
-      "failure_modes": ["timeout", "invalid_input"],
-      "preferred_next": ["biopython_qc"],
+      "failure_modes": [
+        "timeout",
+        "invalid_input"
+      ],
+      "preferred_next": [
+        "biopython_qc"
+      ],
       "version": "1.0.0"
     },
     {
@@ -255,7 +453,9 @@
       "name": "OpenFold3",
       "domain": "protein/structure",
       "description": "OpenFold3 structure prediction via NVIDIA NIM or remote REST GPU service.",
-      "capabilities": ["structure_prediction"],
+      "capabilities": [
+        "structure_prediction"
+      ],
       "io": {
         "io_type_id": "sequence_to_structure",
         "inputs": {
@@ -265,17 +465,26 @@
           "pdb_path": "path",
           "plddt": "float"
         },
-        "input_types": ["sequence"],
-        "output_types": ["structure_pdb", "plddt"],
+        "input_types": [
+          "sequence"
+        ],
+        "output_types": [
+          "structure_pdb",
+          "plddt"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["sequence_provided"],
+        "preconditions": [
+          "sequence_provided"
+        ],
         "resource_assumptions": [
           "network_available",
           "nim_api_key_configured_or_openfold3_rest_service_available"
         ],
-        "model_assumptions": ["single_chain_or_complex"],
+        "model_assumptions": [
+          "single_chain_or_complex"
+        ],
         "limits": {
           "max_length": 1000
         }
@@ -295,10 +504,18 @@
         "https://openfold-3.readthedocs.io/en/latest/"
       ],
       "compat": {
-        "from": ["protein_mpnn.sequence", "protgpt2.sequence"]
+        "from": [
+          "protein_mpnn.sequence",
+          "protgpt2.sequence"
+        ]
       },
-      "failure_modes": ["timeout", "invalid_input"],
-      "preferred_next": ["biopython_qc"],
+      "failure_modes": [
+        "timeout",
+        "invalid_input"
+      ],
+      "preferred_next": [
+        "biopython_qc"
+      ],
       "version": "1.0.0"
     },
     {
@@ -307,7 +524,9 @@
       "name": "ProteinMPNN",
       "domain": "protein/design",
       "description": "Sequence design from backbone coordinates.",
-      "capabilities": ["sequence_design"],
+      "capabilities": [
+        "sequence_design"
+      ],
       "io": {
         "io_type_id": "structure_to_sequence",
         "inputs": {
@@ -317,17 +536,25 @@
           "sequence": "str",
           "sequence_score": "float"
         },
-        "input_types": ["structure_pdb"],
-        "output_types": ["sequence"],
+        "input_types": [
+          "structure_pdb"
+        ],
+        "output_types": [
+          "sequence"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["structure_template_provided"],
+        "preconditions": [
+          "structure_template_provided"
+        ],
         "resource_assumptions": [
           "network_available",
           "nim_api_key_configured"
         ],
-        "model_assumptions": ["backbone_required"],
+        "model_assumptions": [
+          "backbone_required"
+        ],
         "limits": {
           "max_length": 2000
         }
@@ -341,7 +568,9 @@
       "cost_score": 0.4,
       "safety_level": 1,
       "priority": "P0",
-      "official_links": ["https://github.com/dauparas/ProteinMPNN"],
+      "official_links": [
+        "https://github.com/dauparas/ProteinMPNN"
+      ],
       "compat": {
         "from": [
           "esmfold.pdb_path",
@@ -350,8 +579,16 @@
           "openfold.pdb_path"
         ]
       },
-      "failure_modes": ["invalid_backbone", "missing_backbone"],
-      "preferred_next": ["esmfold", "nim_esmfold", "alphafold", "openfold"],
+      "failure_modes": [
+        "invalid_backbone",
+        "missing_backbone"
+      ],
+      "preferred_next": [
+        "esmfold",
+        "nim_esmfold",
+        "alphafold",
+        "openfold"
+      ],
       "version": "1.0.0"
     },
     {
@@ -360,7 +597,9 @@
       "name": "ProtGPT2",
       "domain": "protein/design",
       "description": "PLM-based de novo sequence generator via remote ProtGPT2 REST service.",
-      "capabilities": ["sequence_generation"],
+      "capabilities": [
+        "sequence_generation"
+      ],
       "io": {
         "io_type_id": "goal_to_sequence_candidates",
         "inputs": {
@@ -371,14 +610,26 @@
           "candidates": "list",
           "artifacts": "dict"
         },
-        "input_types": ["goal"],
-        "output_types": ["sequence", "sequence_candidates"],
+        "input_types": [
+          "goal"
+        ],
+        "output_types": [
+          "sequence",
+          "sequence_candidates"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["goal_provided"],
-        "resource_assumptions": ["network_available", "plm_rest_service_available"],
-        "model_assumptions": ["protgpt2_ready"],
+        "preconditions": [
+          "goal_provided"
+        ],
+        "resource_assumptions": [
+          "network_available",
+          "plm_rest_service_available"
+        ],
+        "model_assumptions": [
+          "protgpt2_ready"
+        ],
         "limits": {
           "max_new_tokens": 512,
           "num_candidates_max": 64
@@ -393,12 +644,23 @@
       "cost_score": 0.35,
       "safety_level": 1,
       "priority": "P0",
-      "official_links": ["https://huggingface.co/nferruz/ProtGPT2"],
+      "official_links": [
+        "https://huggingface.co/nferruz/ProtGPT2"
+      ],
       "compat": {
         "from": []
       },
-      "failure_modes": ["timeout", "invalid_generation"],
-      "preferred_next": ["esmfold", "nim_esmfold", "alphafold", "openfold", "protein_mpnn"],
+      "failure_modes": [
+        "timeout",
+        "invalid_generation"
+      ],
+      "preferred_next": [
+        "esmfold",
+        "nim_esmfold",
+        "alphafold",
+        "openfold",
+        "protein_mpnn"
+      ],
       "version": "1.0.0"
     },
     {
@@ -407,7 +669,9 @@
       "name": "BioPython QC",
       "domain": "protein/qc",
       "description": "Executor-callable BioPython QC for sequence and structure gating.",
-      "capabilities": ["quality_qc"],
+      "capabilities": [
+        "quality_qc"
+      ],
       "io": {
         "io_type_id": "sequence_structure_to_qc_metrics",
         "inputs": {
@@ -421,14 +685,25 @@
           "pass_count": "int",
           "fail_count": "int"
         },
-        "input_types": ["sequence", "structure_pdb"],
-        "output_types": ["qc_metrics"],
+        "input_types": [
+          "sequence",
+          "structure_pdb"
+        ],
+        "output_types": [
+          "qc_metrics"
+        ],
         "combinable": true
       },
       "constraints": {
-        "preconditions": ["sequence_or_structure_results_provided"],
-        "resource_assumptions": ["python_environment_ready"],
-        "model_assumptions": ["single_candidate_or_batch"],
+        "preconditions": [
+          "sequence_or_structure_results_provided"
+        ],
+        "resource_assumptions": [
+          "python_environment_ready"
+        ],
+        "model_assumptions": [
+          "single_candidate_or_batch"
+        ],
         "limits": {}
       },
       "execution": "python",
@@ -447,8 +722,199 @@
           "openfold.pdb_path"
         ]
       },
-      "failure_modes": ["invalid_sequence", "missing_structure"],
-      "preferred_next": ["protein_mpnn"],
+      "failure_modes": [
+        "invalid_sequence",
+        "missing_structure"
+      ],
+      "preferred_next": [
+        "protein_mpnn"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "id": "mmseqs2",
+      "tool_id": "mmseqs2",
+      "name": "MMseqs2",
+      "domain": "protein/similarity",
+      "description": "Fast local sequence-similarity search with normalized hit schema for Requirement-2.",
+      "capabilities": [
+        "sequence_similarity_search",
+        "objective_scoring"
+      ],
+      "io": {
+        "io_type_id": "sequence_to_similarity_hits",
+        "inputs": {
+          "sequence": "str",
+          "database_path": "path"
+        },
+        "outputs": {
+          "similarity_hits": "list",
+          "top_hit": "dict",
+          "hit_count": "int"
+        },
+        "input_types": [
+          "sequence"
+        ],
+        "output_types": [
+          "similarity_hits",
+          "coverage",
+          "identity"
+        ],
+        "combinable": true
+      },
+      "constraints": {
+        "preconditions": [
+          "sequence_provided",
+          "database_ready"
+        ],
+        "resource_assumptions": [
+          "python_environment_ready",
+          "local_sequence_database_ready"
+        ],
+        "model_assumptions": [
+          "single_query_or_small_batch"
+        ],
+        "limits": {}
+      },
+      "execution": "python",
+      "cost_score": 0.25,
+      "safety_level": 1,
+      "priority": "P0",
+      "official_links": [
+        "https://github.com/soedinglab/MMseqs2"
+      ],
+      "failure_modes": [
+        "timeout",
+        "database_missing"
+      ],
+      "preferred_next": [
+        "objective_ranker",
+        "biopython_qc"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "id": "blastp",
+      "tool_id": "blastp",
+      "name": "BLASTP",
+      "domain": "protein/similarity",
+      "description": "Classic protein similarity baseline aligned to the MMseqs2 hit schema.",
+      "capabilities": [
+        "sequence_similarity_search",
+        "objective_scoring"
+      ],
+      "io": {
+        "io_type_id": "sequence_to_similarity_hits",
+        "inputs": {
+          "sequence": "str",
+          "database_path": "path"
+        },
+        "outputs": {
+          "similarity_hits": "list",
+          "top_hit": "dict",
+          "hit_count": "int"
+        },
+        "input_types": [
+          "sequence"
+        ],
+        "output_types": [
+          "similarity_hits",
+          "coverage",
+          "identity"
+        ],
+        "combinable": true
+      },
+      "constraints": {
+        "preconditions": [
+          "sequence_provided",
+          "database_ready"
+        ],
+        "resource_assumptions": [
+          "python_environment_ready",
+          "local_blast_database_ready"
+        ],
+        "model_assumptions": [
+          "single_query_or_small_batch"
+        ],
+        "limits": {}
+      },
+      "execution": "python",
+      "cost_score": 0.35,
+      "safety_level": 1,
+      "priority": "P0",
+      "official_links": [
+        "https://www.ncbi.nlm.nih.gov/books/NBK279690/"
+      ],
+      "failure_modes": [
+        "timeout",
+        "database_missing"
+      ],
+      "preferred_next": [
+        "objective_ranker",
+        "biopython_qc"
+      ],
+      "version": "1.0.0"
+    },
+    {
+      "id": "dssp",
+      "tool_id": "dssp",
+      "name": "DSSP",
+      "domain": "protein/annotation",
+      "description": "Secondary-structure annotation that can feed quality-gate and evaluation chains.",
+      "capabilities": [
+        "secondary_structure_annotation",
+        "quality_qc"
+      ],
+      "io": {
+        "io_type_id": "sequence_structure_to_qc_metrics",
+        "inputs": {
+          "pdb_path": "path",
+          "sequence": "str"
+        },
+        "outputs": {
+          "secondary_structure": "list",
+          "secondary_structure_summary": "dict",
+          "qc_metrics": "dict"
+        },
+        "input_types": [
+          "structure_pdb"
+        ],
+        "output_types": [
+          "secondary_structure",
+          "ss_summary",
+          "qc_metrics"
+        ],
+        "combinable": true
+      },
+      "constraints": {
+        "preconditions": [
+          "structure_provided"
+        ],
+        "resource_assumptions": [
+          "python_environment_ready",
+          "structure_file_available"
+        ],
+        "model_assumptions": [
+          "single_candidate_or_batch"
+        ],
+        "limits": {}
+      },
+      "execution": "python",
+      "cost_score": 0.2,
+      "safety_level": 1,
+      "priority": "P0",
+      "official_links": [
+        "https://github.com/PDB-REDO/dssp",
+        "https://pdb-redo.eu/dssp"
+      ],
+      "failure_modes": [
+        "invalid_structure",
+        "binary_missing"
+      ],
+      "preferred_next": [
+        "objective_ranker",
+        "biopython_qc"
+      ],
       "version": "1.0.0"
     }
   ]

--- a/tests/integration/test_local_similarity_tools_smoke.py
+++ b/tests/integration/test_local_similarity_tools_smoke.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.adapters.blastp_adapter import BlastPAdapter
+from src.adapters.dssp_adapter import DSSPAdapter
+from src.adapters.mmseqs2_adapter import MMseqs2Adapter
+
+
+def _require_env(name: str) -> str:
+    value = str(os.getenv(name, "")).strip()
+    if not value:
+        pytest.skip(f"{name} not set")
+    return value
+
+
+def _require_file_env(name: str) -> str:
+    value = _require_env(name)
+    if not Path(value).exists():
+        pytest.skip(f"{name} path does not exist: {value}")
+    return value
+
+
+@pytest.mark.integration
+def test_local_mmseqs2_smoke() -> None:
+    sequence = _require_env("LOCAL_QUERY_SEQUENCE")
+    database_path = _require_env("LOCAL_MMSEQS_DB")
+
+    adapter = MMseqs2Adapter()
+    outputs, metrics = adapter.run_local(
+        {
+            "sequence": sequence,
+            "database_path": database_path,
+            "query_id": "local_smoke_query",
+            "max_seqs": 5,
+        }
+    )
+
+    assert outputs["io_type"] == "sequence_to_similarity_hits"
+    assert outputs["capability_id"] == "sequence_similarity_search"
+    assert outputs["hit_count"] >= 1
+    assert outputs["similarity_hits"]
+    top_hit = outputs["similarity_hits"][0]
+    assert "identity" in top_hit
+    assert "coverage" in top_hit
+    assert "evalue" in top_hit
+    assert metrics["requirement2"]["capability_id"] == "sequence_similarity_search"
+
+
+@pytest.mark.integration
+def test_local_blastp_smoke() -> None:
+    sequence = _require_env("LOCAL_QUERY_SEQUENCE")
+    database_path = _require_env("LOCAL_BLAST_DB")
+
+    adapter = BlastPAdapter()
+    outputs, metrics = adapter.run_local(
+        {
+            "sequence": sequence,
+            "database_path": database_path,
+            "query_id": "local_smoke_query",
+            "max_target_seqs": 5,
+        }
+    )
+
+    assert outputs["io_type"] == "sequence_to_similarity_hits"
+    assert outputs["capability_id"] == "sequence_similarity_search"
+    assert outputs["hit_count"] >= 1
+    assert outputs["similarity_hits"]
+    top_hit = outputs["similarity_hits"][0]
+    assert "identity" in top_hit
+    assert "coverage" in top_hit
+    assert "evalue" in top_hit
+    assert metrics["requirement2"]["capability_id"] == "sequence_similarity_search"
+
+
+@pytest.mark.integration
+def test_local_dssp_smoke() -> None:
+    pdb_path = _require_file_env("LOCAL_DSSP_PDB")
+    sequence = str(os.getenv("LOCAL_DSSP_SEQUENCE", "")).strip() or None
+
+    adapter = DSSPAdapter()
+    payload = {"pdb_path": pdb_path}
+    if sequence:
+        payload["sequence"] = sequence
+    outputs, metrics = adapter.run_local(payload)
+
+    assert outputs["io_type"] == "sequence_structure_to_qc_metrics"
+    assert outputs["secondary_structure"]
+    assert outputs["secondary_structure_summary"]["residue_count"] >= 1
+    assert "q3_counts" in outputs["secondary_structure_summary"]
+    assert metrics["requirement2"]["capability_id"] == "quality_qc"

--- a/tests/unit/test_protein_tool_kg.py
+++ b/tests/unit/test_protein_tool_kg.py
@@ -12,12 +12,20 @@ def test_kg_includes_plm_and_design_capabilities() -> None:
     assert "alphafold" in tool_ids
     assert "openfold" in tool_ids
     assert "biopython_qc" in tool_ids
+    assert "mmseqs2" in tool_ids
+    assert "blastp" in tool_ids
+    assert "dssp" in tool_ids
     assert "sequence_design" in capability_ids
     assert "sequence_generation" in capability_ids
     assert "quality_qc" in capability_ids
+    assert "objective_scoring" in capability_ids
+    assert "sequence_similarity_search" in capability_ids
+    assert "secondary_structure_annotation" in capability_ids
     assert "structure_to_sequence" in io_type_ids
     assert "goal_to_sequence_candidates" in io_type_ids
     assert "sequence_structure_to_qc_metrics" in io_type_ids
+    assert "sequence_to_similarity_hits" in io_type_ids
+    assert "structure_to_secondary_structure" in io_type_ids
 
 
 def test_generation_to_prediction_chain_is_compatible() -> None:

--- a/tests/unit/test_similarity_and_secondary_structure_adapters.py
+++ b/tests/unit/test_similarity_and_secondary_structure_adapters.py
@@ -92,7 +92,7 @@ def test_dssp_adapter_runs_local_and_outputs_qc_metrics(monkeypatch: pytest.Monk
     pdb_path.write_text("ATOM\n", encoding="utf-8")
 
     def fake_runner(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
-        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path = Path(cmd[-1])
         output_path.write_text(
             "HEADER\n"
             "  #  RESIDUE AA STRUCTURE BP1 BP2  ACC\n"
@@ -110,9 +110,11 @@ def test_dssp_adapter_runs_local_and_outputs_qc_metrics(monkeypatch: pytest.Monk
     assert outputs["io_type"] == "sequence_structure_to_qc_metrics"
     assert outputs["qc_metrics"]["secondary_structure_summary"]["q3_counts"] == {"H": 1, "E": 1}
     assert metrics["requirement2"]["capability_id"] == "quality_qc"
+    assert metrics["command"][:3] == ["mkdssp", "--output-format", "dssp"]
 
 
-def test_adapters_raise_when_binary_is_missing() -> None:
+def test_adapters_raise_when_binary_is_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.adapters.mmseqs2_adapter.shutil.which", lambda _: None)
     adapter = MMseqs2Adapter()
 
     with pytest.raises(StepRunError, match="not installed"):

--- a/tests/unit/test_similarity_and_secondary_structure_adapters.py
+++ b/tests/unit/test_similarity_and_secondary_structure_adapters.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.adapters.blastp_adapter import BlastPAdapter, parse_blastp_tabular
+from src.adapters.dssp_adapter import DSSPAdapter, parse_dssp_output
+from src.adapters.mmseqs2_adapter import MMseqs2Adapter, parse_mmseqs_tabular
+from src.workflow.errors import StepRunError
+
+
+def test_parse_mmseqs_tabular_normalizes_hits() -> None:
+    hits = parse_mmseqs_tabular(
+        "q1\ttargetA\t95.5\t90\t0\t0\t1\t90\t3\t92\t1e-20\t180\t100\t120\n"
+    )
+
+    assert hits[0]["query_id"] == "q1"
+    assert hits[0]["target_id"] == "targetA"
+    assert hits[0]["identity"] == "95.5"
+
+
+def test_parse_blastp_tabular_normalizes_hits() -> None:
+    hits = parse_blastp_tabular(
+        "q1\ttargetB\t88.0\t80\t0\t0\t5\t84\t2\t81\t2e-10\t150\t100\t110\n"
+    )
+
+    assert hits[0]["query_start"] == "5"
+    assert hits[0]["target_length"] == "110"
+
+
+def test_parse_dssp_output_extracts_q3_q8_rows() -> None:
+    text = (
+        "HEADER\n"
+        "  #  RESIDUE AA STRUCTURE BP1 BP2  ACC\n"
+        "    1    1 A A  H                  0   0\n"
+        "    2    2 A V  E                  0   0\n"
+        "    3    3 A G                     0   0\n"
+    )
+
+    rows = parse_dssp_output(text)
+
+    assert [row["q8"] for row in rows] == ["H", "E", "C"]
+    assert [row["q3"] for row in rows] == ["H", "E", "C"]
+
+
+def test_mmseqs2_adapter_runs_local_and_emits_unified_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_runner(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        Path(cmd[4]).write_text(
+            "query_1\thit1\t97.0\t90\t0\t0\t1\t90\t1\t90\t1e-30\t210\t100\t100\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("src.adapters.mmseqs2_adapter.shutil.which", lambda _: "/usr/bin/mmseqs")
+    adapter = MMseqs2Adapter(runner=fake_runner)
+
+    outputs, metrics = adapter.run_local(
+        {"sequence": "ACDEFG", "database_path": "/db/mmseqs", "query_id": "query_1"}
+    )
+
+    assert outputs["capability_id"] == "sequence_similarity_search"
+    assert outputs["io_type"] == "sequence_to_similarity_hits"
+    assert outputs["similarity_hits"][0]["coverage"] == 0.9
+    assert metrics["requirement2"]["capability_id"] == "sequence_similarity_search"
+
+
+def test_blastp_adapter_runs_local_and_emits_unified_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_runner(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        output_path = Path(cmd[cmd.index("-out") + 1])
+        output_path.write_text(
+            "query_1\thit2\t89.0\t75\t0\t0\t1\t75\t4\t78\t1e-12\t140\t100\t120\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("src.adapters.blastp_adapter.shutil.which", lambda _: "/usr/bin/blastp")
+    adapter = BlastPAdapter(runner=fake_runner)
+
+    outputs, metrics = adapter.run_local(
+        {"sequence": "ACDEFG", "database_path": "/db/blast", "query_id": "query_1"}
+    )
+
+    assert outputs["similarity_hits"][0]["target_id"] == "hit2"
+    assert outputs["similarity_hits"][0]["coverage"] == 0.75
+    assert metrics["hit_count"] == 1
+
+
+def test_dssp_adapter_runs_local_and_outputs_qc_metrics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pdb_path = tmp_path / "input.pdb"
+    pdb_path.write_text("ATOM\n", encoding="utf-8")
+
+    def fake_runner(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text(
+            "HEADER\n"
+            "  #  RESIDUE AA STRUCTURE BP1 BP2  ACC\n"
+            "    1    1 A A  H                  0   0\n"
+            "    2    2 A V  E                  0   0\n",
+            encoding="utf-8",
+        )
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr("src.adapters.dssp_adapter.shutil.which", lambda _: "/usr/bin/mkdssp")
+    adapter = DSSPAdapter(runner=fake_runner)
+
+    outputs, metrics = adapter.run_local({"pdb_path": str(pdb_path), "sequence": "AV"})
+
+    assert outputs["io_type"] == "sequence_structure_to_qc_metrics"
+    assert outputs["qc_metrics"]["secondary_structure_summary"]["q3_counts"] == {"H": 1, "E": 1}
+    assert metrics["requirement2"]["capability_id"] == "quality_qc"
+
+
+def test_adapters_raise_when_binary_is_missing() -> None:
+    adapter = MMseqs2Adapter()
+
+    with pytest.raises(StepRunError, match="not installed"):
+        adapter.run_local({"sequence": "ACDEFG", "database_path": "/db/mmseqs"})

--- a/tests/unit/test_w12_vertical_experiment.py
+++ b/tests/unit/test_w12_vertical_experiment.py
@@ -199,3 +199,79 @@ def test_aggregate_and_deltas(tmp_path: Path) -> None:
     assert row["to_group"] == "A1"
     assert row["delta"] is not None
     assert row["pairing"] == "paired"
+
+
+def test_requirement2_rows_include_new_similarity_and_secondary_structure_tools(
+    tmp_path: Path,
+) -> None:
+    runs = [
+        {
+            "run_id": "r1",
+            "task_id": "task1",
+            "task_key": "k1",
+            "group_id": "A0",
+            "replicate": 1,
+            "freeze_id": "f1",
+            "event_log_path": "",
+            "snapshot_path": "",
+            "report_path": "",
+            "started_at": "2026-03-15T10:00:00+00:00",
+            "finished_at": "2026-03-15T10:00:02+00:00",
+            "duration_ms": 2000.0,
+            "final_status": "DONE",
+            "success": True,
+            "first_pass_success": True,
+            "schema_valid": True,
+            "executable_plan": True,
+            "patch_event_count": 0,
+            "replan_event_count": 0,
+            "suffix_replan_event_count": 0,
+            "waiting_enter_count": 0,
+            "step_failed_count": 0,
+            "step_finished_count": 3,
+            "waiting_chain_complete": True,
+            "failure_traceable": True,
+            "layer_counter": {},
+            "tool_usage": {"mmseqs2": 1, "blastp": 1, "dssp": 1},
+            "capability_usage": {
+                "sequence_similarity_search": 2,
+                "secondary_structure_annotation": 1,
+                "quality_qc": 1,
+            },
+            "requirement2_coverage": {
+                "sequence_core": False,
+                "quality_qc": True,
+                "objective_scoring": False,
+                "structure_prediction": False,
+                "similarity_search": True,
+                "secondary_structure": True,
+            },
+            "suffix_prefix_samples": [],
+            "abnormal_reasons": [],
+            "step_failed_details": [],
+        }
+    ]
+
+    aggregated = aggregate_group_metrics(
+        runs,
+        group_order=["A0"],
+        iterations=100,
+        seed=7,
+        thresholds={
+            "schema_valid_rate": 0.995,
+            "executable_plan_rate": 0.95,
+            "patch_minimality_hit_rate": 0.8,
+            "suffix_replan_prefix_preservation_rate": 1.0,
+        },
+        requirement2_capability_map=DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    )
+
+    summary = aggregated["summary_rows"][0]
+    rows = aggregated["requirement2_rows"]
+    row_lookup = {(row["slice_type"], row["name"]): row for row in rows}
+
+    assert summary["requirement2_similarity_search"] is True
+    assert summary["requirement2_secondary_structure"] is True
+    assert row_lookup[("tool", "mmseqs2")]["usage_count"] == 1
+    assert row_lookup[("tool", "blastp")]["usage_count"] == 1
+    assert row_lookup[("tool", "dssp")]["usage_count"] == 1


### PR DESCRIPTION
## 概述
本 PR 完成 issue #198：为 Requirement-2 补齐本地相似性检索与二级结构注释工具接入，新增 `MMseqs2`、`BLASTP`、`DSSP` 三个工具的系统内适配能力，并将其统一纳入 ToolKG、Requirement-2 切片统计与测试链路。

本次改动不引入新的业务状态，不改动 HITL 决策所有权，仅在既有执行边界内补充工具接入、输出标准化与验证覆盖。

## 接入工具与实现方式
### 1. MMseqs2
定位：本地蛋白序列相似性检索路径，用于 Requirement-2 中的跨工具可比性与 S3/S5 可解释评估。

实现方式：
- 新增本地 CLI Adapter：`src/adapters/mmseqs2_adapter.py`
- 调用形式：`mmseqs easy-search`
- 输入：`sequence`、`database_path`
- 输出：统一写入 `sequence_to_similarity_hits` 口径

输出字段包括：
- `similarity_hits`
- `top_hit`
- `hit_count`
- 每条 hit 统一包含：`identity`、`coverage`、`query_coverage`、`target_coverage`、`evalue`、`bitscore`、`alignment_length` 等字段

### 2. BLASTP
定位：经典蛋白相似性基线路径，用于与 MMseqs2 形成互证，满足 issue 中“至少 2 种相似性路径可产出同口径结果”的验收要求。

实现方式：
- 新增本地 CLI Adapter：`src/adapters/blastp_adapter.py`
- 调用形式：`blastp`
- 输入：`sequence`、`database_path`
- 输出：与 MMseqs2 对齐到同一 `sequence_to_similarity_hits` schema

这保证了 MMseqs2 / BLASTP 两条本地路径可以直接进行横向聚合和对比分析。

### 3. DSSP
定位：本地二级结构注释路径，用于补齐 Requirement-2 中的结构注释能力，并进入质量门禁 / 评估链路。

实现方式：
- 新增本地 CLI Adapter：`src/adapters/dssp_adapter.py`
- 调用形式：新版 `mkdssp --output-format dssp <input> <output>`
- 输入：`pdb_path`，可选 `sequence`
- 输出：对齐到 `sequence_structure_to_qc_metrics`

输出字段包括：
- `secondary_structure`
- `secondary_structure_summary`
- `qc_metrics.secondary_structure_summary`
- residue 级字段至少包含：`q8`、`q3`、`chain_id`、`residue_number`、`amino_acid`

## 统一输出与 Requirement-2 对齐
### 1. 统一 schema
新增公共标准化辅助：`src/adapters/tool_schema_utils.py`

统一了两类输出：
- 相似性检索输出：`sequence_to_similarity_hits`
- 二级结构 / QC 输出：`sequence_structure_to_qc_metrics`

### 2. ToolKG 扩展
更新：`src/kg/protein_tool_kg.json`

新增 capability：
- `sequence_similarity_search`
- `secondary_structure_annotation`
- `objective_scoring`

新增 io_type：
- `sequence_to_similarity_hits`
- `structure_to_secondary_structure`

新增 tool 节点：
- `mmseqs2`
- `blastp`
- `dssp`

### 3. Requirement-2 切片统计
更新：`src/infra/w12_vertical_experiment.py`

新增 capability bucket：
- `similarity_search`
- `secondary_structure`

这使得 `requirement2_tool_capability_slices.csv` 能输出新增工具及其能力覆盖统计，满足 issue 对实验切片统计的要求。

## 测试与验证
### 1. issue 指定验收测试
已通过：

```bash
uv run pytest tests/unit/test_planner_agent.py tests/unit/test_extract_training_samples.py tests/integration/test_quality_gate_s3.py -q
```

### 2. 新增单元测试
已通过：

```bash
uv run pytest tests/unit/test_similarity_and_secondary_structure_adapters.py tests/unit/test_protein_tool_kg.py tests/unit/test_w12_vertical_experiment.py -q
```

覆盖内容：
- MMseqs2 / BLASTP tabular 输出解析与统一 schema
- DSSP 输出解析与 Q3/Q8 汇总
- ToolKG 中新增 capability / io_type / tool 节点
- Requirement-2 新增切片统计

### 3. 本地 smoke integration
新增：`tests/integration/test_local_similarity_tools_smoke.py`

该测试通过环境变量驱动，本地具备二进制和数据库时可执行，默认不会影响 CI。

执行命令：

```bash
uv run pytest tests/integration/test_local_similarity_tools_smoke.py -q
```

本地实测结果：`3 passed`

覆盖内容：
- MMseqs2 本地 Adapter -> 统一 similarity schema
- BLASTP 本地 Adapter -> 统一 similarity schema
- DSSP 本地 Adapter -> secondary_structure / qc_metrics 链路

## 文档
新增文档：
- `docs/algorithm-and-llm/requirement2-similarity-secondary-structure-tools.md`

内容包括：
- 本地依赖
- 最小输入
- 统一输出字段字典
- Requirement-2 统计对齐说明
- 本地运行提示

## 关联 Issue
- closes #198
