### PR TITLE
feat: 固定 PendingActionCandidate 与 WAITING 运行时摘要契约

### DIFF
--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -13,6 +13,8 @@ from src.llm.baseline_provider import BaselineProvider
 from src.llm.provider_registry import create_provider, load_provider_catalog
 from src.agents.task_goal_parser import enrich_task_from_goal
 from src.models.contracts import (
+    ACTION_SCORE_METADATA_KEY,
+    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     PatchRequest,
     PendingActionType,
     PendingActionCandidate,
@@ -23,7 +25,11 @@ from src.models.contracts import (
     PlanStep,
     ProteinDesignTask,
     ReplanRequest,
+    ScoreSummary,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
     StepResult,
+    SHADOW_SCORE_METADATA_KEY,
+    WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
 from src.models.validation import (
@@ -596,6 +602,11 @@ class PlannerAgent:
             record.plan = plan
 
         if gate.requires_hitl:
+            pending_action_metadata = _build_pending_action_runtime_metadata(
+                default_candidate=candidate,
+                default_recommendation=top_k.default_recommendation,
+                waiting_reason=gate.reason,
+            )
             pending_action = build_pending_action(
                 task_id=task.task_id,
                 action_type=PendingActionType.PLAN_CONFIRM,
@@ -603,6 +614,7 @@ class PlannerAgent:
                 default_suggestion=top_k.default_recommendation,
                 default_recommendation=top_k.default_recommendation,
                 explanation=f"{top_k.explanation} gate={gate.reason}",
+                metadata=pending_action_metadata,
             )
             validate_candidate_set_output(
                 pending_action,
@@ -1791,6 +1803,8 @@ def _build_top_k_result(
             "adapter_mode": adapter_mode,
             "generation_note": payload.note,
             "s5_contract": _build_s5_scoring_contract(score_weights),
+            ACTION_SCORE_METADATA_KEY: _build_action_score_summary(score_breakdown),
+            SHADOW_SCORE_METADATA_KEY: _build_shadow_score_summary(score_breakdown),
         }
         payload_metadata = payload.payload.metadata if isinstance(payload.payload.metadata, dict) else {}
         planner_route = payload_metadata.get("planner_route")
@@ -1855,6 +1869,13 @@ def _build_top_k_result(
     selected_rows = sorted(selected_rows, key=lambda row: row[1])
     candidates = [row[0] for row in selected_rows]
     default_recommendation = candidates[0].candidate_id if candidates else None
+    if candidates:
+        candidates[0].metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
+            _build_default_recommendation_reason(
+                candidate_kind=candidate_kind,
+                candidate_id=candidates[0].candidate_id,
+            )
+        )
     explanation = (
         f"{candidate_kind} Top-K generated with deterministic sort "
         f"(requested={top_k}, returned={len(candidates)}). "
@@ -1871,6 +1892,68 @@ def _build_top_k_result(
         default_recommendation=default_recommendation,
         explanation=explanation,
     )
+
+
+def _build_action_score_summary(score_breakdown: dict[str, float]) -> dict[str, Any]:
+    summary = ScoreSummary(
+        value=float(score_breakdown.get("overall", 0.0)),
+        source="score_breakdown.overall",
+    )
+    return summary.model_dump()
+
+
+def _build_shadow_score_summary(score_breakdown: dict[str, float]) -> dict[str, Any]:
+    summary = ScoreSummary(
+        value=float(score_breakdown.get("overall", 0.0)),
+        source="score_breakdown.overall_passthrough",
+    )
+    return summary.model_dump()
+
+
+def _build_default_recommendation_reason(
+    *,
+    candidate_kind: str,
+    candidate_id: str,
+) -> dict[str, str]:
+    return {
+        "code": f"{candidate_kind}_ranked_first",
+        "message": (
+            f"{candidate_kind} candidate {candidate_id} is the current default "
+            "recommendation after deterministic ranking."
+        ),
+    }
+
+
+def _build_pending_action_runtime_metadata(
+    *,
+    default_candidate: PendingActionCandidate,
+    default_recommendation: str | None,
+    waiting_reason: str,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    candidate_metadata = (
+        default_candidate.metadata
+        if isinstance(default_candidate.metadata, dict)
+        else {}
+    )
+    waiting_summary: dict[str, Any] = {
+        "selected_candidate_id": default_candidate.candidate_id,
+        "waiting_reason": waiting_reason,
+    }
+    if default_recommendation:
+        waiting_summary["default_recommendation"] = default_recommendation
+    for key in (
+        RUNTIME_STATE_SUMMARY_METADATA_KEY,
+        DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+        ACTION_SCORE_METADATA_KEY,
+        SHADOW_SCORE_METADATA_KEY,
+    ):
+        value = candidate_metadata.get(key)
+        if value is not None:
+            waiting_summary[key] = value
+    if waiting_summary:
+        metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY] = waiting_summary
+    return metadata
 
 
 def _select_diverse_top_k(

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -18,6 +18,10 @@ RUNTIME_STATE_SCHEMA_VERSION = 1
 RUNTIME_STATE_ARTIFACT_KEY = "runtime_state"
 RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY = "runtime_observation_summary"
 RUNTIME_STATE_SUMMARY_METADATA_KEY = "runtime_state_summary"
+DEFAULT_RECOMMENDATION_REASON_METADATA_KEY = "default_recommendation_reason"
+ACTION_SCORE_METADATA_KEY = "action_score"
+SHADOW_SCORE_METADATA_KEY = "shadow_score"
+WAITING_RUNTIME_SUMMARY_METADATA_KEY = "waiting_runtime_summary"
 
 
 def _validate_runtime_state_schema_version(value: int) -> int:
@@ -45,6 +49,13 @@ def _validate_finite_float_value(value: float, *, field_name: str) -> float:
     normalized = float(value)
     if not math.isfinite(normalized):
         raise ValueError(f"{field_name} must be finite")
+    return normalized
+
+
+def _validate_non_empty_text(value: str, *, field_name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must not be empty")
     return normalized
 
 
@@ -250,6 +261,67 @@ class RuntimeStateSummary(BaseModel):
         )
 
 
+class RecommendationReason(BaseModel):
+    """默认建议理由的最小稳定摘要。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    message: str
+
+    @field_validator("code", "message")
+    @classmethod
+    def _validate_text(cls, value: str, info) -> str:
+        return _validate_non_empty_text(value, field_name=info.field_name)
+
+
+class ScoreSummary(BaseModel):
+    """动作分或 shadow 分的最小稳定摘要。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: float
+    source: str
+
+    @field_validator("value")
+    @classmethod
+    def _validate_value(cls, value: float) -> float:
+        normalized = _validate_finite_float_value(value, field_name="value")
+        if not 0.0 <= normalized <= 1.0:
+            raise ValueError("value must be between 0 and 1")
+        return normalized
+
+    @field_validator("source")
+    @classmethod
+    def _validate_source(cls, value: str) -> str:
+        return _validate_non_empty_text(value, field_name="source")
+
+
+class WaitingRuntimeSummary(BaseModel):
+    """WAITING 场景下用于 HITL 回放的最小状态摘要。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    selected_candidate_id: str | None = None
+    default_recommendation: str | None = None
+    waiting_reason: str | None = None
+    runtime_state_summary: RuntimeStateSummary | None = None
+    default_recommendation_reason: RecommendationReason | None = None
+    action_score: ScoreSummary | None = None
+    shadow_score: ScoreSummary | None = None
+
+    @field_validator(
+        "selected_candidate_id",
+        "default_recommendation",
+        "waiting_reason",
+    )
+    @classmethod
+    def _validate_optional_text(cls, value: str | None, info) -> str | None:
+        if value is None:
+            return value
+        return _validate_non_empty_text(value, field_name=info.field_name)
+
+
 class DesignResult(BaseModel):
     """SummarizerAgent 汇总后的最终设计结果"""
 
@@ -379,6 +451,8 @@ class PendingActionCandidate(BaseModel):
         summary: 候选摘要信息。
         metadata: 额外元数据。
             - `runtime_state_summary` 可承载候选展示所需的轻量状态摘要。
+            - `default_recommendation_reason` 可承载默认建议理由。
+            - `action_score` / `shadow_score` 用于承载动作分摘要。
     """
 
     candidate_id: str
@@ -485,10 +559,16 @@ class PendingActionCandidate(BaseModel):
         metadata = dict(self.metadata or {})
         self.metadata = metadata
         summary_payload = metadata.get(RUNTIME_STATE_SUMMARY_METADATA_KEY)
-        if summary_payload is None:
-            return self
-        metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = _normalize_runtime_state_summary(
-            summary_payload
+        normalized_summary = (
+            _normalize_runtime_state_summary(summary_payload)
+            if summary_payload is not None
+            else None
+        )
+        if normalized_summary is not None:
+            metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = normalized_summary
+        _normalize_candidate_runtime_contracts(
+            metadata,
+            runtime_state_summary=normalized_summary,
         )
         return self
 
@@ -558,6 +638,65 @@ def _normalize_runtime_state_summary(summary_payload: Any) -> Dict[str, Any]:
     )
 
 
+def _normalize_recommendation_reason(reason_payload: Any) -> Dict[str, Any]:
+    if isinstance(reason_payload, RecommendationReason):
+        return reason_payload.model_dump()
+    if isinstance(reason_payload, dict):
+        return RecommendationReason.model_validate(reason_payload).model_dump()
+    raise ValueError(
+        f"metadata.{DEFAULT_RECOMMENDATION_REASON_METADATA_KEY} must be a mapping"
+    )
+
+
+def _normalize_score_summary(score_payload: Any, *, field_name: str) -> Dict[str, Any]:
+    if isinstance(score_payload, ScoreSummary):
+        return score_payload.model_dump()
+    if isinstance(score_payload, dict):
+        return ScoreSummary.model_validate(score_payload).model_dump()
+    raise ValueError(f"metadata.{field_name} must be a mapping")
+
+
+def _normalize_candidate_runtime_contracts(
+    metadata: Dict[str, Any],
+    *,
+    runtime_state_summary: Dict[str, Any] | None = None,
+) -> None:
+    if runtime_state_summary is not None:
+        metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = runtime_state_summary
+
+    reason_payload = metadata.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY)
+    if reason_payload is not None:
+        metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = _normalize_recommendation_reason(
+            reason_payload
+        )
+
+    action_score_payload = metadata.get(ACTION_SCORE_METADATA_KEY)
+    if action_score_payload is not None:
+        metadata[ACTION_SCORE_METADATA_KEY] = _normalize_score_summary(
+            action_score_payload,
+            field_name=ACTION_SCORE_METADATA_KEY,
+        )
+
+    shadow_score_payload = metadata.get(SHADOW_SCORE_METADATA_KEY)
+    if shadow_score_payload is not None:
+        metadata[SHADOW_SCORE_METADATA_KEY] = _normalize_score_summary(
+            shadow_score_payload,
+            field_name=SHADOW_SCORE_METADATA_KEY,
+        )
+
+
+def _normalize_waiting_runtime_summary(summary_payload: Any) -> Dict[str, Any]:
+    if isinstance(summary_payload, WaitingRuntimeSummary):
+        return summary_payload.model_dump(exclude_none=True)
+    if isinstance(summary_payload, dict):
+        return WaitingRuntimeSummary.model_validate(summary_payload).model_dump(
+            exclude_none=True
+        )
+    raise ValueError(
+        f"metadata.{WAITING_RUNTIME_SUMMARY_METADATA_KEY} must be a mapping"
+    )
+
+
 class PendingAction(BaseModel):
     """等待人工决策的结构化对象。
 
@@ -573,6 +712,7 @@ class PendingAction(BaseModel):
         created_at: 创建时间戳。
         decided_at: 决策完成时间戳。
         created_by: 创建者标识（通常为 system）。
+        metadata: WAITING 回放或审计所需的附加摘要。
     """
 
     pending_action_id: str
@@ -586,6 +726,7 @@ class PendingAction(BaseModel):
     created_at: str = Field(default_factory=now_iso)
     decided_at: Optional[str] = None
     created_by: str = "system"
+    metadata: Dict = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _sync_default_recommendation(self):
@@ -598,6 +739,18 @@ class PendingAction(BaseModel):
         resolved = recommendation or suggestion
         self.default_suggestion = resolved
         self.default_recommendation = resolved
+        return self
+
+    @model_validator(mode="after")
+    def _sync_waiting_runtime_summary_metadata(self):
+        metadata = dict(self.metadata or {})
+        self.metadata = metadata
+        summary_payload = metadata.get(WAITING_RUNTIME_SUMMARY_METADATA_KEY)
+        if summary_payload is None:
+            return self
+        metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY] = _normalize_waiting_runtime_summary(
+            summary_payload
+        )
         return self
 
 

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -10,10 +10,15 @@ from uuid import uuid4
 
 from src.infra.event_log_factory import make_waiting_enter
 from src.models.contracts import (
+    ACTION_SCORE_METADATA_KEY,
+    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     PendingAction,
     PendingActionCandidate,
     PendingActionStatus,
     PendingActionType,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
+    SHADOW_SCORE_METADATA_KEY,
+    WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
 from src.models.db import ExternalStatus, InternalStatus, TaskRecord, to_external_status
@@ -44,6 +49,7 @@ def build_pending_action(
     default_suggestion: Optional[str] = None,
     default_recommendation: Optional[str] = None,
     explanation: str,
+    metadata: Optional[dict] = None,
     created_by: str = "system",
 ) -> PendingAction:
     """构造最小化 PendingAction 实例。
@@ -56,6 +62,7 @@ def build_pending_action(
         default_suggestion: 默认建议的候选 ID。
         default_recommendation: CandidateSetOutput v1 默认推荐候选 ID。
         explanation: 解释说明文本。
+        metadata: 可选的 WAITING 回放 / 审计元数据。
         created_by: 创建者标识（默认 system）。
 
     Returns:
@@ -73,6 +80,7 @@ def build_pending_action(
         created_at=now_iso(),
         decided_at=None,
         created_by=created_by,
+        metadata=dict(metadata or {}),
     )
 
 
@@ -144,6 +152,16 @@ def enter_waiting_state(
         if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
         else {}
     )
+    waiting_runtime_summary = _build_waiting_runtime_summary(
+        pending_action=pending_action,
+        selected_candidate=selected_candidate,
+        waiting_reason=reason,
+    )
+    if waiting_runtime_summary:
+        pending_action.metadata.setdefault(
+            WAITING_RUNTIME_SUMMARY_METADATA_KEY,
+            waiting_runtime_summary,
+        )
     waiting_enter_event = make_waiting_enter(
         task_id=context.task.task_id,
         pending_action_id=pending_action.pending_action_id,
@@ -173,6 +191,11 @@ def enter_waiting_state(
                 selected_candidate.adapter_mode
                 if selected_candidate
                 else selected_meta.get("adapter_mode")
+            ),
+            "waiting_runtime_summary": (
+                pending_action.metadata.get(WAITING_RUNTIME_SUMMARY_METADATA_KEY)
+                if isinstance(pending_action.metadata, dict)
+                else None
             ),
         },
     )
@@ -244,3 +267,35 @@ def _default_event_logger(event: dict) -> None:
     if not task_id:
         return
     append_event(task_id, event)
+
+
+def _build_waiting_runtime_summary(
+    *,
+    pending_action: PendingAction,
+    selected_candidate: PendingActionCandidate | None,
+    waiting_reason: str | None,
+) -> dict | None:
+    candidate_metadata = (
+        selected_candidate.metadata
+        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        else {}
+    )
+    summary: dict[str, object] = {}
+    if selected_candidate is not None:
+        summary["selected_candidate_id"] = selected_candidate.candidate_id
+    if pending_action.default_recommendation:
+        summary["default_recommendation"] = pending_action.default_recommendation
+    if waiting_reason:
+        summary["waiting_reason"] = waiting_reason
+
+    for key in (
+        RUNTIME_STATE_SUMMARY_METADATA_KEY,
+        DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+        ACTION_SCORE_METADATA_KEY,
+        SHADOW_SCORE_METADATA_KEY,
+    ):
+        value = candidate_metadata.get(key)
+        if value is not None:
+            summary[key] = value
+
+    return summary or None

--- a/tests/integration/test_event_log_integration.py
+++ b/tests/integration/test_event_log_integration.py
@@ -9,11 +9,16 @@ from pathlib import Path
 import pytest
 
 from src.models.contracts import (
+    ACTION_SCORE_METADATA_KEY,
+    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     Decision,
     DecisionChoice,
     PendingActionStatus,
     PendingActionType,
     ProteinDesignTask,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
+    SHADOW_SCORE_METADATA_KEY,
+    WAITING_RUNTIME_SUMMARY_METADATA_KEY,
 )
 from src.models.db import ExternalStatus, InternalStatus, TaskRecord
 from src.models.event_log import EventType
@@ -61,10 +66,52 @@ def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
     )
 
     # Build and enter WAITING_PLAN_CONFIRM state
+    from src.models.contracts import PendingActionCandidate, Plan, PlanStep
+
+    candidate_plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="dummy_tool",
+                inputs={"sequence": "ACDE"},
+                metadata={},
+            )
+        ],
+        constraints={},
+        metadata={},
+    )
     pending_action = build_pending_action(
         task_id=task.task_id,
         action_type=PendingActionType.PLAN_CONFIRM,
-        candidates=[],
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="candidate_waiting",
+                payload=candidate_plan,
+                metadata={
+                    RUNTIME_STATE_SUMMARY_METADATA_KEY: {
+                        "schema_version": 1,
+                        "p_success": 0.77,
+                        "p_structural_failure": 0.12,
+                        "recovery_margin": 0.44,
+                        "expected_remaining_cost": 2.5,
+                    },
+                    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY: {
+                        "code": "plan_ranked_first",
+                        "message": "selected by deterministic rank",
+                    },
+                    ACTION_SCORE_METADATA_KEY: {
+                        "value": 0.77,
+                        "source": "score_breakdown.overall",
+                    },
+                    SHADOW_SCORE_METADATA_KEY: {
+                        "value": 0.77,
+                        "source": "score_breakdown.overall_passthrough",
+                    },
+                },
+            )
+        ],
+        default_recommendation="candidate_waiting",
         explanation="test waiting enter",
     )
     enter_waiting_state(
@@ -98,6 +145,11 @@ def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
     assert event["new_status"] == ExternalStatus.WAITING_PLAN_CONFIRM.value
     assert event["internal_status"] == InternalStatus.WAITING_PLAN_CONFIRM.value
     assert event["data"]["waiting_state"] == InternalStatus.WAITING_PLAN_CONFIRM.value
+    waiting_summary = event["data"][WAITING_RUNTIME_SUMMARY_METADATA_KEY]
+    assert waiting_summary["selected_candidate_id"] == "candidate_waiting"
+    assert waiting_summary["default_recommendation"] == "candidate_waiting"
+    assert waiting_summary[ACTION_SCORE_METADATA_KEY]["value"] == pytest.approx(0.77)
+    assert pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]["default_recommendation_reason"]["code"] == "plan_ranked_first"
     assert event["actor_type"] == "system"
 
 

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -2,6 +2,8 @@
 import pytest
 from pydantic import ValidationError
 from src.models.contracts import (
+    ACTION_SCORE_METADATA_KEY,
+    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     PendingAction,
     PendingActionCandidate,
     PendingActionType,
@@ -9,6 +11,8 @@ from src.models.contracts import (
     Plan,
     PlanStep,
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
+    SHADOW_SCORE_METADATA_KEY,
+    WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     RuntimeState,
     StepResult,
     DesignResult,
@@ -448,3 +452,65 @@ class TestCandidateSetContracts:
                     }
                 },
             )
+
+    def test_candidate_runtime_contract_metadata_is_normalized(self, sample_plan: Plan):
+        candidate = PendingActionCandidate(
+            candidate_id="plan_runtime_contract",
+            payload=sample_plan,
+            metadata={
+                RUNTIME_STATE_SUMMARY_METADATA_KEY: {
+                    "schema_version": 1,
+                    "p_success": 0.81,
+                    "p_structural_failure": 0.11,
+                    "recovery_margin": 0.49,
+                    "expected_remaining_cost": 3.0,
+                },
+                DEFAULT_RECOMMENDATION_REASON_METADATA_KEY: {
+                    "code": "plan_ranked_first",
+                    "message": "selected by deterministic rank",
+                },
+                ACTION_SCORE_METADATA_KEY: {
+                    "value": 0.81,
+                    "source": "score_breakdown.overall",
+                },
+                SHADOW_SCORE_METADATA_KEY: {
+                    "value": 0.81,
+                    "source": "score_breakdown.overall_passthrough",
+                },
+            },
+        )
+
+        assert candidate.metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]["code"] == "plan_ranked_first"
+        assert candidate.metadata[ACTION_SCORE_METADATA_KEY]["value"] == pytest.approx(0.81)
+        assert candidate.metadata[SHADOW_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall_passthrough"
+
+    def test_pending_action_waiting_runtime_summary_is_normalized(
+        self, sample_task: ProteinDesignTask, sample_plan: Plan
+    ):
+        candidate = PendingActionCandidate(candidate_id="plan_a", payload=sample_plan)
+        action = PendingAction(
+            pending_action_id="pa_waiting_summary",
+            task_id=sample_task.task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            candidates=[candidate],
+            explanation="test",
+            default_recommendation="plan_a",
+            metadata={
+                WAITING_RUNTIME_SUMMARY_METADATA_KEY: {
+                    "selected_candidate_id": "plan_a",
+                    "default_recommendation": "plan_a",
+                    "waiting_reason": "plan_high_risk",
+                    "default_recommendation_reason": {
+                        "code": "plan_ranked_first",
+                        "message": "selected by deterministic rank",
+                    },
+                    "action_score": {
+                        "value": 0.88,
+                        "source": "score_breakdown.overall",
+                    },
+                }
+            },
+        )
+
+        assert action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]["selected_candidate_id"] == "plan_a"
+        assert action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]["action_score"]["value"] == pytest.approx(0.88)

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -7,6 +7,8 @@ from src.agents.task_goal_parser import enrich_task_from_goal
 from src.llm.base_llm_provider import ProviderConfig
 from src.kg.kg_client import ToolKGError
 from src.models.contracts import (
+    ACTION_SCORE_METADATA_KEY,
+    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     PatchRequest,
     PendingActionType,
     Plan,
@@ -14,6 +16,8 @@ from src.models.contracts import (
     PlanStep,
     ProteinDesignTask,
     ReplanRequest,
+    SHADOW_SCORE_METADATA_KEY,
+    WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     StepResult,
     now_iso,
 )
@@ -543,6 +547,49 @@ class TestPlannerAgent:
             for candidate in first.candidates
         }
         assert len(capability_buckets) >= 2
+        default_metadata = first.candidates[0].metadata
+        assert default_metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]["code"] == "plan_ranked_first"
+        assert default_metadata[ACTION_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall"
+        assert default_metadata[SHADOW_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall_passthrough"
+
+    def test_plan_with_status_waiting_metadata_keeps_runtime_summary_fields(self, monkeypatch):
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        planner = PlannerAgent(tool_registry=_topk_registry())
+        task = ProteinDesignTask(
+            task_id="task_waiting_runtime_summary",
+            goal="de_novo_design",
+            constraints={
+                "length_range": [40, 60],
+                "require_plan_confirm": True,
+            },
+            metadata={},
+        )
+        context = WorkflowContext(
+            task=task,
+            status=InternalStatus.CREATED,
+            plan=None,
+            step_results={},
+            safety_events=[],
+            pending_action=None,
+            design_result=None,
+        )
+        record = TaskRecord(
+            id=task.task_id,
+            goal=task.goal,
+            status=ExternalStatus.CREATED,
+            internal_status=InternalStatus.CREATED,
+            plan=None,
+            pending_action=None,
+            design_result=None,
+        )
+
+        planner.plan_with_status(task, context, record=record)
+
+        assert context.pending_action is not None
+        waiting_summary = context.pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]
+        assert waiting_summary["selected_candidate_id"] == context.pending_action.default_recommendation
+        assert waiting_summary["default_recommendation_reason"]["code"] == "plan_ranked_first"
+        assert waiting_summary["action_score"]["source"] == "score_breakdown.overall"
 
     def test_plan_top_k_has_s5_contract_and_stable_weights(self, monkeypatch):
         monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())


### PR DESCRIPTION
## 背景
- 对齐 issue #226，固定 PendingActionCandidate 与 WAITING 场景下的运行时摘要契约。
- 保持对现有 PendingActionCandidate、PendingAction 和 planner/workflow 行为的向后兼容，不引入动作选择器或排序语义变更。

## 本次改动
- 在 src/models/contracts.py 中新增候选摘要与 WAITING 回放所需的稳定 metadata 键与结构化校验。
- 在 src/workflow/pending_action.py 中进入 WAITING 时汇总默认候选、建议理由、action score、shadow score 和 runtime state 摘要。
- 在 src/agents/planner.py 中为默认候选填充 recommendation reason、action score、shadow score，并将其写入 WAITING metadata。
- 补充 contracts、planner、WAITING 事件链路的测试覆盖。

## 边界说明
- runtime_state_summary 仍然是对 runtime_state 的轻量引用摘要，不承载 observation_summary 等大对象。
- action_score / shadow_score 目前只固定字段形状与接入点，不改变现有默认排序或执行控制流。
- WAITING metadata 只保留 HITL 决策回放所需的最小字段，不与 StepResult.metrics 混用。

## 验证
- uv run pytest tests/unit/test_contracts.py tests/unit/test_planner_agent.py -q
- uv run pytest tests/integration/test_event_log_integration.py -q
- uv run pytest tests/unit/test_decision_validation.py -q

## 关联
- Closes #226
