### PR TITLE
feat(observability): 补齐运行时状态与恢复链审计字段

### DIFF
--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -22,6 +22,7 @@ DEFAULT_RECOMMENDATION_REASON_METADATA_KEY = "default_recommendation_reason"
 ACTION_SCORE_METADATA_KEY = "action_score"
 SHADOW_SCORE_METADATA_KEY = "shadow_score"
 WAITING_RUNTIME_SUMMARY_METADATA_KEY = "waiting_runtime_summary"
+DECISION_SUMMARY_ARTIFACT_KEY = "decision_summary"
 
 
 def _validate_runtime_state_schema_version(value: int) -> int:

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional
 
 from src.infra.event_log_factory import make_waiting_exit, make_decision_applied
 from src.models.contracts import (
+    DECISION_SUMMARY_ARTIFACT_KEY,
     Decision,
     DecisionChoice,
     PendingAction,
@@ -28,8 +29,10 @@ from src.workflow.patch import apply_patch
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
 from src.workflow.snapshots import (
     SnapshotWriter,
+    build_context_runtime_state_summary,
     build_task_snapshot,
     default_snapshot_writer,
+    extract_pending_action_waiting_summary,
 )
 from src.workflow.status import StatusLogger, transition_task_status
 
@@ -134,7 +137,7 @@ def apply_plan_confirm_decision(
     )
 
     logger(_decision_event("DECISION_APPLIED", context, action, decision))
-    _write_snapshot(context, action, snapshot_writer)
+    _write_snapshot(context, action, snapshot_writer, decision=decision)
 
     return DecisionApplyResult(
         status=to_external_status(context.status),
@@ -231,7 +234,7 @@ def apply_patch_confirm_decision(
         )
 
         logger(_decision_event("DECISION_APPLIED", context, action, decision))
-        _write_snapshot(context, replan_action, snapshot_writer)
+        _write_snapshot(context, replan_action, snapshot_writer, decision=decision)
         return DecisionApplyResult(
             status=to_external_status(context.status),
             internal_status=context.status,
@@ -269,7 +272,7 @@ def apply_patch_confirm_decision(
     )
 
     logger(_decision_event("DECISION_APPLIED", context, action, decision))
-    _write_snapshot(context, action, snapshot_writer)
+    _write_snapshot(context, action, snapshot_writer, decision=decision)
 
     return DecisionApplyResult(
         status=to_external_status(context.status),
@@ -353,7 +356,7 @@ def apply_replan_confirm_decision(
     )
 
     logger(_decision_event("DECISION_APPLIED", context, action, decision))
-    _write_snapshot(context, action, snapshot_writer)
+    _write_snapshot(context, action, snapshot_writer, decision=decision)
 
     return DecisionApplyResult(
         status=to_external_status(context.status),
@@ -497,6 +500,8 @@ def _write_snapshot(
     context: WorkflowContext,
     action: PendingAction,
     snapshot_writer: SnapshotWriter | None,
+    *,
+    decision: Decision | None = None,
 ) -> None:
     pending_id = None
     if (
@@ -512,6 +517,7 @@ def _write_snapshot(
     snapshot = build_task_snapshot(
         context,
         pending_action_id=pending_id,
+        artifacts=_build_decision_artifacts(context, action, decision),
         require_runtime_state=True,
     )
     (snapshot_writer or default_snapshot_writer)(snapshot)
@@ -599,6 +605,11 @@ def _emit_decision_applied_event(
                 if selected_candidate
                 else candidate_meta.get("adapter_mode")
             ),
+            "waiting_runtime_summary": extract_pending_action_waiting_summary(context),
+            "runtime_state_summary": build_context_runtime_state_summary(
+                context,
+                require_runtime_state=True,
+            ),
         },
     )
     write_event_log(decision_event)
@@ -633,6 +644,36 @@ def _emit_waiting_exit_event(
             "action_status": action.status.value,
             "decided_by": decision.decided_by,
             "decision_source": "human",
+            "waiting_runtime_summary": extract_pending_action_waiting_summary(context),
+            "runtime_state_summary": build_context_runtime_state_summary(
+                context,
+                require_runtime_state=True,
+            ),
         },
     )
     write_event_log(exit_event)
+
+
+def _build_decision_artifacts(
+    context: WorkflowContext,
+    action: PendingAction,
+    decision: Decision | None,
+) -> dict[str, object] | None:
+    if decision is None:
+        return None
+    summary = {
+        "decision_id": decision.decision_id,
+        "pending_action_id": action.pending_action_id,
+        "choice": decision.choice.value,
+        "selected_candidate_id": decision.selected_candidate_id,
+        "action_type": action.action_type.value,
+        "action_status": action.status.value,
+        "decided_by": decision.decided_by,
+        "decision_source": "human",
+        "runtime_state_summary": build_context_runtime_state_summary(
+            context,
+            require_runtime_state=True,
+        ),
+        "waiting_runtime_summary": extract_pending_action_waiting_summary(context),
+    }
+    return {DECISION_SUMMARY_ARTIFACT_KEY: summary}

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -20,6 +20,7 @@ from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
 from src.workflow.patch import apply_patch, build_patch_request
 from src.workflow.recovery import resolve_s6_recovery_action
+from src.workflow.snapshots import build_context_runtime_state_summary
 from src.workflow.step_runner import StepRunner
 from src.workflow.status import transition_task_status
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
@@ -481,6 +482,15 @@ def _extract_recovery_metadata(
         "io_type": selected_candidate.io_type if selected_candidate else None,
         "adapter_mode": selected_candidate.adapter_mode if selected_candidate else None,
     }
+    for key in (
+        "runtime_state_summary",
+        "action_score",
+        "shadow_score",
+        "default_recommendation_reason",
+    ):
+        value = candidate_meta.get(key)
+        if value is not None:
+            payload[key] = value
     if isinstance(metadata.get("strategy"), str):
         payload["strategy"] = metadata.get("strategy")
     return payload
@@ -531,6 +541,10 @@ def _emit_replacement_decision_event(
             "data": {
                 "decision": decision,
                 "recovery": recovery,
+                "runtime_state_summary": build_context_runtime_state_summary(
+                    context,
+                    require_runtime_state=True,
+                ),
             },
         },
     )
@@ -557,6 +571,10 @@ def _emit_recovery_escalation_event(
                 "reason": reason,
                 "detail": detail,
                 "recovery": recovery,
+                "runtime_state_summary": build_context_runtime_state_summary(
+                    context,
+                    require_runtime_state=True,
+                ),
             },
         },
     )

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -27,6 +27,7 @@ from src.storage.log_store import append_event, write_event_log
 from src.workflow.context import WorkflowContext
 from src.workflow.snapshots import (
     SnapshotWriter,
+    build_context_runtime_state_summary,
     build_task_snapshot,
     default_snapshot_writer,
 )
@@ -162,6 +163,11 @@ def enter_waiting_state(
             WAITING_RUNTIME_SUMMARY_METADATA_KEY,
             waiting_runtime_summary,
         )
+    runtime_state_summary = build_context_runtime_state_summary(
+        context,
+        require_runtime_state=True,
+        external_state=new_status,
+    )
     waiting_enter_event = make_waiting_enter(
         task_id=context.task.task_id,
         pending_action_id=pending_action.pending_action_id,
@@ -197,6 +203,7 @@ def enter_waiting_state(
                 if isinstance(pending_action.metadata, dict)
                 else None
             ),
+            "runtime_state_summary": runtime_state_summary,
         },
     )
     write_event_log(waiting_enter_event)

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -29,6 +29,7 @@ from src.workflow.patch_runner import PatchRunner, PendingPatch
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
 from src.agents.safety import SafetyAgent
 from src.workflow.status import transition_task_status
+from src.workflow.snapshots import build_context_runtime_state_summary
 from src.workflow.errors import (
     FailureType,
     PlanRunError,
@@ -769,6 +770,9 @@ class PlanRunner:
             "external_status": to_external_status(context.status).value,
         }
         event_data = _build_step_trace_data(step_result)
+        runtime_state_summary = build_context_runtime_state_summary(context)
+        if runtime_state_summary is not None:
+            event_data["runtime_state_summary"] = runtime_state_summary
         if event_data:
             event_payload["data"] = event_data
         append_event(

--- a/src/workflow/snapshots.py
+++ b/src/workflow/snapshots.py
@@ -6,8 +6,10 @@ from uuid import uuid4
 from src.models.contracts import (
     RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
     RUNTIME_STATE_ARTIFACT_KEY,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
     RuntimeState,
     TaskSnapshot,
+    WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
 from src.models.db import ExternalStatus, to_external_status
@@ -61,6 +63,7 @@ def build_task_snapshot(
         require_runtime_state=require_runtime_state,
     )
     _inject_runtime_state_artifacts(runtime_state, artifacts_payload)
+    _inject_pending_action_audit_artifacts(context, artifacts_payload)
     if context.pending_action is not None:
         artifacts_payload.setdefault(
             "pending_action", context.pending_action.model_dump()
@@ -105,11 +108,31 @@ def _inject_runtime_state_artifacts(
         RUNTIME_STATE_ARTIFACT_KEY,
         runtime_state.to_snapshot_payload(),
     )
+    artifacts_payload.setdefault(
+        RUNTIME_STATE_SUMMARY_METADATA_KEY,
+        runtime_state.to_summary_payload(),
+    )
 
     if runtime_state.observation_summary:
         artifacts_payload.setdefault(
             RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
             dict(runtime_state.observation_summary),
+        )
+
+
+def _inject_pending_action_audit_artifacts(
+    context: WorkflowContext,
+    artifacts_payload: dict[str, Any],
+) -> None:
+    pending_action = context.pending_action
+    if pending_action is None:
+        return
+    metadata = pending_action.metadata if isinstance(pending_action.metadata, dict) else {}
+    waiting_summary = metadata.get(WAITING_RUNTIME_SUMMARY_METADATA_KEY)
+    if isinstance(waiting_summary, dict):
+        artifacts_payload.setdefault(
+            WAITING_RUNTIME_SUMMARY_METADATA_KEY,
+            dict(waiting_summary),
         )
 
 
@@ -140,3 +163,46 @@ def _extract_total_step_count(context: WorkflowContext) -> int | None:
     if plan is None:
         return None
     return len(plan.steps)
+
+
+def ensure_context_runtime_state(
+    context: WorkflowContext,
+    *,
+    require_runtime_state: bool = False,
+    external_state: ExternalStatus | None = None,
+) -> RuntimeState | None:
+    resolved_external_state = external_state or to_external_status(context.status)
+    return _resolve_runtime_state_for_snapshot(
+        context,
+        external_state=resolved_external_state,
+        require_runtime_state=require_runtime_state,
+    )
+
+
+def build_context_runtime_state_summary(
+    context: WorkflowContext,
+    *,
+    require_runtime_state: bool = False,
+    external_state: ExternalStatus | None = None,
+) -> dict[str, Any] | None:
+    runtime_state = ensure_context_runtime_state(
+        context,
+        require_runtime_state=require_runtime_state,
+        external_state=external_state,
+    )
+    if runtime_state is None:
+        return None
+    return runtime_state.to_summary_payload()
+
+
+def extract_pending_action_waiting_summary(
+    context: WorkflowContext,
+) -> dict[str, Any] | None:
+    pending_action = context.pending_action
+    if pending_action is None:
+        return None
+    metadata = pending_action.metadata if isinstance(pending_action.metadata, dict) else {}
+    summary = metadata.get(WAITING_RUNTIME_SUMMARY_METADATA_KEY)
+    if not isinstance(summary, dict):
+        return None
+    return dict(summary)

--- a/tests/integration/test_event_log_integration.py
+++ b/tests/integration/test_event_log_integration.py
@@ -149,6 +149,7 @@ def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
     assert waiting_summary["selected_candidate_id"] == "candidate_waiting"
     assert waiting_summary["default_recommendation"] == "candidate_waiting"
     assert waiting_summary[ACTION_SCORE_METADATA_KEY]["value"] == pytest.approx(0.77)
+    assert event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
     assert pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]["default_recommendation_reason"]["code"] == "plan_ranked_first"
     assert event["actor_type"] == "system"
 
@@ -252,6 +253,7 @@ def test_decision_apply_emits_waiting_exit_and_decision_applied(cleanup_logs):
     assert decision_event["prev_status"] == ExternalStatus.WAITING_PLAN_CONFIRM.value
     assert decision_event["new_status"] == ExternalStatus.PLANNED.value
     assert decision_event["data"]["choice"] == DecisionChoice.ACCEPT.value
+    assert decision_event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
     assert decision_event["actor_type"] == "human"
 
     # Find WAITING_EXIT event
@@ -269,6 +271,7 @@ def test_decision_apply_emits_waiting_exit_and_decision_applied(cleanup_logs):
         exit_event["data"]["waiting_state"] == InternalStatus.WAITING_PLAN_CONFIRM.value
     )
     assert exit_event["data"]["action_status"] == PendingActionStatus.DECIDED.value
+    assert exit_event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
 def test_fsm_reconstruction_from_logs(cleanup_logs):

--- a/tests/integration/test_recovery_layered_patch.py
+++ b/tests/integration/test_recovery_layered_patch.py
@@ -289,6 +289,7 @@ def test_layered_patch_promotes_from_parameter_to_tool_level(monkeypatch):
     assert recovery["from_tool"] == "failing_tool"
     assert recovery["to_tool"] == "esmfold"
     assert recovery["capability_id"] == "structure_prediction"
+    assert replace_events[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
 @pytest.mark.integration
@@ -361,6 +362,7 @@ def test_layered_patch_promotes_remote_to_local_tool_level(monkeypatch):
     recovery = replace_events[-1]["data"]["recovery"]
     assert recovery["from_tool"] == "failing_tool"
     assert recovery["to_tool"] == "esmfold"
+    assert replace_events[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
 @pytest.mark.integration
@@ -420,6 +422,7 @@ def test_layered_patch_failure_escalates_to_replan_with_trace(monkeypatch):
     escalated = [e for e in events if e.get("event_type") == "RECOVERY_ESCALATED"]
     assert escalated
     assert escalated[-1]["data"]["reason"] == "patch_failed"
+    assert escalated[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
 @pytest.mark.integration
@@ -491,3 +494,4 @@ def test_high_risk_patch_escalates_to_replan(monkeypatch):
     escalated = [e for e in events if e.get("event_type") == "RECOVERY_ESCALATED"]
     assert escalated
     assert escalated[-1]["data"]["reason"] == "patch_high_risk"
+    assert escalated[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)

--- a/tests/unit/test_decision_apply.py
+++ b/tests/unit/test_decision_apply.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from src.models.contracts import (
+    DECISION_SUMMARY_ARTIFACT_KEY,
     Decision,
     DecisionChoice,
     PendingAction,
@@ -12,6 +13,7 @@ from src.models.contracts import (
     PlanPatchOp,
     PlanStep,
     RUNTIME_STATE_ARTIFACT_KEY,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
     now_iso,
 )
 from src.models.db import InternalStatus, TaskRecord, to_external_status
@@ -112,6 +114,8 @@ def test_plan_confirm_accept_transitions_to_planned(sample_task, sample_plan):
     assert snapshots[0].artifacts[RUNTIME_STATE_ARTIFACT_KEY]["last_update_source"] == (
         "runtime_bootstrap"
     )
+    assert snapshots[0].artifacts[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.5)
+    assert snapshots[0].artifacts[DECISION_SUMMARY_ARTIFACT_KEY]["choice"] == DecisionChoice.ACCEPT.value
 
 
 @pytest.mark.unit

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -9,6 +9,7 @@ from src.models.contracts import (
     ProteinDesignTask,
     RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY,
     RUNTIME_STATE_ARTIFACT_KEY,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
     RuntimeState,
     TaskSnapshot,
     now_iso,
@@ -247,6 +248,13 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
         "high_cost_steps_completed": 1
     }
+    assert snapshot.artifacts[RUNTIME_STATE_SUMMARY_METADATA_KEY] == {
+        "schema_version": 1,
+        "p_success": 0.72,
+        "p_structural_failure": 0.18,
+        "recovery_margin": 0.41,
+        "expected_remaining_cost": 12.5,
+    }
 
 
 @pytest.mark.unit
@@ -281,3 +289,4 @@ def test_build_task_snapshot_waiting_bootstraps_runtime_state_when_missing():
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
         "completed_steps": 0
     }
+    assert snapshot.artifacts[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- 为 snapshot artifacts 补齐 `runtime_state_summary`、`waiting_runtime_summary` 和 `decision_summary` 等稳定审计摘要
- 为 `WAITING_ENTER` / `WAITING_EXIT` / `DECISION_APPLIED` 以及 patch/recovery 相关事件补充运行时状态与候选修正审计字段
- 补充 unit 和 integration 测试，验证同一条恢复链可以直接从日志与快照重建关键决策线索

## Why
issue #213 要求把运行时状态、动作分数、升级原因和决策摘要补齐到现有 EventLog / Snapshot 结构里，保证后续实验和案例分析不需要手工拼接字段。当前基线已经有 `waiting_runtime_summary`、`runtime_state` 和 recovery 元数据，但还缺少统一、稳定的摘要落点，导致 patch/replan/decision 路径很难仅靠日志与快照还原完整的决策链。

## What Changed
### 1. Snapshot 摘要补齐
- 在 `src/workflow/snapshots.py` 中为 snapshot artifacts 增加 `runtime_state_summary`
- 将 `pending_action.metadata["waiting_runtime_summary"]` 同步写入 snapshot artifacts
- 在 decision 后的 snapshot 中写入 `decision_summary`，包含 choice、selected candidate、action type/status、runtime state summary 和 waiting summary

### 2. EventLog 审计字段补齐
- 在 `src/workflow/pending_action.py` 的 `WAITING_ENTER` 事件中补充 `runtime_state_summary`
- 在 `src/workflow/decision_apply.py` 的 `DECISION_APPLIED` / `WAITING_EXIT` 事件中补充 `runtime_state_summary` 与 `waiting_runtime_summary`
- 在 `src/workflow/plan_runner.py` 的 step 事件中补充 `runtime_state_summary`
- 在 `src/workflow/patch_runner.py` 的 replacement / escalation 事件中补充 `runtime_state_summary`，并让 recovery 审计携带更多候选修正字段

### 3. 可重建性验证
- 更新 snapshot 相关单元测试，验证新增摘要稳定落盘
- 更新 decision / event log / layered patch 集成测试，验证 WAITING、DECISION、RECOVERY 路径都能读到对应审计字段
- 保持现有 EventLog / Snapshot 结构兼容，不引入新的日志基础设施

## Acceptance Mapping
- [x] 已补充运行时状态和动作相关事件字段
- [x] 已补充 snapshot 中的状态摘要与决策摘要
- [x] patch/replan 路径的关键原因与状态变化可从日志中重建
- [x] snapshot 中可找到对应的状态与决策摘要
- [x] 新增字段对齐已有命名与结构化约定
- [x] 内容可直接供实验端消费，而不需要人工解释拼接

## Validation
```bash
uv run pytest tests/unit/test_task_snapshot.py tests/unit/test_decision_apply.py tests/unit/test_recovery_event_logs.py tests/integration/test_event_log_integration.py tests/integration/test_recovery_layered_patch.py tests/integration/test_snapshot_recovery.py -q
```

Closes #213
