### PR TITLE
feat(experiment): 增加离线 replay 样本与 focused tests

### DIFF
--- a/src/infra/w12_vertical_experiment.py
+++ b/src/infra/w12_vertical_experiment.py
@@ -58,6 +58,9 @@ DEFAULT_HIGH_COST_RULES: list[dict[str, Any]] = [
 ]
 
 _PATCH_EVENT_NAMES = {"PARAM_TWEAK", "REPLACE_TOOL", "STRUCTURE_PATCH"}
+DEFAULT_REPLAY_SAMPLE_DIR = (
+    Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "w14_issue215"
+)
 
 
 def now_iso() -> str:
@@ -92,7 +95,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]], fieldnames: list[str]) -> 
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
-    if not path.exists():
+    if not path.exists() or not path.is_file():
         return rows
     with path.open("r", encoding="utf-8") as f:
         for raw in f:
@@ -106,6 +109,128 @@ def read_jsonl(path: Path) -> list[dict[str, Any]]:
             if isinstance(value, dict):
                 rows.append(value)
     return rows
+
+
+def load_replay_sample(path: Path) -> dict[str, Any]:
+    payload = load_json(path)
+    sample_id = payload.get("sample_id")
+    if not isinstance(sample_id, str) or not sample_id.strip():
+        raise ValueError("replay sample missing sample_id")
+
+    source = payload.get("source")
+    if not isinstance(source, dict):
+        raise ValueError("replay sample missing source")
+    freeze_id = source.get("freeze_id")
+    if not isinstance(freeze_id, str) or not freeze_id.strip():
+        raise ValueError("replay sample source.freeze_id is required")
+    task_key = source.get("task_key")
+    if not isinstance(task_key, str) or not task_key.strip():
+        raise ValueError("replay sample source.task_key is required")
+
+    purpose = payload.get("purpose")
+    if not isinstance(purpose, str) or not purpose.strip():
+        raise ValueError("replay sample purpose is required")
+
+    run = payload.get("run")
+    if not isinstance(run, dict):
+        raise ValueError("replay sample missing run")
+    event_log = payload.get("event_log")
+    if not isinstance(event_log, list) or not event_log:
+        raise ValueError("replay sample event_log must be a non-empty list")
+
+    snapshot = payload.get("snapshot")
+    if snapshot is not None and not isinstance(snapshot, dict):
+        raise ValueError("replay sample snapshot must be a mapping")
+
+    report = payload.get("report")
+    if report is not None and not isinstance(report, dict):
+        raise ValueError("replay sample report must be a mapping")
+
+    return payload
+
+
+def materialize_replay_sample(
+    sample: dict[str, Any],
+    *,
+    output_dir: Path,
+) -> dict[str, Any]:
+    sample_id = str(sample["sample_id"])
+    sample_dir = output_dir / sample_id
+    sample_dir.mkdir(parents=True, exist_ok=True)
+
+    event_log_path = sample_dir / "event_log.jsonl"
+    write_jsonl(event_log_path, sample["event_log"])
+
+    snapshot_path = sample_dir / "snapshot.json"
+    snapshot_payload = sample.get("snapshot")
+    if isinstance(snapshot_payload, dict):
+        write_json(snapshot_path, snapshot_payload)
+        resolved_snapshot_path: Path | None = snapshot_path
+    else:
+        resolved_snapshot_path = None
+
+    report_path = sample_dir / "report.json"
+    report_payload = sample.get("report")
+    if isinstance(report_payload, dict):
+        write_json(report_path, report_payload)
+        resolved_report_path: Path | None = report_path
+    else:
+        resolved_report_path = None
+
+    run = dict(sample["run"])
+    source = dict(sample["source"])
+    run.setdefault("freeze_id", source.get("freeze_id"))
+    run.setdefault("task_key", source.get("task_key"))
+    run["event_log_path"] = str(event_log_path)
+    run["snapshot_path"] = str(resolved_snapshot_path) if resolved_snapshot_path else ""
+    run["report_path"] = str(resolved_report_path) if resolved_report_path else ""
+    run["replay_sample_id"] = sample_id
+    run["replay_source_freeze_id"] = str(source.get("freeze_id") or "")
+    return run
+
+
+def replay_sample(
+    sample_path: Path,
+    *,
+    output_dir: Path,
+    tool_capability_map: dict[str, list[str]],
+    requirement2_capability_map: dict[str, list[str]],
+    high_cost_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    sample = load_replay_sample(sample_path)
+    run = materialize_replay_sample(sample, output_dir=output_dir)
+    metrics = extract_run_metrics(
+        run,
+        tool_capability_map=tool_capability_map,
+        requirement2_capability_map=requirement2_capability_map,
+        high_cost_rules=high_cost_rules,
+    )
+    metrics["replay_sample_id"] = run.get("replay_sample_id")
+    metrics["replay_source_freeze_id"] = run.get("replay_source_freeze_id")
+    metrics["replay_sample_purpose"] = sample.get("purpose")
+    return metrics
+
+
+def replay_samples(
+    sample_paths: Iterable[Path],
+    *,
+    output_dir: Path,
+    tool_capability_map: dict[str, list[str]],
+    requirement2_capability_map: dict[str, list[str]],
+    high_cost_rules: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for sample_path in sample_paths:
+        results.append(
+            replay_sample(
+                sample_path,
+                output_dir=output_dir,
+                tool_capability_map=tool_capability_map,
+                requirement2_capability_map=requirement2_capability_map,
+                high_cost_rules=high_cost_rules,
+            )
+        )
+    return results
 
 
 def parse_iso_datetime(value: Any) -> datetime | None:
@@ -305,6 +430,66 @@ def _nested(row: dict[str, Any], *path: str) -> Any:
     return current
 
 
+def _has_runtime_state_observation(row: dict[str, Any]) -> bool:
+    data = row.get("data")
+    if not isinstance(data, dict):
+        data = {}
+    if isinstance(data.get("runtime_state_summary"), dict):
+        return True
+    waiting_summary = data.get("waiting_runtime_summary")
+    if isinstance(waiting_summary, dict) and isinstance(
+        waiting_summary.get("runtime_state_summary"),
+        dict,
+    ):
+        return True
+    recovery = data.get("recovery")
+    if isinstance(recovery, dict) and isinstance(recovery.get("runtime_state_summary"), dict):
+        return True
+    return False
+
+
+def _has_shadow_output(row: dict[str, Any]) -> bool:
+    data = row.get("data")
+    if not isinstance(data, dict):
+        data = {}
+    if isinstance(data.get("shadow_score"), dict):
+        return True
+    if isinstance(data.get("shadow_action"), str) and data.get("shadow_action"):
+        return True
+    waiting_summary = data.get("waiting_runtime_summary")
+    if isinstance(waiting_summary, dict):
+        if isinstance(waiting_summary.get("shadow_score"), dict):
+            return True
+        if isinstance(waiting_summary.get("shadow_action"), str) and waiting_summary.get("shadow_action"):
+            return True
+    recovery = data.get("recovery")
+    if isinstance(recovery, dict):
+        if isinstance(recovery.get("shadow_score"), dict):
+            return True
+        if isinstance(recovery.get("shadow_action"), str) and recovery.get("shadow_action"):
+            return True
+    return False
+
+
+def _load_snapshot_payload(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = load_json(path)
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _optional_path(value: Any) -> Path | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    return Path(text)
+
+
 def extract_run_metrics(
     run: dict[str, Any],
     *,
@@ -312,9 +497,17 @@ def extract_run_metrics(
     requirement2_capability_map: dict[str, list[str]],
     high_cost_rules: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    event_log_path = Path(str(run.get("event_log_path") or ""))
+    event_log_path = _optional_path(run.get("event_log_path")) or Path("")
+    snapshot_path = _optional_path(run.get("snapshot_path"))
+    report_path = _optional_path(run.get("report_path"))
     rows = read_jsonl(event_log_path)
     resolved_high_cost_rules = normalize_high_cost_rules(high_cost_rules)
+    snapshot_payload = _load_snapshot_payload(snapshot_path) if snapshot_path else None
+    snapshot_artifacts = (
+        snapshot_payload.get("artifacts")
+        if isinstance(snapshot_payload, dict) and isinstance(snapshot_payload.get("artifacts"), dict)
+        else {}
+    )
 
     timestamps: list[datetime] = []
     step_failed_details: list[dict[str, Any]] = []
@@ -336,12 +529,16 @@ def extract_run_metrics(
     waiting_enter_count = 0
     high_cost_call_count = 0
     high_cost_failure_count = 0
+    runtime_state_observable = False
+    shadow_output_observable = False
 
     suffix_prefix_samples: list[bool] = []
     final_status: str | None = None
 
     for row in rows:
         event_name = _event_name(row)
+        runtime_state_observable = runtime_state_observable or _has_runtime_state_observation(row)
+        shadow_output_observable = shadow_output_observable or _has_shadow_output(row)
 
         ts = parse_iso_datetime(row.get("timestamp") or row.get("ts"))
         if ts is not None:
@@ -486,6 +683,15 @@ def extract_run_metrics(
     for bucket, capabilities in requirement2_capability_map.items():
         requirement2_coverage[bucket] = any(capability_usage.get(cap, 0) > 0 for cap in capabilities)
 
+    if isinstance(snapshot_artifacts.get("runtime_state"), dict):
+        runtime_state_observable = True
+    if isinstance(snapshot_artifacts.get("decision_summary"), dict):
+        decision_summary = snapshot_artifacts.get("decision_summary") or {}
+        if isinstance(decision_summary.get("shadow_score"), dict):
+            shadow_output_observable = True
+        if isinstance(decision_summary.get("shadow_action"), str) and decision_summary.get("shadow_action"):
+            shadow_output_observable = True
+
     return {
         "run_id": run.get("run_id"),
         "task_id": run.get("task_id"),
@@ -493,9 +699,9 @@ def extract_run_metrics(
         "group_id": run.get("group_id"),
         "replicate": run.get("replicate"),
         "freeze_id": run.get("freeze_id"),
-        "event_log_path": str(event_log_path),
-        "snapshot_path": str(run.get("snapshot_path") or ""),
-        "report_path": str(run.get("report_path") or ""),
+        "event_log_path": str(event_log_path) if str(event_log_path) != "." else "",
+        "snapshot_path": str(snapshot_path) if snapshot_path else "",
+        "report_path": str(report_path) if report_path else "",
         "started_at": run.get("started_at"),
         "finished_at": run.get("finished_at"),
         "duration_ms": round(duration_ms_value, 3),
@@ -512,6 +718,10 @@ def extract_run_metrics(
         "step_finished_count": step_finished_count,
         "waiting_chain_complete": waiting_chain_complete,
         "failure_traceable": failure_traceable,
+        "snapshot_linked": bool(snapshot_path and snapshot_path.exists()),
+        "report_linked": bool(report_path and report_path.exists()),
+        "runtime_state_observable": runtime_state_observable,
+        "shadow_output_observable": shadow_output_observable,
         "layer_counter": dict(layer_counter),
         "tool_usage": dict(tool_usage),
         "capability_usage": dict(capability_usage),
@@ -522,6 +732,8 @@ def extract_run_metrics(
         "suffix_prefix_samples": suffix_prefix_samples,
         "abnormal_reasons": abnormal_reasons,
         "step_failed_details": step_failed_details,
+        "replay_sample_id": run.get("replay_sample_id"),
+        "replay_source_freeze_id": run.get("replay_source_freeze_id"),
     }
 
 
@@ -585,6 +797,13 @@ def aggregate_group_metrics(
         executable = _proportion_summary([bool(item.get("executable_plan")) for item in rows])
         waiting_chain = _proportion_summary([bool(item.get("waiting_chain_complete")) for item in rows])
         traceability = _proportion_summary([bool(item.get("failure_traceable")) for item in rows])
+        snapshot_linked = _proportion_summary([bool(item.get("snapshot_linked")) for item in rows])
+        runtime_state_observable = _proportion_summary(
+            [bool(item.get("runtime_state_observable")) for item in rows]
+        )
+        shadow_output_observable = _proportion_summary(
+            [bool(item.get("shadow_output_observable")) for item in rows]
+        )
 
         patch_counts = [float(item.get("patch_event_count", 0) or 0) for item in rows]
         replan_counts = [float(item.get("replan_event_count", 0) or 0) for item in rows]
@@ -666,6 +885,9 @@ def aggregate_group_metrics(
             "executable_ci_high": executable["ci_high"],
             "waiting_chain_complete_rate": waiting_chain["rate"],
             "failure_traceable_rate": traceability["rate"],
+            "snapshot_linked_rate": snapshot_linked["rate"],
+            "runtime_state_observable_rate": runtime_state_observable["rate"],
+            "shadow_output_observable_rate": shadow_output_observable["rate"],
             "patch_events_mean": patch_summary["mean"],
             "patch_events_ci_low": patch_summary["ci_low"],
             "patch_events_ci_high": patch_summary["ci_high"],

--- a/tests/fixtures/w14_issue215/README.md
+++ b/tests/fixtures/w14_issue215/README.md
@@ -1,0 +1,17 @@
+W14 issue #215 replay samples
+
+Purpose:
+- Provide minimal offline replay inputs for runtime-state, snapshot, audit-log,
+  and shadow-output focused tests.
+- Keep the samples small enough for local and CI reuse.
+
+Source:
+- Derived from the frozen experiment lineage around
+  `issue209-baseline-freeze-smoke`.
+- Reduced to the smallest event/snapshot/report subset needed for deterministic
+  replay in `tests/unit/test_w12_vertical_experiment.py`.
+
+Usage:
+- Load the JSON sample with `load_replay_sample()`.
+- Materialize it into a temp directory with `materialize_replay_sample()`.
+- Replay and extract metrics with `replay_sample()` or `replay_samples()`.

--- a/tests/fixtures/w14_issue215/replan_waiting_shadow_sample.json
+++ b/tests/fixtures/w14_issue215/replan_waiting_shadow_sample.json
@@ -1,0 +1,146 @@
+{
+  "sample_id": "replan_waiting_shadow_sample",
+  "source": {
+    "freeze_id": "issue209-baseline-freeze-smoke",
+    "task_key": "a4-replan-shadow",
+    "source_manifest": "output/experiment/w13-expr-0/issue209-baseline-freeze-smoke/baseline_freeze_manifest.json"
+  },
+  "purpose": "Replay a replan-oriented waiting chain with suffix_replan shadow evidence and stable snapshot linkage.",
+  "run": {
+    "run_id": "replan_waiting_shadow_sample_r1",
+    "task_id": "task_replan_waiting_shadow",
+    "group_id": "A4",
+    "replicate": 1,
+    "started_at": "2026-04-04T11:00:00+00:00",
+    "finished_at": "2026-04-04T11:00:06+00:00",
+    "status_external": "DONE"
+  },
+  "event_log": [
+    {
+      "event": "TASK_STATUS_CHANGED",
+      "task_id": "task_replan_waiting_shadow",
+      "from_status": "RUNNING",
+      "to_status": "REPLANNING",
+      "reason": "suffix_replan_requested",
+      "timestamp": "2026-04-04T11:00:00+00:00"
+    },
+    {
+      "event": "RECOVERY_ESCALATED",
+      "task_id": "task_replan_waiting_shadow",
+      "step_id": "S3",
+      "timestamp": "2026-04-04T11:00:01+00:00",
+      "data": {
+        "reason": "patch_high_risk",
+        "recovery": {
+          "recovery_layer": "tool_level",
+          "shadow_score": {
+            "value": 0.33,
+            "source": "score_breakdown.overall+runtime_state.suffix_replan.v1"
+          },
+          "shadow_action": "suffix_replan",
+          "runtime_state_summary": {
+            "schema_version": 1,
+            "p_success": 0.27,
+            "p_structural_failure": 0.77,
+            "recovery_margin": -0.22,
+            "expected_remaining_cost": 3.9
+          }
+        }
+      }
+    },
+    {
+      "event": "WAITING_ENTER",
+      "task_id": "task_replan_waiting_shadow",
+      "pending_action_id": "pa_replan_001",
+      "ts": "2026-04-04T11:00:02+00:00",
+      "data": {
+        "action_name": "replan",
+        "waiting_runtime_summary": {
+          "selected_candidate_id": "cand_replan_1",
+          "default_recommendation": "cand_replan_1",
+          "runtime_state_summary": {
+            "schema_version": 1,
+            "p_success": 0.27,
+            "p_structural_failure": 0.77,
+            "recovery_margin": -0.22,
+            "expected_remaining_cost": 3.9
+          },
+          "action_score": {
+            "value": 0.58,
+            "source": "score_breakdown.overall"
+          },
+          "shadow_score": {
+            "value": 0.33,
+            "source": "score_breakdown.overall+runtime_state.suffix_replan.v1"
+          },
+          "shadow_action": "suffix_replan"
+        }
+      }
+    },
+    {
+      "event": "DECISION_APPLIED",
+      "task_id": "task_replan_waiting_shadow",
+      "pending_action_id": "pa_replan_001",
+      "decision_id": "dec_replan_001",
+      "ts": "2026-04-04T11:00:03+00:00"
+    },
+    {
+      "event": "WAITING_EXIT",
+      "task_id": "task_replan_waiting_shadow",
+      "pending_action_id": "pa_replan_001",
+      "ts": "2026-04-04T11:00:04+00:00"
+    },
+    {
+      "event": "STEP_FINISHED",
+      "task_id": "task_replan_waiting_shadow",
+      "step_id": "S1",
+      "tool": "seqgen_local",
+      "status": "success",
+      "timestamp": "2026-04-04T11:00:05+00:00",
+      "data": {
+        "runtime_state_summary": {
+          "schema_version": 1,
+          "p_success": 0.51,
+          "p_structural_failure": 0.24,
+          "recovery_margin": 0.18,
+          "expected_remaining_cost": 1.9
+        }
+      }
+    },
+    {
+      "event": "TASK_STATUS_CHANGED",
+      "task_id": "task_replan_waiting_shadow",
+      "from_status": "SUMMARIZING",
+      "to_status": "DONE",
+      "reason": "summarizer_placeholder",
+      "timestamp": "2026-04-04T11:00:06+00:00"
+    }
+  ],
+  "snapshot": {
+    "task_id": "task_replan_waiting_shadow",
+    "state": "DONE",
+    "artifacts": {
+      "runtime_state": {
+        "schema_version": 1,
+        "p_success": 0.51,
+        "p_structural_failure": 0.24,
+        "recovery_margin": 0.18,
+        "expected_remaining_cost": 1.9,
+        "last_update_source": "sample"
+      },
+      "decision_summary": {
+        "shadow_action": "suffix_replan",
+        "shadow_score": {
+          "value": 0.33,
+          "source": "score_breakdown.overall+runtime_state.suffix_replan.v1"
+        }
+      }
+    }
+  },
+  "report": {
+    "summary": {
+      "status": "done",
+      "notes": "replan replay sample"
+    }
+  }
+}

--- a/tests/fixtures/w14_issue215/runtime_shadow_success_sample.json
+++ b/tests/fixtures/w14_issue215/runtime_shadow_success_sample.json
@@ -1,0 +1,138 @@
+{
+  "sample_id": "runtime_shadow_success_sample",
+  "source": {
+    "freeze_id": "issue209-baseline-freeze-smoke",
+    "task_key": "a3-runtime-shadow",
+    "source_manifest": "output/experiment/w13-expr-0/issue209-baseline-freeze-smoke/baseline_freeze_manifest.json"
+  },
+  "purpose": "Replay a completed waiting-to-success path with runtime_state and shadow outputs attached.",
+  "run": {
+    "run_id": "runtime_shadow_success_sample_r1",
+    "task_id": "task_runtime_shadow_success",
+    "group_id": "A3",
+    "replicate": 1,
+    "started_at": "2026-04-04T10:00:00+00:00",
+    "finished_at": "2026-04-04T10:00:05+00:00",
+    "status_external": "DONE"
+  },
+  "event_log": [
+    {
+      "event": "TASK_STATUS_CHANGED",
+      "task_id": "task_runtime_shadow_success",
+      "from_status": "RUNNING",
+      "to_status": "WAITING_PATCH_CONFIRM",
+      "reason": "patch_review_requested",
+      "timestamp": "2026-04-04T10:00:00+00:00"
+    },
+    {
+      "event": "WAITING_ENTER",
+      "task_id": "task_runtime_shadow_success",
+      "pending_action_id": "pa_runtime_001",
+      "ts": "2026-04-04T10:00:01+00:00",
+      "data": {
+        "action_name": "patch",
+        "waiting_runtime_summary": {
+          "selected_candidate_id": "cand_patch_1",
+          "default_recommendation": "cand_patch_1",
+          "runtime_state_summary": {
+            "schema_version": 1,
+            "p_success": 0.41,
+            "p_structural_failure": 0.52,
+            "recovery_margin": 0.12,
+            "expected_remaining_cost": 2.7
+          },
+          "action_score": {
+            "value": 0.62,
+            "source": "score_breakdown.overall"
+          },
+          "shadow_score": {
+            "value": 0.49,
+            "source": "score_breakdown.overall+runtime_state.suffix_replan.v1"
+          },
+          "shadow_action": "suffix_replan"
+        }
+      }
+    },
+    {
+      "event": "DECISION_APPLIED",
+      "task_id": "task_runtime_shadow_success",
+      "pending_action_id": "pa_runtime_001",
+      "decision_id": "dec_runtime_001",
+      "ts": "2026-04-04T10:00:02+00:00",
+      "data": {
+        "choice": "accept",
+        "action_name": "patch",
+        "shadow_score": {
+          "value": 0.49,
+          "source": "score_breakdown.overall+runtime_state.suffix_replan.v1"
+        },
+        "shadow_action": "suffix_replan",
+        "runtime_state_summary": {
+          "schema_version": 1,
+          "p_success": 0.41,
+          "p_structural_failure": 0.52,
+          "recovery_margin": 0.12,
+          "expected_remaining_cost": 2.7
+        }
+      }
+    },
+    {
+      "event": "WAITING_EXIT",
+      "task_id": "task_runtime_shadow_success",
+      "pending_action_id": "pa_runtime_001",
+      "ts": "2026-04-04T10:00:03+00:00"
+    },
+    {
+      "event": "STEP_FINISHED",
+      "task_id": "task_runtime_shadow_success",
+      "step_id": "S2",
+      "tool": "esmfold",
+      "status": "success",
+      "timestamp": "2026-04-04T10:00:04+00:00",
+      "data": {
+        "runtime_state_summary": {
+          "schema_version": 1,
+          "p_success": 0.74,
+          "p_structural_failure": 0.18,
+          "recovery_margin": 0.45,
+          "expected_remaining_cost": 1.1
+        }
+      }
+    },
+    {
+      "event": "TASK_STATUS_CHANGED",
+      "task_id": "task_runtime_shadow_success",
+      "from_status": "SUMMARIZING",
+      "to_status": "DONE",
+      "reason": "summarizer_placeholder",
+      "timestamp": "2026-04-04T10:00:05+00:00"
+    }
+  ],
+  "snapshot": {
+    "task_id": "task_runtime_shadow_success",
+    "state": "DONE",
+    "artifacts": {
+      "runtime_state": {
+        "schema_version": 1,
+        "p_success": 0.74,
+        "p_structural_failure": 0.18,
+        "recovery_margin": 0.45,
+        "expected_remaining_cost": 1.1,
+        "last_update_source": "sample"
+      },
+      "decision_summary": {
+        "shadow_action": "suffix_replan",
+        "shadow_score": {
+          "value": 0.49,
+          "source": "score_breakdown.overall+runtime_state.suffix_replan.v1"
+        }
+      }
+    }
+  },
+  "report": {
+    "summary": {
+      "status": "done",
+      "notes": "minimal replay sample"
+    }
+  }
+}

--- a/tests/unit/test_w12_vertical_experiment.py
+++ b/tests/unit/test_w12_vertical_experiment.py
@@ -4,10 +4,16 @@ import json
 from pathlib import Path
 
 from src.infra.w12_vertical_experiment import (
+    DEFAULT_REPLAY_SAMPLE_DIR,
     DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
     aggregate_group_metrics,
     compute_increment_deltas,
     extract_run_metrics,
+    load_replay_sample,
+    materialize_replay_sample,
+    replay_sample,
+    replay_samples,
+    stable_hash,
     wilson_interval,
 )
 
@@ -120,6 +126,94 @@ def test_extract_run_metrics_and_requirement2(tmp_path: Path) -> None:
     assert metrics["high_cost_rule_hits"]["structure_mapping"] == 1
 
 
+def test_replay_sample_materialization_extracts_runtime_snapshot_and_shadow_fields(
+    tmp_path: Path,
+) -> None:
+    sample = load_replay_sample(
+        DEFAULT_REPLAY_SAMPLE_DIR / "runtime_shadow_success_sample.json"
+    )
+    run = materialize_replay_sample(sample, output_dir=tmp_path)
+    tool_map = {
+        "seqgen_local": ["sequence_generation"],
+        "esmfold": ["structure_prediction"],
+    }
+
+    metrics = extract_run_metrics(
+        run,
+        tool_capability_map=tool_map,
+        requirement2_capability_map=DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    )
+
+    assert metrics["success"] is True
+    assert metrics["waiting_chain_complete"] is True
+    assert metrics["snapshot_linked"] is True
+    assert metrics["report_linked"] is True
+    assert metrics["runtime_state_observable"] is True
+    assert metrics["shadow_output_observable"] is True
+    assert metrics["replay_sample_id"] == "runtime_shadow_success_sample"
+    assert metrics["replay_source_freeze_id"] == "issue209-baseline-freeze-smoke"
+
+
+def test_replay_sample_is_deterministic_for_same_fixture(tmp_path: Path) -> None:
+    sample_path = DEFAULT_REPLAY_SAMPLE_DIR / "runtime_shadow_success_sample.json"
+    tool_map = {
+        "seqgen_local": ["sequence_generation"],
+        "esmfold": ["structure_prediction"],
+    }
+
+    first = replay_sample(
+        sample_path,
+        output_dir=tmp_path / "bundle",
+        tool_capability_map=tool_map,
+        requirement2_capability_map=DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    )
+    second = replay_sample(
+        sample_path,
+        output_dir=tmp_path / "bundle",
+        tool_capability_map=tool_map,
+        requirement2_capability_map=DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    )
+
+    keys = (
+        "success",
+        "final_status",
+        "waiting_chain_complete",
+        "runtime_state_observable",
+        "shadow_output_observable",
+        "high_cost_call_count",
+        "requirement2_coverage",
+        "step_finished_count",
+    )
+    first_subset = {key: first[key] for key in keys}
+    second_subset = {key: second[key] for key in keys}
+    assert first_subset == second_subset
+    assert stable_hash(first_subset) == stable_hash(second_subset)
+
+
+def test_replay_samples_batch_returns_reusable_metrics(tmp_path: Path) -> None:
+    tool_map = {
+        "seqgen_local": ["sequence_generation"],
+        "esmfold": ["structure_prediction"],
+    }
+    sample_paths = [
+        DEFAULT_REPLAY_SAMPLE_DIR / "runtime_shadow_success_sample.json",
+        DEFAULT_REPLAY_SAMPLE_DIR / "replan_waiting_shadow_sample.json",
+    ]
+
+    rows = replay_samples(
+        sample_paths,
+        output_dir=tmp_path / "batch",
+        tool_capability_map=tool_map,
+        requirement2_capability_map=DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    )
+
+    assert len(rows) == 2
+    by_id = {row["replay_sample_id"]: row for row in rows}
+    assert by_id["runtime_shadow_success_sample"]["shadow_output_observable"] is True
+    assert by_id["replan_waiting_shadow_sample"]["replan_event_count"] == 1
+    assert by_id["replan_waiting_shadow_sample"]["requirement2_coverage"]["sequence_core"] is True
+
+
 def test_aggregate_and_deltas(tmp_path: Path) -> None:
     def make_run(group_id: str, task_key: str, replicate: int, success: bool, patch_count: int) -> dict:
         return {
@@ -188,6 +282,8 @@ def test_aggregate_and_deltas(tmp_path: Path) -> None:
     assert summary["A1"]["success_rate"] == 1.0
     assert summary["A1"]["patch_events_mean"] == 0.0
     assert summary["A0"]["high_cost_call_mean"] == 0.0
+    assert summary["A0"]["runtime_state_observable_rate"] == 0.0
+    assert summary["A1"]["shadow_output_observable_rate"] == 0.0
 
     deltas = compute_increment_deltas(
         runs,


### PR DESCRIPTION
## 变更摘要
- 在 `src/infra/w12_vertical_experiment.py` 增加离线 replay sample 的加载、物化、单样本回放与批量回放入口。
- 增加 `snapshot_linked`、`runtime_state_observable`、`shadow_output_observable` 等可复用指标，便于后续实验直接消费。
- 补充最小 replay 样本与说明文档，并在 focused tests 中覆盖状态更新、snapshot、日志字段读取、shadow output 和确定性回放。

## 为什么这样改
issue #215 的目标是为后续动态对照实验准备可离线复算的最小样本和契约级测试入口，避免 Week15/16 再从零构造输入。这次实现把样本、说明、回放入口和 focused tests 一起固定下来，同时保持范围只在评估/回放侧，不扩展 workflow 或实验矩阵。

## 与任务拆解/验收标准的映射
- 准备最小 replay 样本与说明
  - 新增 `tests/fixtures/w14_issue215/README.md`
  - 新增 `runtime_shadow_success_sample.json` 与 `replan_waiting_shadow_sample.json`
- 补充状态更新、snapshot、日志读取相关测试
  - 在 `tests/unit/test_w12_vertical_experiment.py` 增加样本物化、runtime_state/snapshot/shadow 字段读取与批量回放校验
- 验证同一样本重复回放结果稳定
  - 新增同一样本重复 replay 的确定性测试
- 整理后续 Week15/16 的输入路径
  - 在 `src/infra/w12_vertical_experiment.py` 提供 `load_replay_sample()`、`materialize_replay_sample()`、`replay_sample()`、`replay_samples()` 作为复用入口

## 兼容性说明
- 未改动 workflow/FSM 语义。
- 仅扩展评估侧回放工具和 focused tests，保持现有实验入口兼容。

## 验证
```bash
uv run pytest tests/unit/test_w12_vertical_experiment.py -q
```

Closes #215
