### PR TITLE
feat(runtime): 固化 belief-state 更新接口与回放边界

### DIFF
--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -141,6 +141,131 @@ class StepResult(BaseModel):
     timestamp: str
 
 
+class RuntimeFailureContext(BaseModel):
+    """运行时状态更新器消费的稳定失败上下文。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    failure_type: str | None = None
+    failure_code: str | None = None
+    retry_exhausted: bool = False
+    recovery_action: str | None = None
+    patch: Dict[str, Any] | None = None
+    recovery: Dict[str, Any] | None = None
+
+    @field_validator("failure_type", "failure_code", "recovery_action")
+    @classmethod
+    def _validate_optional_text(cls, value: str | None, info) -> str | None:
+        if value is None:
+            return None
+        return _validate_non_empty_text(value, field_name=info.field_name)
+
+    @field_validator("patch", "recovery")
+    @classmethod
+    def _validate_optional_mapping(
+        cls,
+        value: Dict[str, Any] | None,
+        info,
+    ) -> Dict[str, Any] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise ValueError(f"{info.field_name} must be a mapping")
+        try:
+            json.dumps(value, ensure_ascii=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{info.field_name} must be JSON-serializable"
+            ) from exc
+        return value
+
+    def to_replay_payload(self) -> Dict[str, Any]:
+        return self.model_dump(exclude_none=True)
+
+
+class RuntimeStateUpdateInput(BaseModel):
+    """belief-state 更新器的稳定输入接口。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    step_result: StepResult | None = None
+    safety_result: SafetyResult | None = None
+    failure_context: RuntimeFailureContext | None = None
+    completed_steps: int | None = None
+    total_steps: int | None = None
+
+    @field_validator("completed_steps", "total_steps")
+    @classmethod
+    def _validate_optional_progress_value(
+        cls,
+        value: int | None,
+        info,
+    ) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{info.field_name} must be an integer")
+        normalized = int(value)
+        if normalized < 0:
+            raise ValueError(f"{info.field_name} must be >= 0")
+        return normalized
+
+    @model_validator(mode="after")
+    def _validate_bounds_and_observation(self) -> "RuntimeStateUpdateInput":
+        if (
+            self.completed_steps is not None
+            and self.total_steps is not None
+            and self.completed_steps > self.total_steps
+        ):
+            raise ValueError("completed_steps must be <= total_steps")
+        if (
+            self.step_result is None
+            and self.safety_result is None
+            and self.failure_context is None
+            and self.completed_steps is None
+            and self.total_steps is None
+        ):
+            raise ValueError(
+                "at least one observation or progress counter must be provided"
+            )
+        return self
+
+    @classmethod
+    def from_step_result(
+        cls,
+        *,
+        step_result: StepResult,
+        failure_context: RuntimeFailureContext | None = None,
+        completed_steps: int | None = None,
+        total_steps: int | None = None,
+    ) -> "RuntimeStateUpdateInput":
+        return cls(
+            step_result=step_result,
+            failure_context=failure_context,
+            completed_steps=completed_steps,
+            total_steps=total_steps,
+        )
+
+    @classmethod
+    def from_safety_result(
+        cls,
+        *,
+        safety_result: SafetyResult,
+        failure_context: RuntimeFailureContext | None = None,
+        completed_steps: int | None = None,
+        total_steps: int | None = None,
+    ) -> "RuntimeStateUpdateInput":
+        return cls(
+            safety_result=safety_result,
+            failure_context=failure_context,
+            completed_steps=completed_steps,
+            total_steps=total_steps,
+        )
+
+    def to_replay_payload(self) -> Dict[str, Any]:
+        return self.model_dump(mode="json", exclude_none=True)
+
+
 class RuntimeState(BaseModel):
     """稳定的运行时状态 schema。
 

--- a/src/workflow/belief_state.py
+++ b/src/workflow/belief_state.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from src.models.contracts import RuntimeState, SafetyResult, StepResult
+from src.models.contracts import (
+    RuntimeFailureContext,
+    RuntimeState,
+    RuntimeStateUpdateInput,
+    SafetyResult,
+    StepResult,
+)
 
 __all__ = ["extract_failure_context", "update_runtime_state"]
 
@@ -16,9 +22,10 @@ _STRUCTURAL_STAGE_IDS = {"S2", "S3", "S4"}
 def update_runtime_state(
     *,
     previous_state: RuntimeState | None,
+    update_input: RuntimeStateUpdateInput | None = None,
     step_result: StepResult | None = None,
     safety_result: SafetyResult | None = None,
-    failure_context: Mapping[str, Any] | None = None,
+    failure_context: RuntimeFailureContext | Mapping[str, Any] | None = None,
     completed_steps: int | None = None,
     total_steps: int | None = None,
 ) -> RuntimeState:
@@ -28,7 +35,24 @@ def update_runtime_state(
     - 直接序列化；
     - 跨快照回放；
     - 被测试稳定复现。
+    
+    调用方优先传入 ``RuntimeStateUpdateInput``，以固定更新器输入边界。
+    保留原有关键字参数仅用于兼容既有调用路径。
     """
+
+    update = _coerce_update_input(
+        update_input=update_input,
+        step_result=step_result,
+        safety_result=safety_result,
+        failure_context=failure_context,
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+    )
+    step_result = update.step_result
+    safety_result = update.safety_result
+    failure_context = update.failure_context
+    completed_steps = update.completed_steps
+    total_steps = update.total_steps
 
     state = previous_state or RuntimeState(
         p_success=_BASELINE_P_SUCCESS,
@@ -120,9 +144,10 @@ def update_runtime_state(
             recovery_margin -= 0.16
             cost_penalty += 0.75
 
-    if failure_context:
-        recovery_action = _normalize_recovery_action(failure_context)
-        failure_code = _as_non_empty_text(failure_context.get("failure_code"))
+    if failure_context is not None:
+        failure_payload = failure_context.to_replay_payload()
+        recovery_action = _normalize_recovery_action(failure_payload)
+        failure_code = _as_non_empty_text(failure_payload.get("failure_code"))
         if failure_code:
             observation_summary["last_failure_code"] = failure_code
         if recovery_action:
@@ -141,7 +166,7 @@ def update_runtime_state(
             p_success -= 0.15
             recovery_margin = 0.0
 
-        if _as_bool(failure_context.get("retry_exhausted")):
+        if failure_context.retry_exhausted:
             p_success -= 0.03
             recovery_margin -= 0.04
             cost_penalty += 0.25
@@ -167,7 +192,7 @@ def update_runtime_state(
     )
 
 
-def extract_failure_context(step_result: StepResult) -> dict[str, Any]:
+def extract_failure_context(step_result: StepResult) -> RuntimeFailureContext:
     """从 StepResult 提取适合回放与复用的失败上下文。"""
 
     patch_meta = step_result.metrics.get("patch")
@@ -207,7 +232,39 @@ def extract_failure_context(step_result: StepResult) -> dict[str, Any]:
     if s6_action:
         failure_context["recovery_action"] = s6_action
 
-    return _drop_none_values(failure_context)
+    return RuntimeFailureContext.model_validate(
+        _drop_none_values(failure_context)
+    )
+
+
+def _coerce_update_input(
+    *,
+    update_input: RuntimeStateUpdateInput | None,
+    step_result: StepResult | None,
+    safety_result: SafetyResult | None,
+    failure_context: RuntimeFailureContext | Mapping[str, Any] | None,
+    completed_steps: int | None,
+    total_steps: int | None,
+) -> RuntimeStateUpdateInput:
+    if update_input is not None:
+        return update_input
+    return RuntimeStateUpdateInput(
+        step_result=step_result,
+        safety_result=safety_result,
+        failure_context=_coerce_failure_context(failure_context),
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+    )
+
+
+def _coerce_failure_context(
+    failure_context: RuntimeFailureContext | Mapping[str, Any] | None,
+) -> RuntimeFailureContext | None:
+    if failure_context is None:
+        return None
+    if isinstance(failure_context, RuntimeFailureContext):
+        return failure_context
+    return RuntimeFailureContext.model_validate(dict(failure_context))
 
 
 def _initial_remaining_cost(

--- a/src/workflow/context.py
+++ b/src/workflow/context.py
@@ -19,7 +19,9 @@ from src.models.contracts import (
     PendingAction,
     Plan,
     ProteinDesignTask,
+    RuntimeFailureContext,
     RuntimeState,
+    RuntimeStateUpdateInput,
     SafetyResult,
     StepResult,
 )
@@ -95,12 +97,9 @@ class WorkflowContext(BaseModel):
             如果 step_id 已存在，会覆盖之前的结果
         """
         self.step_results[result.step_id] = result
-        self.runtime_state = update_runtime_state(
-            previous_state=self.runtime_state,
+        self.apply_runtime_state_update(
             step_result=result,
             failure_context=extract_failure_context(result),
-            completed_steps=len(self.step_results),
-            total_steps=self._get_total_step_count(),
         )
     
     def add_safety_event(self, event: SafetyResult) -> None:
@@ -110,12 +109,36 @@ class WorkflowContext(BaseModel):
             event: 安全检查结果事件
         """
         self.safety_events.append(event)
+        self.apply_runtime_state_update(safety_result=event)
+
+    def apply_runtime_state_update(
+        self,
+        *,
+        step_result: StepResult | None = None,
+        safety_result: SafetyResult | None = None,
+        failure_context: RuntimeFailureContext | None = None,
+    ) -> RuntimeState:
+        """通过稳定更新接口刷新 runtime_state。
+
+        PlanRunner / PatchRunner / StepRunner 应通过 WorkflowContext helpers
+        间接接入 belief-state 更新器，而不是散落地直接修改 runtime_state。
+        """
+        completed_steps = len(self.step_results)
+        total_steps = self._get_total_step_count()
+        if total_steps is not None and total_steps < completed_steps:
+            total_steps = completed_steps
+        update_input = RuntimeStateUpdateInput(
+            step_result=step_result,
+            safety_result=safety_result,
+            failure_context=failure_context,
+            completed_steps=completed_steps,
+            total_steps=total_steps,
+        )
         self.runtime_state = update_runtime_state(
             previous_state=self.runtime_state,
-            safety_result=event,
-            completed_steps=len(self.step_results),
-            total_steps=self._get_total_step_count(),
+            update_input=update_input,
         )
+        return self.runtime_state
 
     def get_step_output(self, step_id: str, key: str) -> Any:
         """便捷访问，读取某一步的输出字段

--- a/tests/unit/test_belief_state.py
+++ b/tests/unit/test_belief_state.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.contracts import (
+    Plan,
+    PlanStep,
+    ProteinDesignTask,
+    RiskFlag,
+    RuntimeFailureContext,
+    RuntimeStateUpdateInput,
+    SafetyResult,
+    StepResult,
+    now_iso,
+)
+from src.workflow.belief_state import extract_failure_context, update_runtime_state
+from src.workflow.context import WorkflowContext
+
+
+def _build_failed_step_result() -> StepResult:
+    return StepResult(
+        task_id="task_belief",
+        step_id="S2",
+        tool="esmfold",
+        status="failed",
+        failure_type="retryable",
+        error_message="remote endpoint timeout",
+        error_details={"failure_code": "NIM_TIMEOUT"},
+        inputs={},
+        outputs={"stage_id": "S2"},
+        artifacts={},
+        metrics={
+            "retry_exhausted": True,
+            "patch": {
+                "applied": True,
+                "layer": "tool_swap",
+                "reason": "remote_timeout",
+            },
+        },
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+
+
+def test_extract_failure_context_returns_stable_schema() -> None:
+    failure_context = extract_failure_context(_build_failed_step_result())
+
+    assert failure_context == RuntimeFailureContext(
+        failure_type="retryable",
+        failure_code="NIM_TIMEOUT",
+        retry_exhausted=True,
+        recovery_action="patch_local",
+        patch={
+            "applied": True,
+            "layer": "tool_swap",
+            "reason": "remote_timeout",
+        },
+    )
+    assert failure_context.to_replay_payload()["recovery_action"] == "patch_local"
+
+
+def test_runtime_state_update_input_rejects_invalid_progress_bounds() -> None:
+    with pytest.raises(ValidationError):
+        RuntimeStateUpdateInput(completed_steps=3, total_steps=2)
+
+
+def test_runtime_state_update_input_emits_replay_payload() -> None:
+    step_result = _build_failed_step_result()
+    failure_context = extract_failure_context(step_result)
+    update_input = RuntimeStateUpdateInput.from_step_result(
+        step_result=step_result,
+        failure_context=failure_context,
+        completed_steps=1,
+        total_steps=4,
+    )
+
+    payload = update_input.to_replay_payload()
+
+    assert payload["step_result"]["step_id"] == "S2"
+    assert payload["failure_context"]["failure_code"] == "NIM_TIMEOUT"
+    assert payload["completed_steps"] == 1
+    assert payload["total_steps"] == 4
+    json.dumps(payload, ensure_ascii=True)
+
+
+def test_update_runtime_state_accepts_structured_update_input() -> None:
+    step_result = _build_failed_step_result()
+    update_input = RuntimeStateUpdateInput.from_step_result(
+        step_result=step_result,
+        failure_context=extract_failure_context(step_result),
+        completed_steps=1,
+        total_steps=4,
+    )
+
+    state = update_runtime_state(
+        previous_state=None,
+        update_input=update_input,
+    )
+
+    assert state.p_success == 0.2
+    assert state.p_structural_failure == 0.47
+    assert state.recovery_margin == 0.31
+    assert state.expected_remaining_cost == 5.0
+
+
+def test_workflow_context_apply_runtime_state_update_is_runner_entrypoint() -> None:
+    task = ProteinDesignTask(task_id="task_belief", goal="demo")
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S1", tool="protein_mpnn", inputs={}, metadata={}),
+            PlanStep(id="S2", tool="esmfold", inputs={}, metadata={}),
+        ],
+        constraints={},
+        metadata={},
+    )
+    context = WorkflowContext(task=task, plan=plan)
+
+    context.apply_runtime_state_update(
+        safety_result=SafetyResult(
+            task_id=task.task_id,
+            phase="step",
+            scope="step:S2",
+            risk_flags=[
+                RiskFlag(
+                    level="warn",
+                    code="LOW_CONFIDENCE",
+                    message="confidence trending down",
+                    scope="step",
+                    step_id="S2",
+                    details={},
+                )
+            ],
+            action="warn",
+            timestamp=now_iso(),
+        )
+    )
+
+    assert context.runtime_state is not None
+    assert context.runtime_state.last_update_source == "safety_result:step:S2"
+    assert context.runtime_state.observation_summary["completed_steps"] == 0
+    assert context.runtime_state.observation_summary["remaining_steps"] == 2


### PR DESCRIPTION
## Summary
- 固化 belief-state 更新器的稳定输入契约，新增 `RuntimeFailureContext` 与 `RuntimeStateUpdateInput`
- 让 `src/workflow/belief_state.py` 优先消费结构化输入，明确 failure context 的可回放语义，同时保留旧调用方式兼容现有路径
- 在 `WorkflowContext` 中收口 runtime state 更新入口，明确 `PlanRunner / PatchRunner / StepRunner` 应通过 helper 间接接入更新器
- 新增 focused unit tests，覆盖接口边界、离线回放 payload 和 runner 接缝

## Why
issue #228 要求把 belief-state 更新核心收敛为可重放、可测试的纯函数层，并对最小状态集的字段语义、输入边界和 Workflow 接入点做明确标定。当前 `dev` 分支虽然已经具备可工作的 Lite 更新器，但还缺少稳定输入模型和明确的 runner 侧接缝，这会让后续 `#214`、`#216`、`#219` 复用时继续依赖零散 dict 约定。

## What Changed
### 1. 固定更新器输入/输出接口
- 在 `src/models/contracts.py` 新增 `RuntimeFailureContext`
- 在 `src/models/contracts.py` 新增 `RuntimeStateUpdateInput`
- 保持输出仍为现有 `RuntimeState`，不改动最小状态集字段集合

### 2. 固定字段语义与更新边界
- 将 `failure_context` 收紧为稳定模型，明确 `failure_type`、`failure_code`、`retry_exhausted`、`recovery_action` 以及 `patch/recovery` 回放字段
- 为 `completed_steps` / `total_steps` 增加结构化边界校验
- 保留旧关键字参数调用方式，避免破坏现有运行时代码

### 3. 明确 Workflow 接入点
- 在 `src/workflow/context.py` 新增 `apply_runtime_state_update()`
- `add_step_result()` 和 `add_safety_event()` 统一通过该 helper 刷新 `runtime_state`
- 对 `completed_steps > total_steps` 的历史兼容场景做保守收敛，避免旧路径被新契约卡死

### 4. 测试与回放输入
- 新增 `tests/unit/test_belief_state.py`
- 覆盖稳定 failure context schema、update input 边界、replay payload、结构化输入更新和 WorkflowContext 接缝
- 回归已有 runtime_state / snapshot / recovery 相关单元测试

## Acceptance Mapping
- [x] 已形成更新器接口与字段语义规范
- [x] 已形成最小状态集更新规则的结构化输入边界与回放语义
- [x] 内容与 `#208` 中识别的 F1 缺口一致
- [x] 已映射到 `src/workflow/` 与 `src/models/contracts.py`
- [x] 已明确纯函数更新与 Workflow 侧状态持有/落盘边界
- [x] 可直接供 `#214`、`#216`、`#219` 继续复用

## Validation
```bash
uv run pytest tests/unit/test_belief_state.py tests/unit/test_plan_runner_step_trace.py tests/unit/test_contracts.py tests/unit/test_recovery_event_logs.py tests/unit/test_task_snapshot.py -q
```

Closes #228
