### PR TITLE
[codex] 实现 issue #212 Lite 运行时 belief-state 更新器

### DIFF
--- a/src/workflow/belief_state.py
+++ b/src/workflow/belief_state.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.models.contracts import RuntimeState, SafetyResult, StepResult
+
+__all__ = ["extract_failure_context", "update_runtime_state"]
+
+_BASELINE_P_SUCCESS = 0.5
+_BASELINE_P_STRUCTURAL_FAILURE = 0.25
+_BASELINE_RECOVERY_MARGIN = 0.6
+_BASELINE_EXPECTED_REMAINING_COST = 1.0
+_STRUCTURAL_STAGE_IDS = {"S2", "S3", "S4"}
+
+
+def update_runtime_state(
+    *,
+    previous_state: RuntimeState | None,
+    step_result: StepResult | None = None,
+    safety_result: SafetyResult | None = None,
+    failure_context: Mapping[str, Any] | None = None,
+    completed_steps: int | None = None,
+    total_steps: int | None = None,
+) -> RuntimeState:
+    """以确定性规则更新 Lite 版运行时 belief-state。
+
+    第一版刻意采用小步、可解释的规则增减，确保结果能够：
+    - 直接序列化；
+    - 跨快照回放；
+    - 被测试稳定复现。
+    """
+
+    state = previous_state or RuntimeState(
+        p_success=_BASELINE_P_SUCCESS,
+        p_structural_failure=_BASELINE_P_STRUCTURAL_FAILURE,
+        recovery_margin=_BASELINE_RECOVERY_MARGIN,
+        expected_remaining_cost=_initial_remaining_cost(
+            completed_steps=completed_steps,
+            total_steps=total_steps,
+        ),
+        last_update_source="runtime_bootstrap",
+        observation_summary={},
+    )
+
+    p_success = state.p_success
+    p_structural_failure = state.p_structural_failure
+    recovery_margin = _clamp_unit_interval(state.recovery_margin)
+    expected_remaining_cost = state.expected_remaining_cost
+    observation_summary = dict(state.observation_summary)
+    last_update_source = state.last_update_source
+    cost_penalty = 0.0
+    cost_reward = 0.0
+
+    _write_progress_summary(
+        observation_summary,
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+    )
+
+    if step_result is not None:
+        stage_id = _extract_stage_id(step_result)
+        last_update_source = f"step_result:{step_result.step_id}"
+        observation_summary.update(
+            {
+                "last_step_id": step_result.step_id,
+                "last_step_status": step_result.status,
+                "last_tool": step_result.tool,
+                "last_stage_id": stage_id,
+                "last_failure_type": _as_non_empty_text(step_result.failure_type),
+                "last_failure_code": _extract_failure_code(step_result),
+            }
+        )
+
+        if step_result.status == "success":
+            p_success += 0.12
+            p_structural_failure -= 0.08
+            recovery_margin += 0.06
+            cost_reward += 0.35
+            if _is_structural_step(stage_id=stage_id, tool_id=step_result.tool):
+                p_success += 0.04
+                p_structural_failure -= 0.05
+        elif step_result.status == "failed":
+            p_success -= 0.18
+            p_structural_failure += 0.14
+            recovery_margin -= 0.12
+            cost_penalty += 0.75
+            if _is_structural_step(stage_id=stage_id, tool_id=step_result.tool):
+                p_structural_failure += 0.08
+            if _as_bool(step_result.metrics.get("retry_exhausted")):
+                p_success -= 0.05
+                recovery_margin -= 0.06
+                cost_penalty += 0.4
+        elif step_result.status == "skipped":
+            p_success -= 0.02
+            cost_penalty += 0.15
+
+    if safety_result is not None:
+        last_update_source = f"safety_result:{safety_result.scope}"
+        block_flags = sum(flag.level == "block" for flag in safety_result.risk_flags)
+        warn_flags = sum(flag.level == "warn" for flag in safety_result.risk_flags)
+        observation_summary.update(
+            {
+                "last_safety_action": safety_result.action,
+                "last_safety_scope": safety_result.scope,
+                "last_safety_phase": safety_result.phase,
+                "last_safety_flag_count": len(safety_result.risk_flags),
+                "last_safety_warn_count": warn_flags,
+                "last_safety_block_count": block_flags,
+            }
+        )
+
+        if safety_result.action == "warn":
+            p_success -= 0.04 + (0.01 * warn_flags)
+            p_structural_failure += 0.05
+            recovery_margin -= 0.03
+            cost_penalty += 0.25
+        elif safety_result.action == "block":
+            p_success -= 0.18 + (0.02 * block_flags)
+            p_structural_failure += 0.12 + (0.01 * block_flags)
+            recovery_margin -= 0.16
+            cost_penalty += 0.75
+
+    if failure_context:
+        recovery_action = _normalize_recovery_action(failure_context)
+        failure_code = _as_non_empty_text(failure_context.get("failure_code"))
+        if failure_code:
+            observation_summary["last_failure_code"] = failure_code
+        if recovery_action:
+            observation_summary["last_recovery_action"] = recovery_action
+
+        if recovery_action == "patch_local":
+            p_success -= 0.04
+            recovery_margin -= 0.07
+            cost_penalty += 0.6
+        elif recovery_action in {"suffix_replan", "replan"}:
+            p_success -= 0.1
+            p_structural_failure += 0.08
+            recovery_margin -= 0.12
+            cost_penalty += 1.2
+        elif recovery_action == "stop":
+            p_success -= 0.15
+            recovery_margin = 0.0
+
+        if _as_bool(failure_context.get("retry_exhausted")):
+            p_success -= 0.03
+            recovery_margin -= 0.04
+            cost_penalty += 0.25
+
+    expected_remaining_cost = _resolve_remaining_cost(
+        previous_cost=expected_remaining_cost,
+        step_result=step_result,
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+        cost_penalty=cost_penalty,
+        cost_reward=cost_reward,
+    )
+
+    return RuntimeState(
+        p_success=_round_metric(_clamp_unit_interval(p_success)),
+        p_structural_failure=_round_metric(
+            _clamp_unit_interval(p_structural_failure)
+        ),
+        recovery_margin=_round_metric(_clamp_unit_interval(recovery_margin)),
+        expected_remaining_cost=_round_metric(max(expected_remaining_cost, 0.0)),
+        last_update_source=last_update_source,
+        observation_summary=_drop_none_values(observation_summary),
+    )
+
+
+def extract_failure_context(step_result: StepResult) -> dict[str, Any]:
+    """从 StepResult 提取适合回放与复用的失败上下文。"""
+
+    patch_meta = step_result.metrics.get("patch")
+    recovery_meta = step_result.metrics.get("recovery")
+    failure_context: dict[str, Any] = {
+        "failure_type": _as_non_empty_text(step_result.failure_type),
+        "failure_code": _extract_failure_code(step_result),
+        "retry_exhausted": _as_bool(step_result.metrics.get("retry_exhausted")),
+    }
+
+    if isinstance(patch_meta, dict):
+        failure_context["patch"] = {
+            "applied": _as_bool(patch_meta.get("applied")),
+            "layer": _as_non_empty_text(patch_meta.get("layer")),
+            "reason": _as_non_empty_text(patch_meta.get("reason")),
+        }
+        failure_context["recovery_action"] = "patch_local"
+
+    if isinstance(recovery_meta, dict):
+        failure_context["recovery"] = {
+            "reason": _as_non_empty_text(recovery_meta.get("reason")),
+            "upgrade_reason": _as_non_empty_text(
+                recovery_meta.get("upgrade_reason")
+            ),
+            "recovery_layer": _as_non_empty_text(
+                recovery_meta.get("recovery_layer")
+            ),
+        }
+        upgrade_reason = _as_non_empty_text(recovery_meta.get("upgrade_reason"))
+        reason = _as_non_empty_text(recovery_meta.get("reason"))
+        if upgrade_reason:
+            failure_context["recovery_action"] = upgrade_reason
+        elif reason and "replan" in reason:
+            failure_context["recovery_action"] = "replan"
+
+    s6_action = _as_non_empty_text(step_result.metrics.get("s6_recovery_action"))
+    if s6_action:
+        failure_context["recovery_action"] = s6_action
+
+    return _drop_none_values(failure_context)
+
+
+def _initial_remaining_cost(
+    *,
+    completed_steps: int | None,
+    total_steps: int | None,
+) -> float:
+    if total_steps is None or completed_steps is None:
+        return _BASELINE_EXPECTED_REMAINING_COST
+    return float(max(total_steps - completed_steps, 0))
+
+
+def _resolve_remaining_cost(
+    *,
+    previous_cost: float,
+    step_result: StepResult | None,
+    completed_steps: int | None,
+    total_steps: int | None,
+    cost_penalty: float,
+    cost_reward: float,
+) -> float:
+    if total_steps is not None and completed_steps is not None:
+        base_cost = float(max(total_steps - completed_steps, 0))
+        return max(base_cost + cost_penalty, 0.0)
+
+    base_cost = previous_cost
+    if step_result is not None:
+        if step_result.status == "success":
+            base_cost = max(base_cost - 1.0, 0.0)
+        elif step_result.status == "failed":
+            base_cost += 0.5
+    return max(base_cost + cost_penalty - cost_reward, 0.0)
+
+
+def _write_progress_summary(
+    observation_summary: dict[str, Any],
+    *,
+    completed_steps: int | None,
+    total_steps: int | None,
+) -> None:
+    if completed_steps is not None:
+        observation_summary["completed_steps"] = completed_steps
+    if total_steps is not None:
+        observation_summary["total_steps"] = total_steps
+    if completed_steps is None or total_steps is None or total_steps <= 0:
+        return
+    observation_summary["remaining_steps"] = max(total_steps - completed_steps, 0)
+    observation_summary["completed_ratio"] = _round_metric(
+        completed_steps / total_steps
+    )
+
+
+def _normalize_recovery_action(failure_context: Mapping[str, Any]) -> str | None:
+    action = _as_non_empty_text(failure_context.get("recovery_action"))
+    if action:
+        return action
+    reason = _as_non_empty_text(failure_context.get("reason"))
+    if reason and "replan" in reason:
+        return "replan"
+    return reason
+
+
+def _extract_stage_id(step_result: StepResult) -> str | None:
+    outputs = step_result.outputs if isinstance(step_result.outputs, dict) else {}
+    stage_id = outputs.get("stage_id")
+    return _as_non_empty_text(stage_id)
+
+
+def _extract_failure_code(step_result: StepResult) -> str | None:
+    if isinstance(step_result.error_details, dict):
+        failure_code = _as_non_empty_text(step_result.error_details.get("failure_code"))
+        if failure_code:
+            return failure_code
+    for flag in step_result.risk_flags:
+        code = _as_non_empty_text(flag.code)
+        if code:
+            return code
+    return None
+
+
+def _is_structural_step(*, stage_id: str | None, tool_id: str) -> bool:
+    if stage_id in _STRUCTURAL_STAGE_IDS:
+        return True
+    tool_key = tool_id.strip().lower()
+    return any(
+        token in tool_key
+        for token in ("fold", "esm", "alphafold", "mpnn", "qc", "quality")
+    )
+
+
+def _clamp_unit_interval(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+def _round_metric(value: float) -> float:
+    return round(float(value), 6)
+
+
+def _as_non_empty_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _as_bool(value: Any) -> bool:
+    return bool(value)
+
+
+def _drop_none_values(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}

--- a/src/workflow/context.py
+++ b/src/workflow/context.py
@@ -24,6 +24,7 @@ from src.models.contracts import (
     StepResult,
 )
 from src.models.db import InternalStatus
+from src.workflow.belief_state import extract_failure_context, update_runtime_state
 
 __all__ = ["WorkflowContext"]
 
@@ -94,6 +95,13 @@ class WorkflowContext(BaseModel):
             如果 step_id 已存在，会覆盖之前的结果
         """
         self.step_results[result.step_id] = result
+        self.runtime_state = update_runtime_state(
+            previous_state=self.runtime_state,
+            step_result=result,
+            failure_context=extract_failure_context(result),
+            completed_steps=len(self.step_results),
+            total_steps=self._get_total_step_count(),
+        )
     
     def add_safety_event(self, event: SafetyResult) -> None:
         """记录一次安全检查结果
@@ -102,6 +110,12 @@ class WorkflowContext(BaseModel):
             event: 安全检查结果事件
         """
         self.safety_events.append(event)
+        self.runtime_state = update_runtime_state(
+            previous_state=self.runtime_state,
+            safety_result=event,
+            completed_steps=len(self.step_results),
+            total_steps=self._get_total_step_count(),
+        )
 
     def get_step_output(self, step_id: str, key: str) -> Any:
         """便捷访问，读取某一步的输出字段
@@ -185,3 +199,8 @@ class WorkflowContext(BaseModel):
         if key not in result.outputs:
             raise KeyError(f"Output key '{key}' not found in step '{result.step_id}'")
         return result.outputs[key]
+
+    def _get_total_step_count(self) -> int | None:
+        if self.plan is None:
+            return None
+        return len(self.plan.steps)

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -262,7 +262,7 @@ class PlanRunner:
                             step_result,
                             pending_patch,
                         )
-                    context.step_results[step_result.step_id] = step_result
+                    self._add_step_result(context, step_result)
                     self._emit_step_event(context, step_result)
                     # 读取失败分类与可重试标记，供日志/上层使用（不改变控制流）
                     step_result.metrics.setdefault(
@@ -446,6 +446,13 @@ class PlanRunner:
             context.add_safety_event(event)
         else:
             context.safety_events.append(event)
+
+    def _add_step_result(self, context: WorkflowContext, result: StepResult) -> None:
+        """步骤结果写入上下文，优先复用 WorkflowContext 辅助方法。"""
+        if hasattr(context, "add_step_result"):
+            context.add_step_result(result)
+        else:
+            context.step_results[result.step_id] = result
 
     def _add_failed_step_safety_event(
         self,

--- a/tests/unit/test_plan_runner_step_trace.py
+++ b/tests/unit/test_plan_runner_step_trace.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from src.models.contracts import StepResult, now_iso
+from src.models.contracts import (
+    Plan,
+    ProteinDesignTask,
+    RiskFlag,
+    SafetyResult,
+    StepResult,
+    now_iso,
+)
+from src.workflow.belief_state import extract_failure_context, update_runtime_state
+from src.workflow.context import WorkflowContext
 from src.workflow.plan_runner import _build_step_trace_data
 
 
@@ -40,3 +49,159 @@ def test_build_step_trace_data_contains_quality_gate_summary() -> None:
     assert data["stage_id"] == "S3"
     assert data["quality_gate"]["fail_count"] == 2
     assert data["quality_gate"]["failed_samples"][0]["candidate_id"] == "cand_1"
+
+
+def test_update_runtime_state_with_success_step_is_deterministic() -> None:
+    step_result = StepResult(
+        task_id="task_trace",
+        step_id="S2",
+        tool="esmfold",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        error_details={},
+        inputs={},
+        outputs={"stage_id": "S2", "pdb_path": "mock.pdb"},
+        artifacts={},
+        metrics={"duration_ms": 1200},
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+    state = update_runtime_state(
+        previous_state=None,
+        step_result=step_result,
+        failure_context=extract_failure_context(step_result),
+        completed_steps=1,
+        total_steps=4,
+    )
+
+    assert state.last_update_source == "step_result:S2"
+    assert state.p_success == 0.66
+    assert state.p_structural_failure == 0.12
+    assert state.recovery_margin == 0.66
+    assert state.expected_remaining_cost == 3.0
+    assert state.observation_summary["completed_steps"] == 1
+    assert state.observation_summary["remaining_steps"] == 3
+
+
+def test_update_runtime_state_captures_patch_failure_context() -> None:
+    failed_result = StepResult(
+        task_id="task_trace",
+        step_id="S2",
+        tool="esmfold",
+        status="failed",
+        failure_type="retryable",
+        error_message="remote endpoint timeout",
+        error_details={"failure_code": "NIM_TIMEOUT"},
+        inputs={},
+        outputs={"stage_id": "S2"},
+        artifacts={},
+        metrics={
+            "retry_exhausted": True,
+            "patch": {
+                "applied": True,
+                "layer": "tool_swap",
+                "reason": "remote_timeout",
+            },
+        },
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+    state = update_runtime_state(
+        previous_state=None,
+        step_result=failed_result,
+        failure_context=extract_failure_context(failed_result),
+        completed_steps=1,
+        total_steps=4,
+    )
+
+    assert state.p_success == 0.2
+    assert state.p_structural_failure == 0.47
+    assert state.recovery_margin == 0.31
+    assert state.expected_remaining_cost == 5.0
+    assert state.observation_summary["last_failure_code"] == "NIM_TIMEOUT"
+    assert state.observation_summary["last_recovery_action"] == "patch_local"
+
+
+def test_update_runtime_state_handles_safety_block_and_suffix_replan() -> None:
+    previous_state = update_runtime_state(
+        previous_state=None,
+        completed_steps=1,
+        total_steps=4,
+    )
+    safety_result = SafetyResult(
+        task_id="task_trace",
+        phase="step",
+        scope="step:S3",
+        risk_flags=[
+            RiskFlag(
+                level="block",
+                code="S3_ALL_CANDIDATES_REJECTED",
+                message="all candidates rejected",
+                scope="step",
+                step_id="S3",
+                details={},
+            )
+        ],
+        action="block",
+        timestamp=now_iso(),
+    )
+
+    state = update_runtime_state(
+        previous_state=previous_state,
+        safety_result=safety_result,
+        failure_context={"recovery_action": "suffix_replan"},
+        completed_steps=1,
+        total_steps=4,
+    )
+
+    assert state.last_update_source == "safety_result:step:S3"
+    assert state.p_success == 0.2
+    assert state.p_structural_failure == 0.46
+    assert state.recovery_margin == 0.32
+    assert state.expected_remaining_cost == 4.95
+    assert state.observation_summary["last_safety_action"] == "block"
+    assert state.observation_summary["last_recovery_action"] == "suffix_replan"
+
+
+def test_workflow_context_helpers_refresh_runtime_state() -> None:
+    task = ProteinDesignTask(task_id="task_trace", goal="demo")
+    plan = Plan(task_id=task.task_id, steps=[], constraints={}, metadata={})
+    context = WorkflowContext(task=task, plan=plan)
+
+    context.add_safety_event(
+        SafetyResult(
+            task_id=task.task_id,
+            phase="input",
+            scope="task",
+            risk_flags=[],
+            action="allow",
+            timestamp=now_iso(),
+        )
+    )
+    context.add_step_result(
+        StepResult(
+            task_id=task.task_id,
+            step_id="S1",
+            tool="protein_mpnn",
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            inputs={},
+            outputs={"stage_id": "S1", "sequence": "AAAA"},
+            artifacts={},
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+    )
+
+    assert context.runtime_state is not None
+    assert context.runtime_state.last_update_source == "step_result:S1"
+    assert context.runtime_state.observation_summary["completed_steps"] == 1


### PR DESCRIPTION
## 摘要

- 新增独立的 Lite 运行时 belief-state 更新模块，落实 issue #212
- 基于 `StepResult` 与 `SafetyResult` 刷新 `WorkflowContext.runtime_state`，不直接修改 FSM 状态
- 补齐成功、失败、安全阻断、patch/replan 等关键场景的确定性测试

## 变更内容

### 1. 新增独立运行时状态更新模块
- 新增 `src/workflow/belief_state.py`
- 以确定性规则对 Lite belief-state 进行更新
- 输入来源限定为：
  - `StepResult`
  - `SafetyResult`
  - failure context
- 输出保持为可序列化、可回放的普通结构

### 2. 在现有运行时观测写入点接线
- 在 `WorkflowContext.add_step_result(...)` 中接入状态更新
- 在 `WorkflowContext.add_safety_event(...)` 中接入状态更新
- 保持更新逻辑集中，不把规则散落到 `planner.py` 或 `plan_runner.py`

### 3. 最小化调整 PlanRunner 写回路径
- `PlanRunner` 改为通过 `WorkflowContext` 辅助方法写入步骤结果
- 这样运行时状态更新能够复用上下文入口，保持模块解耦

### 4. 测试补齐
- 新增/更新 `tests/unit/test_plan_runner_step_trace.py`
- 覆盖以下场景：
  - 正常成功更新
  - 带 patch 上下文的失败更新
  - safety block 更新
  - suffix replan 更新
  - `WorkflowContext` 辅助方法触发状态刷新

## 为什么要这样改

issue #212 要求第一版运行时状态更新器满足以下约束：

- 与现有运行时观测兼容
- 保持确定性、可解释、可回放
- 作为独立模块接入
- 不直接驱动最终动作选择
- 不直接改写 Planner 评分逻辑

本次实现将更新器独立在单独模块中，只在既有观测写入点做最小接线，避免破坏现有 FSM、Planner 与恢复流程边界。

## 与任务拆解对照

- [x] 实现 Lite state update 输入输出接口
- [x] 根据已有观测计算最小状态集
- [x] 为正常、失败、safety block、patch/replan 场景补齐更新测试
- [x] 保证更新结果可被后续 shadow score 和动作选择复用

## 验收标准对照

- [x] 状态更新器可基于现有观测稳定输出 Lite belief-state
- [x] 关键场景测试通过且输出可解释
- [x] 更新模块与现有运行时代码解耦

## 验证

- `uv run pytest tests/unit/test_plan_runner_step_trace.py -q`
- `uv run pytest tests/unit/test_contracts.py tests/unit/test_task_snapshot.py -q`
- `uv run pytest tests/unit/test_plan_runner.py tests/unit/test_step_runner.py tests/unit/test_recovery_event_logs.py -q`

Closes #212
