### PR TITLE
docs(showcase): 增加中文版全流程展示手册

### DIFF
--- a/examples/README_DEMO.md
+++ b/examples/README_DEMO.md
@@ -1,41 +1,41 @@
-# One-Command Demo
+# 一键演示
 
-This repository provides a one-command launcher for the minimal end-to-end demo:
+本仓库提供了一套最小可运行的端到端演示入口，覆盖：
 
-- FastAPI input layer (`/docs`, `/health`, `/tasks`)
-- Planner/Executor/Safety/Summarizer workflow chain
-- Runtime resources (ProteinToolKG, logs, snapshots, output dirs)
+- FastAPI 输入层（`/docs`、`/health`、`/tasks`）
+- Planner / Executor / Safety / Summarizer 工作链路
+- 运行时资源（ProteinToolKG、日志、快照、输出目录）
 
-## Quick Start
+## 快速开始
 
-From repository root:
+在仓库根目录执行：
 
 ```bash
 ./run_demo.sh
 ```
 
-What this does:
+该命令会完成以下动作：
 
-1. Checks runtime prerequisites (Python 3.12, `uv`, optional Nextflow).
-2. Initializes runtime resources:
+1. 检查运行前置条件（Python 3.12、`uv`、可选的 Nextflow）。
+2. 初始化运行时目录与资源：
    - `output/`
    - `data/logs/`
    - `data/snapshots/`
-   - `src/kg/protein_tool_kg.json` load check
-3. Starts FastAPI service.
-4. Runs smoke check:
-   - `GET /health` must return `200`
-   - `POST /tasks` creates a demo task
-   - `GET /tasks/{id}` observes task status
-   - verifies EventLog file `data/logs/{task_id}.jsonl`
+   - 检查 `src/kg/protein_tool_kg.json` 是否可加载
+3. 启动 FastAPI 服务。
+4. 执行一次 smoke check：
+   - `GET /health` 必须返回 `200`
+   - `POST /tasks` 创建一个 demo 任务
+   - `GET /tasks/{id}` 观察任务状态
+   - 校验 `data/logs/{task_id}.jsonl` 已生成
 
-After startup:
+启动后可访问：
 
-- API docs: `http://127.0.0.1:8000/docs`
-- Health: `http://127.0.0.1:8000/health`
-- HITL dashboard: `http://127.0.0.1:8000/ui`
-- Event timeline: `http://127.0.0.1:8000/ui/tasks/<task_id>/events`
-- Candidate compare demo (seeded, in-process preview): `uv run python examples/run_hitl_candidate_ui_demo.py`
+- API 文档：`http://127.0.0.1:8000/docs`
+- 健康检查：`http://127.0.0.1:8000/health`
+- HITL 仪表盘：`http://127.0.0.1:8000/ui`
+- 事件时间线：`http://127.0.0.1:8000/ui/tasks/<task_id>/events`
+- 候选对比演示（内置种子数据、进程内预览）：`uv run python examples/run_hitl_candidate_ui_demo.py`
 
 ## 全流程展示
 
@@ -63,72 +63,72 @@ UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py
 UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py --prepare
 ```
 
-## Issue #142 Candidate Compare Demo
+## Issue #142 候选对比演示
 
-Run reproducible in-process preview (no extra dependency):
+运行可复现的进程内预览（不需要额外依赖）：
 
 ```bash
 uv run python examples/run_hitl_candidate_ui_demo.py
 ```
 
-This seeds deterministic demo data:
+该脚本会写入固定的演示数据：
 
 - `task_id=task_demo_142`
 - `pending_action_id=pa_demo_142`
 
-Optional real HTTP UI serving (requires `uvicorn`):
+如果希望启动真实 HTTP UI 服务（需要 `uvicorn`），可执行：
 
 ```bash
 uv run python examples/run_hitl_candidate_ui_demo.py --serve --port 8012
 ```
 
-When served, open:
+服务启动后，打开：
 
 - `http://127.0.0.1:8012/ui/tasks/task_demo_142`
 - `http://127.0.0.1:8012/ui/tasks/task_demo_142/events`
 - `http://127.0.0.1:8012/pending-actions/pa_demo_142`
 
-Expected checkpoints:
+建议检查以下点位：
 
-1. Candidate table contains rank/risk/cost/recommendation fields.
-2. Tool fields are visible (`tool_id/capability_id/io_type/adapter_mode/source`).
-3. One candidate is rendered as degraded when tool metadata is missing.
-4. After decision submit, Decision Result shows status update and latest decision/transition event summary.
+1. 候选表格中包含 rank / risk / cost / recommendation 字段。
+2. 工具字段可见（`tool_id/capability_id/io_type/adapter_mode/source`）。
+3. 至少有一个候选在工具元数据缺失时走降级展示路径。
+4. 提交决策后，Decision Result 区域能展示状态变化和最新决策/状态迁移事件摘要。
 
-## Main Options
+## 常用选项
 
 ```bash
 ./run_demo.sh --port 8010 --model-backend mock --mock-tools
 ```
 
-Useful flags:
+常用参数：
 
-- `--host`, `--port`: API bind address
-- `--model-backend`: backend label for demo metadata
-- `--mock-tools` / `--no-mock-tools`: toggle mock mode flag
-- `--data-dir`, `--output-dir`: runtime directories
-- `--kg-path`: ProteinToolKG file path
-- `--smoke-test` / `--no-smoke-test`: enable/disable smoke run
-- `--smoke-task-config`: task payload JSON (default `configs/demo_task.json`)
-- `--exit-after-smoke`: exit after checks (useful in CI)
+- `--host`, `--port`：API 监听地址
+- `--model-backend`：写入 demo 元数据的后端标签
+- `--mock-tools` / `--no-mock-tools`：切换 mock 工具模式
+- `--data-dir`, `--output-dir`：运行时目录
+- `--kg-path`：ProteinToolKG 文件路径
+- `--smoke-test` / `--no-smoke-test`：启用或关闭 smoke run
+- `--smoke-task-config`：任务请求 JSON（默认 `configs/demo_task.json`）
+- `--exit-after-smoke`：smoke 检查通过后立即退出，适合 CI
 
-All arguments are implemented in `scripts/run_demo.py`.
+所有参数都在 `scripts/run_demo.py` 中实现。
 
-## Cleanup
+## 清理
 
 ```bash
 ./run_demo.sh clean
 ```
 
-This resets:
+该命令会重置：
 
 - `output/`
 - `data/logs/`
 - `data/snapshots/`
 
-## Manual Smoke Commands
+## 手动 Smoke 命令
 
-If you start demo with `--no-smoke-test`, use:
+如果启动 demo 时使用了 `--no-smoke-test`，可以手动执行：
 
 ```bash
 curl -sS http://127.0.0.1:8000/health

--- a/examples/README_DEMO.md
+++ b/examples/README_DEMO.md
@@ -37,6 +37,32 @@ After startup:
 - Event timeline: `http://127.0.0.1:8000/ui/tasks/<task_id>/events`
 - Candidate compare demo (seeded, in-process preview): `uv run python examples/run_hitl_candidate_ui_demo.py`
 
+## 全流程展示
+
+如果要用于中期答辩或评审展示，可以生成一份统一的中文操作手册，把以下内容串成一条主线：
+
+- API 可用性与冒烟检查
+- HITL 候选对比界面
+- Issue #151 回放/审计证据
+- Issue #174 / #152 实验与报告证据
+
+生成展示包：
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py
+```
+
+生成文件：
+
+- `reports/showcase/full_flow_showcase_guide.md`
+- `reports/showcase/full_flow_showcase_manifest.json`
+
+如果希望在生成手册前顺带刷新一次相关产物，可使用：
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py --prepare
+```
+
 ## Issue #142 Candidate Compare Demo
 
 Run reproducible in-process preview (no extra dependency):

--- a/reports/showcase/full_flow_showcase_guide.md
+++ b/reports/showcase/full_flow_showcase_guide.md
@@ -1,0 +1,63 @@
+# 全流程展示操作手册
+
+## 1. 一次性准备
+
+- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_demo.py --port 8000 --exit-after-smoke`
+- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_w12_issue151_demo_audit.py`
+- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/generate_w12_issue174_midterm_pack.py`
+- `UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/generate_w12_issue152_release_pack.py`
+
+## 2. 启动长期运行界面
+
+- API 演示服务：`UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_demo.py --port 8000 --no-smoke-test`
+- HITL 候选对比服务：`UV_CACHE_DIR=/tmp/uv-cache uv run python examples/run_hitl_candidate_ui_demo.py --serve --port 8012`
+
+## 3. 现场展示顺序
+
+1. 打开 `http://127.0.0.1:8000/docs` 和 `http://127.0.0.1:8000/health`，先展示服务可用性。
+2. 打开 `http://127.0.0.1:8012/ui/tasks/task_demo_142`，展示候选对比、排序、风险/成本和人工决策界面。
+3. 打开 `http://127.0.0.1:8012/ui/tasks/task_demo_142/events`，展示种子 HITL 任务的事件时间线。
+4. 打开 `output/demo/w12-issue-151/replay-record-001-six-stage-hitl.md`，讲解端到端回放。
+5. 打开 `output/demo/w12-issue-151/replay-record-002-tool-fallback.md`，讲解 patch/recovery 与工具切换。
+6. 打开 `reports/w12-issue-174/midterm_experiment_chapter.md` 和 `reports/w12-issue-152/three_week_report.md`，用实验与报告证据收尾。
+
+## 4. 关键设计点检查清单
+
+### 1. FSM 与 HITL 暂停/恢复
+
+- 展示入口：`http://127.0.0.1:8012/ui/tasks/task_demo_142`
+- 检查点：必须能看到候选对比、默认推荐、人工决策提交，以及决策后状态继续推进。
+- 证据：
+  - `output/demo/w12-issue-151/replay-record-001-six-stage-hitl.md` [已就绪] - WAITING_ENTER -> DECISION_APPLIED -> WAITING_EXIT 回放记录
+  - `output/demo/w12-issue-151/release-validation.md` [已就绪] - Issue #151 审计门禁摘要
+
+### 2. 分层恢复与工具回退
+
+- 展示入口：`output/demo/w12-issue-151/replay-record-002-tool-fallback.md`
+- 检查点：要展示 REPLACE_TOOL 或路由决策字段，并解释为什么回退不破坏系统契约。
+- 证据：
+  - `output/demo/w12-issue-151/replay-record-002-tool-fallback.md` [已就绪] - from_tool -> to_tool 回放记录
+  - `scripts/w12-issue-150-dual-route-fallback.md` [已就绪] - 运行时回退触发条件与审计字段
+
+### 3. 可审计性与可回放
+
+- 展示入口：`http://127.0.0.1:8000/ui/tasks/<task_id>/events`
+- 检查点：时间线页面与 markdown 回放记录必须在事件顺序和任务结果上保持一致。
+- 证据：
+  - `output/demo/w12-issue-151/logs/int_s6_patch_decision_replay_done.jsonl` [已就绪] - 原始可回放事件日志
+  - `reports/w12-issue-152/artifact_evidence_index.csv` [已就绪] - 报告追溯用产物索引
+
+### 4. 实验与报告证据
+
+- 展示入口：`reports/w12-issue-174/midterm_experiment_chapter.md`
+- 检查点：要明确说明项目已具备演示与报告能力，但因为 #149 门禁仍阻断，所以还不能宣称正式可发布。
+- 证据：
+  - `reports/w12-issue-174/midterm_experiment_chapter.md` [已就绪] - 中期实验章节草稿
+  - `reports/w12-issue-152/three_week_report.md` [已就绪] - 三周成果总报告
+  - `reports/w12-issue-152/release_candidate_draft.md` [已就绪] - RC 草案与阻断项摘要
+
+## 5. 讲解备注
+
+- 最优主线是：可用性 -> HITL -> 回放/审计 -> 回退机制 -> 实验/报告证据。
+- 不要夸大当前实验结果。准确表述应是：系统已经具备演示能力和证据整理能力，但正式发布仍受离线门禁缺口阻断。
+- 如果时间不足，可以只保留第 1、2、4、6 步。

--- a/reports/showcase/full_flow_showcase_manifest.json
+++ b/reports/showcase/full_flow_showcase_manifest.json
@@ -1,0 +1,99 @@
+{
+  "generated_at": "2026-03-19T09:18:19.346529+00:00",
+  "goal": "\u7528\u4e8e\u5c55\u793a API\u3001HITL\u3001\u5ba1\u8ba1\u56de\u653e\u3001\u6062\u590d\u673a\u5236\u4e0e\u5b9e\u9a8c\u62a5\u544a\u8bc1\u636e\u7684\u5168\u6d41\u7a0b\u6f14\u793a\u5305\u3002",
+  "servers": {
+    "api_demo": {
+      "command": "UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_demo.py --port 8000 --no-smoke-test",
+      "url_docs": "http://127.0.0.1:8000/docs",
+      "url_health": "http://127.0.0.1:8000/health",
+      "url_dashboard": "http://127.0.0.1:8000/ui"
+    },
+    "hitl_compare": {
+      "command": "UV_CACHE_DIR=/tmp/uv-cache uv run python examples/run_hitl_candidate_ui_demo.py --serve --port 8012",
+      "url_task": "http://127.0.0.1:8012/ui/tasks/task_demo_142",
+      "url_events": "http://127.0.0.1:8012/ui/tasks/task_demo_142/events",
+      "url_pending_action": "http://127.0.0.1:8012/pending-actions/pa_demo_142"
+    }
+  },
+  "prepare_commands": [
+    "UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_demo.py --port 8000 --exit-after-smoke",
+    "UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_w12_issue151_demo_audit.py",
+    "UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/generate_w12_issue174_midterm_pack.py",
+    "UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/generate_w12_issue152_release_pack.py"
+  ],
+  "design_points": [
+    {
+      "name": "FSM \u4e0e HITL \u6682\u505c/\u6062\u590d",
+      "demo_entry": "http://127.0.0.1:8012/ui/tasks/task_demo_142",
+      "evidence": [
+        {
+          "path": "output/demo/w12-issue-151/replay-record-001-six-stage-hitl.md",
+          "exists": true,
+          "role": "WAITING_ENTER -> DECISION_APPLIED -> WAITING_EXIT \u56de\u653e\u8bb0\u5f55"
+        },
+        {
+          "path": "output/demo/w12-issue-151/release-validation.md",
+          "exists": true,
+          "role": "Issue #151 \u5ba1\u8ba1\u95e8\u7981\u6458\u8981"
+        }
+      ],
+      "checkpoint": "\u5fc5\u987b\u80fd\u770b\u5230\u5019\u9009\u5bf9\u6bd4\u3001\u9ed8\u8ba4\u63a8\u8350\u3001\u4eba\u5de5\u51b3\u7b56\u63d0\u4ea4\uff0c\u4ee5\u53ca\u51b3\u7b56\u540e\u72b6\u6001\u7ee7\u7eed\u63a8\u8fdb\u3002"
+    },
+    {
+      "name": "\u5206\u5c42\u6062\u590d\u4e0e\u5de5\u5177\u56de\u9000",
+      "demo_entry": "output/demo/w12-issue-151/replay-record-002-tool-fallback.md",
+      "evidence": [
+        {
+          "path": "output/demo/w12-issue-151/replay-record-002-tool-fallback.md",
+          "exists": true,
+          "role": "from_tool -> to_tool \u56de\u653e\u8bb0\u5f55"
+        },
+        {
+          "path": "scripts/w12-issue-150-dual-route-fallback.md",
+          "exists": true,
+          "role": "\u8fd0\u884c\u65f6\u56de\u9000\u89e6\u53d1\u6761\u4ef6\u4e0e\u5ba1\u8ba1\u5b57\u6bb5"
+        }
+      ],
+      "checkpoint": "\u8981\u5c55\u793a REPLACE_TOOL \u6216\u8def\u7531\u51b3\u7b56\u5b57\u6bb5\uff0c\u5e76\u89e3\u91ca\u4e3a\u4ec0\u4e48\u56de\u9000\u4e0d\u7834\u574f\u7cfb\u7edf\u5951\u7ea6\u3002"
+    },
+    {
+      "name": "\u53ef\u5ba1\u8ba1\u6027\u4e0e\u53ef\u56de\u653e",
+      "demo_entry": "http://127.0.0.1:8000/ui/tasks/<task_id>/events",
+      "evidence": [
+        {
+          "path": "output/demo/w12-issue-151/logs/int_s6_patch_decision_replay_done.jsonl",
+          "exists": true,
+          "role": "\u539f\u59cb\u53ef\u56de\u653e\u4e8b\u4ef6\u65e5\u5fd7"
+        },
+        {
+          "path": "reports/w12-issue-152/artifact_evidence_index.csv",
+          "exists": true,
+          "role": "\u62a5\u544a\u8ffd\u6eaf\u7528\u4ea7\u7269\u7d22\u5f15"
+        }
+      ],
+      "checkpoint": "\u65f6\u95f4\u7ebf\u9875\u9762\u4e0e markdown \u56de\u653e\u8bb0\u5f55\u5fc5\u987b\u5728\u4e8b\u4ef6\u987a\u5e8f\u548c\u4efb\u52a1\u7ed3\u679c\u4e0a\u4fdd\u6301\u4e00\u81f4\u3002"
+    },
+    {
+      "name": "\u5b9e\u9a8c\u4e0e\u62a5\u544a\u8bc1\u636e",
+      "demo_entry": "reports/w12-issue-174/midterm_experiment_chapter.md",
+      "evidence": [
+        {
+          "path": "reports/w12-issue-174/midterm_experiment_chapter.md",
+          "exists": true,
+          "role": "\u4e2d\u671f\u5b9e\u9a8c\u7ae0\u8282\u8349\u7a3f"
+        },
+        {
+          "path": "reports/w12-issue-152/three_week_report.md",
+          "exists": true,
+          "role": "\u4e09\u5468\u6210\u679c\u603b\u62a5\u544a"
+        },
+        {
+          "path": "reports/w12-issue-152/release_candidate_draft.md",
+          "exists": true,
+          "role": "RC \u8349\u6848\u4e0e\u963b\u65ad\u9879\u6458\u8981"
+        }
+      ],
+      "checkpoint": "\u8981\u660e\u786e\u8bf4\u660e\u9879\u76ee\u5df2\u5177\u5907\u6f14\u793a\u4e0e\u62a5\u544a\u80fd\u529b\uff0c\u4f46\u56e0\u4e3a #149 \u95e8\u7981\u4ecd\u963b\u65ad\uff0c\u6240\u4ee5\u8fd8\u4e0d\u80fd\u5ba3\u79f0\u6b63\u5f0f\u53ef\u53d1\u5e03\u3002"
+    }
+  ]
+}

--- a/scripts/build_full_flow_showcase.py
+++ b/scripts/build_full_flow_showcase.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_DIR = Path("reports/showcase")
+UV_CACHE_DIR = "/tmp/uv-cache"
+
+
+def _run(cmd: list[str]) -> None:
+    env = os.environ.copy()
+    env["UV_CACHE_DIR"] = UV_CACHE_DIR
+    completed = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({' '.join(cmd)}):\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+        )
+
+
+def _artifact_entry(path: str, *, role: str) -> dict[str, Any]:
+    resolved = REPO_ROOT / path
+    return {
+        "path": path,
+        "exists": resolved.exists(),
+        "role": role,
+    }
+
+
+def build_showcase_manifest(*, api_port: int, hitl_port: int) -> dict[str, Any]:
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "goal": "用于展示 API、HITL、审计回放、恢复机制与实验报告证据的全流程演示包。",
+        "servers": {
+            "api_demo": {
+                "command": f"UV_CACHE_DIR={UV_CACHE_DIR} uv run python scripts/run_demo.py --port {api_port} --no-smoke-test",
+                "url_docs": f"http://127.0.0.1:{api_port}/docs",
+                "url_health": f"http://127.0.0.1:{api_port}/health",
+                "url_dashboard": f"http://127.0.0.1:{api_port}/ui",
+            },
+            "hitl_compare": {
+                "command": f"UV_CACHE_DIR={UV_CACHE_DIR} uv run python examples/run_hitl_candidate_ui_demo.py --serve --port {hitl_port}",
+                "url_task": f"http://127.0.0.1:{hitl_port}/ui/tasks/task_demo_142",
+                "url_events": f"http://127.0.0.1:{hitl_port}/ui/tasks/task_demo_142/events",
+                "url_pending_action": f"http://127.0.0.1:{hitl_port}/pending-actions/pa_demo_142",
+            },
+        },
+        "prepare_commands": [
+            f"UV_CACHE_DIR={UV_CACHE_DIR} uv run python scripts/run_demo.py --port {api_port} --exit-after-smoke",
+            f"UV_CACHE_DIR={UV_CACHE_DIR} uv run python scripts/run_w12_issue151_demo_audit.py",
+            f"UV_CACHE_DIR={UV_CACHE_DIR} uv run python scripts/generate_w12_issue174_midterm_pack.py",
+            f"UV_CACHE_DIR={UV_CACHE_DIR} uv run python scripts/generate_w12_issue152_release_pack.py",
+        ],
+        "design_points": [
+            {
+                "name": "FSM 与 HITL 暂停/恢复",
+                "demo_entry": f"http://127.0.0.1:{hitl_port}/ui/tasks/task_demo_142",
+                "evidence": [
+                    _artifact_entry(
+                        "output/demo/w12-issue-151/replay-record-001-six-stage-hitl.md",
+                        role="WAITING_ENTER -> DECISION_APPLIED -> WAITING_EXIT 回放记录",
+                    ),
+                    _artifact_entry(
+                        "output/demo/w12-issue-151/release-validation.md",
+                        role="Issue #151 审计门禁摘要",
+                    ),
+                ],
+                "checkpoint": "必须能看到候选对比、默认推荐、人工决策提交，以及决策后状态继续推进。",
+            },
+            {
+                "name": "分层恢复与工具回退",
+                "demo_entry": "output/demo/w12-issue-151/replay-record-002-tool-fallback.md",
+                "evidence": [
+                    _artifact_entry(
+                        "output/demo/w12-issue-151/replay-record-002-tool-fallback.md",
+                        role="from_tool -> to_tool 回放记录",
+                    ),
+                    _artifact_entry(
+                        "scripts/w12-issue-150-dual-route-fallback.md",
+                        role="运行时回退触发条件与审计字段",
+                    ),
+                ],
+                "checkpoint": "要展示 REPLACE_TOOL 或路由决策字段，并解释为什么回退不破坏系统契约。",
+            },
+            {
+                "name": "可审计性与可回放",
+                "demo_entry": f"http://127.0.0.1:{api_port}/ui/tasks/<task_id>/events",
+                "evidence": [
+                    _artifact_entry(
+                        "output/demo/w12-issue-151/logs/int_s6_patch_decision_replay_done.jsonl",
+                        role="原始可回放事件日志",
+                    ),
+                    _artifact_entry(
+                        "reports/w12-issue-152/artifact_evidence_index.csv",
+                        role="报告追溯用产物索引",
+                    ),
+                ],
+                "checkpoint": "时间线页面与 markdown 回放记录必须在事件顺序和任务结果上保持一致。",
+            },
+            {
+                "name": "实验与报告证据",
+                "demo_entry": "reports/w12-issue-174/midterm_experiment_chapter.md",
+                "evidence": [
+                    _artifact_entry(
+                        "reports/w12-issue-174/midterm_experiment_chapter.md",
+                        role="中期实验章节草稿",
+                    ),
+                    _artifact_entry(
+                        "reports/w12-issue-152/three_week_report.md",
+                        role="三周成果总报告",
+                    ),
+                    _artifact_entry(
+                        "reports/w12-issue-152/release_candidate_draft.md",
+                        role="RC 草案与阻断项摘要",
+                    ),
+                ],
+                "checkpoint": "要明确说明项目已具备演示与报告能力，但因为 #149 门禁仍阻断，所以还不能宣称正式可发布。",
+            },
+        ],
+    }
+
+
+def render_showcase_guide(manifest: dict[str, Any]) -> str:
+    api_demo = manifest["servers"]["api_demo"]
+    hitl_compare = manifest["servers"]["hitl_compare"]
+    lines = [
+        "# 全流程展示操作手册",
+        "",
+        "## 1. 一次性准备",
+        "",
+    ]
+    for cmd in manifest["prepare_commands"]:
+        lines.append(f"- `{cmd}`")
+
+    lines.extend(
+        [
+            "",
+            "## 2. 启动长期运行界面",
+            "",
+            f"- API 演示服务：`{api_demo['command']}`",
+            f"- HITL 候选对比服务：`{hitl_compare['command']}`",
+            "",
+            "## 3. 现场展示顺序",
+            "",
+            f"1. 打开 `{api_demo['url_docs']}` 和 `{api_demo['url_health']}`，先展示服务可用性。",
+            f"2. 打开 `{hitl_compare['url_task']}`，展示候选对比、排序、风险/成本和人工决策界面。",
+            f"3. 打开 `{hitl_compare['url_events']}`，展示种子 HITL 任务的事件时间线。",
+            "4. 打开 `output/demo/w12-issue-151/replay-record-001-six-stage-hitl.md`，讲解端到端回放。",
+            "5. 打开 `output/demo/w12-issue-151/replay-record-002-tool-fallback.md`，讲解 patch/recovery 与工具切换。",
+            "6. 打开 `reports/w12-issue-174/midterm_experiment_chapter.md` 和 `reports/w12-issue-152/three_week_report.md`，用实验与报告证据收尾。",
+            "",
+            "## 4. 关键设计点检查清单",
+            "",
+        ]
+    )
+
+    for index, item in enumerate(manifest["design_points"], start=1):
+        lines.append(f"### {index}. {item['name']}")
+        lines.append("")
+        lines.append(f"- 展示入口：`{item['demo_entry']}`")
+        lines.append(f"- 检查点：{item['checkpoint']}")
+        lines.append("- 证据：")
+        for evidence in item["evidence"]:
+            status = "已就绪" if evidence["exists"] else "缺失"
+            lines.append(f"  - `{evidence['path']}` [{status}] - {evidence['role']}")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## 5. 讲解备注",
+            "",
+            "- 最优主线是：可用性 -> HITL -> 回放/审计 -> 回退机制 -> 实验/报告证据。",
+            "- 不要夸大当前实验结果。准确表述应是：系统已经具备演示能力和证据整理能力，但正式发布仍受离线门禁缺口阻断。",
+            "- 如果时间不足，可以只保留第 1、2、4、6 步。",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def build_showcase_bundle(
+    *,
+    output_dir: Path,
+    api_port: int,
+    hitl_port: int,
+    prepare: bool,
+) -> dict[str, Path]:
+    if prepare:
+        _run(
+            [
+                "uv",
+                "run",
+                "python",
+                "scripts/run_demo.py",
+                "--port",
+                str(api_port),
+                "--exit-after-smoke",
+            ]
+        )
+        _run(["uv", "run", "python", "scripts/run_w12_issue151_demo_audit.py"])
+        _run(["uv", "run", "python", "scripts/generate_w12_issue174_midterm_pack.py"])
+        _run(["uv", "run", "python", "scripts/generate_w12_issue152_release_pack.py"])
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = build_showcase_manifest(api_port=api_port, hitl_port=hitl_port)
+    manifest_path = output_dir / "full_flow_showcase_manifest.json"
+    guide_path = output_dir / "full_flow_showcase_guide.md"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=True, indent=2), encoding="utf-8")
+    guide_path.write_text(render_showcase_guide(manifest), encoding="utf-8")
+    return {"manifest": manifest_path, "guide": guide_path}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build a full-flow showcase guide and optional preparation bundle."
+    )
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--api-port", type=int, default=8000)
+    parser.add_argument("--hitl-port", type=int, default=8012)
+    parser.add_argument(
+        "--prepare",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run smoke/audit/report generation before writing the showcase bundle.",
+    )
+    args = parser.parse_args()
+
+    result = build_showcase_bundle(
+        output_dir=args.output_dir,
+        api_port=args.api_port,
+        hitl_port=args.hitl_port,
+        prepare=args.prepare,
+    )
+    print(json.dumps({key: str(value) for key, value in result.items()}, ensure_ascii=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_w12_issue151_demo_audit.py
+++ b/scripts/run_w12_issue151_demo_audit.py
@@ -67,17 +67,16 @@ def _copy_log(task_id: str) -> Path:
     return dst
 
 
-def _write_replay_markdown(scenario: DemoScenario, events: list[dict], log_copy: Path) -> None:
-    replay_path = OUTPUT_ROOT / scenario.replay_filename
+def build_replay_markdown(scenario: DemoScenario, events: list[dict], log_copy: Path) -> str:
     event_types = [str(event.get("event_type")) for event in events]
     lines = [
-        f"# Replay Record: {scenario.name}",
+        f"# 回放记录：{scenario.name}",
         "",
-        f"- Task ID: `{scenario.task_id}`",
-        f"- Source test: `{scenario.pytest_target}`",
-        f"- Log copy: `{log_copy}`",
+        f"- Task ID：`{scenario.task_id}`",
+        f"- 来源测试：`{scenario.pytest_target}`",
+        f"- 日志副本：`{log_copy}`",
         "",
-        "## Event Sequence",
+        "## 事件序列",
         "",
     ]
     for index, event in enumerate(events, start=1):
@@ -88,18 +87,22 @@ def _write_replay_markdown(scenario: DemoScenario, events: list[dict], log_copy:
     lines.extend(
         [
             "",
-            "## Checkpoints",
+            "## 检查点",
             "",
-            f"- Total events: `{len(events)}`",
-            f"- Contains WAITING_ENTER: `{ 'WAITING_ENTER' in event_types }`",
-            f"- Contains DECISION_APPLIED: `{ 'DECISION_APPLIED' in event_types }`",
-            f"- Contains WAITING_EXIT: `{ 'WAITING_EXIT' in event_types }`",
-            f"- Contains REPLACE_TOOL: `{ 'REPLACE_TOOL' in event_types }`",
+            f"- 事件总数：`{len(events)}`",
+            f"- 包含 WAITING_ENTER：`{'WAITING_ENTER' in event_types}`",
+            f"- 包含 DECISION_APPLIED：`{'DECISION_APPLIED' in event_types}`",
+            f"- 包含 WAITING_EXIT：`{'WAITING_EXIT' in event_types}`",
+            f"- 包含 REPLACE_TOOL：`{'REPLACE_TOOL' in event_types}`",
             "",
         ]
     )
+    return "\n".join(lines)
 
-    replay_path.write_text("\n".join(lines), encoding="utf-8")
+
+def _write_replay_markdown(scenario: DemoScenario, events: list[dict], log_copy: Path) -> None:
+    replay_path = OUTPUT_ROOT / scenario.replay_filename
+    replay_path.write_text(build_replay_markdown(scenario, events, log_copy), encoding="utf-8")
 
 
 def _extract_release_checks(six_stage_events: list[dict], fallback_events: list[dict]) -> dict[str, bool]:
@@ -135,29 +138,28 @@ def _extract_release_checks(six_stage_events: list[dict], fallback_events: list[
     }
 
 
-def _write_release_validation(checks: dict[str, bool]) -> None:
-    release_path = OUTPUT_ROOT / "release-validation.md"
+def build_release_validation_markdown(checks: dict[str, bool]) -> str:
     known_issues = [
-        "Demo scenarios are test-driven with mock runners; real remote services (NIM/Nextflow) are not required in this replay package.",
-        "Event ordering relies on timestamp + append sequence; cross-process log writes should keep a single writer per task ID.",
+        "演示场景由测试驱动并使用 mock runner；该回放证据包不依赖真实远端服务（NIM/Nextflow）。",
+        "事件顺序依赖时间戳 + 追加序列；跨进程写日志时应保证每个 task ID 仅单写者。",
     ]
     lines = [
-        "# Release Validation (Issue #151)",
+        "# 发布验证（Issue #151）",
         "",
-        "## Scope",
+        "## 范围",
         "",
-        "- Candidate generation -> HITL decision -> execution recovery -> terminal output",
-        "- Audit replay chain verification: `PendingAction -> Decision -> EventLog`",
-        "- Tool fallback replay verification",
+        "- 候选生成 -> HITL 决策 -> 执行恢复 -> 终态输出",
+        "- 审计回放链校验：`PendingAction -> Decision -> EventLog`",
+        "- 工具回退回放校验",
         "",
-        "## Command Set",
+        "## 命令集合",
         "",
         "```bash",
         "uv run pytest tests/integration/test_s6_control_layer_e2e.py::test_six_stage_waiting_patch_decision_replay_to_done -q",
         "uv run pytest tests/integration/test_recovery_layered_patch.py::test_layered_patch_promotes_remote_to_local_tool_level -q",
         "```",
         "",
-        "## Gate Result",
+        "## 门禁结果",
         "",
     ]
     for key, value in checks.items():
@@ -166,14 +168,18 @@ def _write_release_validation(checks: dict[str, bool]) -> None:
     lines.extend(
         [
             "",
-            "## Known Issues",
+            "## 已知问题",
             "",
         ]
     )
     for item in known_issues:
         lines.append(f"- {item}")
+    return "\n".join(lines)
 
-    release_path.write_text("\n".join(lines), encoding="utf-8")
+
+def _write_release_validation(checks: dict[str, bool]) -> None:
+    release_path = OUTPUT_ROOT / "release-validation.md"
+    release_path.write_text(build_release_validation_markdown(checks), encoding="utf-8")
 
 
 def main() -> int:

--- a/tests/unit/test_build_full_flow_showcase.py
+++ b/tests/unit/test_build_full_flow_showcase.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "build_full_flow_showcase.py"
+    spec = importlib.util.spec_from_file_location("full_showcase", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_showcase_bundle_writes_manifest_and_guide(tmp_path: Path) -> None:
+    module = _load_module()
+
+    result = module.build_showcase_bundle(
+        output_dir=tmp_path,
+        api_port=18000,
+        hitl_port=18012,
+        prepare=False,
+    )
+
+    manifest = json.loads(result["manifest"].read_text(encoding="utf-8"))
+    guide = result["guide"].read_text(encoding="utf-8")
+
+    assert manifest["servers"]["api_demo"]["url_docs"] == "http://127.0.0.1:18000/docs"
+    assert manifest["servers"]["hitl_compare"]["url_task"] == "http://127.0.0.1:18012/ui/tasks/task_demo_142"
+    assert "全流程展示操作手册" in guide
+    assert "关键设计点检查清单" in guide
+    assert "reports/w12-issue-174/midterm_experiment_chapter.md" in guide

--- a/tests/unit/test_run_w12_issue151_demo_audit.py
+++ b/tests/unit/test_run_w12_issue151_demo_audit.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "run_w12_issue151_demo_audit.py"
+    spec = importlib.util.spec_from_file_location("issue151_demo_audit", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_issue151_markdown_templates_are_chinese(tmp_path: Path) -> None:
+    module = _load_module()
+    scenario = module.DemoScenario(
+        name="six_stage_hitl_replay",
+        pytest_target="tests/integration/test_s6_control_layer_e2e.py::test_case",
+        task_id="task_demo_151",
+        replay_filename="replay.md",
+    )
+    events = [
+        {"event_type": "WAITING_ENTER", "ts": "2026-03-19T09:00:00+00:00", "summary": "Enter waiting state"},
+        {"event_type": "DECISION_APPLIED", "ts": "2026-03-19T09:00:01+00:00", "summary": "Decision applied"},
+        {"event_type": "WAITING_EXIT", "ts": "2026-03-19T09:00:02+00:00", "summary": "Exit waiting state"},
+    ]
+
+    replay = module.build_replay_markdown(scenario, events, tmp_path / "task_demo_151.jsonl")
+    release = module.build_release_validation_markdown(
+        {
+            "audit_chain_pendingaction_decision_eventlog": True,
+            "tool_fallback_switch_recorded": True,
+            "e2e_flow_reaches_done": True,
+        }
+    )
+
+    assert "# 回放记录：" in replay
+    assert "## 事件序列" in replay
+    assert "## 检查点" in replay
+    assert "# 发布验证（Issue #151）" in release
+    assert "## 范围" in release
+    assert "## 命令集合" in release
+    assert "## 门禁结果" in release
+    assert "## 已知问题" in release


### PR DESCRIPTION
## 变更概述
本 PR 为项目补充一套**中文版全流程展示（showcase）方案**，用于中期答辩、项目评审和本地演示排练。

这次改动**不涉及运行时语义、FSM、Agent 边界或恢复流程实现**，核心目标是把已经存在的 demo / HITL / 审计回放 / 恢复证据 / 实验报告产物，整理成一条可以稳定复现、便于讲解、适合现场展示的主线，并确保展示过程中关键证据文件也能以中文形式直接使用。

## 背景与动机
当前仓库中的演示能力已经具备，但入口分散在多个位置：
- `scripts/run_demo.py`：API 就绪与冒烟检查
- `examples/run_hitl_candidate_ui_demo.py`：HITL 候选对比界面
- `scripts/run_w12_issue151_demo_audit.py`：端到端审计回放与工具回退证据
- `reports/w12-issue-174/*`、`reports/w12-issue-152/*`：实验章节与收官/RC 证据

这些能力单独存在时没有问题，但在现场展示时存在三个明显风险：
1. 讲解顺序依赖人工记忆，容易漏掉关键设计点。
2. 现有总控说明偏英文，不适合直接用于中文答辩或评审演示。
3. 即使总控手册是中文，`#151` 的回放/验证产物如果仍是英文，现场展示时仍会出现语言断层。

因此本 PR 的目标是补一个**总控展示脚本 + 中文展示手册 + issue #151 中文回放模板**，把演示动作和证据路径固定下来。

## 本次改动内容
### 1. 新增总控展示脚本
新增：`scripts/build_full_flow_showcase.py`

该脚本会生成两类产物：
- `reports/showcase/full_flow_showcase_guide.md`
- `reports/showcase/full_flow_showcase_manifest.json`

脚本定义了一条固定展示主线，串联以下内容：
- API readiness：`/docs`、`/health`
- HITL 候选对比 UI
- Issue #151 的端到端回放与审计证据
- 工具回退 / 恢复链路证据
- Issue #174 / #152 的实验与报告证据

同时支持：
- 默认模式：只生成展示手册与 manifest
- `--prepare` 模式：在生成手册前顺带刷新 smoke / audit / report 相关产物

### 2. showcase 输出改为中文版
生成出来的 showcase 文案已经统一改为中文，包括：
- 手册标题
- 章节标题
- 现场展示顺序
- 关键设计点检查清单
- 证据项状态标记
- 讲解备注

这样可以直接拿来作为中期答辩或评审展示的操作稿，不需要再额外翻译。

### 3. issue #151 输出模板中文化
更新：`scripts/run_w12_issue151_demo_audit.py`

把以下产物的模板输出统一改为中文：
- `output/demo/w12-issue-151/release-validation.md`
- `output/demo/w12-issue-151/replay-record-001-six-stage-hitl.md`
- `output/demo/w12-issue-151/replay-record-002-tool-fallback.md`

为避免之后再次被英文模板刷回去，这次额外把文案抽成可测试的渲染函数，并新增聚焦单测：
- `tests/unit/test_run_w12_issue151_demo_audit.py`

这一步的意义是：不只是 showcase 总控手册中文，而是展示时真正打开的关键证据文件也能保持中文。

### 4. README 增加入口并全量中文化
更新：`examples/README_DEMO.md`

本次除了新增 showcase 入口外，也将整份 `README_DEMO.md` 统一改为中文说明，包括：
- 文档标题与章节标题
- Quick Start / 清理 / 手动 smoke 等操作说明
- Issue #142 候选对比演示说明
- 常用参数说明

同时保留原有命令、路径和访问 URL，不改变使用方式。

这样后续使用者不需要先读源码，也能从 demo 文档直接发现这条展示链路，并且整份演示说明可以直接用于中文展示场景。

### 5. 增加聚焦单测
新增：
- `tests/unit/test_build_full_flow_showcase.py`
- `tests/unit/test_run_w12_issue151_demo_audit.py`

测试覆盖点：
- guide 与 manifest 能正常生成
- API/HITL URL 使用传入端口正确拼接
- 生成内容中包含中文版标题与检查清单关键字
- issue #151 回放/验证模板保持中文输出

## 影响范围
本 PR 仅影响展示与文档组织层，不改变业务逻辑：
- 不新增 FSM 状态
- 不修改 HITL 决策语义
- 不改变 Planner / Executor / Safety / Summarizer 边界
- 不改写现有实验结论与门禁逻辑

## 新增/修改文件
- `scripts/build_full_flow_showcase.py`
- `tests/unit/test_build_full_flow_showcase.py`
- `scripts/run_w12_issue151_demo_audit.py`
- `tests/unit/test_run_w12_issue151_demo_audit.py`
- `reports/showcase/full_flow_showcase_guide.md`
- `reports/showcase/full_flow_showcase_manifest.json`
- `examples/README_DEMO.md`

## 使用方式
生成中文版展示包：
```bash
UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py
```

在生成前刷新相关产物：
```bash
UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py --prepare
```

单独刷新 issue #151 中文回放/验证产物：
```bash
UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/run_w12_issue151_demo_audit.py
```

## 验证
```bash
UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/test_build_full_flow_showcase.py tests/unit/test_run_w12_issue151_demo_audit.py -q
python -m py_compile scripts/build_full_flow_showcase.py
python -m py_compile scripts/run_w12_issue151_demo_audit.py
UV_CACHE_DIR=/tmp/uv-cache uv run python scripts/build_full_flow_showcase.py
```

## 预期收益
合入后，项目可以用一条清晰的中文主线来展示：
1. 系统服务已启动且可访问
2. HITL 决策界面可操作
3. 关键审计链可以回放，且回放证据文件本身也是中文
4. 恢复/回退机制有证据支撑
5. 实验与报告产物可作为收尾证据

这能显著降低现场展示的组织成本，也能减少“功能已经有，但讲不全/讲不顺”的风险。
