### PR TITLE
feat(experiment): freeze issue #209 baseline assets

### DIFF
--- a/configs/experiments/w13_issue209_baseline_freeze.json
+++ b/configs/experiments/w13_issue209_baseline_freeze.json
@@ -1,0 +1,206 @@
+{
+  "issue_id": 209,
+  "freeze_id": "issue209-baseline-freeze-20260326",
+  "output_root": "output/experiment/w13-expr-0",
+  "task_set_version": "issue209-taskset-v1",
+  "difficulty_scheme_version": "issue209-difficulty-v1",
+  "source_task_config_path": "configs/experiments/w12_issue171_vertical_a0_a6.json",
+  "source_dataset_freeze": {
+    "freeze_id": "issue170-remote-batch3-20260316",
+    "manifest_path": "output/experiment/w12-expr-1/issue170-remote-batch3-20260316/dataset_manifest.json",
+    "note": "Reference freeze id kept for experiment lineage even if the manifest is not present in the local workspace."
+  },
+  "high_cost_rules": [
+    {
+      "rule_id": "structure_mapping",
+      "label": "结构映射",
+      "stage_ids": ["S2"],
+      "tool_ids": ["esmfold", "nim_esmfold", "openfold3"],
+      "capability_ids": ["structure_prediction"],
+      "cost_tier": "high",
+      "rationale": "Structure prediction calls consume the main high-cost model budget."
+    },
+    {
+      "rule_id": "structure_refinement",
+      "label": "结构条件下的序列精修",
+      "stage_ids": ["S4"],
+      "tool_ids": ["protein_mpnn"],
+      "capability_ids": ["sequence_design"],
+      "cost_tier": "high",
+      "rationale": "Iterative backbone-conditioned sequence refinement is expensive and recovery-heavy."
+    },
+    {
+      "rule_id": "heavy_objective_evaluation",
+      "label": "重型目标评估",
+      "stage_ids": ["S5"],
+      "tool_ids": [],
+      "capability_ids": ["objective_scoring"],
+      "cost_tier": "medium_high",
+      "rationale": "Heavy multi-objective scoring or remote property evaluation adds significant evaluation cost."
+    }
+  ],
+  "tasks": [
+    {
+      "task_key": "enzyme_like_fold",
+      "display_name": "Enzyme-Like Fold",
+      "difficulty": "medium",
+      "budget_tier": "standard",
+      "rationale": "Requires stable fold formation and balanced structural evidence, but objective pressure is moderate.",
+      "prompt": "Design a compact enzyme-like fold with stable core.",
+      "length_range": [40, 80]
+    },
+    {
+      "task_key": "binding_scaffold",
+      "display_name": "Binding Scaffold",
+      "difficulty": "hard",
+      "budget_tier": "high_cost_sensitive",
+      "rationale": "Pocket exposure and function-oriented constraints increase dependence on structure mapping and heavy evaluation.",
+      "prompt": "Generate a scaffold with exposed pocket for small-molecule binding.",
+      "length_range": [45, 95]
+    },
+    {
+      "task_key": "high_solubility",
+      "display_name": "High Solubility",
+      "difficulty": "easy",
+      "budget_tier": "low_cost_first",
+      "rationale": "Primary objective is comparatively soft and can often be filtered earlier with cheaper evidence.",
+      "prompt": "Favor high-solubility sequence candidates under mild constraints.",
+      "length_range": [35, 75]
+    },
+    {
+      "task_key": "secondary_balance",
+      "display_name": "Secondary Balance",
+      "difficulty": "medium",
+      "budget_tier": "standard",
+      "rationale": "Requires both sequence exploration and structure verification, but without the strongest downstream function pressure.",
+      "prompt": "Balance alpha/beta secondary elements for robust foldability.",
+      "length_range": [50, 90]
+    }
+  ],
+  "baselines": [
+    {
+      "id": "static_top1",
+      "label": "静态 Top-1",
+      "comparison_order": 0,
+      "implementation_status": "implemented",
+      "runtime_policy": "static_single_candidate",
+      "supports_current_repo": true,
+      "constraint_overrides": {
+        "plan_top_k": 1,
+        "patch_top_k": 1,
+        "replan_top_k": 1,
+        "enforce_candidate_validation": true,
+        "min_candidate_confidence": 0.0,
+        "high_cost_min_overall": 0.0,
+        "require_plan_confirm": false,
+        "require_patch_confirm": false
+      },
+      "output_fields": [
+        "success_rate",
+        "duration_ms_mean",
+        "high_cost_call_mean",
+        "patch_events_mean",
+        "replan_events_mean"
+      ],
+      "notes": "Pure static baseline with a single recommended candidate and no runtime adaptation."
+    },
+    {
+      "id": "fixed_threshold_gate",
+      "label": "固定阈值 gate",
+      "comparison_order": 1,
+      "implementation_status": "implemented",
+      "runtime_policy": "static_threshold_gate",
+      "supports_current_repo": true,
+      "constraint_overrides": {
+        "plan_top_k": 3,
+        "patch_top_k": 1,
+        "replan_top_k": 1,
+        "enforce_candidate_validation": true,
+        "min_candidate_confidence": 0.75,
+        "high_cost_min_overall": 0.85,
+        "require_plan_confirm": false,
+        "require_patch_confirm": false
+      },
+      "output_fields": [
+        "success_rate",
+        "first_pass_success_rate",
+        "high_cost_call_mean",
+        "patch_minimality_hit_rate",
+        "suffix_replan_prefix_preservation_rate"
+      ],
+      "notes": "Uses current fixed score/risk/cost thresholds without explicit runtime state."
+    },
+    {
+      "id": "dynamic_no_belief_state",
+      "label": "动态无 belief-state",
+      "comparison_order": 2,
+      "implementation_status": "planned",
+      "runtime_policy": "dynamic_observation_only",
+      "supports_current_repo": false,
+      "constraint_overrides": {
+        "plan_top_k": 3,
+        "patch_top_k": 3,
+        "replan_top_k": 3,
+        "enforce_candidate_validation": true,
+        "min_candidate_confidence": 0.75,
+        "high_cost_min_overall": 0.85
+      },
+      "output_fields": [
+        "success_rate",
+        "high_cost_call_mean",
+        "patch_events_mean",
+        "replan_events_mean",
+        "waiting_chain_complete_rate"
+      ],
+      "notes": "Reserved baseline for direct-observation dynamic action selection without persistent runtime_state."
+    },
+    {
+      "id": "lite_belief_state",
+      "label": "Lite belief-state",
+      "comparison_order": 3,
+      "implementation_status": "planned",
+      "runtime_policy": "lite_belief_state",
+      "supports_current_repo": false,
+      "constraint_overrides": {
+        "plan_top_k": 3,
+        "patch_top_k": 3,
+        "replan_top_k": 3,
+        "enforce_candidate_validation": true,
+        "min_candidate_confidence": 0.75,
+        "high_cost_min_overall": 0.85
+      },
+      "output_fields": [
+        "success_rate",
+        "high_cost_call_mean",
+        "high_cost_failure_mean",
+        "patch_events_mean",
+        "replan_events_mean"
+      ],
+      "notes": "Reserved baseline for the future runtime_state/belief_state contract with lightweight state estimation."
+    }
+  ],
+  "metrics_contract": {
+    "effect": [
+      "success_rate",
+      "first_pass_success_rate",
+      "executable_plan_rate"
+    ],
+    "cost": [
+      "duration_ms_mean",
+      "high_cost_call_mean",
+      "high_cost_failure_mean"
+    ],
+    "recovery": [
+      "patch_events_mean",
+      "replan_events_mean",
+      "suffix_replan_events_mean",
+      "patch_minimality_hit_rate",
+      "suffix_replan_prefix_preservation_rate"
+    ],
+    "governance": [
+      "waiting_chain_complete_rate",
+      "failure_traceable_rate"
+    ],
+    "task_stratification_key": "difficulty"
+  }
+}

--- a/scripts/evaluate_w12_vertical_issue171.py
+++ b/scripts/evaluate_w12_vertical_issue171.py
@@ -110,6 +110,7 @@ def main() -> int:
             row,
             tool_capability_map=tool_capability_map,
             requirement2_capability_map=requirement2_capability_map,
+            high_cost_rules=manifest.get("high_cost_rules"),
         )
         for row in runs
         if isinstance(row, dict)
@@ -132,6 +133,7 @@ def main() -> int:
         "patch_event_count",
         "replan_event_count",
         "duration_ms",
+        "high_cost_call_count",
     ]
     delta_rows = []
     for metric in delta_metrics:
@@ -150,6 +152,7 @@ def main() -> int:
 
     summary_rows = aggregated["summary_rows"]
     patch_rows = aggregated["patch_rows"]
+    high_cost_rows = aggregated["high_cost_rows"]
     requirement2_rows = aggregated["requirement2_rows"]
     abnormal_rows = aggregated["abnormal_rows"]
     gate_rows = aggregated["gate_rows"]
@@ -185,6 +188,12 @@ def main() -> int:
         "duration_ms_mean",
         "duration_ms_ci_low",
         "duration_ms_ci_high",
+        "high_cost_call_mean",
+        "high_cost_call_ci_low",
+        "high_cost_call_ci_high",
+        "high_cost_failure_mean",
+        "high_cost_failure_ci_low",
+        "high_cost_failure_ci_high",
         "patch_minimality_hit_rate",
         "suffix_replan_prefix_preservation_rate",
         "requirement2_sequence_core",
@@ -208,6 +217,14 @@ def main() -> int:
         "suffix_prefix_preservation_rate",
     ]
     write_csv(output_dir / "patch_replan_breakdown.csv", patch_rows, patch_fields)
+
+    high_cost_fields = [
+        "group_id",
+        "high_cost_calls_total",
+        "high_cost_failures_total",
+        "high_cost_rule_hits",
+    ]
+    write_csv(output_dir / "high_cost_breakdown.csv", high_cost_rows, high_cost_fields)
 
     requirement2_fields = ["group_id", "slice_type", "name", "covered", "usage_count"]
     write_csv(

--- a/scripts/freeze_w13_issue209_baseline_freeze.py
+++ b/scripts/freeze_w13_issue209_baseline_freeze.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.infra.w12_vertical_experiment import (
+    DEFAULT_HIGH_COST_RULES,
+    load_json,
+    normalize_high_cost_rules,
+    now_iso,
+    stable_hash,
+    write_json,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Freeze issue #209 high-cost step definitions, task set, and baseline matrix."
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/experiments/w13_issue209_baseline_freeze.json"),
+        help="Freeze config JSON path.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help="Override output root directory.",
+    )
+    parser.add_argument(
+        "--freeze-id",
+        type=str,
+        default=None,
+        help="Override freeze id.",
+    )
+    return parser.parse_args()
+
+
+def _normalize_tasks(raw_tasks: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_tasks, list) or not raw_tasks:
+        raise ValueError("config.tasks must be a non-empty list")
+
+    tasks: list[dict[str, Any]] = []
+    for raw in raw_tasks:
+        if not isinstance(raw, dict):
+            continue
+        task_key = raw.get("task_key")
+        difficulty = raw.get("difficulty")
+        if not isinstance(task_key, str) or not task_key:
+            raise ValueError("each task requires non-empty task_key")
+        if not isinstance(difficulty, str) or not difficulty:
+            raise ValueError(f"task {task_key} missing difficulty")
+        tasks.append(
+            {
+                "task_key": task_key,
+                "display_name": str(raw.get("display_name") or task_key),
+                "difficulty": difficulty,
+                "budget_tier": str(raw.get("budget_tier") or "standard"),
+                "rationale": str(raw.get("rationale") or ""),
+                "prompt": raw.get("prompt"),
+                "length_range": raw.get("length_range"),
+            }
+        )
+
+    if not tasks:
+        raise ValueError("config.tasks contains no valid task rows")
+    return tasks
+
+
+def _normalize_baselines(raw_baselines: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_baselines, list) or len(raw_baselines) != 4:
+        raise ValueError("config.baselines must contain exactly four rows")
+
+    required_ids = {
+        "static_top1",
+        "fixed_threshold_gate",
+        "dynamic_no_belief_state",
+        "lite_belief_state",
+    }
+    baselines: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, raw in enumerate(raw_baselines):
+        if not isinstance(raw, dict):
+            raise ValueError("baseline rows must be objects")
+        baseline_id = raw.get("id")
+        if not isinstance(baseline_id, str) or not baseline_id:
+            raise ValueError(f"baseline at index {index} missing id")
+        if baseline_id in seen_ids:
+            raise ValueError(f"duplicate baseline id: {baseline_id}")
+        seen_ids.add(baseline_id)
+        baselines.append(
+            {
+                "id": baseline_id,
+                "label": str(raw.get("label") or baseline_id),
+                "comparison_order": int(raw.get("comparison_order") or index),
+                "implementation_status": str(raw.get("implementation_status") or "planned"),
+                "runtime_policy": str(raw.get("runtime_policy") or "static"),
+                "supports_current_repo": bool(raw.get("supports_current_repo", False)),
+                "constraint_overrides": raw.get("constraint_overrides")
+                if isinstance(raw.get("constraint_overrides"), dict)
+                else {},
+                "output_fields": raw.get("output_fields")
+                if isinstance(raw.get("output_fields"), list)
+                else [],
+                "notes": str(raw.get("notes") or ""),
+            }
+        )
+
+    if seen_ids != required_ids:
+        missing = sorted(required_ids - seen_ids)
+        extra = sorted(seen_ids - required_ids)
+        raise ValueError(f"baseline ids mismatch missing={missing} extra={extra}")
+    return sorted(baselines, key=lambda item: item["comparison_order"])
+
+
+def _validate_source_task_alignment(
+    *,
+    source_task_config_path: Path | None,
+    frozen_tasks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if source_task_config_path is None:
+        return {
+            "source_task_config_path": None,
+            "aligned": False,
+            "source_task_keys": [],
+            "missing_in_freeze": [],
+            "extra_in_freeze": [row["task_key"] for row in frozen_tasks],
+        }
+
+    source_payload = load_json(source_task_config_path)
+    raw_tasks = source_payload.get("tasks")
+    source_task_keys: list[str] = []
+    if isinstance(raw_tasks, list):
+        source_task_keys = [
+            str(item.get("task_key"))
+            for item in raw_tasks
+            if isinstance(item, dict) and isinstance(item.get("task_key"), str)
+        ]
+    frozen_task_keys = [row["task_key"] for row in frozen_tasks]
+    missing_in_freeze = sorted(set(source_task_keys) - set(frozen_task_keys))
+    extra_in_freeze = sorted(set(frozen_task_keys) - set(source_task_keys))
+    return {
+        "source_task_config_path": str(source_task_config_path),
+        "aligned": not missing_in_freeze and not extra_in_freeze,
+        "source_task_keys": source_task_keys,
+        "missing_in_freeze": missing_in_freeze,
+        "extra_in_freeze": extra_in_freeze,
+    }
+
+
+def _build_report(manifest: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("# Issue #209 Baseline Freeze")
+    lines.append("")
+    lines.append(f"- freeze_id: `{manifest['freeze_id']}`")
+    lines.append(f"- generated_at: `{manifest['generated_at']}`")
+    lines.append(f"- task_set_version: `{manifest['task_set_version']}`")
+    lines.append(f"- difficulty_scheme_version: `{manifest['difficulty_scheme_version']}`")
+    lines.append("")
+    lines.append("## High-Cost Rules")
+    lines.append("")
+    lines.append("| rule_id | label | stage_ids | capability_ids | tool_ids | cost_tier |")
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for row in manifest["high_cost_rules"]:
+        lines.append(
+            "| {rule_id} | {label} | {stage_ids} | {capability_ids} | {tool_ids} | {cost_tier} |".format(
+                rule_id=row["rule_id"],
+                label=row["label"],
+                stage_ids=", ".join(row["stage_ids"]) or "-",
+                capability_ids=", ".join(row["capability_ids"]) or "-",
+                tool_ids=", ".join(row["tool_ids"]) or "-",
+                cost_tier=row["cost_tier"],
+            )
+        )
+    lines.append("")
+    lines.append("## Task Catalog")
+    lines.append("")
+    lines.append("| task_key | difficulty | budget_tier |")
+    lines.append("| --- | --- | --- |")
+    for row in manifest["tasks"]:
+        lines.append(
+            f"| {row['task_key']} | {row['difficulty']} | {row['budget_tier']} |"
+        )
+    lines.append("")
+    lines.append("## Baselines")
+    lines.append("")
+    lines.append("| id | label | status | runtime_policy | current_repo |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in manifest["baselines"]:
+        lines.append(
+            "| {id} | {label} | {implementation_status} | {runtime_policy} | {supports_current_repo} |".format(
+                **row
+            )
+        )
+    lines.append("")
+    lines.append("## Metrics Contract")
+    lines.append("")
+    for group_name, metric_names in manifest["metrics_contract"].items():
+        if group_name.endswith("_key"):
+            continue
+        lines.append(f"- {group_name}: `{', '.join(metric_names)}`")
+    lines.append("")
+    lines.append("## Notes")
+    lines.append("")
+    lines.append("- `dynamic_no_belief_state` and `lite_belief_state` are frozen as comparison contracts even when current repo support is partial.")
+    lines.append("- High-cost call counting is aligned to the freeze rules and can be consumed by the vertical experiment evaluator.")
+    return "\n".join(lines) + "\n"
+
+
+def build_issue209_baseline_freeze(
+    *,
+    config: dict[str, Any],
+    output_root: Path | None = None,
+    freeze_id: str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    if output_root is None:
+        raw_output_root = config.get("output_root")
+        output_root = (
+            Path(raw_output_root)
+            if isinstance(raw_output_root, str) and raw_output_root
+            else Path("output/experiment/w13-expr-0")
+        )
+
+    freeze_id = freeze_id or str(config.get("freeze_id") or "issue209-baseline-freeze")
+    output_dir = output_root / freeze_id
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tasks = _normalize_tasks(config.get("tasks"))
+    baselines = _normalize_baselines(config.get("baselines"))
+    high_cost_rules = normalize_high_cost_rules(config.get("high_cost_rules") or DEFAULT_HIGH_COST_RULES)
+
+    source_task_config_path = config.get("source_task_config_path")
+    source_path = Path(source_task_config_path) if isinstance(source_task_config_path, str) and source_task_config_path else None
+    source_alignment = _validate_source_task_alignment(
+        source_task_config_path=source_path,
+        frozen_tasks=tasks,
+    )
+
+    difficulty_counter = Counter(row["difficulty"] for row in tasks)
+    metrics_contract = config.get("metrics_contract")
+    if not isinstance(metrics_contract, dict):
+        raise ValueError("config.metrics_contract must be an object")
+
+    manifest = {
+        "schema_version": "w13.issue209.freeze.v1",
+        "issue_id": 209,
+        "freeze_id": freeze_id,
+        "generated_at": now_iso(),
+        "task_set_version": str(config.get("task_set_version") or "issue209-taskset-v1"),
+        "difficulty_scheme_version": str(
+            config.get("difficulty_scheme_version") or "issue209-difficulty-v1"
+        ),
+        "source_references": {
+            "source_task_config_path": str(source_path) if source_path else None,
+            "source_dataset_freeze": config.get("source_dataset_freeze"),
+            "source_alignment": source_alignment,
+        },
+        "tasks": tasks,
+        "difficulty_distribution": dict(sorted(difficulty_counter.items())),
+        "high_cost_rules": high_cost_rules,
+        "baselines": baselines,
+        "metrics_contract": metrics_contract,
+        "fingerprint": stable_hash(
+            {
+                "tasks": tasks,
+                "high_cost_rules": high_cost_rules,
+                "baselines": baselines,
+                "metrics_contract": metrics_contract,
+            }
+        ),
+        "artifacts": {
+            "output_dir": str(output_dir),
+            "manifest_path": str((output_dir / "baseline_freeze_manifest.json").resolve()),
+            "report_path": str((output_dir / "baseline_freeze_report.md").resolve()),
+        },
+    }
+
+    write_json(output_dir / "baseline_freeze_manifest.json", manifest)
+    (output_dir / "baseline_freeze_report.md").write_text(
+        _build_report(manifest),
+        encoding="utf-8",
+    )
+    return manifest, output_dir
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_json(args.config)
+    manifest, output_dir = build_issue209_baseline_freeze(
+        config=config,
+        output_root=args.output_root,
+        freeze_id=args.freeze_id,
+    )
+
+    print(f"[issue209] freeze_id={manifest['freeze_id']}")
+    print(f"[issue209] output_dir={output_dir}")
+    print(f"[issue209] manifest={output_dir / 'baseline_freeze_manifest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/w13-issue-209-baseline-freeze.md
+++ b/scripts/w13-issue-209-baseline-freeze.md
@@ -1,0 +1,40 @@
+# W13 Issue #209：高代价步骤、任务集与比较基线冻结
+
+## 目标
+
+冻结未来一个月实验所用的：
+
+- 高代价步骤定义；
+- 任务集版本与难度分层；
+- 四组比较基线；
+- 统一指标口径。
+
+## 一键生成冻结产物
+
+```bash
+uv run python scripts/freeze_w13_issue209_baseline_freeze.py \
+  --config configs/experiments/w13_issue209_baseline_freeze.json
+```
+
+默认输出目录：
+
+- `output/experiment/w13-expr-0/<freeze_id>/`
+
+核心产物：
+
+- `baseline_freeze_manifest.json`
+- `baseline_freeze_report.md`
+
+## 冻结原则
+
+- 高代价步骤沿用 SSOT 中的 `workflow.stage.high_cost_control` 定义，不新增工作流语义。
+- 任务集默认锚定到 `configs/experiments/w12_issue171_vertical_a0_a6.json` 的四个任务键，并在本 issue 内冻结难度标签。
+- 四组基线必须同时保留“当前仓库已支持”与“后续计划实现”状态，避免把计划态误写成已实现态。
+- 指标字段直接对齐 `src/infra/w12_vertical_experiment.py` 的聚合输出。
+
+## 当前仓库映射
+
+- `静态 Top-1`：已可由 `plan_top_k=1` 等约束表达。
+- `固定阈值 gate`：已可由 `min_candidate_confidence` 与 `high_cost_min_overall` 等阈值表达。
+- `动态无 belief-state`：本次冻结比较契约，但当前仓库尚未完整实现动作选择器。
+- `Lite belief-state`：本次冻结比较契约，但当前仓库尚未落地 `runtime_state / belief_state` 契约。

--- a/src/infra/w12_vertical_experiment.py
+++ b/src/infra/w12_vertical_experiment.py
@@ -27,6 +27,36 @@ DEFAULT_OFFLINE_THRESHOLDS: dict[str, float] = {
     "suffix_replan_prefix_preservation_rate": 1.0,
 }
 
+DEFAULT_HIGH_COST_RULES: list[dict[str, Any]] = [
+    {
+        "rule_id": "structure_mapping",
+        "label": "结构映射",
+        "stage_ids": ["S2"],
+        "tool_ids": ["esmfold", "nim_esmfold", "openfold3"],
+        "capability_ids": ["structure_prediction"],
+        "cost_tier": "high",
+        "rationale": "结构预测调用通常消耗远程/重模型预算，是高代价主来源。",
+    },
+    {
+        "rule_id": "structure_refinement",
+        "label": "结构条件下的序列精修",
+        "stage_ids": ["S4"],
+        "tool_ids": ["protein_mpnn"],
+        "capability_ids": ["sequence_design"],
+        "cost_tier": "high",
+        "rationale": "ProteinMPNN 多轮采样与回放属于高暴露恢复环节。",
+    },
+    {
+        "rule_id": "heavy_objective_evaluation",
+        "label": "重型目标评估",
+        "stage_ids": ["S5"],
+        "tool_ids": [],
+        "capability_ids": ["objective_scoring"],
+        "cost_tier": "medium_high",
+        "rationale": "重型目标/物性评估会引入额外模型或批量打分成本。",
+    },
+]
+
 _PATCH_EVENT_NAMES = {"PARAM_TWEAK", "REPLACE_TOOL", "STRUCTURE_PATCH"}
 
 
@@ -129,6 +159,59 @@ def load_tool_capability_map(kg_path: Path) -> dict[str, list[str]]:
     return mapping
 
 
+def normalize_high_cost_rules(raw_rules: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw_rules, list):
+        raw_rules = DEFAULT_HIGH_COST_RULES
+
+    normalized: list[dict[str, Any]] = []
+    for index, raw in enumerate(raw_rules):
+        if not isinstance(raw, dict):
+            continue
+        rule_id = raw.get("rule_id")
+        if not isinstance(rule_id, str) or not rule_id.strip():
+            rule_id = f"high_cost_rule_{index + 1}"
+
+        def _normalize_str_list(value: Any) -> list[str]:
+            if not isinstance(value, list):
+                return []
+            return [str(item) for item in value if isinstance(item, str) and item]
+
+        normalized.append(
+            {
+                "rule_id": rule_id.strip(),
+                "label": str(raw.get("label") or rule_id).strip(),
+                "stage_ids": _normalize_str_list(raw.get("stage_ids")),
+                "tool_ids": _normalize_str_list(raw.get("tool_ids")),
+                "capability_ids": _normalize_str_list(raw.get("capability_ids")),
+                "cost_tier": str(raw.get("cost_tier") or "unknown"),
+                "rationale": str(raw.get("rationale") or ""),
+            }
+        )
+
+    return normalized or list(DEFAULT_HIGH_COST_RULES)
+
+
+def _match_high_cost_rule(
+    *,
+    row: dict[str, Any],
+    tool: str,
+    capabilities: list[str],
+    rule: dict[str, Any],
+) -> bool:
+    stage_ids = set(rule.get("stage_ids") or [])
+    tool_ids = set(rule.get("tool_ids") or [])
+    capability_ids = set(rule.get("capability_ids") or [])
+
+    step_id = row.get("step_id")
+    if stage_ids and not (isinstance(step_id, str) and step_id in stage_ids):
+        return False
+    if tool_ids and tool not in tool_ids:
+        return False
+    if capability_ids and not capability_ids.intersection(capabilities):
+        return False
+    return bool(stage_ids or tool_ids or capability_ids)
+
+
 def validate_freeze_manifest(
     manifest: dict[str, Any],
     *,
@@ -227,15 +310,18 @@ def extract_run_metrics(
     *,
     tool_capability_map: dict[str, list[str]],
     requirement2_capability_map: dict[str, list[str]],
+    high_cost_rules: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     event_log_path = Path(str(run.get("event_log_path") or ""))
     rows = read_jsonl(event_log_path)
+    resolved_high_cost_rules = normalize_high_cost_rules(high_cost_rules)
 
     timestamps: list[datetime] = []
     step_failed_details: list[dict[str, Any]] = []
     layer_counter: Counter[str] = Counter()
     tool_usage: Counter[str] = Counter()
     capability_usage: Counter[str] = Counter()
+    high_cost_rule_hits: Counter[str] = Counter()
 
     waiting_enter_ids: set[str] = set()
     waiting_exit_ids: set[str] = set()
@@ -248,6 +334,8 @@ def extract_run_metrics(
     step_failed_count = 0
     step_finished_count = 0
     waiting_enter_count = 0
+    high_cost_call_count = 0
+    high_cost_failure_count = 0
 
     suffix_prefix_samples: list[bool] = []
     final_status: str | None = None
@@ -324,8 +412,25 @@ def extract_run_metrics(
             tool = row.get("tool")
             if isinstance(tool, str) and tool:
                 tool_usage[tool] += 1
-                for capability in tool_capability_map.get(tool, []):
+                capabilities = tool_capability_map.get(tool, [])
+                for capability in capabilities:
                     capability_usage[capability] += 1
+                matched_rules = [
+                    rule["rule_id"]
+                    for rule in resolved_high_cost_rules
+                    if _match_high_cost_rule(
+                        row=row,
+                        tool=tool,
+                        capabilities=capabilities,
+                        rule=rule,
+                    )
+                ]
+                if matched_rules:
+                    high_cost_call_count += 1
+                    if status == "failed" or event_name == "STEP_FAILED":
+                        high_cost_failure_count += 1
+                    for rule_id in matched_rules:
+                        high_cost_rule_hits[rule_id] += 1
 
     if final_status is None:
         explicit = run.get("status_external")
@@ -410,6 +515,9 @@ def extract_run_metrics(
         "layer_counter": dict(layer_counter),
         "tool_usage": dict(tool_usage),
         "capability_usage": dict(capability_usage),
+        "high_cost_call_count": high_cost_call_count,
+        "high_cost_failure_count": high_cost_failure_count,
+        "high_cost_rule_hits": dict(high_cost_rule_hits),
         "requirement2_coverage": requirement2_coverage,
         "suffix_prefix_samples": suffix_prefix_samples,
         "abnormal_reasons": abnormal_reasons,
@@ -461,6 +569,7 @@ def aggregate_group_metrics(
 
     summary_rows: list[dict[str, Any]] = []
     patch_rows: list[dict[str, Any]] = []
+    high_cost_rows: list[dict[str, Any]] = []
     requirement2_rows: list[dict[str, Any]] = []
     abnormal_rows: list[dict[str, Any]] = []
     gate_rows: list[dict[str, Any]] = []
@@ -481,16 +590,31 @@ def aggregate_group_metrics(
         replan_counts = [float(item.get("replan_event_count", 0) or 0) for item in rows]
         suffix_counts = [float(item.get("suffix_replan_event_count", 0) or 0) for item in rows]
         duration_values = [float(item.get("duration_ms", 0.0) or 0.0) for item in rows]
+        high_cost_counts = [float(item.get("high_cost_call_count", 0) or 0) for item in rows]
+        high_cost_failure_counts = [
+            float(item.get("high_cost_failure_count", 0) or 0) for item in rows
+        ]
 
         patch_summary = _mean_summary(patch_counts, iterations=iterations, seed=seed + idx * 11 + 1)
         replan_summary = _mean_summary(replan_counts, iterations=iterations, seed=seed + idx * 11 + 2)
         suffix_summary = _mean_summary(suffix_counts, iterations=iterations, seed=seed + idx * 11 + 3)
         duration_summary = _mean_summary(duration_values, iterations=iterations, seed=seed + idx * 11 + 4)
+        high_cost_summary = _mean_summary(
+            high_cost_counts,
+            iterations=iterations,
+            seed=seed + idx * 11 + 5,
+        )
+        high_cost_failure_summary = _mean_summary(
+            high_cost_failure_counts,
+            iterations=iterations,
+            seed=seed + idx * 11 + 6,
+        )
 
         patch_layer_counter: Counter[str] = Counter()
         suffix_prefix_samples: list[bool] = []
         capability_counter: Counter[str] = Counter()
         tool_counter: Counter[str] = Counter()
+        high_cost_rule_counter: Counter[str] = Counter()
         total_patch_events_with_layer = 0
 
         for row in rows:
@@ -504,6 +628,9 @@ def aggregate_group_metrics(
             for key, value in (row.get("tool_usage") or {}).items():
                 if isinstance(key, str) and isinstance(value, (int, float)):
                     tool_counter[key] += int(value)
+            for key, value in (row.get("high_cost_rule_hits") or {}).items():
+                if isinstance(key, str) and isinstance(value, (int, float)):
+                    high_cost_rule_counter[key] += int(value)
             suffix_prefix_samples.extend([bool(v) for v in row.get("suffix_prefix_samples") or []])
 
         patch_minimality_hit_rate = None
@@ -551,6 +678,12 @@ def aggregate_group_metrics(
             "duration_ms_mean": duration_summary["mean"],
             "duration_ms_ci_low": duration_summary["ci_low"],
             "duration_ms_ci_high": duration_summary["ci_high"],
+            "high_cost_call_mean": high_cost_summary["mean"],
+            "high_cost_call_ci_low": high_cost_summary["ci_low"],
+            "high_cost_call_ci_high": high_cost_summary["ci_high"],
+            "high_cost_failure_mean": high_cost_failure_summary["mean"],
+            "high_cost_failure_ci_low": high_cost_failure_summary["ci_low"],
+            "high_cost_failure_ci_high": high_cost_failure_summary["ci_high"],
             "patch_minimality_hit_rate": patch_minimality_hit_rate,
             "suffix_replan_prefix_preservation_rate": suffix_prefix_preservation_rate,
             "requirement2_sequence_core": requirement2_bucket_status.get("sequence_core", False),
@@ -574,6 +707,15 @@ def aggregate_group_metrics(
                 "patch_minimality_hit_rate": patch_minimality_hit_rate,
                 "suffix_prefix_sample_size": len(suffix_prefix_samples),
                 "suffix_prefix_preservation_rate": suffix_prefix_preservation_rate,
+            }
+        )
+
+        high_cost_rows.append(
+            {
+                "group_id": group_id,
+                "high_cost_calls_total": sum(high_cost_counts),
+                "high_cost_failures_total": sum(high_cost_failure_counts),
+                "high_cost_rule_hits": dict(high_cost_rule_counter),
             }
         )
 
@@ -651,6 +793,7 @@ def aggregate_group_metrics(
     return {
         "summary_rows": summary_rows,
         "patch_rows": patch_rows,
+        "high_cost_rows": high_cost_rows,
         "requirement2_rows": requirement2_rows,
         "abnormal_rows": abnormal_rows,
         "gate_rows": gate_rows,
@@ -775,18 +918,19 @@ def build_markdown_report(
     lines.append("## Unified Metrics (effect / mechanism / cost / governance)")
     lines.append("")
     lines.append(
-        "| group | runs | success_rate | first_pass | schema_valid | executable | patch_mean | replan_mean | duration_ms_mean |"
+        "| group | runs | success_rate | first_pass | schema_valid | executable | high_cost_mean | patch_mean | replan_mean | duration_ms_mean |"
     )
-    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
     for row in summary_rows:
         lines.append(
-            "| {group_id} | {runs} | {success_rate:.4f} | {first_pass_success_rate:.4f} | {schema_valid_rate:.4f} | {executable_plan_rate:.4f} | {patch_events_mean:.4f} | {replan_events_mean:.4f} | {duration_ms_mean:.2f} |".format(
+            "| {group_id} | {runs} | {success_rate:.4f} | {first_pass_success_rate:.4f} | {schema_valid_rate:.4f} | {executable_plan_rate:.4f} | {high_cost_call_mean:.4f} | {patch_events_mean:.4f} | {replan_events_mean:.4f} | {duration_ms_mean:.2f} |".format(
                 group_id=row.get("group_id"),
                 runs=row.get("runs", 0),
                 success_rate=float(row.get("success_rate") or 0.0),
                 first_pass_success_rate=float(row.get("first_pass_success_rate") or 0.0),
                 schema_valid_rate=float(row.get("schema_valid_rate") or 0.0),
                 executable_plan_rate=float(row.get("executable_plan_rate") or 0.0),
+                high_cost_call_mean=float(row.get("high_cost_call_mean") or 0.0),
                 patch_events_mean=float(row.get("patch_events_mean") or 0.0),
                 replan_events_mean=float(row.get("replan_events_mean") or 0.0),
                 duration_ms_mean=float(row.get("duration_ms_mean") or 0.0),

--- a/tests/unit/test_freeze_w13_issue209_baseline_freeze.py
+++ b/tests/unit/test_freeze_w13_issue209_baseline_freeze.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from src.infra.w12_vertical_experiment import DEFAULT_HIGH_COST_RULES, normalize_high_cost_rules
+
+
+def _load_module():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "freeze_w13_issue209_baseline_freeze.py"
+    )
+    spec = importlib.util.spec_from_file_location("issue209_freeze", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_high_cost_rules_uses_default_shape() -> None:
+    rules = normalize_high_cost_rules(None)
+    assert rules == DEFAULT_HIGH_COST_RULES
+    assert rules[0]["rule_id"] == "structure_mapping"
+
+
+def test_issue209_freeze_script_writes_manifest(tmp_path: Path) -> None:
+    module = _load_module()
+    source_task_config_path = tmp_path / "source_tasks.json"
+
+    source_task_config_path.write_text(
+        json.dumps(
+            {
+                "tasks": [
+                    {"task_key": "enzyme_like_fold"},
+                    {"task_key": "binding_scaffold"},
+                    {"task_key": "high_solubility"},
+                    {"task_key": "secondary_balance"},
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    manifest, output_dir = module.build_issue209_baseline_freeze(
+        config={
+            "freeze_id": "issue209-test-freeze",
+            "output_root": str(tmp_path / "out"),
+            "task_set_version": "issue209-taskset-v1",
+            "difficulty_scheme_version": "issue209-difficulty-v1",
+            "source_task_config_path": str(source_task_config_path),
+            "tasks": [
+                {"task_key": "enzyme_like_fold", "difficulty": "medium"},
+                {"task_key": "binding_scaffold", "difficulty": "hard"},
+                {"task_key": "high_solubility", "difficulty": "easy"},
+                {"task_key": "secondary_balance", "difficulty": "medium"},
+            ],
+            "baselines": [
+                {"id": "static_top1", "label": "静态 Top-1"},
+                {"id": "fixed_threshold_gate", "label": "固定阈值 gate"},
+                {"id": "dynamic_no_belief_state", "label": "动态无 belief-state"},
+                {"id": "lite_belief_state", "label": "Lite belief-state"},
+            ],
+            "metrics_contract": {
+                "effect": ["success_rate"],
+                "cost": ["duration_ms_mean", "high_cost_call_mean"],
+                "recovery": ["patch_events_mean"],
+                "governance": ["failure_traceable_rate"],
+                "task_stratification_key": "difficulty",
+            },
+        }
+    )
+
+    assert manifest["difficulty_distribution"] == {"easy": 1, "hard": 1, "medium": 2}
+    assert manifest["source_references"]["source_alignment"]["aligned"] is True
+    assert (output_dir / "baseline_freeze_manifest.json").exists()
+    assert (output_dir / "baseline_freeze_report.md").exists()

--- a/tests/unit/test_w12_vertical_experiment.py
+++ b/tests/unit/test_w12_vertical_experiment.py
@@ -51,8 +51,8 @@ def test_extract_run_metrics_and_requirement2(tmp_path: Path) -> None:
             {
                 "event": "STEP_FINISHED",
                 "task_id": "task_a0",
-                "step_id": "S1",
-                "tool": "protgpt2",
+                "step_id": "S2",
+                "tool": "esmfold",
                 "status": "success",
                 "timestamp": "2026-03-15T10:00:02+00:00",
             },
@@ -113,9 +113,11 @@ def test_extract_run_metrics_and_requirement2(tmp_path: Path) -> None:
     assert metrics["patch_event_count"] == 1
     assert metrics["replan_event_count"] == 1
     assert metrics["waiting_chain_complete"] is True
-    assert metrics["requirement2_coverage"]["sequence_core"] is True
-    assert metrics["requirement2_coverage"]["structure_prediction"] is False
+    assert metrics["requirement2_coverage"]["sequence_core"] is False
+    assert metrics["requirement2_coverage"]["structure_prediction"] is True
     assert metrics["layer_counter"]["parameter_level"] == 1
+    assert metrics["high_cost_call_count"] == 1
+    assert metrics["high_cost_rule_hits"]["structure_mapping"] == 1
 
 
 def test_aggregate_and_deltas(tmp_path: Path) -> None:
@@ -185,6 +187,7 @@ def test_aggregate_and_deltas(tmp_path: Path) -> None:
     assert summary["A0"]["success_rate"] == 0.5
     assert summary["A1"]["success_rate"] == 1.0
     assert summary["A1"]["patch_events_mean"] == 0.0
+    assert summary["A0"]["high_cost_call_mean"] == 0.0
 
     deltas = compute_increment_deltas(
         runs,


### PR DESCRIPTION
## 摘要

本 PR 实现 issue #209，对未来一个月实验所需的高代价步骤定义、任务集与难度分层、四组比较基线以及统一指标口径进行冻结，并补齐实验基础设施中的高代价调用统计能力。

Closes #209

## 变更内容

### 1. 新增 Issue #209 冻结资产
- 新增配置文件：`configs/experiments/w13_issue209_baseline_freeze.json`
- 新增冻结脚本：`scripts/freeze_w13_issue209_baseline_freeze.py`
- 新增说明文档：`scripts/w13-issue-209-baseline-freeze.md`
- 新增单测：`tests/unit/test_freeze_w13_issue209_baseline_freeze.py`

冻结内容包括：
- 高代价步骤规则：`结构映射`、`结构条件下的序列精修`、`重型目标评估`
- 任务集版本与难度分层：4 个任务键及 `easy/medium/hard` 标签
- 四组基线：`静态 Top-1`、`固定阈值 gate`、`动态无 belief-state`、`Lite belief-state`
- 指标口径：effect / cost / recovery / governance 四类统一字段

### 2. 扩展实验聚合层的高代价指标
- 更新 `src/infra/w12_vertical_experiment.py`
- 增加默认高代价规则与规则归一化逻辑
- 在 run-level 指标中新增：
  - `high_cost_call_count`
  - `high_cost_failure_count`
  - `high_cost_rule_hits`
- 在 group-level 汇总中新增：
  - `high_cost_call_mean` 及其 CI
  - `high_cost_failure_mean` 及其 CI
  - `high_cost_breakdown.csv` 所需明细
- Markdown 报告总表同步纳入高代价调用均值

### 3. 对齐既有纵向实验评估脚本
- 更新 `scripts/evaluate_w12_vertical_issue171.py`
- 评估时允许从 manifest 读取 `high_cost_rules`
- 增加 `high_cost_call_count` 的增量对比输出
- 在 `vertical_metrics_summary.csv` 中导出高代价统计字段
- 新增 `high_cost_breakdown.csv`

## 与当前代码基线的关系

本 PR 兼顾了 issue #208 所要求的“以当前代码真实状态为准”原则：
- `静态 Top-1` 与 `固定阈值 gate` 明确标记为当前仓库已支持；
- `动态无 belief-state` 与 `Lite belief-state` 先冻结为比较契约与输出字段，不在本 PR 中虚构为已实现能力；
- 不修改 FSM、Agent 边界或执行语义，仅补充实验冻结资产与统计能力。

## 验证

已执行：

```bash
UV_CACHE_DIR=.uv-cache uv run pytest tests/unit/test_w12_vertical_experiment.py tests/unit/test_freeze_w13_issue209_baseline_freeze.py -q
UV_CACHE_DIR=.uv-cache uv run python scripts/freeze_w13_issue209_baseline_freeze.py --config configs/experiments/w13_issue209_baseline_freeze.json --freeze-id issue209-baseline-freeze-smoke
```

结果：
- 单测通过：`6 passed`
- Freeze 脚本可成功生成 `baseline_freeze_manifest.json` 与 `baseline_freeze_report.md`

## 影响范围

- 仅涉及实验/报告基础设施与 issue #209 冻结资产。
- 不触碰 FSM 状态定义。
- 不新增 Agent 角色或改变职责边界。
