### PR TITLE
feat(observability): 补齐 action/runtime 审计字段

### DIFF
--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -32,6 +32,20 @@ _LEGACY_EVENT_TYPE_MAP = {
     "STEP_FAILED": "STEP_FAILED",
 }
 
+_PENDING_ACTION_NAME_MAP = {
+    "plan_confirm": "plan",
+    "patch_confirm": "patch",
+    "replan_confirm": "replan",
+}
+
+_WAITING_STATUS_ACTION_NAME_MAP = {
+    "WAITING_PLAN_CONFIRM": "plan",
+    "WAITING_PATCH_CONFIRM": "patch",
+    "WAITING_REPLAN_CONFIRM": "replan",
+    "WAITING_PATCH": "patch",
+    "WAITING_REPLAN": "replan",
+}
+
 
 def append_event(
     task_id: str,
@@ -188,6 +202,12 @@ def _normalize_timeline_event(
         "failure_code": observability["failure_code"],
         "candidate_id": observability["candidate_id"],
         "decision_source": observability["decision_source"],
+        "action_name": observability["action_name"],
+        "action_score": observability["action_score"],
+        "shadow_score": observability["shadow_score"],
+        "runtime_state_summary": observability["runtime_state_summary"],
+        "waiting_runtime_summary": observability["waiting_runtime_summary"],
+        "evidence_source": observability["evidence_source"],
         "recovery_layer": observability["recovery_layer"],
         "recovery_reason": observability["recovery_reason"],
         "status": _string_field(payload, "status"),
@@ -305,6 +325,33 @@ def _extract_observability_fields(
 ) -> dict[str, Any]:
     recovery = data.get("recovery") if isinstance(data.get("recovery"), dict) else {}
     patch = data.get("patch") if isinstance(data.get("patch"), dict) else {}
+    waiting_runtime_summary = (
+        data.get("waiting_runtime_summary")
+        if isinstance(data.get("waiting_runtime_summary"), dict)
+        else {}
+    )
+    runtime_state_summary = _first_mapping(
+        data.get("runtime_state_summary"),
+        waiting_runtime_summary.get("runtime_state_summary"),
+        recovery.get("runtime_state_summary"),
+    )
+    action_score = _first_mapping(
+        data.get("action_score"),
+        waiting_runtime_summary.get("action_score"),
+        recovery.get("action_score"),
+    )
+    shadow_score = _first_mapping(
+        data.get("shadow_score"),
+        waiting_runtime_summary.get("shadow_score"),
+        recovery.get("shadow_score"),
+    )
+    evidence_source = _first_mapping(
+        data.get("evidence_source"),
+        data.get("default_recommendation_reason"),
+        waiting_runtime_summary.get("default_recommendation_reason"),
+        recovery.get("evidence_source"),
+        recovery.get("default_recommendation_reason"),
+    )
 
     tool_id = (
         _string_field(payload, "tool_id")
@@ -391,6 +438,7 @@ def _extract_observability_fields(
         or _string_field(recovery, "upgrade_reason")
         or _string_field(data, "reason")
     )
+    action_name = _extract_action_name(payload=payload, data=data, recovery=recovery)
 
     return {
         "tool_id": tool_id,
@@ -403,6 +451,56 @@ def _extract_observability_fields(
         "failure_code": failure_code,
         "candidate_id": candidate_id,
         "decision_source": decision_source,
+        "action_name": action_name,
+        "action_score": action_score,
+        "shadow_score": shadow_score,
+        "runtime_state_summary": runtime_state_summary,
+        "waiting_runtime_summary": waiting_runtime_summary or None,
+        "evidence_source": evidence_source,
         "recovery_layer": recovery_layer,
         "recovery_reason": recovery_reason,
     }
+
+
+def _extract_action_name(
+    *,
+    payload: dict[str, Any],
+    data: dict[str, Any],
+    recovery: dict[str, Any],
+) -> str | None:
+    action_name = _string_field(payload, "action_name") or _string_field(data, "action_name")
+    if action_name:
+        return action_name
+
+    s6 = data.get("s6")
+    if isinstance(s6, dict):
+        action_name = _string_field(s6, "action")
+        if action_name:
+            return action_name
+
+    action_type = _string_field(payload, "action_type") or _string_field(data, "action_type")
+    if action_type:
+        return _PENDING_ACTION_NAME_MAP.get(action_type, action_type)
+
+    event_type = _canonical_event_type(payload)
+    if event_type in {"PARAM_TWEAK", "REPLACE_TOOL", "STRUCTURE_PATCH"}:
+        return "patch"
+    if event_type == "RECOVERY_ESCALATED":
+        return "replan"
+
+    for status_key in ("to_status", "new_status", "from_status", "prev_status"):
+        status_value = _string_field(payload, status_key)
+        if status_value and status_value in _WAITING_STATUS_ACTION_NAME_MAP:
+            return _WAITING_STATUS_ACTION_NAME_MAP[status_value]
+
+    recovery_action = _string_field(recovery, "action_name")
+    if recovery_action:
+        return recovery_action
+    return None
+
+
+def _first_mapping(*values: Any) -> dict[str, Any] | None:
+    for value in values:
+        if isinstance(value, dict):
+            return dict(value)
+    return None

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -44,6 +44,12 @@ _EXPECTED_EXTERNAL = {
     PendingActionType.REPLAN_CONFIRM: ExternalStatus.WAITING_REPLAN_CONFIRM,
 }
 
+_ACTION_NAME_MAP = {
+    PendingActionType.PLAN_CONFIRM: "plan",
+    PendingActionType.PATCH_CONFIRM: "patch",
+    PendingActionType.REPLAN_CONFIRM: "replan",
+}
+
 
 class DecisionApplyError(ValueError):
     """Base error for decision application."""
@@ -586,6 +592,7 @@ def _emit_decision_applied_event(
         data={
             "selected_candidate_id": decision.selected_candidate_id,
             "action_type": action.action_type.value,
+            "action_name": _ACTION_NAME_MAP[action.action_type],
             "decided_by": decision.decided_by,
             "decision_source": "human",
             "comment": decision.comment,
@@ -606,6 +613,9 @@ def _emit_decision_applied_event(
                 else candidate_meta.get("adapter_mode")
             ),
             "waiting_runtime_summary": extract_pending_action_waiting_summary(context),
+            "action_score": candidate_meta.get("action_score"),
+            "shadow_score": candidate_meta.get("shadow_score"),
+            "evidence_source": candidate_meta.get("default_recommendation_reason"),
             "runtime_state_summary": build_context_runtime_state_summary(
                 context,
                 require_runtime_state=True,
@@ -631,6 +641,17 @@ def _emit_waiting_exit_event(
         waiting_state: The waiting state description.
     """
     current_status = to_external_status(context.status)
+    selected_candidate = None
+    if decision.selected_candidate_id:
+        selected_candidate = find_pending_action_candidate(
+            action,
+            decision.selected_candidate_id,
+        )
+    candidate_meta = (
+        selected_candidate.metadata
+        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        else {}
+    )
     exit_event = make_waiting_exit(
         task_id=context.task.task_id,
         prev_status=prev_status,
@@ -641,10 +662,14 @@ def _emit_waiting_exit_event(
         pending_action_id=action.pending_action_id,
         data={
             "action_type": action.action_type.value,
+            "action_name": _ACTION_NAME_MAP[action.action_type],
             "action_status": action.status.value,
             "decided_by": decision.decided_by,
             "decision_source": "human",
             "waiting_runtime_summary": extract_pending_action_waiting_summary(context),
+            "action_score": candidate_meta.get("action_score"),
+            "shadow_score": candidate_meta.get("shadow_score"),
+            "evidence_source": candidate_meta.get("default_recommendation_reason"),
             "runtime_state_summary": build_context_runtime_state_summary(
                 context,
                 require_runtime_state=True,

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -539,7 +539,11 @@ def _emit_replacement_decision_event(
             "state": context.status.value,
             "external_status": to_external_status(context.status).value,
             "data": {
+                "action_name": "patch",
+                "action_score": recovery.get("action_score"),
                 "decision": decision,
+                "shadow_score": recovery.get("shadow_score"),
+                "evidence_source": recovery.get("default_recommendation_reason"),
                 "recovery": recovery,
                 "runtime_state_summary": build_context_runtime_state_summary(
                     context,
@@ -568,8 +572,12 @@ def _emit_recovery_escalation_event(
             "state": context.status.value,
             "external_status": to_external_status(context.status).value,
             "data": {
+                "action_name": "replan",
+                "action_score": recovery.get("action_score"),
                 "reason": reason,
                 "detail": detail,
+                "shadow_score": recovery.get("shadow_score"),
+                "evidence_source": recovery.get("default_recommendation_reason"),
                 "recovery": recovery,
                 "runtime_state_summary": build_context_runtime_state_summary(
                     context,

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -40,6 +40,12 @@ _WAITING_ACTION_MAP = {
     InternalStatus.WAITING_REPLAN: PendingActionType.REPLAN_CONFIRM,
 }
 
+_ACTION_NAME_MAP = {
+    PendingActionType.PLAN_CONFIRM: "plan",
+    PendingActionType.PATCH_CONFIRM: "patch",
+    PendingActionType.REPLAN_CONFIRM: "replan",
+}
+
 
 def build_pending_action(
     task_id: str,
@@ -178,6 +184,7 @@ def enter_waiting_state(
         internal_status=to_status,
         data={
             "action_type": pending_action.action_type.value,
+            "action_name": _ACTION_NAME_MAP[pending_action.action_type],
             "reason": reason or "entering_waiting_state",
             "candidate_count": len(pending_action.candidates),
             "explanation": pending_action.explanation,
@@ -201,6 +208,21 @@ def enter_waiting_state(
             "waiting_runtime_summary": (
                 pending_action.metadata.get(WAITING_RUNTIME_SUMMARY_METADATA_KEY)
                 if isinstance(pending_action.metadata, dict)
+                else None
+            ),
+            "action_score": (
+                selected_meta.get(ACTION_SCORE_METADATA_KEY)
+                if isinstance(selected_meta.get(ACTION_SCORE_METADATA_KEY), dict)
+                else None
+            ),
+            "shadow_score": (
+                selected_meta.get(SHADOW_SCORE_METADATA_KEY)
+                if isinstance(selected_meta.get(SHADOW_SCORE_METADATA_KEY), dict)
+                else None
+            ),
+            "evidence_source": (
+                selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY)
+                if isinstance(selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY), dict)
                 else None
             ),
             "runtime_state_summary": runtime_state_summary,

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -831,6 +831,7 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
 
     s6_action = step_result.metrics.get("s6_recovery_action")
     if isinstance(s6_action, str) and s6_action:
+        data["action_name"] = s6_action
         data["s6"] = {
             "action": s6_action,
             "trigger_stage_id": step_result.metrics.get("s6_trigger_stage_id"),

--- a/src/workflow/status.py
+++ b/src/workflow/status.py
@@ -12,6 +12,7 @@ from src.models.db import (
 )
 from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
+from src.workflow.snapshots import build_context_runtime_state_summary
 
 # 状态变更的轻量日志回调。
 StatusLogger = Callable[[dict], None]
@@ -154,14 +155,21 @@ def _apply_status_update(
             record.updated_at = now_iso()
 
     log_handler = logger or _default_status_logger
+    event: dict[str, object] = {
+        "event": "TASK_STATUS_CHANGED",
+        "task_id": context.task.task_id,
+        "from_status": from_status.value,
+        "to_status": to_status.value,
+        "state": context.status.value,
+        "external_status": to_external_status(context.status).value,
+        "reason": reason,
+    }
+    runtime_state_summary = build_context_runtime_state_summary(
+        context,
+        external_state=to_external_status(to_status),
+    )
+    if runtime_state_summary is not None:
+        event["data"] = {"runtime_state_summary": runtime_state_summary}
     log_handler(
-        {
-            "event": "TASK_STATUS_CHANGED",
-            "task_id": context.task.task_id,
-            "from_status": from_status.value,
-            "to_status": to_status.value,
-            "state": context.status.value,
-            "external_status": to_external_status(context.status).value,
-            "reason": reason,
-        }
+        event
     )

--- a/tests/integration/test_event_log_integration.py
+++ b/tests/integration/test_event_log_integration.py
@@ -149,6 +149,10 @@ def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
     assert waiting_summary["selected_candidate_id"] == "candidate_waiting"
     assert waiting_summary["default_recommendation"] == "candidate_waiting"
     assert waiting_summary[ACTION_SCORE_METADATA_KEY]["value"] == pytest.approx(0.77)
+    assert event["data"]["action_name"] == "plan"
+    assert event["data"]["action_score"]["value"] == pytest.approx(0.77)
+    assert event["data"]["shadow_score"]["value"] == pytest.approx(0.77)
+    assert event["data"]["evidence_source"]["code"] == "plan_ranked_first"
     assert event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
     assert pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]["default_recommendation_reason"]["code"] == "plan_ranked_first"
     assert event["actor_type"] == "system"
@@ -206,6 +210,20 @@ def test_decision_apply_emits_waiting_exit_and_decision_applied(cleanup_logs):
                 payload=candidate_plan,
                 summary="test plan",
                 score_breakdown={},
+                metadata={
+                    ACTION_SCORE_METADATA_KEY: {
+                        "value": 0.66,
+                        "source": "candidate.overall",
+                    },
+                    SHADOW_SCORE_METADATA_KEY: {
+                        "value": 0.61,
+                        "source": "candidate.shadow",
+                    },
+                    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY: {
+                        "code": "human_selected_default",
+                        "message": "default candidate selected",
+                    },
+                },
             )
         ],
         default_suggestion="candidate_1",
@@ -253,6 +271,10 @@ def test_decision_apply_emits_waiting_exit_and_decision_applied(cleanup_logs):
     assert decision_event["prev_status"] == ExternalStatus.WAITING_PLAN_CONFIRM.value
     assert decision_event["new_status"] == ExternalStatus.PLANNED.value
     assert decision_event["data"]["choice"] == DecisionChoice.ACCEPT.value
+    assert decision_event["data"]["action_name"] == "plan"
+    assert decision_event["data"]["action_score"]["value"] == pytest.approx(0.66)
+    assert decision_event["data"]["shadow_score"]["value"] == pytest.approx(0.61)
+    assert decision_event["data"]["evidence_source"]["code"] == "human_selected_default"
     assert decision_event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
     assert decision_event["actor_type"] == "human"
 
@@ -271,6 +293,10 @@ def test_decision_apply_emits_waiting_exit_and_decision_applied(cleanup_logs):
         exit_event["data"]["waiting_state"] == InternalStatus.WAITING_PLAN_CONFIRM.value
     )
     assert exit_event["data"]["action_status"] == PendingActionStatus.DECIDED.value
+    assert exit_event["data"]["action_name"] == "plan"
+    assert exit_event["data"]["action_score"]["value"] == pytest.approx(0.66)
+    assert exit_event["data"]["shadow_score"]["value"] == pytest.approx(0.61)
+    assert exit_event["data"]["evidence_source"]["code"] == "human_selected_default"
     assert exit_event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 

--- a/tests/integration/test_recovery_layered_patch.py
+++ b/tests/integration/test_recovery_layered_patch.py
@@ -289,6 +289,7 @@ def test_layered_patch_promotes_from_parameter_to_tool_level(monkeypatch):
     assert recovery["from_tool"] == "failing_tool"
     assert recovery["to_tool"] == "esmfold"
     assert recovery["capability_id"] == "structure_prediction"
+    assert replace_events[-1]["action_name"] == "patch"
     assert replace_events[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
@@ -362,6 +363,7 @@ def test_layered_patch_promotes_remote_to_local_tool_level(monkeypatch):
     recovery = replace_events[-1]["data"]["recovery"]
     assert recovery["from_tool"] == "failing_tool"
     assert recovery["to_tool"] == "esmfold"
+    assert replace_events[-1]["action_name"] == "patch"
     assert replace_events[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
@@ -422,6 +424,7 @@ def test_layered_patch_failure_escalates_to_replan_with_trace(monkeypatch):
     escalated = [e for e in events if e.get("event_type") == "RECOVERY_ESCALATED"]
     assert escalated
     assert escalated[-1]["data"]["reason"] == "patch_failed"
+    assert escalated[-1]["action_name"] == "replan"
     assert escalated[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
 
 
@@ -494,4 +497,5 @@ def test_high_risk_patch_escalates_to_replan(monkeypatch):
     escalated = [e for e in events if e.get("event_type") == "RECOVERY_ESCALATED"]
     assert escalated
     assert escalated[-1]["data"]["reason"] == "patch_high_risk"
+    assert escalated[-1]["action_name"] == "replan"
     assert escalated[-1]["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)

--- a/tests/unit/test_log_store_timeline.py
+++ b/tests/unit/test_log_store_timeline.py
@@ -80,6 +80,89 @@ def test_read_timeline_events_extracts_recovery_observability_fields(tmp_path: P
 
 
 @pytest.mark.unit
+def test_read_timeline_events_extracts_action_runtime_audit_fields(tmp_path: Path) -> None:
+    task_id = "timeline_action_runtime_001"
+    log_file = tmp_path / f"{task_id}.jsonl"
+    events = [
+        {
+            "event_type": "WAITING_ENTER",
+            "task_id": task_id,
+            "pending_action_id": "pa_001",
+            "ts": "2026-03-16T00:59:59+00:00",
+            "new_status": "WAITING_PLAN_CONFIRM",
+            "data": {
+                "action_type": "plan_confirm",
+                "waiting_runtime_summary": {
+                    "action_score": {"value": 0.82, "source": "planner.rank"},
+                    "shadow_score": {"value": 0.79, "source": "planner.shadow"},
+                    "default_recommendation_reason": {
+                        "code": "plan_ranked_first",
+                        "message": "selected by deterministic rank",
+                    },
+                    "runtime_state_summary": {"p_success": 0.61},
+                },
+                "runtime_state_summary": {"p_success": 0.61},
+            },
+        },
+        {
+            "event": "RECOVERY_ESCALATED",
+            "task_id": task_id,
+            "step_id": "S3",
+            "timestamp": "2026-03-16T01:00:00+00:00",
+            "to_status": "WAITING_REPLAN_CONFIRM",
+            "data": {
+                "recovery": {
+                    "reason": "patch_high_risk",
+                    "action_score": {"value": 0.31, "source": "candidate.overall"},
+                    "shadow_score": {"value": 0.24, "source": "candidate.shadow"},
+                    "default_recommendation_reason": {
+                        "code": "patch_high_risk",
+                        "message": "blocked by high risk gate",
+                    },
+                    "runtime_state_summary": {"p_success": 0.22},
+                }
+            },
+        },
+        {
+            "event": "TASK_STATUS_CHANGED",
+            "task_id": task_id,
+            "timestamp": "2026-03-16T01:00:01+00:00",
+            "from_status": "RUNNING",
+            "to_status": "WAITING_REPLAN_CONFIRM",
+            "data": {"runtime_state_summary": {"p_success": 0.22}},
+        },
+    ]
+
+    with log_file.open("w", encoding="utf-8") as handle:
+        for item in events:
+            handle.write(json.dumps(item, ensure_ascii=True) + "\n")
+
+    timeline = read_timeline_events(task_id, log_dir=tmp_path)
+
+    assert len(timeline) == 3
+
+    waiting = timeline[0]
+    assert waiting["action_name"] == "plan"
+    assert waiting["action_score"]["value"] == pytest.approx(0.82)
+    assert waiting["shadow_score"]["value"] == pytest.approx(0.79)
+    assert waiting["runtime_state_summary"]["p_success"] == pytest.approx(0.61)
+    assert waiting["waiting_runtime_summary"]["default_recommendation_reason"]["code"] == "plan_ranked_first"
+    assert waiting["evidence_source"]["code"] == "plan_ranked_first"
+
+    escalated = timeline[1]
+    assert escalated["action_name"] == "replan"
+    assert escalated["action_score"]["value"] == pytest.approx(0.31)
+    assert escalated["shadow_score"]["value"] == pytest.approx(0.24)
+    assert escalated["runtime_state_summary"]["p_success"] == pytest.approx(0.22)
+    assert escalated["evidence_source"]["code"] == "patch_high_risk"
+    assert escalated["recovery_reason"] == "patch_high_risk"
+
+    transition = timeline[2]
+    assert transition["action_name"] == "replan"
+    assert transition["runtime_state_summary"]["p_success"] == pytest.approx(0.22)
+
+
+@pytest.mark.unit
 def test_read_timeline_events_keeps_legacy_entries_compatible(tmp_path: Path) -> None:
     task_id = "timeline_legacy_001"
     log_file = tmp_path / f"{task_id}.jsonl"


### PR DESCRIPTION
## 变更摘要
- 补齐 WAITING、DECISION_APPLIED、STEP_*、RECOVERY_ESCALATED、TASK_STATUS_CHANGED 事件中的 action/runtime 审计字段
- 在 `read_timeline_events()` 中统一抬平 `action_name`、`action_score`、`shadow_score`、`runtime_state_summary`、`waiting_runtime_summary`、`evidence_source`
- 补充 timeline、WAITING 事件和 layered patch 恢复链路的回归测试

## 为什么这样改
issue #233 需要把 action-level 与 runtime-level 审计字段固定到稳定命名上，并给实验脚本提供可直接消费的 timeline 入口，避免继续依赖事件 payload 的二次拼装。

## 与验收标准/任务拆解的映射
- 固定 action/runtime 审计字段清单与命名
  - 统一补齐 `action_name`、`action_score`、`shadow_score`、`runtime_state_summary`、`waiting_runtime_summary`、`evidence_source`
- 固定字段进入的事件类型和最小完整度要求
  - 覆盖 `STEP_*`、`RECOVERY_ESCALATED`、`TASK_STATUS_CHANGED`、`WAITING_*`、`DECISION_APPLIED`
- 明确与 `StepResult.metrics`、`PendingActionCandidate.metadata` 的映射关系
  - `STEP_*` 从 `s6_recovery_action` 映射 `action_name`
  - WAITING/DECISION/PATCH/RECOVERY 事件从 `PendingActionCandidate.metadata` 提取评分、证据与 runtime 摘要
- 给出实验脚本侧的直接消费入口说明
  - `src/storage/log_store.py` 的 `read_timeline_events()` 已输出归一化后的直接消费字段

## 验证
- `uv run pytest tests/unit/test_log_store_timeline.py tests/unit/test_status_transition.py tests/integration/test_event_log_integration.py tests/integration/test_recovery_layered_patch.py -q`
- `uv run pytest tests/unit/test_decision_apply.py tests/unit/test_w12_vertical_experiment.py tests/integration/test_event_log_integration.py tests/integration/test_s6_control_layer_e2e.py -q`

Closes #233
