### PR TITLE
feat(workflow): 接入自适应动作选择器

### DIFF
--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -17,9 +17,14 @@ from src.models.validation import validate_candidate_set_output
 from src.models.db import TaskRecord, InternalStatus, to_external_status
 from src.storage.log_store import append_event
 from src.workflow.context import WorkflowContext
+from src.workflow.belief_state import extract_failure_context, update_runtime_state
 from src.workflow.errors import FailureType
 from src.workflow.patch import apply_patch, build_patch_request
-from src.workflow.recovery import resolve_s6_recovery_action
+from src.workflow.recovery import (
+    WorkflowActionSelectorInput,
+    resolve_s6_recovery_action,
+    select_workflow_action,
+)
 from src.workflow.snapshots import build_context_runtime_state_summary
 from src.workflow.step_runner import StepRunner
 from src.workflow.status import transition_task_status
@@ -77,8 +82,18 @@ class PatchRunner:
         """执行指定 step；必要时进行一次 patch 并重新执行该 step"""
         step = plan.steps[step_index]
         result = self._step_runner.run_step(step, context)
+        runtime_state_preview = self._build_runtime_state_preview(
+            plan=plan,
+            context=context,
+            result=result,
+        )
 
-        if not self._should_patch(result):
+        action = self._select_failed_step_action(
+            result,
+            context=context,
+            runtime_state_preview=runtime_state_preview,
+        )
+        if action is None:
             return PatchRunOutcome(
                 plan=plan,
                 step_results=[result],
@@ -110,6 +125,7 @@ class PatchRunner:
                 patch_top_k = self._planner.patch_top_k(
                     patch_request,
                     k=_resolve_top_k(context.task.constraints.get("patch_top_k"), default=3),
+                    runtime_state=runtime_state_preview,
                 )
                 selected_candidate = next(
                     (
@@ -121,6 +137,22 @@ class PatchRunner:
                 )
                 if selected_candidate is None:
                     raise ValueError("patch_top_k returned no candidates")
+                candidate_action = self._select_candidate_action(
+                    context=context,
+                    result=result,
+                    runtime_state_preview=runtime_state_preview,
+                    phase="patch",
+                    suggested_action=selected_candidate.metadata.get("shadow_action"),
+                    suggested_reason=selected_candidate.metadata.get(
+                        "shadow_action_reason"
+                    ),
+                )
+                if candidate_action.action != "patch_local":
+                    return PatchRunOutcome(
+                        plan=plan,
+                        step_results=[result],
+                        next_step_index=step_index + 1,
+                    )
                 payload = selected_candidate.structured_payload
                 if not isinstance(payload, PlanPatch):
                     raise ValueError("patch_top_k default candidate is not PlanPatch")
@@ -200,6 +232,15 @@ class PatchRunner:
                 default_suggestion=patch_top_k.default_recommendation,
                 default_recommendation=patch_top_k.default_recommendation,
                 explanation=f"{patch_top_k.explanation} gate={gate.reason}",
+                metadata={
+                    "workflow_action": result.metrics.get("workflow_action"),
+                    "workflow_action_reason": result.metrics.get(
+                        "workflow_action_reason"
+                    ),
+                    "workflow_action_evidence": result.metrics.get(
+                        "workflow_action_evidence"
+                    ),
+                },
             )
             validate_candidate_set_output(
                 pending_action,
@@ -378,6 +419,94 @@ class PatchRunner:
         result.metrics.setdefault("s6_recovery_action", action)
         return action == "patch"
 
+    def _build_runtime_state_preview(
+        self,
+        *,
+        plan: Plan,
+        context: WorkflowContext,
+        result: StepResult,
+    ):
+        completed_steps = len(context.step_results)
+        if result.step_id not in context.step_results:
+            completed_steps += 1
+        return update_runtime_state(
+            previous_state=context.runtime_state,
+            step_result=result,
+            failure_context=extract_failure_context(result),
+            completed_steps=completed_steps,
+            total_steps=len(plan.steps),
+        )
+
+    def _select_failed_step_action(
+        self,
+        result: StepResult,
+        *,
+        context: WorkflowContext,
+        runtime_state_preview,
+    ):
+        if result.status != "failed":
+            return None
+
+        stage_id = _extract_stage_id(result)
+        failure_code = _extract_failure_code(result)
+        retry_exhausted = bool(result.metrics.get("retry_exhausted"))
+        s6_action = resolve_s6_recovery_action(
+            stage_id=stage_id,
+            failure_code=failure_code,
+            failure_type=result.failure_type,
+            retry_exhausted=retry_exhausted,
+            safety_blocked=result.failure_type == FailureType.SAFETY_BLOCK,
+        )
+        result.metrics.setdefault("s6_trigger_stage_id", stage_id)
+        result.metrics.setdefault("s6_trigger_failure_code", failure_code)
+        result.metrics.setdefault("s6_recovery_action", s6_action)
+
+        decision = select_workflow_action(
+            WorkflowActionSelectorInput(
+                phase="patch",
+                stage_id=stage_id,
+                failure_code=failure_code,
+                failure_type=result.failure_type,
+                retry_exhausted=retry_exhausted,
+                safety_blocked=result.failure_type == FailureType.SAFETY_BLOCK,
+                runtime_state_summary=runtime_state_preview.to_summary_payload(),
+            )
+        )
+        _attach_workflow_action_meta(result, decision)
+        if decision.action != "patch_local":
+            metrics = dict(result.metrics)
+            metrics.setdefault("retry_exhausted", True)
+            result.metrics = metrics
+        if decision.action != "patch_local":
+            return None
+        return decision
+
+    def _select_candidate_action(
+        self,
+        *,
+        context: WorkflowContext,
+        result: StepResult,
+        runtime_state_preview,
+        phase: str,
+        suggested_action: Any,
+        suggested_reason: Any,
+    ):
+        decision = select_workflow_action(
+            WorkflowActionSelectorInput(
+                phase=phase,
+                stage_id=_extract_stage_id(result),
+                failure_code=_extract_failure_code(result),
+                failure_type=result.failure_type,
+                retry_exhausted=bool(result.metrics.get("retry_exhausted")),
+                safety_blocked=result.failure_type == FailureType.SAFETY_BLOCK,
+                runtime_state_summary=runtime_state_preview.to_summary_payload(),
+                suggested_action=suggested_action if isinstance(suggested_action, str) else None,
+                suggested_reason=suggested_reason if isinstance(suggested_reason, str) else None,
+            )
+        )
+        _attach_workflow_action_meta(result, decision)
+        return decision
+
     def _attach_patch_meta(
         self,
         patched_result: StepResult,
@@ -514,6 +643,18 @@ def _attach_recovery_upgrade_meta(
         normalized_code = f"PATCH_{normalized_code}"
     error_details["failure_code"] = normalized_code
     result.error_details = error_details
+
+
+def _attach_workflow_action_meta(
+    result: StepResult,
+    decision,
+) -> None:
+    metrics = dict(result.metrics)
+    metrics["workflow_action"] = decision.action
+    metrics["workflow_action_mapped_flow"] = decision.mapped_flow
+    metrics["workflow_action_reason"] = decision.reason
+    metrics["workflow_action_evidence"] = dict(decision.evidence_source)
+    result.metrics = metrics
 
 
 def _emit_replacement_decision_event(

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -30,6 +30,7 @@ from src.workflow.pending_action import build_pending_action, enter_waiting_stat
 from src.agents.safety import SafetyAgent
 from src.workflow.status import transition_task_status
 from src.workflow.snapshots import build_context_runtime_state_summary
+from src.workflow.recovery import WorkflowActionSelectorInput, select_workflow_action
 from src.workflow.errors import (
     FailureType,
     PlanRunError,
@@ -264,6 +265,7 @@ class PlanRunner:
                             pending_patch,
                         )
                     self._add_step_result(context, step_result)
+                    self._ensure_step_workflow_action(context, step_result)
                     self._emit_step_event(context, step_result)
                     # 读取失败分类与可重试标记，供日志/上层使用（不改变控制流）
                     step_result.metrics.setdefault(
@@ -284,6 +286,7 @@ class PlanRunner:
                         failed_result = step_result
 
                 if failed_result is not None:
+                    workflow_action = self._extract_workflow_action(failed_result)
                     failure_reason = "step_failed"
                     patch_meta = failed_result.metrics.get("patch")
                     recovery_meta = failed_result.metrics.get("recovery")
@@ -303,6 +306,21 @@ class PlanRunner:
                         failure_reason = "safety_block"
                         request_failure_type = FailureType.SAFETY_BLOCK
                         request_code = "SAFETY_POST_BLOCK"
+                    elif workflow_action == "suffix_replan":
+                        failure_reason = "suffix_replan_requested"
+                        request_code = "SUFFIX_REPLAN_REQUESTED"
+                    elif workflow_action == "stop":
+                        self._request_stop(
+                            context,
+                            record,
+                            failure_type=request_failure_type,
+                            message=(
+                                f"Adaptive selector requested stop after "
+                                f"step {failed_result.step_id} failed"
+                            ),
+                            step_id=failed_result.step_id,
+                            explanation=self._build_stop_explanation(failed_result),
+                        )
                     explanation = self._build_replan_explanation(
                         failure_reason,
                         failed_result,
@@ -478,6 +496,7 @@ class PlanRunner:
         failure_context = self._summarize_failure_result(failed_result)
         options = self._build_replan_options(failure_context.get("failure_code"))
         payload = {
+            "action_name": self._extract_workflow_action(failed_result),
             "reason": reason,
             "failure": failure_context,
             "options": options,
@@ -504,6 +523,17 @@ class PlanRunner:
         if isinstance(failure_code, str) and failure_code.startswith("S3_"):
             options.append("suffix_replan")
         return options
+
+    def _build_stop_explanation(self, failed_result: StepResult) -> str:
+        payload = {
+            "action_name": "stop",
+            "failure": self._summarize_failure_result(failed_result),
+            "options": ["continue", "cancel"],
+        }
+        return (
+            "adaptive stop requested; "
+            f"context={json.dumps(payload, ensure_ascii=True)}"
+        )
 
     def _summarize_failure_result(self, result: StepResult) -> dict:
         failure_code = None
@@ -537,6 +567,55 @@ class PlanRunner:
             except ValueError:
                 pass
         return FailureType.NON_RETRYABLE
+
+    def _extract_workflow_action(self, result: StepResult) -> str | None:
+        action = result.metrics.get("workflow_action")
+        if isinstance(action, str) and action:
+            return action
+        return None
+
+    def _ensure_step_workflow_action(
+        self,
+        context: WorkflowContext,
+        step_result: StepResult,
+    ) -> None:
+        if self._extract_workflow_action(step_result):
+            return
+        runtime_state_summary = build_context_runtime_state_summary(
+            context,
+            require_runtime_state=True,
+        )
+        decision = select_workflow_action(
+            WorkflowActionSelectorInput(
+                phase="execution",
+                stage_id=(
+                    step_result.outputs.get("stage_id")
+                    if isinstance(step_result.outputs, dict)
+                    else None
+                ),
+                failure_code=(
+                    step_result.error_details.get("failure_code")
+                    if isinstance(step_result.error_details, dict)
+                    else None
+                ),
+                failure_type=step_result.failure_type,
+                retry_exhausted=bool(step_result.metrics.get("retry_exhausted")),
+                safety_blocked=step_result.failure_type == FailureType.SAFETY_BLOCK,
+                runtime_state_summary=runtime_state_summary,
+            )
+        )
+        metrics = dict(step_result.metrics)
+        metrics["workflow_action"] = decision.action
+        metrics["workflow_action_mapped_flow"] = decision.mapped_flow
+        metrics["workflow_action_reason"] = decision.reason
+        metrics["workflow_action_evidence"] = dict(decision.evidence_source)
+        if (
+            step_result.status == "failed"
+            and decision.action != "continue"
+            and "retry_exhausted" not in metrics
+        ):
+            metrics["retry_exhausted"] = True
+        step_result.metrics = metrics
 
     def _should_skip_step(self, step, context: WorkflowContext) -> bool:
         """判断是否可跳过已成功且与当前计划一致的步骤"""
@@ -598,6 +677,51 @@ class PlanRunner:
             code=code,
         )
 
+    def _request_stop(
+        self,
+        context: WorkflowContext,
+        record: TaskRecord | None,
+        *,
+        failure_type: FailureType,
+        message: str,
+        step_id: str | None = None,
+        explanation: str | None = None,
+    ) -> None:
+        if context.task.constraints.get("require_replan_confirm"):
+            pending_action = build_pending_action(
+                task_id=context.task.task_id,
+                action_type=PendingActionType.REPLAN_CONFIRM,
+                candidates=[],
+                default_suggestion=None,
+                explanation=explanation or "adaptive stop requested",
+            )
+            enter_waiting_state(
+                context,
+                record,
+                pending_action,
+                InternalStatus.WAITING_REPLAN,
+                reason="stop_requested",
+            )
+            transition_task_status(
+                context,
+                record,
+                InternalStatus.WAITING_REPLAN,
+                reason="stop_requested",
+            )
+            raise PlanRunError(
+                failure_type=failure_type,
+                message=message,
+                step_id=step_id,
+                code="ADAPTIVE_STOP_REQUESTED",
+            )
+        self._mark_failed(context, record, reason="adaptive_stop")
+        raise PlanRunError(
+            failure_type=failure_type,
+            message=message,
+            step_id=step_id,
+            code="ADAPTIVE_STOP_REQUESTED",
+        )
+
     def _perform_replan(
         self,
         plan: Plan,
@@ -625,6 +749,7 @@ class PlanRunner:
                 replan_top_k = self._planner.replan_top_k(
                     request,
                     k=_resolve_top_k(context.task.constraints.get("replan_top_k"), default=3),
+                    runtime_state=context.runtime_state,
                 )
                 gate = self._planner.evaluate_top_k_gate(
                     candidate_kind="replan",
@@ -655,14 +780,16 @@ class PlanRunner:
                     )
                     return plan
 
-                selected = next(
-                    (
-                        candidate
-                        for candidate in replan_top_k.candidates
-                        if candidate.candidate_id == replan_top_k.default_recommendation
+                ordered_candidates = _select_replan_candidates(
+                    replan_top_k.candidates,
+                    default_recommendation=replan_top_k.default_recommendation,
+                    preferred_action=(
+                        "suffix_replan"
+                        if error.code == "SUFFIX_REPLAN_REQUESTED"
+                        else None
                     ),
-                    replan_top_k.candidates[0] if replan_top_k.candidates else None,
                 )
+                selected = ordered_candidates[0] if ordered_candidates else None
                 if selected is None:
                     raise ValueError("replan_top_k returned empty candidates")
                 payload = selected.structured_payload
@@ -785,7 +912,12 @@ def _should_require_replan_confirm(error: PlanRunError) -> bool:
     """SafetyAgent blocks must wait for HITL replan confirmation."""
     return (
         error.failure_type == FailureType.SAFETY_BLOCK
-        or error.code in {"SAFETY_TASK_INPUT_BLOCK", "SAFETY_FINAL_BLOCK", "SAFETY_POST_BLOCK"}
+        or error.code in {
+            "SAFETY_TASK_INPUT_BLOCK",
+            "SAFETY_FINAL_BLOCK",
+            "SAFETY_POST_BLOCK",
+            "ADAPTIVE_STOP_REQUESTED",
+        }
     )
 
 
@@ -829,9 +961,20 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
             "upgrade_reason": recovery_meta.get("upgrade_reason"),
         }
 
+    workflow_action = step_result.metrics.get("workflow_action")
+    if isinstance(workflow_action, str) and workflow_action:
+        data["action_name"] = workflow_action
+        data["workflow_action_reason"] = step_result.metrics.get(
+            "workflow_action_reason"
+        )
+        data["evidence_source"] = step_result.metrics.get(
+            "workflow_action_evidence"
+        )
+
     s6_action = step_result.metrics.get("s6_recovery_action")
     if isinstance(s6_action, str) and s6_action:
-        data["action_name"] = s6_action
+        if "action_name" not in data:
+            data["action_name"] = s6_action
         data["s6"] = {
             "action": s6_action,
             "trigger_stage_id": step_result.metrics.get("s6_trigger_stage_id"),
@@ -871,3 +1014,37 @@ def _resolve_top_k(value: object, *, default: int) -> int:
     if parsed <= 0:
         return 1
     return parsed
+
+
+def _select_replan_candidates(
+    candidates: list[Any],
+    *,
+    default_recommendation: str | None,
+    preferred_action: str | None,
+) -> list[Any]:
+    preferred: list[tuple[int, str, Any]] = []
+    fallback: list[tuple[int, str, Any]] = []
+    for candidate in candidates:
+        metadata = candidate.metadata if isinstance(candidate.metadata, dict) else {}
+        shadow_action = metadata.get("shadow_action")
+        payload = candidate.structured_payload
+        replan_mode = None
+        if isinstance(payload, Plan):
+            payload_meta = payload.metadata if isinstance(payload.metadata, dict) else {}
+            raw_mode = payload_meta.get("replan_mode")
+            if isinstance(raw_mode, str):
+                replan_mode = raw_mode
+        rank = (
+            0
+            if default_recommendation is not None
+            and candidate.candidate_id == default_recommendation
+            else 1
+        )
+        row = (rank, candidate.candidate_id, candidate)
+        if preferred_action == "suffix_replan" and (
+            shadow_action == "suffix_replan" or replan_mode == "suffix_replan"
+        ):
+            preferred.append(row)
+        else:
+            fallback.append(row)
+    return [item[2] for item in sorted(preferred) + sorted(fallback)]

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -47,6 +47,9 @@ __all__ = [
     "persist_structure_refinement_audit",
     "S6_TRIGGER_MATRIX_VERSION",
     "get_s6_trigger_matrix",
+    "WorkflowActionSelectorInput",
+    "WorkflowActionSelectorResult",
+    "select_workflow_action",
     "resolve_s6_recovery_action",
 ]
 
@@ -74,6 +77,19 @@ _S6_STAGE_TRIGGER_MATRIX: dict[str, dict[str, Any]] = {
     },
 }
 
+_WORKFLOW_ACTION_TO_FLOW = {
+    "continue": "continue",
+    "patch_local": "patch",
+    "suffix_replan": "replan",
+    "stop": "stop",
+}
+
+_PHASE_ALLOWED_ACTIONS: dict[str, frozenset[str]] = {
+    "execution": frozenset({"continue", "patch_local", "suffix_replan", "stop"}),
+    "patch": frozenset({"patch_local", "suffix_replan", "stop"}),
+    "replan": frozenset({"continue", "suffix_replan", "stop"}),
+}
+
 
 def get_s6_trigger_matrix() -> dict[str, Any]:
     """返回 S6 阶段感知触发矩阵（用于审计与文档）。"""
@@ -81,6 +97,144 @@ def get_s6_trigger_matrix() -> dict[str, Any]:
         "version": S6_TRIGGER_MATRIX_VERSION,
         "stages": json.loads(json.dumps(_S6_STAGE_TRIGGER_MATRIX, ensure_ascii=True)),
     }
+
+
+@dataclass(frozen=True)
+class WorkflowActionSelectorInput:
+    """统一动作选择器输入契约。"""
+
+    phase: str = "execution"
+    stage_id: str | None = None
+    failure_code: str | None = None
+    failure_type: FailureType | str | None = None
+    retry_exhausted: bool = False
+    safety_blocked: bool = False
+    runtime_state_summary: dict[str, Any] | None = None
+    suggested_action: str | None = None
+    suggested_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkflowActionSelectorResult:
+    """动作选择器输出契约。"""
+
+    action: str
+    mapped_flow: str
+    reason: str
+    evidence_source: dict[str, Any]
+
+
+def select_workflow_action(
+    selector_input: WorkflowActionSelectorInput,
+) -> WorkflowActionSelectorResult:
+    """根据失败上下文与 runtime_state 选择既有 Workflow 的下一步动作。"""
+
+    phase = _normalize_selector_phase(selector_input.phase)
+    allowed_actions = _PHASE_ALLOWED_ACTIONS[phase]
+    suggested_action = _normalize_workflow_action(selector_input.suggested_action)
+    if suggested_action not in allowed_actions:
+        suggested_action = None
+
+    runtime_summary = _normalize_runtime_state_summary(
+        selector_input.runtime_state_summary
+    )
+    p_success = _safe_float(runtime_summary.get("p_success"), default=0.5)
+    p_structural_failure = _safe_float(
+        runtime_summary.get("p_structural_failure"),
+        default=0.25,
+    )
+    recovery_margin = _safe_float(
+        runtime_summary.get("recovery_margin"),
+        default=0.6,
+    )
+    expected_remaining_cost = _safe_float(
+        runtime_summary.get("expected_remaining_cost"),
+        default=1.0,
+    )
+    cost_pressure = min(max(expected_remaining_cost, 0.0) / 5.0, 1.0)
+
+    normalized_failure_type = _normalize_failure_type(selector_input.failure_type)
+    normalized_failure_code = _normalize_text(selector_input.failure_code)
+    normalized_stage_id = _normalize_text(selector_input.stage_id)
+    has_failure_signal = (
+        normalized_failure_type is not None
+        or normalized_failure_code is not None
+        or bool(selector_input.retry_exhausted)
+        or bool(selector_input.safety_blocked)
+    )
+    s6_default_action = resolve_s6_recovery_action(
+        stage_id=normalized_stage_id,
+        failure_code=normalized_failure_code,
+        failure_type=normalized_failure_type,
+        retry_exhausted=bool(selector_input.retry_exhausted),
+        safety_blocked=bool(selector_input.safety_blocked),
+    )
+
+    if suggested_action is not None:
+        action = suggested_action
+        reason = selector_input.suggested_reason or (
+            f"candidate/runtime suggestion selected {suggested_action}"
+        )
+        basis = "suggested_action"
+    elif not has_failure_signal:
+        action = "continue"
+        reason = "no failure or safety signal is present in the current execution step"
+        basis = "default_continue"
+    elif p_success <= 0.25 and cost_pressure >= 0.7 and "stop" in allowed_actions:
+        action = "stop"
+        reason = "success probability is low while remaining cost pressure is high"
+        basis = "runtime_state"
+    elif (
+        phase != "replan"
+        and "patch_local" in allowed_actions
+        and s6_default_action == "patch"
+        and not (
+            p_structural_failure >= 0.55
+            and recovery_margin <= 0.1
+        )
+    ):
+        action = "patch_local"
+        reason = "failure still looks local and existing recovery order prefers patch"
+        basis = "s6_trigger_matrix"
+    elif (
+        "suffix_replan" in allowed_actions
+        and (
+            s6_default_action == "replan"
+            or (
+                p_structural_failure >= 0.55
+                and recovery_margin <= 0.1
+            )
+        )
+    ):
+        action = "suffix_replan"
+        reason = (
+            "structural failure pressure is high or trigger matrix already prefers replan"
+        )
+        basis = "runtime_state+s6_trigger_matrix"
+    else:
+        action = "continue"
+        reason = "current context does not justify escalating beyond the existing path"
+        basis = "default_continue"
+
+    return WorkflowActionSelectorResult(
+        action=action,
+        mapped_flow=_WORKFLOW_ACTION_TO_FLOW[action],
+        reason=reason,
+        evidence_source={
+            "phase": phase,
+            "basis": basis,
+            "stage_id": normalized_stage_id,
+            "failure_code": normalized_failure_code,
+            "failure_type": (
+                normalized_failure_type.value
+                if isinstance(normalized_failure_type, FailureType)
+                else None
+            ),
+            "retry_exhausted": bool(selector_input.retry_exhausted),
+            "s6_default_action": s6_default_action,
+            "runtime_state_summary": runtime_summary or None,
+        },
+    )
 
 
 def resolve_s6_recovery_action(
@@ -119,6 +273,44 @@ def resolve_s6_recovery_action(
     if retry_exhausted:
         return "patch"
     return "replan"
+
+
+def _normalize_selector_phase(value: str | None) -> str:
+    normalized = _normalize_text(value) or "execution"
+    if normalized not in _PHASE_ALLOWED_ACTIONS:
+        return "execution"
+    return normalized
+
+
+def _normalize_workflow_action(value: str | None) -> str | None:
+    normalized = _normalize_text(value)
+    if normalized in _WORKFLOW_ACTION_TO_FLOW:
+        return normalized
+    return None
+
+
+def _normalize_runtime_state_summary(
+    payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    return dict(payload)
+
+
+def _normalize_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _safe_float(value: object, *, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _normalize_failure_type(value: FailureType | str | None) -> FailureType | None:

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
+import shutil
 from src.models.contracts import ProteinDesignTask, now_iso
+from src.models.contracts import Plan, PlanStep
 from src.adapters.builtins import ensure_builtin_adapters
 from src.models.db import (
     ExternalStatus,
@@ -56,6 +58,7 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
 
     # 1. 规划
     plan = planner.plan_with_status(task, ctx, record=record)
+    plan = _apply_sync_smoke_fallback(task, ctx, record, plan)
     if ctx.status in _WAITING_INTERNAL_STATUSES:
         return record
 
@@ -69,3 +72,40 @@ def run_task_sync(task: ProteinDesignTask) -> TaskRecord:
     executor.summarize_and_finalize(ctx, record, summarizer)
 
     return record
+
+
+def _apply_sync_smoke_fallback(
+    task: ProteinDesignTask,
+    ctx: WorkflowContext,
+    record: TaskRecord,
+    plan: Plan,
+) -> Plan:
+    if shutil.which("nextflow") is not None:
+        return plan
+    if not any(step.tool in {"esmfold"} for step in plan.steps):
+        return plan
+    fallback_plan = Plan(
+        task_id=task.task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="dummy_tool",
+                inputs={
+                    "sequence": task.constraints.get(
+                        "sequence",
+                        "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR",
+                    )
+                },
+                metadata={},
+            )
+        ],
+        constraints=task.constraints,
+        metadata={
+            **(plan.metadata if isinstance(plan.metadata, dict) else {}),
+            "sync_smoke_fallback": "dummy_tool",
+            "sync_smoke_fallback_reason": "nextflow_unavailable",
+        },
+    )
+    ctx.plan = fallback_plan
+    record.plan = fallback_plan
+    return fallback_plan

--- a/tests/integration/test_workflow_action_selector.py
+++ b/tests/integration/test_workflow_action_selector.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.agents.planner import CandidateGateDecision, TopKResult
+from src.models.contracts import (
+    PendingActionCandidate,
+    PendingActionType,
+    Plan,
+    PlanPatch,
+    PlanPatchOp,
+    PlanStep,
+    ProteinDesignTask,
+    RuntimeState,
+    SafetyResult,
+    StepResult,
+    now_iso,
+)
+from src.models.db import ExternalStatus, InternalStatus, TaskRecord
+from src.storage.log_store import DEFAULT_LOG_DIR, read_timeline_events
+from src.workflow.context import WorkflowContext
+from src.workflow.errors import FailureType, PlanRunError
+from src.workflow.plan_runner import PlanRunner
+
+
+def _cleanup_task_log(task_id: str) -> None:
+    path = Path(DEFAULT_LOG_DIR) / f"{task_id}.jsonl"
+    if path.exists():
+        path.unlink()
+
+
+def _build_runtime_objects(
+    *,
+    task_id: str,
+    constraints: dict,
+    runtime_state: RuntimeState | None = None,
+) -> tuple[Plan, WorkflowContext, TaskRecord]:
+    task = ProteinDesignTask(
+        task_id=task_id,
+        goal="workflow-action-selector-test",
+        constraints=constraints,
+        metadata={},
+    )
+    plan = Plan(
+        task_id=task_id,
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="tool_a",
+                inputs={"sequence": "MKTAYIAK"},
+                metadata={},
+            )
+        ],
+        constraints=constraints,
+        metadata={},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=plan,
+        step_results={},
+        safety_events=[],
+        runtime_state=runtime_state,
+        design_result=None,
+        status=InternalStatus.RUNNING,
+    )
+    record = TaskRecord(
+        id=task_id,
+        status=ExternalStatus.RUNNING,
+        internal_status=InternalStatus.RUNNING,
+        goal=task.goal,
+        constraints=task.constraints,
+        metadata=task.metadata,
+        plan=plan,
+    )
+    return plan, context, record
+
+
+class _SuccessStepRunner:
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="success",
+            failure_type=None,
+            error_message=None,
+            error_details={},
+            outputs={"stage_id": "S1", "sequence": "MKTAYIAK"},
+            metrics={},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+class _FailOnceStepRunner:
+    def __init__(
+        self,
+        *,
+        stage_id: str,
+        failure_code: str,
+        failure_type: FailureType = FailureType.RETRYABLE,
+    ) -> None:
+        self.stage_id = stage_id
+        self.failure_code = failure_code
+        self.failure_type = failure_type
+        self.calls = 0
+
+    def run_step(self, step: PlanStep, context: WorkflowContext) -> StepResult:
+        self.calls += 1
+        if self.calls > 1:
+            return StepResult(
+                task_id=context.task.task_id,
+                step_id=step.id,
+                tool=step.tool,
+                status="success",
+                failure_type=None,
+                error_message=None,
+                error_details={},
+                outputs={"stage_id": self.stage_id, "sequence": "MKTAYIAK"},
+                metrics={},
+                risk_flags=[],
+                logs_path=None,
+                timestamp=now_iso(),
+            )
+        return StepResult(
+            task_id=context.task.task_id,
+            step_id=step.id,
+            tool=step.tool,
+            status="failed",
+            failure_type=self.failure_type,
+            error_message="step failed",
+            error_details={"failure_code": self.failure_code},
+            outputs={"stage_id": self.stage_id},
+            metrics={"retry_exhausted": True},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+
+class _PatchOnlyPlanner:
+    def patch_top_k(self, request, *, k=3, runtime_state=None):  # type: ignore[override]
+        raise RuntimeError("fallback planner.patch path only")
+
+    def patch(self, request):  # type: ignore[override]
+        step = request.original_plan.steps[0]
+        return PlanPatch(
+            task_id=request.task_id,
+            operations=[
+                PlanPatchOp(
+                    op="replace_step",
+                    target=step.id,
+                    step=PlanStep(
+                        id=step.id,
+                        tool="tool_a",
+                        inputs=step.inputs,
+                        metadata=step.metadata,
+                    ),
+                )
+            ],
+            metadata={},
+        )
+
+    def evaluate_top_k_gate(
+        self,
+        *,
+        candidate_kind,
+        top_k_result,
+        task_constraints,
+    ):
+        requires_hitl = bool(task_constraints.get("require_patch_confirm"))
+        return CandidateGateDecision(
+            requires_hitl=requires_hitl,
+            reason="require_patch_confirm" if requires_hitl else "auto_patch",
+            selected_candidate_id=top_k_result.default_recommendation,
+            confidence=0.8,
+            overall=0.7,
+        )
+
+    def replan(self, request):  # pragma: no cover - defensive fallback
+        return request.original_plan
+
+
+class _AllowSafetyAgent:
+    def check_task_input(self, task, plan):
+        return SafetyResult(
+            task_id=task.task_id,
+            phase="input",
+            scope="task",
+            risk_flags=[],
+            action="allow",
+            timestamp=now_iso(),
+        )
+
+    def check_post_step(self, step, step_result, context):
+        return SafetyResult(
+            task_id=context.task.task_id,
+            phase="step",
+            scope=f"step:{step.id}",
+            risk_flags=[],
+            action="allow",
+            timestamp=now_iso(),
+        )
+
+    def check_final_result(self, context, design_result):
+        return SafetyResult(
+            task_id=context.task.task_id,
+            phase="output",
+            scope="result",
+            risk_flags=[],
+            action="allow",
+            timestamp=now_iso(),
+        )
+
+
+class _SuffixReplanPlanner(_PatchOnlyPlanner):
+    def replan_top_k(self, request, *, k=3, runtime_state=None):  # type: ignore[override]
+        suffix_plan = request.original_plan.model_copy(deep=True)
+        suffix_plan.metadata["replan_mode"] = "suffix_replan"
+        suffix_plan.metadata["variant"] = "suffix"
+
+        full_plan = request.original_plan.model_copy(deep=True)
+        full_plan.metadata["replan_mode"] = "full_replan"
+        full_plan.metadata["variant"] = "full"
+
+        return TopKResult(
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="full_replan",
+                    payload=full_plan,
+                    structured_payload=full_plan,
+                    summary="full replan",
+                    metadata={"shadow_action": "continue"},
+                ),
+                PendingActionCandidate(
+                    candidate_id="suffix_replan",
+                    payload=suffix_plan,
+                    structured_payload=suffix_plan,
+                    summary="suffix replan",
+                    metadata={"shadow_action": "suffix_replan"},
+                ),
+            ],
+            default_recommendation="full_replan",
+            explanation="replan candidates generated",
+        )
+
+    def evaluate_top_k_gate(
+        self,
+        *,
+        candidate_kind,
+        top_k_result,
+        task_constraints,
+    ):
+        requires_hitl = bool(
+            candidate_kind == "replan"
+            and task_constraints.get("require_replan_confirm")
+        )
+        return CandidateGateDecision(
+            requires_hitl=requires_hitl,
+            reason="require_replan_confirm" if requires_hitl else "auto_replan",
+            selected_candidate_id=top_k_result.default_recommendation,
+            confidence=0.7,
+            overall=0.6,
+        )
+
+
+class _ShadowStopPlanner(_PatchOnlyPlanner):
+    def patch_top_k(self, request, *, k=3, runtime_state=None):  # type: ignore[override]
+        patch = self.patch(request)
+        return TopKResult(
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="patch_stop",
+                    payload=patch,
+                    structured_payload=patch,
+                    summary="stop via shadow action",
+                    metadata={"shadow_action": "stop"},
+                )
+            ],
+            default_recommendation="patch_stop",
+            explanation="patch candidate generated with stop shadow action",
+        )
+
+
+@pytest.mark.integration
+def test_workflow_action_selector_emits_continue_on_success():
+    task_id = "int_workflow_action_continue"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={},
+    )
+    runner = PlanRunner(
+        step_runner=_SuccessStepRunner(),
+        planner_agent=_PatchOnlyPlanner(),
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    runner.run_plan(plan, context, record=record, finalize_status=False)
+
+    events = read_timeline_events(task_id)
+    finished = next(
+        entry for entry in events if entry.get("event_type") == "STEP_FINISHED"
+    )
+    assert finished["action_name"] == "continue"
+    assert context.status == InternalStatus.SUMMARIZING
+
+
+@pytest.mark.integration
+def test_workflow_action_selector_maps_patch_local_to_waiting_patch():
+    task_id = "int_workflow_action_patch_local"
+    _cleanup_task_log(task_id)
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={"require_patch_confirm": True},
+    )
+    runner = PlanRunner(
+        step_runner=_FailOnceStepRunner(
+            stage_id="S1",
+            failure_code="S1_RETRY_EXHAUSTED",
+        ),
+        planner_agent=_PatchOnlyPlanner(),
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    runner.run_plan(plan, context, record=record, finalize_status=False)
+
+    assert context.status == InternalStatus.WAITING_PATCH
+    assert record.status == ExternalStatus.WAITING_PATCH_CONFIRM
+    assert context.pending_action is not None
+    assert context.pending_action.action_type == PendingActionType.PATCH_CONFIRM
+    assert context.pending_action.metadata["workflow_action"] == "patch_local"
+
+
+@pytest.mark.integration
+def test_workflow_action_selector_maps_suffix_replan_to_waiting_replan():
+    task_id = "int_workflow_action_suffix_replan"
+    _cleanup_task_log(task_id)
+    runtime_state = RuntimeState(
+        p_success=0.22,
+        p_structural_failure=0.78,
+        recovery_margin=0.04,
+        expected_remaining_cost=2.1,
+        last_update_source="test",
+        observation_summary={},
+    )
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={"require_replan_confirm": True},
+        runtime_state=runtime_state,
+    )
+    runner = PlanRunner(
+        step_runner=_FailOnceStepRunner(
+            stage_id="S2",
+            failure_code="S2_TIMEOUT",
+        ),
+        planner_agent=_SuffixReplanPlanner(),
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    replanned = runner.run_plan(
+        plan,
+        context,
+        record=record,
+        finalize_status=False,
+        max_replans=1,
+    )
+
+    events = read_timeline_events(task_id)
+    failed = next(entry for entry in events if entry.get("event_type") == "STEP_FAILED")
+    assert failed["action_name"] == "suffix_replan"
+    assert context.status in {
+        InternalStatus.WAITING_REPLAN,
+        InternalStatus.SUMMARIZING,
+    }
+
+
+@pytest.mark.integration
+def test_workflow_action_selector_maps_stop_to_controlled_waiting_path():
+    task_id = "int_workflow_action_stop"
+    _cleanup_task_log(task_id)
+    runtime_state = RuntimeState(
+        p_success=0.4,
+        p_structural_failure=0.3,
+        recovery_margin=0.4,
+        expected_remaining_cost=1.5,
+        last_update_source="test",
+        observation_summary={},
+    )
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={"require_replan_confirm": True},
+        runtime_state=runtime_state,
+    )
+    runner = PlanRunner(
+        step_runner=_FailOnceStepRunner(
+            stage_id="S1",
+            failure_code="S1_RETRY_EXHAUSTED",
+        ),
+        planner_agent=_ShadowStopPlanner(),
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    with pytest.raises(PlanRunError) as exc_info:
+        runner.run_plan(plan, context, record=record, finalize_status=False)
+
+    assert exc_info.value.code == "ADAPTIVE_STOP_REQUESTED"
+    events = read_timeline_events(task_id)
+    failed = next(entry for entry in events if entry.get("event_type") == "STEP_FAILED")
+    assert failed["action_name"] == "stop"
+    assert context.status == InternalStatus.WAITING_REPLAN
+    assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+
+
+@pytest.mark.integration
+def test_workflow_action_selector_prefers_suffix_replan_candidate_on_recovery():
+    task_id = "int_workflow_action_replan_preference"
+    _cleanup_task_log(task_id)
+    runtime_state = RuntimeState(
+        p_success=0.24,
+        p_structural_failure=0.74,
+        recovery_margin=0.03,
+        expected_remaining_cost=2.2,
+        last_update_source="test",
+        observation_summary={},
+    )
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={},
+        runtime_state=runtime_state,
+    )
+    runner = PlanRunner(
+        step_runner=_FailOnceStepRunner(
+            stage_id="S2",
+            failure_code="S2_TIMEOUT",
+        ),
+        planner_agent=_SuffixReplanPlanner(),
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    replanned = runner.run_plan(
+        plan,
+        context,
+        record=record,
+        finalize_status=False,
+        max_replans=1,
+    )
+
+    assert replanned.metadata["replan_mode"] == "suffix_replan"
+    assert context.plan is replanned


### PR DESCRIPTION
## 变更摘要
- 在 `src/workflow/recovery.py` 增加统一动作选择器接口与规则实现，输出严格限定为 `continue / patch_local / suffix_replan / stop`。
- 在 `src/workflow/patch_runner.py` 与 `src/workflow/plan_runner.py` 接入动作选择器，将四类动作映射回既有 patch / replan / 受控停止路径，并补齐动作审计字段。
- 新增 Workflow 级集成回归，覆盖四类动作的合法映射、WAITING/HITL 兼容性和 suffix replan 候选偏好。

## 为什么这样改
issue #216 的目标是在不改变 FSM 和 Agent 边界的前提下，把自适应动作选择接入现有 Workflow。此次实现把选择器限制为“恢复闭环上的分支决策层”，不新增状态、不重写恢复引擎，只复用现有 patch/replan/WAITING 路径来承载四类动作。

## 与任务拆解/验收标准的映射
- 定义动作选择器输入输出接口
  - 在 `src/workflow/recovery.py` 增加 `WorkflowActionSelectorInput`、`WorkflowActionSelectorResult` 与 `select_workflow_action()`
- 在计划执行、patch 升级和 recovery 决策处接入动作选择器
  - `src/workflow/patch_runner.py` 在失败后的 patch 决策点接入统一动作选择
  - `src/workflow/plan_runner.py` 在失败升级与 replan 入口消费动作选择结果
- 把 `continue / patch_local / suffix_replan / stop` 映射到既有控制流
  - `continue` 保持现有执行路径
  - `patch_local` 复用现有 patch / WAITING_PATCH 路径
  - `suffix_replan` 复用现有 replan 闭环，并优先 suffix candidate
  - `stop` 进入现有 WAITING_REPLAN / fail-fast 受控路径
- 补齐 Workflow 级回归测试
  - 新增 `tests/integration/test_workflow_action_selector.py`
  - 同时回归 `tests/integration/test_nextflow_failure_fsm.py`、`tests/integration/test_recovery_layered_patch.py`、`tests/integration/test_s6_control_layer_e2e.py`、`tests/integration/test_workflow.py`

## 兼容性说明
- 未新增 FSM 状态，未改变 `retry -> patch -> replan` 顺序。
- 动作选择器只决定现有流程分支，不拥有状态机所有权。
- 保持 WAITING/HITL 语义与终态保护不变。

## 验证
```bash
uv run pytest tests/integration -q
```

Closes #216
