### PR TITLE
feat: 冻结 RuntimeState schema 与 snapshot 持久化键

### DIFF
--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Literal, cast
@@ -11,6 +12,11 @@ from pydantic import BaseModel, Field, ConfigDict, field_validator, model_valida
 def now_iso() -> str:
     """Small helper to generate ISO8601 timestamp strings."""
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+RUNTIME_STATE_SCHEMA_VERSION = 1
+RUNTIME_STATE_ARTIFACT_KEY = "runtime_state"
+RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY = "runtime_observation_summary"
 
 
 class ProteinDesignTask(BaseModel):
@@ -93,6 +99,91 @@ class StepResult(BaseModel):
     risk_flags: List[RiskFlag] = Field(default_factory=list)
     logs_path: Optional[str] = None
     timestamp: str
+
+
+class RuntimeState(BaseModel):
+    """稳定的运行时状态 schema。
+
+    该模型冻结 issue #227 所需的最小字段集合；后续扩展必须保持 additive。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=RUNTIME_STATE_SCHEMA_VERSION)
+    p_success: float
+    p_structural_failure: float
+    recovery_margin: float
+    expected_remaining_cost: float
+    last_update_source: str
+    observation_summary: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, value: int) -> int:
+        if value != RUNTIME_STATE_SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version must be {RUNTIME_STATE_SCHEMA_VERSION}"
+            )
+        return value
+
+    @field_validator("p_success", "p_structural_failure")
+    @classmethod
+    def _validate_probability(cls, value: float) -> float:
+        if isinstance(value, bool):
+            raise ValueError("probability fields must be numeric")
+        normalized = float(value)
+        if not math.isfinite(normalized):
+            raise ValueError("probability fields must be finite")
+        if not 0.0 <= normalized <= 1.0:
+            raise ValueError("probability fields must be between 0 and 1")
+        return normalized
+
+    @field_validator("recovery_margin")
+    @classmethod
+    def _validate_recovery_margin(cls, value: float) -> float:
+        if isinstance(value, bool):
+            raise ValueError("recovery_margin must be numeric")
+        normalized = float(value)
+        if not math.isfinite(normalized):
+            raise ValueError("recovery_margin must be finite")
+        return normalized
+
+    @field_validator("expected_remaining_cost")
+    @classmethod
+    def _validate_expected_remaining_cost(cls, value: float) -> float:
+        if isinstance(value, bool):
+            raise ValueError("expected_remaining_cost must be numeric")
+        normalized = float(value)
+        if not math.isfinite(normalized):
+            raise ValueError("expected_remaining_cost must be finite")
+        if normalized < 0.0:
+            raise ValueError("expected_remaining_cost must be >= 0")
+        return normalized
+
+    @field_validator("last_update_source")
+    @classmethod
+    def _validate_last_update_source(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("last_update_source must not be empty")
+        return normalized
+
+    @field_validator("observation_summary")
+    @classmethod
+    def _validate_observation_summary(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ValueError("observation_summary must be a mapping")
+        try:
+            json.dumps(value, ensure_ascii=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "observation_summary must be JSON-serializable"
+            ) from exc
+        return value
+
+    def to_snapshot_payload(self) -> Dict[str, Any]:
+        """Serialize the stable persisted fields for TaskSnapshot.artifacts."""
+        return self.model_dump(exclude={"observation_summary"})
 
 
 class DesignResult(BaseModel):

--- a/src/workflow/context.py
+++ b/src/workflow/context.py
@@ -19,6 +19,7 @@ from src.models.contracts import (
     PendingAction,
     Plan,
     ProteinDesignTask,
+    RuntimeState,
     SafetyResult,
     StepResult,
 )
@@ -53,6 +54,12 @@ class WorkflowContext(BaseModel):
         safety_events: List[SafetyResult]
             历史安全检查列表
             包括输入预检、步骤级 pre/post 检查、最终输出检查等
+
+        runtime_state: Optional[RuntimeState]
+            运行时状态的单一工作副本
+            - 用于承载轻量 belief-state / runtime_state 估计
+            - 由 Workflow / Runner 在执行中更新
+            - 可通过 TaskSnapshot.artifacts["runtime_state"] 持久化恢复
             
         design_result: Optional[DesignResult]
             SummarizerAgent 在 SUMMARIZING 阶段生成的最终设计成果
@@ -68,6 +75,7 @@ class WorkflowContext(BaseModel):
     plan: Optional[Plan] = None
     step_results: Dict[str, StepResult] = Field(default_factory=dict)
     safety_events: List[SafetyResult] = Field(default_factory=list)
+    runtime_state: Optional[RuntimeState] = None
     design_result: Optional[DesignResult] = None
     pending_action: Optional[PendingAction] = None
     status: InternalStatus = InternalStatus.CREATED

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -21,6 +21,9 @@ from src.models.contracts import (
     Plan,
     PlanStep,
     ProteinDesignTask,
+    RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
+    RUNTIME_STATE_ARTIFACT_KEY,
+    RuntimeState,
     StepResult,
     TaskSnapshot,
     now_iso,
@@ -371,6 +374,7 @@ def restore_context_from_snapshot(
     context = WorkflowContext(
         task=task,
         plan=plan,
+        runtime_state=_extract_runtime_state(snapshot),
         status=internal_status,
     )
 
@@ -407,6 +411,27 @@ def extract_remote_job_context(
     try:
         return RemoteJobContext.from_dict(job_data)
     except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _extract_runtime_state(snapshot: TaskSnapshot) -> RuntimeState | None:
+    runtime_payload = snapshot.artifacts.get(RUNTIME_STATE_ARTIFACT_KEY)
+    if not isinstance(runtime_payload, dict):
+        return None
+
+    payload = dict(runtime_payload)
+    observation_summary = snapshot.artifacts.get(
+        RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY
+    )
+    if (
+        "observation_summary" not in payload
+        and isinstance(observation_summary, dict)
+    ):
+        payload["observation_summary"] = observation_summary
+
+    try:
+        return RuntimeState.model_validate(payload)
+    except Exception:
         return None
 
 

--- a/src/workflow/snapshots.py
+++ b/src/workflow/snapshots.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 from uuid import uuid4
 
-from src.models.contracts import TaskSnapshot, now_iso
+from src.models.contracts import (
+    RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
+    RUNTIME_STATE_ARTIFACT_KEY,
+    RuntimeState,
+    TaskSnapshot,
+    now_iso,
+)
 from src.models.db import ExternalStatus, to_external_status
 from src.storage.snapshot_store import append_snapshot
 from src.workflow.context import WorkflowContext
@@ -40,6 +46,7 @@ def build_task_snapshot(
     external_state = state_override or to_external_status(context.status)
     step_ids = list(context.step_results.keys())
     artifacts_payload = dict(artifacts or {})
+    _inject_runtime_state_artifacts(context.runtime_state, artifacts_payload)
     if context.pending_action is not None:
         artifacts_payload.setdefault(
             "pending_action", context.pending_action.model_dump()
@@ -71,3 +78,22 @@ def _extract_plan_version(context: WorkflowContext) -> Optional[int]:
         except (TypeError, ValueError):
             return None
     return None
+
+
+def _inject_runtime_state_artifacts(
+    runtime_state: RuntimeState | None,
+    artifacts_payload: dict[str, Any],
+) -> None:
+    if runtime_state is None:
+        return
+
+    artifacts_payload.setdefault(
+        RUNTIME_STATE_ARTIFACT_KEY,
+        runtime_state.to_snapshot_payload(),
+    )
+
+    if runtime_state.observation_summary:
+        artifacts_payload.setdefault(
+            RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
+            dict(runtime_state.observation_summary),
+        )

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -8,6 +8,7 @@ from src.models.contracts import (
     ProteinDesignTask,
     Plan,
     PlanStep,
+    RuntimeState,
     StepResult,
     DesignResult,
     RiskFlag,
@@ -154,6 +155,35 @@ class TestDesignResult:
 
 
 @pytest.mark.unit
+class TestRuntimeState:
+    """RuntimeState 测试类"""
+
+    def test_runtime_state_creation(self):
+        state = RuntimeState(
+            p_success=0.8,
+            p_structural_failure=0.15,
+            recovery_margin=0.35,
+            expected_remaining_cost=4.5,
+            last_update_source="step_result:S2",
+            observation_summary={"completed_high_cost_steps": 1},
+        )
+
+        assert state.schema_version == 1
+        assert state.p_success == 0.8
+        assert state.observation_summary["completed_high_cost_steps"] == 1
+
+    def test_runtime_state_rejects_invalid_probability(self):
+        with pytest.raises(ValidationError):
+            RuntimeState(
+                p_success=1.1,
+                p_structural_failure=0.2,
+                recovery_margin=0.35,
+                expected_remaining_cost=4.5,
+                last_update_source="step_result:S2",
+            )
+
+
+@pytest.mark.unit
 class TestWorkflowContext:
     """WorkflowContext测试类"""
 
@@ -164,6 +194,7 @@ class TestWorkflowContext:
             plan=None,
             step_results={},
             safety_events=[],
+            runtime_state=None,
             design_result=None,
             status=InternalStatus.CREATED,
         )
@@ -172,6 +203,7 @@ class TestWorkflowContext:
         assert context.plan is None
         assert isinstance(context.step_results, dict)
         assert isinstance(context.safety_events, list)
+        assert context.runtime_state is None
         assert context.status == InternalStatus.CREATED
 
 

--- a/tests/unit/test_recovery_event_logs.py
+++ b/tests/unit/test_recovery_event_logs.py
@@ -10,6 +10,9 @@ from src.models.contracts import (
     Plan,
     PlanStep,
     ProteinDesignTask,
+    RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
+    RUNTIME_STATE_ARTIFACT_KEY,
+    RuntimeState,
     TaskSnapshot,
     now_iso,
 )
@@ -53,6 +56,49 @@ def test_restore_context_from_snapshot_restores_completed_steps():
     assert "S1" in context.step_results
     assert context.step_results["S1"].tool == "esmfold"
     assert context.step_results["S1"].status == "success"
+
+
+@pytest.mark.unit
+def test_restore_context_from_snapshot_restores_runtime_state():
+    task = ProteinDesignTask(
+        task_id="task_recovery_runtime_state",
+        goal="recover runtime state",
+        constraints={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S1", tool="esmfold", inputs={"sequence": "ACDE"}, metadata={}),
+        ],
+    )
+    runtime_state = RuntimeState(
+        p_success=0.61,
+        p_structural_failure=0.21,
+        recovery_margin=0.28,
+        expected_remaining_cost=7.0,
+        last_update_source="step_result:S1",
+        observation_summary={"completed_steps": 1},
+    )
+    snapshot = TaskSnapshot(
+        snapshot_id="snapshot_runtime_state_001",
+        task_id=task.task_id,
+        state=ExternalStatus.RUNNING.value,
+        plan_version=1,
+        step_index=1,
+        completed_step_ids=["S1"],
+        artifacts={
+            RUNTIME_STATE_ARTIFACT_KEY: runtime_state.to_snapshot_payload(),
+            RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY: runtime_state.observation_summary,
+        },
+        created_at=now_iso(),
+    )
+
+    context = restore_context_from_snapshot(task=task, plan=plan, snapshot=snapshot)
+
+    assert context is not None
+    assert context.runtime_state is not None
+    assert context.runtime_state.p_success == pytest.approx(0.61)
+    assert context.runtime_state.observation_summary == {"completed_steps": 1}
 
 
 @pytest.mark.unit

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -2,13 +2,25 @@ import pytest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from src.models.contracts import ArtifactRef, TaskSnapshot, now_iso
-from src.models.db import ExternalStatus
+from src.models.contracts import (
+    ArtifactRef,
+    Plan,
+    PlanStep,
+    ProteinDesignTask,
+    RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
+    RUNTIME_STATE_ARTIFACT_KEY,
+    RuntimeState,
+    TaskSnapshot,
+    now_iso,
+)
+from src.models.db import ExternalStatus, InternalStatus
 from src.storage.snapshot_store import (
     append_snapshot,
     read_snapshots,
     read_latest_snapshot,
 )
+from src.workflow.context import WorkflowContext
+from src.workflow.snapshots import build_task_snapshot
 
 
 @pytest.mark.unit
@@ -192,3 +204,46 @@ def test_snapshot_with_remote_job_artifacts():
     assert restored.artifacts["remote_jobs"]["S1"]["job_id"] == "esmfold_job_123"
     assert restored.artifacts["remote_jobs"]["S1"]["endpoint"] == "http://example.com/esmfold"
     assert restored.artifacts["remote_jobs"]["S1"]["status"] == "running"
+
+
+@pytest.mark.unit
+def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
+    task = ProteinDesignTask(
+        task_id="task_runtime_state_001",
+        goal="freeze runtime state schema",
+        constraints={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[PlanStep(id="S1", tool="dummy_tool", inputs={}, metadata={})],
+        metadata={"plan_version": 3},
+    )
+    runtime_state = RuntimeState(
+        p_success=0.72,
+        p_structural_failure=0.18,
+        recovery_margin=0.41,
+        expected_remaining_cost=12.5,
+        last_update_source="safety:post_step",
+        observation_summary={"high_cost_steps_completed": 1},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        runtime_state=runtime_state,
+        status=InternalStatus.RUNNING,
+    )
+
+    snapshot = build_task_snapshot(context)
+
+    assert snapshot.plan_version == 3
+    assert snapshot.artifacts[RUNTIME_STATE_ARTIFACT_KEY] == {
+        "schema_version": 1,
+        "p_success": 0.72,
+        "p_structural_failure": 0.18,
+        "recovery_margin": 0.41,
+        "expected_remaining_cost": 12.5,
+        "last_update_source": "safety:post_step",
+    }
+    assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
+        "high_cost_steps_completed": 1
+    }


### PR DESCRIPTION
## 背景
- 对齐 issue #227，冻结 RuntimeState / BeliefState 的最小稳定 schema、snapshot 持久化键与版本字段约定。
- 保持对现有 WorkflowContext、TaskSnapshot、StepResult 契约的 additive change，不引入状态更新逻辑。

## 本次改动
- 在 src/models/contracts.py 新增 RuntimeState 契约，固定 schema_version=1 与最小必填字段。
- 新增稳定持久化键常量：runtime_state、runtime_observation_summary。
- 在 src/workflow/context.py 为 WorkflowContext 增加可选 runtime_state 工作副本。
- 在 src/workflow/snapshots.py 中将 context.runtime_state 序列化到 TaskSnapshot.artifacts。
- 在 src/workflow/recovery.py 中从 snapshot 恢复 runtime_state，保持 WAITING_* / snapshot 恢复链路兼容。
- 补充 contracts、snapshot、recovery 的单元测试覆盖。

## 边界说明
- WorkflowContext.runtime_state 是运行中的单一工作副本。
- TaskSnapshot.artifacts["runtime_state"] 只是稳定持久化载体，不是新的契约所有者。
- runtime_observation_summary 用于承载可选观测摘要，避免把可从 StepResult / SafetyResult / EventLog 重建的大对象塞回 runtime_state 主体。
- 本 PR 不实现运行时状态更新逻辑，不接入动作选择，也不扩展事件日志字段。

## 验证
- uv run pytest tests/unit/test_contracts.py tests/unit/test_task_snapshot.py tests/unit/test_recovery_event_logs.py
- uv run pytest tests/integration/test_snapshot_recovery.py

## 关联
- Closes #227
