### PR TITLE
feat(snapshot): 固化 runtime_state 持久化与恢复口径

### DIFF
--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -512,6 +512,7 @@ def _write_snapshot(
     snapshot = build_task_snapshot(
         context,
         pending_action_id=pending_id,
+        require_runtime_state=True,
     )
     (snapshot_writer or default_snapshot_writer)(snapshot)
 

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -205,6 +205,7 @@ def enter_waiting_state(
         context,
         state_override=new_status,
         pending_action_id=pending_action.pending_action_id,
+        require_runtime_state=True,
     )
     (snapshot_writer or default_snapshot_writer)(snapshot)
     _ = reason

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -32,6 +32,7 @@ from src.models.db import ExternalStatus, InternalStatus
 from src.models.event_log import EventLog, EventType
 from src.storage.log_store import DEFAULT_LOG_DIR, read_event_logs
 from src.storage.snapshot_store import read_latest_snapshot, DEFAULT_SNAPSHOT_DIR
+from src.workflow.belief_state import update_runtime_state
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
 
@@ -374,7 +375,7 @@ def restore_context_from_snapshot(
     context = WorkflowContext(
         task=task,
         plan=plan,
-        runtime_state=_extract_runtime_state(snapshot),
+        runtime_state=_extract_runtime_state(snapshot, plan),
         status=internal_status,
     )
 
@@ -414,25 +415,95 @@ def extract_remote_job_context(
         return None
 
 
-def _extract_runtime_state(snapshot: TaskSnapshot) -> RuntimeState | None:
+def _extract_runtime_state(
+    snapshot: TaskSnapshot,
+    plan: Plan,
+) -> RuntimeState | None:
     runtime_payload = snapshot.artifacts.get(RUNTIME_STATE_ARTIFACT_KEY)
-    if not isinstance(runtime_payload, dict):
-        return None
+    if runtime_payload is not None and not isinstance(runtime_payload, dict):
+        runtime_payload = None
 
-    payload = dict(runtime_payload)
+    if not isinstance(runtime_payload, dict):
+        payload: dict[str, Any] = {}
+    else:
+        payload = dict(runtime_payload)
+
     observation_summary = snapshot.artifacts.get(
         RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY
     )
-    if (
+    bootstrap = None
+    if not _has_complete_runtime_state_payload(payload):
+        bootstrap = _bootstrap_runtime_state_from_snapshot(snapshot, plan)
+    if bootstrap is not None:
+        payload = {
+            **bootstrap.model_dump(),
+            **payload,
+        }
+        if isinstance(observation_summary, dict):
+            payload["observation_summary"] = {
+                **bootstrap.observation_summary,
+                **observation_summary,
+            }
+    elif (
         "observation_summary" not in payload
         and isinstance(observation_summary, dict)
     ):
         payload["observation_summary"] = observation_summary
 
+    if not payload:
+        return None
+
     try:
         return RuntimeState.model_validate(payload)
     except Exception:
+        return bootstrap
+
+
+def _has_complete_runtime_state_payload(payload: dict[str, Any]) -> bool:
+    required_keys = {
+        "p_success",
+        "p_structural_failure",
+        "recovery_margin",
+        "expected_remaining_cost",
+        "last_update_source",
+    }
+    return required_keys.issubset(payload.keys())
+
+
+def _bootstrap_runtime_state_from_snapshot(
+    snapshot: TaskSnapshot,
+    plan: Plan,
+) -> RuntimeState | None:
+    completed_steps = _resolve_completed_steps(snapshot)
+    total_steps = len(plan.steps)
+    if (
+        completed_steps == 0
+        and snapshot.state not in {
+            ExternalStatus.WAITING_PLAN_CONFIRM.value,
+            ExternalStatus.WAITING_PATCH_CONFIRM.value,
+            ExternalStatus.WAITING_REPLAN_CONFIRM.value,
+        }
+        and not isinstance(
+            snapshot.artifacts.get(RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY),
+            dict,
+        )
+        and not isinstance(snapshot.artifacts.get(RUNTIME_STATE_ARTIFACT_KEY), dict)
+    ):
         return None
+    return update_runtime_state(
+        previous_state=None,
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+    )
+
+
+def _resolve_completed_steps(snapshot: TaskSnapshot) -> int:
+    if snapshot.completed_step_ids:
+        return len(snapshot.completed_step_ids)
+    return max(
+        int(snapshot.current_step_index or 0),
+        int(snapshot.step_index or 0),
+    )
 
 
 def recover_context_with_event_logs(

--- a/src/workflow/snapshots.py
+++ b/src/workflow/snapshots.py
@@ -12,9 +12,16 @@ from src.models.contracts import (
 )
 from src.models.db import ExternalStatus, to_external_status
 from src.storage.snapshot_store import append_snapshot
+from src.workflow.belief_state import update_runtime_state
 from src.workflow.context import WorkflowContext
 
 SnapshotWriter = Callable[[TaskSnapshot], None]
+
+_WAITING_EXTERNAL_STATUSES = {
+    ExternalStatus.WAITING_PLAN_CONFIRM,
+    ExternalStatus.WAITING_PATCH_CONFIRM,
+    ExternalStatus.WAITING_REPLAN_CONFIRM,
+}
 
 
 def default_snapshot_writer(snapshot: TaskSnapshot) -> None:
@@ -27,6 +34,7 @@ def build_task_snapshot(
     state_override: Optional[ExternalStatus] = None,
     pending_action_id: Optional[str] = None,
     artifacts: Optional[dict] = None,
+    require_runtime_state: bool = False,
 ) -> TaskSnapshot:
     """构建用于恢复的最小化 TaskSnapshot
 
@@ -39,6 +47,7 @@ def build_task_snapshot(
                   - 远程作业引用（job_id、endpoint、status、trace）
                   - 文件路径和 URI
                   - 其他恢复相关的元数据
+        require_runtime_state: 是否在写 snapshot 前确保最小 runtime_state 已落盘
 
     Returns:
         准备好持久化的 TaskSnapshot 实例
@@ -46,7 +55,12 @@ def build_task_snapshot(
     external_state = state_override or to_external_status(context.status)
     step_ids = list(context.step_results.keys())
     artifacts_payload = dict(artifacts or {})
-    _inject_runtime_state_artifacts(context.runtime_state, artifacts_payload)
+    runtime_state = _resolve_runtime_state_for_snapshot(
+        context,
+        external_state=external_state,
+        require_runtime_state=require_runtime_state,
+    )
+    _inject_runtime_state_artifacts(runtime_state, artifacts_payload)
     if context.pending_action is not None:
         artifacts_payload.setdefault(
             "pending_action", context.pending_action.model_dump()
@@ -97,3 +111,32 @@ def _inject_runtime_state_artifacts(
             RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
             dict(runtime_state.observation_summary),
         )
+
+
+def _resolve_runtime_state_for_snapshot(
+    context: WorkflowContext,
+    *,
+    external_state: ExternalStatus,
+    require_runtime_state: bool,
+) -> RuntimeState | None:
+    if context.runtime_state is not None:
+        return context.runtime_state
+    if not (
+        require_runtime_state
+        or external_state in _WAITING_EXTERNAL_STATUSES
+    ):
+        return None
+
+    context.runtime_state = update_runtime_state(
+        previous_state=None,
+        completed_steps=len(context.step_results),
+        total_steps=_extract_total_step_count(context),
+    )
+    return context.runtime_state
+
+
+def _extract_total_step_count(context: WorkflowContext) -> int | None:
+    plan = context.plan
+    if plan is None:
+        return None
+    return len(plan.steps)

--- a/tests/unit/test_decision_apply.py
+++ b/tests/unit/test_decision_apply.py
@@ -11,6 +11,7 @@ from src.models.contracts import (
     PlanPatch,
     PlanPatchOp,
     PlanStep,
+    RUNTIME_STATE_ARTIFACT_KEY,
     now_iso,
 )
 from src.models.db import InternalStatus, TaskRecord, to_external_status
@@ -108,6 +109,9 @@ def test_plan_confirm_accept_transitions_to_planned(sample_task, sample_plan):
     assert events[0]["event"] == "DECISION_SUBMITTED"
     assert events[-1]["event"] == "DECISION_APPLIED"
     assert snapshots, "snapshot should be written after decision applied"
+    assert snapshots[0].artifacts[RUNTIME_STATE_ARTIFACT_KEY]["last_update_source"] == (
+        "runtime_bootstrap"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_recovery_event_logs.py
+++ b/tests/unit/test_recovery_event_logs.py
@@ -102,6 +102,56 @@ def test_restore_context_from_snapshot_restores_runtime_state():
 
 
 @pytest.mark.unit
+def test_restore_context_from_snapshot_backfills_partial_runtime_state_payload():
+    task = ProteinDesignTask(
+        task_id="task_recovery_runtime_state_partial",
+        goal="recover partial runtime state",
+        constraints={},
+    )
+    plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(id="S1", tool="esmfold", inputs={"sequence": "ACDE"}, metadata={}),
+            PlanStep(id="S2", tool="dummy_tool", inputs={"sequence": "S1.sequence"}, metadata={}),
+        ],
+    )
+    snapshot = TaskSnapshot(
+        snapshot_id="snapshot_runtime_state_partial_001",
+        task_id=task.task_id,
+        state=ExternalStatus.WAITING_PATCH_CONFIRM.value,
+        plan_version=1,
+        step_index=1,
+        completed_step_ids=["S1"],
+        artifacts={
+            RUNTIME_STATE_ARTIFACT_KEY: {
+                "last_update_source": "waiting_snapshot",
+            },
+            RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY: {
+                "selected_candidate_id": "patch_a",
+            },
+        },
+        created_at=now_iso(),
+    )
+
+    context = restore_context_from_snapshot(task=task, plan=plan, snapshot=snapshot)
+
+    assert context is not None
+    assert context.runtime_state is not None
+    assert context.runtime_state.last_update_source == "waiting_snapshot"
+    assert context.runtime_state.p_success == pytest.approx(0.5)
+    assert context.runtime_state.p_structural_failure == pytest.approx(0.25)
+    assert context.runtime_state.recovery_margin == pytest.approx(0.6)
+    assert context.runtime_state.expected_remaining_cost == pytest.approx(1.0)
+    assert context.runtime_state.observation_summary == {
+        "completed_steps": 1,
+        "total_steps": 2,
+        "remaining_steps": 1,
+        "completed_ratio": 0.5,
+        "selected_candidate_id": "patch_a",
+    }
+
+
+@pytest.mark.unit
 def test_recover_context_with_event_logs_updates_status_and_clears_pending_action():
     task = ProteinDesignTask(
         task_id="task_recovery_eventlog",

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -247,3 +247,37 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
         "high_cost_steps_completed": 1
     }
+
+
+@pytest.mark.unit
+def test_build_task_snapshot_waiting_bootstraps_runtime_state_when_missing():
+    task = ProteinDesignTask(
+        task_id="task_waiting_runtime_state_001",
+        goal="persist waiting runtime state",
+        constraints={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=None,
+        runtime_state=None,
+        status=InternalStatus.WAITING_PLAN_CONFIRM,
+    )
+
+    snapshot = build_task_snapshot(
+        context,
+        state_override=ExternalStatus.WAITING_PLAN_CONFIRM,
+        require_runtime_state=True,
+    )
+
+    assert context.runtime_state is not None
+    assert snapshot.artifacts[RUNTIME_STATE_ARTIFACT_KEY] == {
+        "schema_version": 1,
+        "p_success": 0.5,
+        "p_structural_failure": 0.25,
+        "recovery_margin": 0.6,
+        "expected_remaining_cost": 1.0,
+        "last_update_source": "runtime_bootstrap",
+    }
+    assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
+        "completed_steps": 0
+    }


### PR DESCRIPTION
## Summary
- 固化 `runtime_state` 在 WAITING 前和决策后关键恢复点的 snapshot 写入入口
- 明确 snapshot 恢复时优先读取 `artifacts["runtime_state"]`，并在 payload 不完整时仅基于 snapshot 自身做最小回填
- 补充 WAITING snapshot、decision snapshot 和 partial runtime_state payload 恢复相关回归测试

## Why
issue #229 要求把 `runtime_state` 的 snapshot 持久化和恢复口径固定下来，避免 Workflow 在进入 `WAITING_*` 前遗漏可恢复状态，或在恢复时依赖 event log 反推运行时状态。当前基线已经有 `TaskSnapshot.artifacts` 和基本读写逻辑，但还缺少统一的写入时机控制与“不完整 payload 如何回填”的明确实现边界。

## What Changed
### 1. 固定 WAITING 前与关键恢复点的 snapshot 写入时机
- 在 `src/workflow/snapshots.py` 中为 `build_task_snapshot()` 增加 `require_runtime_state` 入口
- 当进入 `WAITING_*` 或关键恢复点写 snapshot 时，如果 `context.runtime_state` 仍为空，则先 bootstrap 出最小 `runtime_state` 再落盘
- 在 `src/workflow/pending_action.py` 的 `enter_waiting_state()` 中启用该入口，确保 WAITING 前 snapshot 具备最小运行时状态摘要
- 在 `src/workflow/decision_apply.py` 的 `_write_snapshot()` 中启用该入口，确保决策后的恢复点 snapshot 同样具备最小运行时状态摘要

### 2. 固定 snapshot 恢复时的 runtime_state 读取与回填规则
- 在 `src/workflow/recovery.py` 中让 `restore_context_from_snapshot()` 优先读取 snapshot 自带的 `runtime_state`
- 当 `artifacts["runtime_state"]` 缺少最小必填字段时，仅基于 snapshot 的 `completed_step_ids / step_index / current_step_index` 和 plan 步数做最小回填
- 对于已经完整写入的旧 payload，保持原值优先，不额外叠加 bootstrap 生成的 progress 摘要
- 恢复逻辑不依赖 event log 反推 `runtime_state`

### 3. 明确最低完整度要求与测试覆盖
- 最低完整度要求收敛为 `p_success`、`p_structural_failure`、`recovery_margin`、`expected_remaining_cost`、`last_update_source`
- `runtime_observation_summary` 继续作为可选扩展摘要存储
- 新增与更新单元测试，覆盖 waiting snapshot、decision snapshot、完整 payload 恢复和 partial payload 回填
- 运行相关集成测试，验证 WAITING snapshot 与 snapshot recovery 真实入口未回归

## Acceptance Mapping
- [x] 已形成 WAITING 前 snapshot 持久化时机规范
- [x] 已形成恢复时 runtime_state 读取与回填规范
- [x] 已明确 `artifacts["runtime_state"]` 的最低完整度要求
- [x] 输出与回放样本、恢复测试相匹配的持久化口径
- [x] 已映射到 `TaskSnapshot.artifacts`、`snapshot_store`、`WorkflowContext`
- [x] 恢复时优先使用 snapshot，而不是依赖 event log 反推
- [x] 内容与 `#208` 中识别的 E2 缺口一致

## Validation
```bash
uv run pytest tests/unit/test_task_snapshot.py tests/unit/test_recovery_event_logs.py tests/unit/test_decision_apply.py -q
uv run pytest tests/integration/test_event_log_integration.py tests/integration/test_snapshot_recovery.py -q
```

Closes #229
