### PR TITLE
docs(evidence): freeze issue #210 evidence conventions

### DIFF
--- a/reports/w13-issue-210/evidence-index.baseline.json
+++ b/reports/w13-issue-210/evidence-index.baseline.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "w13.issue210.evidence-index.v1",
+  "naming_convention_version": "w13-issue-210-v1",
+  "issue_id": 210,
+  "freeze_id": "ISSUE209_FREEZE_ID",
+  "run_id": "EXPERIMENT_RUN_ID",
+  "report_pack": "reports/w16-experiment-pack",
+  "generated_at": "2026-03-27T00:00:00+08:00",
+  "roots": {
+    "raw_logs": "data/logs",
+    "snapshots": "data/snapshots",
+    "experiment_output": "output/experiment/<experiment_family>/<run_id>",
+    "report_output": "reports/<report_pack>"
+  },
+  "traceability_chains": {
+    "chart": {
+      "required_refs": [
+        "config_path",
+        "resolved_config_snapshot_path",
+        "run_manifest_path",
+        "run_log_index_path",
+        "aggregate_source_path",
+        "chart_source_manifest_path",
+        "chart_artifact_path"
+      ],
+      "chain_rule": "config -> resolved_config -> run_manifest/run_log_index -> aggregate -> chart_sources -> chart"
+    },
+    "case_study": {
+      "required_refs": [
+        "run_log_index_path",
+        "event_log_path",
+        "snapshot_path",
+        "task_report_path",
+        "case_artifact_path"
+      ],
+      "chain_rule": "run_log_index -> event_log -> snapshot -> task_report -> case_markdown"
+    }
+  },
+  "artifacts": [
+    {
+      "artifact_id": "figure-1-success-latency",
+      "artifact_type": "chart",
+      "title": "成功率-时延平衡图",
+      "status": "planned",
+      "path": "reports/<report_pack>/charts/figure-1-success-latency.svg",
+      "run_ref": {
+        "issue_id": 171,
+        "freeze_id": "ISSUE209_FREEZE_ID",
+        "run_id": "EXPERIMENT_RUN_ID",
+        "group_scope": [
+          "static_top1",
+          "fixed_threshold_gate",
+          "dynamic_no_belief_state",
+          "lite_belief_state"
+        ]
+      },
+      "source_refs": {
+        "config_path": "configs/experiments/<issue_or_pack>_<topic>.json",
+        "resolved_config_snapshot_path": "output/experiment/<experiment_family>/<run_id>/resolved_config_snapshot.json",
+        "run_manifest_path": "output/experiment/<experiment_family>/<run_id>/runs_manifest.json",
+        "run_log_index_path": "output/experiment/<experiment_family>/<run_id>/run_log_index.csv",
+        "aggregate_source_path": "output/experiment/<experiment_family>/<run_id>/vertical_metrics_summary.csv",
+        "chart_source_manifest_path": "reports/<report_pack>/charts/figure-1-success-latency.sources.json"
+      },
+      "upstream_refs": [
+        "table-1-overall-summary"
+      ],
+      "generated_by": {
+        "script_path": "scripts/<chart_script>.py",
+        "command": "uv run python scripts/<chart_script>.py ..."
+      },
+      "conclusion": "TODO: summary conclusion",
+      "tags": [
+        "chart",
+        "effect",
+        "latency",
+        "paper-ready"
+      ]
+    },
+    {
+      "artifact_id": "case-1-loss-control",
+      "artifact_type": "case_study",
+      "title": "止损成功案例",
+      "status": "planned",
+      "path": "reports/<report_pack>/cases/case-1-loss-control.md",
+      "run_ref": {
+        "issue_id": 171,
+        "freeze_id": "ISSUE209_FREEZE_ID",
+        "run_id": "EXPERIMENT_RUN_ID",
+        "task_key": "binding_scaffold",
+        "group_id": "lite_belief_state",
+        "task_id": "TASK_ID"
+      },
+      "source_refs": {
+        "run_log_index_path": "output/experiment/<experiment_family>/<run_id>/run_log_index.csv",
+        "event_log_path": "data/logs/<task_id>.jsonl",
+        "snapshot_path": "data/snapshots/<task_id>.jsonl",
+        "task_report_path": "output/reports/<task_id>.json",
+        "case_artifact_manifest_path": "reports/<report_pack>/cases/case-1-loss-control.artifacts.json"
+      },
+      "upstream_refs": [
+        "summary-row-binding-scaffold-lite-belief-state"
+      ],
+      "generated_by": {
+        "script_path": "manual_or_scripted",
+        "command": "manual synthesis from indexed evidence"
+      },
+      "conclusion": "TODO: summary conclusion",
+      "tags": [
+        "case-study",
+        "recovery",
+        "traceability"
+      ]
+    }
+  ]
+}

--- a/reports/w13-issue-210/evidence-template.md
+++ b/reports/w13-issue-210/evidence-template.md
@@ -1,0 +1,40 @@
+# Evidence Template Notes
+
+## Chart Template
+
+每张图表至少补齐以下信息：
+
+- 标题：图表要表达的命题
+- 图表文件：`reports/<report_pack>/charts/<chart_id>.<ext>`
+- 数据源说明：`reports/<report_pack>/charts/<chart_id>.sources.json`
+- 上游聚合表：如 `vertical_metrics_summary.csv`
+- 结论一句话：图表支撑的核心判断
+- 追溯链：
+  - `config_path`
+  - `resolved_config_snapshot_path`
+  - `run_log_index_path`
+  - `aggregate_source_path`
+
+## Case Study Template
+
+每个案例文档建议包含以下段落：
+
+- 背景：任务、分组、难度、run_id
+- 触发点：失败/升级/止损/回退发生在什么位置
+- 关键证据：
+  - `run_log_index.csv`
+  - `event_log`
+  - `snapshot`
+  - `task_report`
+- 动作与原因：系统为何 patch / replan / stop
+- 结果：成功、失败或止损收益
+- 结论：该案例对论文或 issue 说明了什么
+
+## Summary Row Alias
+
+若案例或图表引用聚合表中的单行结果，建议生成稳定别名：
+
+- `summary-row-<task_key>-<group_id>`
+- `summary-row-overall-<group_id>`
+
+这样后续在 `evidence-index.json.upstream_refs` 中可以稳定引用，而不依赖临时行号。

--- a/scripts/w13-issue-210-evidence-freeze.md
+++ b/scripts/w13-issue-210-evidence-freeze.md
@@ -1,0 +1,165 @@
+# W13 Issue #210：证据资产目录与命名约定冻结
+
+## 目标
+
+在正式跑 W16 实验之前，先冻结实验、图表和案例证据的目录结构、命名规则与最小追溯链，避免结果出来后再返工整理证据包。
+
+本冻结只定义约定，不新增实验执行语义，也不在本 issue 内生成最终图表或证据包。
+
+## 目录结构约定
+
+### 1. 运行期原始证据
+
+- Event log：`data/logs/<task_id>.jsonl`
+- Snapshot：`data/snapshots/<task_id>.jsonl`
+- 单任务报告：`output/reports/<task_id>.json`
+- 单任务指标：`output/metrics/<task_id>.json`
+
+### 2. 实验批次产物
+
+- 运行根目录：`output/experiment/<experiment_family>/<run_id>/`
+- 必备文件：
+  - `runs_manifest.json`
+  - `resolved_config_snapshot.json`
+  - `runs.jsonl`
+  - `run_log_index.csv`
+- 聚合结果：
+  - `vertical_metrics_summary.csv`
+  - `mechanism_increment_deltas.csv`
+  - `patch_replan_breakdown.csv`
+  - `high_cost_breakdown.csv`
+  - `offline_gate_assessment.json`
+  - `vertical_report.md`
+
+### 3. 报告与论文证据包
+
+- 报告根目录：`reports/<report_pack>/`
+- 图表目录：`reports/<report_pack>/charts/`
+- 案例目录：`reports/<report_pack>/cases/`
+- 索引文件：
+  - `reports/<report_pack>/evidence-index.json`
+  - `reports/<report_pack>/figure_table_index.csv`
+
+## 命名规则冻结
+
+### Run 配置
+
+- 实验配置：`configs/experiments/<issue_or_pack>_<topic>.json`
+- 运行配置快照：`resolved_config_snapshot.json`
+- 命名重点：
+  - `<issue_or_pack>` 必须稳定指向 issue 或实验包，例如 `w13_issue210`、`w16_matrix`
+  - `<topic>` 必须体现实验主题，而不是机器名或临时备注
+
+### Run 级文件
+
+- 批次目录：`output/experiment/<experiment_family>/<run_id>/`
+- `run_id` 推荐格式：`<experiment_family>-<purpose>-<yyyymmdd>-<suffix>`
+- 日志索引：`run_log_index.csv`
+- 聚合总表：`vertical_metrics_summary.csv` 或 `<summary_topic>_summary.csv`
+
+### 图表文件
+
+- 图表数据源说明：`charts/<chart_id>.sources.json`
+- 图表图像：`charts/<chart_id>.<png|svg|pdf>`
+- 图表文案：`charts/<chart_id>.md`
+- `chart_id` 推荐格式：`figure-<n>-<topic>` 或 `table-<n>-<topic>`
+
+### 案例文件
+
+- 案例文档：`cases/<case_id>.md`
+- 案例附件清单：`cases/<case_id>.artifacts.json`
+- `case_id` 推荐格式：`case-<n>-<theme>`
+
+## 版本字段冻结
+
+后续所有 `evidence-index.json` 至少记录以下版本字段：
+
+- `schema_version`
+- `naming_convention_version`
+- `freeze_id`
+- `run_id`
+- `report_pack`
+- `generated_at`
+
+## `evidence-index.json` 字段基线
+
+基线文件见：
+
+- `reports/w13-issue-210/evidence-index.baseline.json`
+
+字段分层要求：
+
+- 顶层元信息：
+  - `schema_version`
+  - `naming_convention_version`
+  - `issue_id`
+  - `freeze_id`
+  - `run_id`
+  - `report_pack`
+  - `generated_at`
+- 目录根信息：
+  - `roots.raw_logs`
+  - `roots.snapshots`
+  - `roots.experiment_output`
+  - `roots.report_output`
+- 追溯链模板：
+  - `traceability_chains.chart`
+  - `traceability_chains.case_study`
+- 产物清单：
+  - `artifacts[]`
+
+每条 `artifacts[]` 至少包含：
+
+- `artifact_id`
+- `artifact_type`
+- `title`
+- `status`
+- `path`
+- `run_ref`
+- `source_refs`
+- `upstream_refs`
+- `generated_by`
+- `conclusion`
+- `tags`
+
+## 最小追溯链模板
+
+### 图表
+
+统一链路：
+
+`run config -> resolved config snapshot -> run manifest / run_log_index -> aggregate summary -> chart sources -> chart file`
+
+最少要能回链到：
+
+- `configs/experiments/...json`
+- `resolved_config_snapshot.json`
+- `run_log_index.csv`
+- 聚合表，例如 `vertical_metrics_summary.csv`
+- 图表数据源说明文件，例如 `charts/figure-1-success-latency.sources.json`
+
+### 案例
+
+统一链路：
+
+`run_log_index -> event log -> snapshot -> task-level report -> case markdown`
+
+最少要能回链到：
+
+- `run_log_index.csv`
+- `data/logs/<task_id>.jsonl`
+- `data/snapshots/<task_id>.jsonl`
+- `output/reports/<task_id>.json`
+- `cases/<case_id>.md`
+
+## 与既有产物的兼容关系
+
+- `run_log_index.csv`：继续作为 run 到原始日志/快照的主索引。
+- `artifact_evidence_index.csv`：保留为历史阶段性索引；后续可由 `evidence-index.json` 衍生生成。
+- `figure_table_index.csv`：继续作为图表清单；后续应被 `evidence-index.json.artifacts[]` 引用，而不是单独悬空存在。
+
+## 后续 issue 复用要求
+
+- W16 图表、表格、案例都必须复用上述目录结构。
+- 任一图表或案例若无法回链到 `run config -> log/snapshot -> aggregate -> artifact`，视为证据不合格。
+- 后续若需新增字段，只允许向 `evidence-index.json` 做向后兼容的增量扩展，不重命名已冻结字段。


### PR DESCRIPTION
## 摘要

本 PR 实现 issue #210，冻结实验产物、日志、快照、图表和案例证据的目录与命名约定，并给出 `evidence-index.json` 的字段基线与通用证据模板，供后续 W16 实验结果包和论文/issue 追溯直接复用。

Closes #210

## 变更内容

### 1. 冻结证据资产目录与命名约定
- 新增文档：`scripts/w13-issue-210-evidence-freeze.md`
- 明确以下内容：
  - 原始证据目录：`data/logs`、`data/snapshots`、`output/reports`、`output/metrics`
  - 实验批次目录：`output/experiment/<experiment_family>/<run_id>/`
  - 报告与论文证据包目录：`reports/<report_pack>/`
  - 图表目录：`reports/<report_pack>/charts/`
  - 案例目录：`reports/<report_pack>/cases/`
- 固定 run 配置、run 级文件、图表文件、案例文件的命名规则与版本字段

### 2. 新增 `evidence-index.json` 字段基线
- 新增基线文件：`reports/w13-issue-210/evidence-index.baseline.json`
- 冻结了：
  - 顶层元信息字段
  - `roots` 目录根字段
  - `traceability_chains.chart` 与 `traceability_chains.case_study`
  - `artifacts[]` 的最小字段集合
- 预置了 chart 与 case study 两类示例条目，供后续 issue 直接套用

### 3. 补充通用证据模板说明
- 新增模板说明：`reports/w13-issue-210/evidence-template.md`
- 补充了：
  - 图表模板的最小必填信息
  - 案例模板的最小段落结构
  - `summary-row-<task_key>-<group_id>` 等稳定别名约定

## 与既有产物的关系

本 PR 不新增实验脚本功能，只对既有证据资产做统一冻结与模板化约定。

兼容关系如下：
- `run_log_index.csv` 继续作为 run 到原始日志/快照的主索引；
- `artifact_evidence_index.csv` 保留为历史阶段性索引，后续可由 `evidence-index.json` 衍生；
- `figure_table_index.csv` 继续作为图表清单，但后续应被 `evidence-index.json.artifacts[]` 引用。

## 验证

已执行：

```bash
jq empty reports/w13-issue-210/evidence-index.baseline.json
```

结果：
- JSON 基线文件语法合法。

## 影响范围

- 仅涉及文档与模板冻结。
- 不修改 FSM、Agent 边界或实验执行逻辑。
- 为后续 W16 图表、案例和证据包提供统一输入约定。
