### PR TITLE
feat: 补充 RuntimeState 候选摘要契约

### DIFF
--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -17,6 +17,35 @@ def now_iso() -> str:
 RUNTIME_STATE_SCHEMA_VERSION = 1
 RUNTIME_STATE_ARTIFACT_KEY = "runtime_state"
 RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY = "runtime_observation_summary"
+RUNTIME_STATE_SUMMARY_METADATA_KEY = "runtime_state_summary"
+
+
+def _validate_runtime_state_schema_version(value: int) -> int:
+    if value != RUNTIME_STATE_SCHEMA_VERSION:
+        raise ValueError(
+            f"schema_version must be {RUNTIME_STATE_SCHEMA_VERSION}"
+        )
+    return value
+
+
+def _validate_probability_value(value: float) -> float:
+    if isinstance(value, bool):
+        raise ValueError("probability fields must be numeric")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise ValueError("probability fields must be finite")
+    if not 0.0 <= normalized <= 1.0:
+        raise ValueError("probability fields must be between 0 and 1")
+    return normalized
+
+
+def _validate_finite_float_value(value: float, *, field_name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be numeric")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise ValueError(f"{field_name} must be finite")
+    return normalized
 
 
 class ProteinDesignTask(BaseModel):
@@ -120,42 +149,25 @@ class RuntimeState(BaseModel):
     @field_validator("schema_version")
     @classmethod
     def _validate_schema_version(cls, value: int) -> int:
-        if value != RUNTIME_STATE_SCHEMA_VERSION:
-            raise ValueError(
-                f"schema_version must be {RUNTIME_STATE_SCHEMA_VERSION}"
-            )
-        return value
+        return _validate_runtime_state_schema_version(value)
 
     @field_validator("p_success", "p_structural_failure")
     @classmethod
     def _validate_probability(cls, value: float) -> float:
-        if isinstance(value, bool):
-            raise ValueError("probability fields must be numeric")
-        normalized = float(value)
-        if not math.isfinite(normalized):
-            raise ValueError("probability fields must be finite")
-        if not 0.0 <= normalized <= 1.0:
-            raise ValueError("probability fields must be between 0 and 1")
-        return normalized
+        return _validate_probability_value(value)
 
     @field_validator("recovery_margin")
     @classmethod
     def _validate_recovery_margin(cls, value: float) -> float:
-        if isinstance(value, bool):
-            raise ValueError("recovery_margin must be numeric")
-        normalized = float(value)
-        if not math.isfinite(normalized):
-            raise ValueError("recovery_margin must be finite")
-        return normalized
+        return _validate_finite_float_value(value, field_name="recovery_margin")
 
     @field_validator("expected_remaining_cost")
     @classmethod
     def _validate_expected_remaining_cost(cls, value: float) -> float:
-        if isinstance(value, bool):
-            raise ValueError("expected_remaining_cost must be numeric")
-        normalized = float(value)
-        if not math.isfinite(normalized):
-            raise ValueError("expected_remaining_cost must be finite")
+        normalized = _validate_finite_float_value(
+            value,
+            field_name="expected_remaining_cost",
+        )
         if normalized < 0.0:
             raise ValueError("expected_remaining_cost must be >= 0")
         return normalized
@@ -184,6 +196,58 @@ class RuntimeState(BaseModel):
     def to_snapshot_payload(self) -> Dict[str, Any]:
         """Serialize the stable persisted fields for TaskSnapshot.artifacts."""
         return self.model_dump(exclude={"observation_summary"})
+
+    def to_summary_payload(self) -> Dict[str, Any]:
+        """Serialize the candidate-facing runtime state summary."""
+        return RuntimeStateSummary.from_runtime_state(self).model_dump()
+
+
+class RuntimeStateSummary(BaseModel):
+    """候选展示态可复用的运行时状态摘要。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=RUNTIME_STATE_SCHEMA_VERSION)
+    p_success: float
+    p_structural_failure: float
+    recovery_margin: float
+    expected_remaining_cost: float
+
+    @field_validator("schema_version")
+    @classmethod
+    def _validate_schema_version(cls, value: int) -> int:
+        return _validate_runtime_state_schema_version(value)
+
+    @field_validator("p_success", "p_structural_failure")
+    @classmethod
+    def _validate_probability(cls, value: float) -> float:
+        return _validate_probability_value(value)
+
+    @field_validator("recovery_margin")
+    @classmethod
+    def _validate_recovery_margin(cls, value: float) -> float:
+        return _validate_finite_float_value(value, field_name="recovery_margin")
+
+    @field_validator("expected_remaining_cost")
+    @classmethod
+    def _validate_expected_remaining_cost(cls, value: float) -> float:
+        normalized = _validate_finite_float_value(
+            value,
+            field_name="expected_remaining_cost",
+        )
+        if normalized < 0.0:
+            raise ValueError("expected_remaining_cost must be >= 0")
+        return normalized
+
+    @classmethod
+    def from_runtime_state(cls, runtime_state: RuntimeState) -> "RuntimeStateSummary":
+        return cls(
+            schema_version=runtime_state.schema_version,
+            p_success=runtime_state.p_success,
+            p_structural_failure=runtime_state.p_structural_failure,
+            recovery_margin=runtime_state.recovery_margin,
+            expected_remaining_cost=runtime_state.expected_remaining_cost,
+        )
 
 
 class DesignResult(BaseModel):
@@ -314,6 +378,7 @@ class PendingActionCandidate(BaseModel):
         adapter_mode: 适配器模式（local/remote/mock/hybrid/unknown）。
         summary: 候选摘要信息。
         metadata: 额外元数据。
+            - `runtime_state_summary` 可承载候选展示所需的轻量状态摘要。
     """
 
     candidate_id: str
@@ -415,6 +480,18 @@ class PendingActionCandidate(BaseModel):
 
         return self
 
+    @model_validator(mode="after")
+    def _sync_runtime_state_summary_metadata(self):
+        metadata = dict(self.metadata or {})
+        self.metadata = metadata
+        summary_payload = metadata.get(RUNTIME_STATE_SUMMARY_METADATA_KEY)
+        if summary_payload is None:
+            return self
+        metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = _normalize_runtime_state_summary(
+            summary_payload
+        )
+        return self
+
 
 def _sync_metadata_field(
     metadata: Dict[str, Any],
@@ -469,6 +546,16 @@ def _sync_adapter_mode(
         raise ValueError("metadata.adapter_mode must match adapter_mode")
     metadata["adapter_mode"] = field_value
     return field_value
+
+
+def _normalize_runtime_state_summary(summary_payload: Any) -> Dict[str, Any]:
+    if isinstance(summary_payload, RuntimeStateSummary):
+        return summary_payload.model_dump()
+    if isinstance(summary_payload, dict):
+        return RuntimeStateSummary.model_validate(summary_payload).model_dump()
+    raise ValueError(
+        f"metadata.{RUNTIME_STATE_SUMMARY_METADATA_KEY} must be a mapping"
+    )
 
 
 class PendingAction(BaseModel):

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -8,6 +8,7 @@ from src.models.contracts import (
     ProteinDesignTask,
     Plan,
     PlanStep,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
     RuntimeState,
     StepResult,
     DesignResult,
@@ -181,6 +182,24 @@ class TestRuntimeState:
                 expected_remaining_cost=4.5,
                 last_update_source="step_result:S2",
             )
+
+    def test_runtime_state_can_emit_candidate_summary_payload(self):
+        state = RuntimeState(
+            p_success=0.74,
+            p_structural_failure=0.19,
+            recovery_margin=0.32,
+            expected_remaining_cost=5.5,
+            last_update_source="step_result:S3",
+            observation_summary={"completed_steps": 2},
+        )
+
+        assert state.to_summary_payload() == {
+            "schema_version": 1,
+            "p_success": 0.74,
+            "p_structural_failure": 0.19,
+            "recovery_margin": 0.32,
+            "expected_remaining_cost": 5.5,
+        }
 
 
 @pytest.mark.unit
@@ -383,4 +402,49 @@ class TestCandidateSetContracts:
                 explanation="test",
                 default_suggestion="plan_a",
                 default_recommendation="plan_b",
+            )
+
+    def test_candidate_runtime_state_summary_is_normalized(self, sample_plan: Plan):
+        state = RuntimeState(
+            p_success=0.81,
+            p_structural_failure=0.11,
+            recovery_margin=0.49,
+            expected_remaining_cost=3.0,
+            last_update_source="safety:post_step",
+        )
+        candidate = PendingActionCandidate(
+            candidate_id="plan_state_summary",
+            payload=sample_plan,
+            metadata={
+                RUNTIME_STATE_SUMMARY_METADATA_KEY: state.to_summary_payload(),
+            },
+        )
+
+        assert candidate.metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] == {
+            "schema_version": 1,
+            "p_success": 0.81,
+            "p_structural_failure": 0.11,
+            "recovery_margin": 0.49,
+            "expected_remaining_cost": 3.0,
+        }
+
+    def test_candidate_invalid_runtime_state_summary_rejected(
+        self, sample_plan: Plan
+    ):
+        with pytest.raises(
+            ValueError,
+            match="probability fields must be between 0 and 1",
+        ):
+            PendingActionCandidate(
+                candidate_id="plan_bad_state_summary",
+                payload=sample_plan,
+                metadata={
+                    RUNTIME_STATE_SUMMARY_METADATA_KEY: {
+                        "schema_version": 1,
+                        "p_success": 1.2,
+                        "p_structural_failure": 0.2,
+                        "recovery_margin": 0.1,
+                        "expected_remaining_cost": 4.0,
+                    }
+                },
             )


### PR DESCRIPTION
## 背景
- 对齐 issue #211，在现有 RuntimeState/context/snapshot 基础上，补齐候选展示态所需的运行时状态摘要挂点。
- 保持对 WorkflowContext、TaskSnapshot、PendingActionCandidate 契约的向后兼容，不引入状态更新逻辑。

## 本次改动
- 在 src/models/contracts.py 中新增 runtime_state_summary 稳定 metadata 键。
- 新增 RuntimeStateSummary 校验模型，固定候选展示态允许暴露的最小字段集合。
- 为 RuntimeState 增加 to_summary_payload()，用于导出可序列化、可审阅的轻量状态摘要。
- 在 PendingActionCandidate.metadata 中对 runtime_state_summary 做规范化与校验，确保摘要结构稳定且向后兼容。
- 补充对应的 contract 单元测试。

## 边界说明
- 该摘要挂点仅用于候选展示态，不承载 observation_summary 或其他大对象。
- 本 PR 不实现 runtime state 更新逻辑，不接入动作选择，不修改 snapshot 恢复语义。
- 现有 runtime_state 与 TaskSnapshot.artifacts 的往返能力保持不变。

## 验证
- uv run pytest tests/unit/test_contracts.py -q
- uv run pytest tests/unit/test_task_snapshot.py -q
- uv run pytest tests/unit/test_decision_validation.py -q

## 关联
- Closes #211
