### PR TITLE
Issue 231: 接入统一动作选择器与 recovery 映射

### DIFF
--- a/reports/w15-issue-231/unified-action-selector-recovery-mapping.md
+++ b/reports/w15-issue-231/unified-action-selector-recovery-mapping.md
@@ -1,0 +1,97 @@
+# Issue 231: Unified Action Selector And Recovery Mapping
+
+## Scope
+
+This note captures the implementation-facing contract for issue `#231` and aligns the code path with the 2026-03-29 frozen design:
+
+- `SID:planner.algorithm.runtime_action_selection`
+- `SID:planner.algorithm.action_priority_resolution`
+- `SID:planner.algorithm.stop_semantics`
+- `SID:fsm.states.waiting_replan_confirm`
+- `SID:arch.contracts.pending_action`
+
+## Unified Selector Interface
+
+The unified runtime selector entrypoint is [`src/workflow/recovery.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/recovery.py):
+
+- `WorkflowActionSelectorInput`
+- `select_workflow_action(...)`
+- `resolve_workflow_action_route(...)`
+
+The selector action space is fixed to:
+
+- `continue`
+- `patch_local`
+- `suffix_replan`
+- `stop`
+
+The selector remains recovery-aware instead of bypassing recovery.
+
+## Recovery Mapping
+
+The action-to-flow mapping is centralized in `WorkflowActionRoute`:
+
+- `continue -> continue`
+- `patch_local -> patch`
+- `suffix_replan -> replan`
+- `stop -> stop`
+
+Workflow ownership remains unchanged:
+
+- [`src/workflow/patch_runner.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/patch_runner.py) owns local patch attempts.
+- [`src/workflow/plan_runner.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/plan_runner.py) owns replan escalation and WAITING entry.
+- [`src/workflow/decision_apply.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/decision_apply.py) owns human decision application.
+
+## Terminal Stop Semantics
+
+`stop` no longer jumps directly to terminal failure from the selector path.
+
+The implemented compatibility mapping is:
+
+- selector chooses `stop`
+- [`src/workflow/plan_runner.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/plan_runner.py) builds a `replan_confirm` `PendingAction`
+- the pending action carries a `terminal_stop`-style candidate encoded as:
+  - `replan_mode = "suffix_replan"`
+  - `terminal_policy = "stop"`
+  - `terminal_reason = economic_stop | evidence_exhausted | unsafe_to_continue | recovery_exhausted`
+- task enters `WAITING_REPLAN_CONFIRM`
+- if the human accepts that candidate, [`src/workflow/decision_apply.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/decision_apply.py) transitions to `FAILED`
+- if the human continues, the task returns to `RUNNING`
+- if the human cancels, the task transitions to `CANCELLED`
+
+No new FSM state is introduced.
+
+## Audit Fields
+
+The WAITING/decision path now preserves the selector-facing audit fields needed for downstream integration:
+
+- `workflow_action`
+- `workflow_action_mapped_flow`
+- `workflow_action_reason`
+- `workflow_action_target`
+- `terminal_policy`
+- `terminal_reason`
+- `replan_mode`
+- `preserve_prefix_until_step_index`
+- `runtime_state_summary`
+
+These fields are surfaced through:
+
+- [`src/workflow/pending_action.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/pending_action.py)
+- [`src/workflow/decision_apply.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/decision_apply.py)
+
+## File Mapping
+
+Required issue landing points are now explicit:
+
+- [`src/workflow/recovery.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/recovery.py): unified selector interface, action priority handling, action route mapping, terminal-stop candidate helper
+- [`src/workflow/plan_runner.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/plan_runner.py): `stop -> WAITING_REPLAN_CONFIRM` integration
+- [`src/workflow/decision_apply.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/decision_apply.py): `terminal_stop accept -> FAILED`
+- [`src/workflow/pending_action.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/workflow/pending_action.py): WAITING audit propagation
+
+## Acceptance Checklist
+
+- unified selector interface and fixed action space: implemented
+- four actions mapped to existing recovery loop: implemented
+- `terminal_stop` WAITING/Decision/FAILED boundary: implemented
+- consistent with 2026-03-29 frozen design and no new FSM state: implemented

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -27,6 +27,10 @@ from src.storage.log_store import append_event, write_event_log
 from src.workflow.context import WorkflowContext
 from src.workflow.patch import apply_patch
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
+from src.workflow.recovery import (
+    extract_candidate_recovery_metadata,
+    is_terminal_stop_candidate,
+)
 from src.workflow.snapshots import (
     SnapshotWriter,
     build_context_runtime_state_summary,
@@ -313,15 +317,28 @@ def apply_replan_confirm_decision(
     selected_plan: Optional[Plan] = None
     if decision.choice == DecisionChoice.ACCEPT:
         candidate = _select_candidate(action, decision)
-        selected_plan = _ensure_plan_payload(candidate)
-        _apply_plan_to_context(context, record, selected_plan)
-        transition_task_status(
-            context,
-            record,
-            InternalStatus.PLANNING,
-            reason="decision_accept_replan",
-            logger=status_logger,
-        )
+        if is_terminal_stop_candidate(candidate):
+            candidate_meta = extract_candidate_recovery_metadata(candidate)
+            transition_task_status(
+                context,
+                record,
+                InternalStatus.FAILED,
+                reason=str(
+                    candidate_meta.get("terminal_reason")
+                    or "decision_accept_terminal_stop"
+                ),
+                logger=status_logger,
+            )
+        else:
+            selected_plan = _ensure_plan_payload(candidate)
+            _apply_plan_to_context(context, record, selected_plan)
+            transition_task_status(
+                context,
+                record,
+                InternalStatus.PLANNING,
+                reason="decision_accept_replan",
+                logger=status_logger,
+            )
         action.status = PendingActionStatus.DECIDED
     elif decision.choice == DecisionChoice.CONTINUE:
         transition_task_status(
@@ -576,8 +593,8 @@ def _emit_decision_applied_event(
             decision.selected_candidate_id,
         )
     candidate_meta = (
-        selected_candidate.metadata
-        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        extract_candidate_recovery_metadata(selected_candidate)
+        if selected_candidate is not None
         else {}
     )
     decision_event = make_decision_applied(
@@ -616,6 +633,8 @@ def _emit_decision_applied_event(
             "action_score": candidate_meta.get("action_score"),
             "shadow_score": candidate_meta.get("shadow_score"),
             "evidence_source": candidate_meta.get("default_recommendation_reason"),
+            "terminal_policy": candidate_meta.get("terminal_policy"),
+            "terminal_reason": candidate_meta.get("terminal_reason"),
             "runtime_state_summary": build_context_runtime_state_summary(
                 context,
                 require_runtime_state=True,
@@ -648,8 +667,8 @@ def _emit_waiting_exit_event(
             decision.selected_candidate_id,
         )
     candidate_meta = (
-        selected_candidate.metadata
-        if selected_candidate is not None and isinstance(selected_candidate.metadata, dict)
+        extract_candidate_recovery_metadata(selected_candidate)
+        if selected_candidate is not None
         else {}
     )
     exit_event = make_waiting_exit(
@@ -670,6 +689,8 @@ def _emit_waiting_exit_event(
             "action_score": candidate_meta.get("action_score"),
             "shadow_score": candidate_meta.get("shadow_score"),
             "evidence_source": candidate_meta.get("default_recommendation_reason"),
+            "terminal_policy": candidate_meta.get("terminal_policy"),
+            "terminal_reason": candidate_meta.get("terminal_reason"),
             "runtime_state_summary": build_context_runtime_state_summary(
                 context,
                 require_runtime_state=True,
@@ -686,6 +707,17 @@ def _build_decision_artifacts(
 ) -> dict[str, object] | None:
     if decision is None:
         return None
+    selected_candidate = None
+    if decision.selected_candidate_id:
+        selected_candidate = find_pending_action_candidate(
+            action,
+            decision.selected_candidate_id,
+        )
+    candidate_meta = (
+        extract_candidate_recovery_metadata(selected_candidate)
+        if selected_candidate is not None
+        else {}
+    )
     summary = {
         "decision_id": decision.decision_id,
         "pending_action_id": action.pending_action_id,
@@ -695,6 +727,8 @@ def _build_decision_artifacts(
         "action_status": action.status.value,
         "decided_by": decision.decided_by,
         "decision_source": "human",
+        "terminal_policy": candidate_meta.get("terminal_policy"),
+        "terminal_reason": candidate_meta.get("terminal_reason"),
         "runtime_state_summary": build_context_runtime_state_summary(
             context,
             require_runtime_state=True,

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -220,6 +220,12 @@ def enter_waiting_state(
                 if isinstance(selected_meta.get(SHADOW_SCORE_METADATA_KEY), dict)
                 else None
             ),
+            "terminal_policy": selected_meta.get("terminal_policy"),
+            "terminal_reason": selected_meta.get("terminal_reason"),
+            "replan_mode": selected_meta.get("replan_mode"),
+            "preserve_prefix_until_step_index": selected_meta.get(
+                "preserve_prefix_until_step_index"
+            ),
             "evidence_source": (
                 selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY)
                 if isinstance(selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY), dict)
@@ -323,6 +329,10 @@ def _build_waiting_runtime_summary(
         DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
         ACTION_SCORE_METADATA_KEY,
         SHADOW_SCORE_METADATA_KEY,
+        "terminal_policy",
+        "terminal_reason",
+        "replan_mode",
+        "preserve_prefix_until_step_index",
     ):
         value = candidate_metadata.get(key)
         if value is not None:

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -30,7 +30,12 @@ from src.workflow.pending_action import build_pending_action, enter_waiting_stat
 from src.agents.safety import SafetyAgent
 from src.workflow.status import transition_task_status
 from src.workflow.snapshots import build_context_runtime_state_summary
-from src.workflow.recovery import WorkflowActionSelectorInput, select_workflow_action
+from src.workflow.recovery import (
+    WorkflowActionSelectorInput,
+    build_terminal_stop_candidate,
+    resolve_workflow_action_route,
+    select_workflow_action,
+)
 from src.workflow.errors import (
     FailureType,
     PlanRunError,
@@ -287,6 +292,9 @@ class PlanRunner:
 
                 if failed_result is not None:
                     workflow_action = self._extract_workflow_action(failed_result)
+                    action_route = None
+                    if workflow_action:
+                        action_route = resolve_workflow_action_route(workflow_action)
                     failure_reason = "step_failed"
                     patch_meta = failed_result.metrics.get("patch")
                     recovery_meta = failed_result.metrics.get("recovery")
@@ -306,10 +314,10 @@ class PlanRunner:
                         failure_reason = "safety_block"
                         request_failure_type = FailureType.SAFETY_BLOCK
                         request_code = "SAFETY_POST_BLOCK"
-                    elif workflow_action == "suffix_replan":
+                    elif action_route and action_route.action == "suffix_replan":
                         failure_reason = "suffix_replan_requested"
                         request_code = "SUFFIX_REPLAN_REQUESTED"
-                    elif workflow_action == "stop":
+                    elif action_route and action_route.action == "stop":
                         self._request_stop(
                             context,
                             record,
@@ -320,6 +328,7 @@ class PlanRunner:
                             ),
                             step_id=failed_result.step_id,
                             explanation=self._build_stop_explanation(failed_result),
+                            failed_result=failed_result,
                         )
                     explanation = self._build_replan_explanation(
                         failure_reason,
@@ -527,11 +536,12 @@ class PlanRunner:
     def _build_stop_explanation(self, failed_result: StepResult) -> str:
         payload = {
             "action_name": "stop",
+            "terminal_policy": "stop",
             "failure": self._summarize_failure_result(failed_result),
-            "options": ["continue", "cancel"],
+            "options": ["accept_terminal_stop", "continue", "cancel"],
         }
         return (
-            "adaptive stop requested; "
+            "adaptive terminal_stop requested; "
             f"context={json.dumps(payload, ensure_ascii=True)}"
         )
 
@@ -686,35 +696,66 @@ class PlanRunner:
         message: str,
         step_id: str | None = None,
         explanation: str | None = None,
+        failed_result: StepResult | None = None,
     ) -> None:
-        if context.task.constraints.get("require_replan_confirm"):
-            pending_action = build_pending_action(
-                task_id=context.task.task_id,
-                action_type=PendingActionType.REPLAN_CONFIRM,
-                candidates=[],
-                default_suggestion=None,
-                explanation=explanation or "adaptive stop requested",
-            )
-            enter_waiting_state(
-                context,
-                record,
-                pending_action,
-                InternalStatus.WAITING_REPLAN,
-                reason="stop_requested",
-            )
-            transition_task_status(
-                context,
-                record,
-                InternalStatus.WAITING_REPLAN,
-                reason="stop_requested",
-            )
+        if context.plan is None:
             raise PlanRunError(
                 failure_type=failure_type,
                 message=message,
                 step_id=step_id,
                 code="ADAPTIVE_STOP_REQUESTED",
             )
-        self._mark_failed(context, record, reason="adaptive_stop")
+        failure_code = None
+        failure_reason = message
+        if failed_result is not None:
+            failure_summary = self._summarize_failure_result(failed_result)
+            raw_code = failure_summary.get("failure_code")
+            if isinstance(raw_code, str) and raw_code:
+                failure_code = raw_code
+            raw_reason = failure_summary.get("failure_reason")
+            if isinstance(raw_reason, str) and raw_reason:
+                failure_reason = raw_reason
+        runtime_state_summary = build_context_runtime_state_summary(
+            context,
+            require_runtime_state=True,
+        )
+        terminal_stop_candidate = build_terminal_stop_candidate(
+            plan=context.plan,
+            step_id=step_id,
+            failure_type=failure_type,
+            failure_code=failure_code,
+            failure_reason=failure_reason,
+            runtime_state_summary=runtime_state_summary,
+            explanation=explanation,
+        )
+        pending_action = build_pending_action(
+            task_id=context.task.task_id,
+            action_type=PendingActionType.REPLAN_CONFIRM,
+            candidates=[terminal_stop_candidate],
+            default_suggestion=terminal_stop_candidate.candidate_id,
+            default_recommendation=terminal_stop_candidate.candidate_id,
+            explanation=explanation or "adaptive terminal_stop requested",
+            metadata={
+                "workflow_action": "stop",
+                "workflow_action_mapped_flow": "stop",
+                "workflow_action_reason": failure_reason,
+                "workflow_action_target": "failed",
+                "terminal_policy": "stop",
+            },
+        )
+        enter_waiting_state(
+            context,
+            record,
+            pending_action,
+            InternalStatus.WAITING_REPLAN,
+            reason="terminal_stop_requested",
+        )
+        transition_task_status(
+            context,
+            record,
+            InternalStatus.WAITING_REPLAN,
+            reason="terminal_stop_requested",
+        )
         raise PlanRunError(
             failure_type=failure_type,
             message=message,

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Iterable, Optional, Sequence
 
 from src.models.contracts import (
     PendingAction,
+    PendingActionCandidate,
     Plan,
     PlanStep,
     ProteinDesignTask,
@@ -49,8 +50,14 @@ __all__ = [
     "get_s6_trigger_matrix",
     "WorkflowActionSelectorInput",
     "WorkflowActionSelectorResult",
+    "WorkflowActionRoute",
     "select_workflow_action",
     "resolve_s6_recovery_action",
+    "resolve_workflow_action_route",
+    "build_terminal_stop_candidate",
+    "extract_candidate_recovery_metadata",
+    "is_terminal_stop_candidate",
+    "resolve_terminal_stop_reason",
 ]
 
 S6_TRIGGER_MATRIX_VERSION = "2026-03-16.v1"
@@ -77,17 +84,52 @@ _S6_STAGE_TRIGGER_MATRIX: dict[str, dict[str, Any]] = {
     },
 }
 
-_WORKFLOW_ACTION_TO_FLOW = {
-    "continue": "continue",
-    "patch_local": "patch",
-    "suffix_replan": "replan",
-    "stop": "stop",
+_TERMINAL_STOP_REASON_BY_FAILURE_TYPE = {
+    FailureType.SAFETY_BLOCK: "unsafe_to_continue",
+    FailureType.TOOL_ERROR: "recovery_exhausted",
+    FailureType.NON_RETRYABLE: "evidence_exhausted",
+    FailureType.RETRYABLE: "economic_stop",
 }
 
 _PHASE_ALLOWED_ACTIONS: dict[str, frozenset[str]] = {
     "execution": frozenset({"continue", "patch_local", "suffix_replan", "stop"}),
     "patch": frozenset({"patch_local", "suffix_replan", "stop"}),
     "replan": frozenset({"continue", "suffix_replan", "stop"}),
+}
+
+
+@dataclass(frozen=True)
+class WorkflowActionRoute:
+    """统一动作到既有 recovery 闭环的映射。"""
+
+    action: str
+    mapped_flow: str
+    waiting_status: InternalStatus | None = None
+    terminal_policy: str | None = None
+    terminal_status: InternalStatus | None = None
+
+
+_WORKFLOW_ACTION_ROUTES: dict[str, WorkflowActionRoute] = {
+    "continue": WorkflowActionRoute(
+        action="continue",
+        mapped_flow="continue",
+    ),
+    "patch_local": WorkflowActionRoute(
+        action="patch_local",
+        mapped_flow="patch",
+    ),
+    "suffix_replan": WorkflowActionRoute(
+        action="suffix_replan",
+        mapped_flow="replan",
+        waiting_status=InternalStatus.WAITING_REPLAN,
+    ),
+    "stop": WorkflowActionRoute(
+        action="stop",
+        mapped_flow="stop",
+        waiting_status=InternalStatus.WAITING_REPLAN,
+        terminal_policy="stop",
+        terminal_status=InternalStatus.FAILED,
+    ),
 }
 
 
@@ -124,6 +166,15 @@ class WorkflowActionSelectorResult:
     evidence_source: dict[str, Any]
 
 
+def resolve_workflow_action_route(action: str) -> WorkflowActionRoute:
+    """返回统一动作的 recovery 映射信息。"""
+
+    normalized = _normalize_workflow_action(action)
+    if normalized is None:
+        raise ValueError(f"Unsupported workflow action: {action}")
+    return _WORKFLOW_ACTION_ROUTES[normalized]
+
+
 def select_workflow_action(
     selector_input: WorkflowActionSelectorInput,
 ) -> WorkflowActionSelectorResult:
@@ -152,6 +203,25 @@ def select_workflow_action(
         default=1.0,
     )
     cost_pressure = min(max(expected_remaining_cost, 0.0) / 5.0, 1.0)
+    budget_pressure = _safe_float(
+        runtime_summary.get("budget_pressure"),
+        default=cost_pressure,
+    )
+    intervention_value = _safe_float(
+        runtime_summary.get("intervention_value"),
+        default=1.0,
+    )
+    prefix_preservability = _safe_optional_float(
+        runtime_summary.get("prefix_preservability")
+    )
+    local_patchability = _safe_optional_float(
+        runtime_summary.get("local_patchability")
+    )
+    u_stop = _safe_float(runtime_summary.get("u_stop"), default=0.0)
+    allow_auto_stop = _safe_bool(
+        runtime_summary.get("allow_auto_stop"),
+        default=False,
+    )
 
     normalized_failure_type = _normalize_failure_type(selector_input.failure_type)
     normalized_failure_code = _normalize_text(selector_input.failure_code)
@@ -170,7 +240,26 @@ def select_workflow_action(
         safety_blocked=bool(selector_input.safety_blocked),
     )
 
-    if suggested_action is not None:
+    if (
+        selector_input.safety_blocked
+        and "suffix_replan" in allowed_actions
+        and not _should_choose_stop(
+            allowed_actions=allowed_actions,
+            allow_auto_stop=allow_auto_stop,
+            u_stop=u_stop,
+            p_success=p_success,
+            budget_pressure=budget_pressure,
+            recovery_margin=recovery_margin,
+            intervention_value=intervention_value,
+        )
+    ):
+        action = "suffix_replan"
+        reason = "safety block disables continue and escalates to suffix replan"
+        basis = "hard_priority"
+    elif suggested_action is not None and not _is_hard_blocked_suggestion(
+        suggested_action=suggested_action,
+        safety_blocked=bool(selector_input.safety_blocked),
+    ):
         action = suggested_action
         reason = selector_input.suggested_reason or (
             f"candidate/runtime suggestion selected {suggested_action}"
@@ -180,14 +269,31 @@ def select_workflow_action(
         action = "continue"
         reason = "no failure or safety signal is present in the current execution step"
         basis = "default_continue"
-    elif p_success <= 0.25 and cost_pressure >= 0.7 and "stop" in allowed_actions:
+    elif _should_choose_stop(
+        allowed_actions=allowed_actions,
+        allow_auto_stop=allow_auto_stop,
+        u_stop=u_stop,
+        p_success=p_success,
+        budget_pressure=budget_pressure,
+        recovery_margin=recovery_margin,
+        intervention_value=intervention_value,
+    ):
         action = "stop"
-        reason = "success probability is low while remaining cost pressure is high"
-        basis = "runtime_state"
+        reason = (
+            "runtime stop threshold met; route through terminal_stop replan candidate"
+        )
+        basis = "action_priority"
     elif (
         phase != "replan"
         and "patch_local" in allowed_actions
         and s6_default_action == "patch"
+        and (
+            local_patchability is None
+            or (
+                local_patchability >= 0.55
+                and recovery_margin >= 0.30
+            )
+        )
         and not (
             p_structural_failure >= 0.55
             and recovery_margin <= 0.1
@@ -195,7 +301,7 @@ def select_workflow_action(
     ):
         action = "patch_local"
         reason = "failure still looks local and existing recovery order prefers patch"
-        basis = "s6_trigger_matrix"
+        basis = "action_priority"
     elif (
         "suffix_replan" in allowed_actions
         and (
@@ -210,15 +316,16 @@ def select_workflow_action(
         reason = (
             "structural failure pressure is high or trigger matrix already prefers replan"
         )
-        basis = "runtime_state+s6_trigger_matrix"
+        basis = "action_priority"
     else:
         action = "continue"
         reason = "current context does not justify escalating beyond the existing path"
         basis = "default_continue"
 
+    route = resolve_workflow_action_route(action)
     return WorkflowActionSelectorResult(
         action=action,
-        mapped_flow=_WORKFLOW_ACTION_TO_FLOW[action],
+        mapped_flow=route.mapped_flow,
         reason=reason,
         evidence_source={
             "phase": phase,
@@ -232,9 +339,116 @@ def select_workflow_action(
             ),
             "retry_exhausted": bool(selector_input.retry_exhausted),
             "s6_default_action": s6_default_action,
+            "budget_pressure": budget_pressure,
+            "intervention_value": intervention_value,
+            "prefix_preservability": prefix_preservability,
+            "local_patchability": local_patchability,
+            "allow_auto_stop": allow_auto_stop,
+            "u_stop": u_stop,
             "runtime_state_summary": runtime_summary or None,
         },
     )
+
+
+def build_terminal_stop_candidate(
+    *,
+    plan: Plan,
+    step_id: str | None,
+    failure_type: FailureType | str | None,
+    failure_code: str | None,
+    failure_reason: str,
+    runtime_state_summary: dict[str, Any] | None = None,
+    explanation: str | None = None,
+) -> PendingActionCandidate:
+    """构造复用 replan_confirm 闭环的 terminal_stop 候选。"""
+
+    stop_reason = resolve_terminal_stop_reason(
+        failure_type=failure_type,
+        failure_code=failure_code,
+    )
+    preserve_prefix_until_step_index = _resolve_preserve_prefix_until_step_index(
+        plan,
+        step_id,
+    )
+    payload = plan.model_copy(deep=True)
+    payload.metadata = {
+        **(payload.metadata if isinstance(payload.metadata, dict) else {}),
+        "replan_mode": "suffix_replan",
+        "terminal_policy": "stop",
+        "terminal_reason": stop_reason,
+        "preserve_prefix_until_step_index": preserve_prefix_until_step_index,
+    }
+    metadata: dict[str, Any] = {
+        "shadow_action": "stop",
+        "shadow_action_reason": explanation or failure_reason,
+        "replan_mode": "suffix_replan",
+        "terminal_policy": "stop",
+        "terminal_reason": stop_reason,
+        "preserve_prefix_until_step_index": preserve_prefix_until_step_index,
+    }
+    if runtime_state_summary:
+        metadata["runtime_state_summary"] = dict(runtime_state_summary)
+    candidate_suffix = (step_id or "task").strip().lower()
+    return PendingActionCandidate(
+        candidate_id=f"terminal_stop_{candidate_suffix}",
+        payload=payload,
+        structured_payload=payload,
+        summary="terminal stop candidate",
+        explanation=explanation or failure_reason,
+        metadata=metadata,
+    )
+
+
+def extract_candidate_recovery_metadata(
+    candidate: PendingActionCandidate | None,
+) -> dict[str, Any]:
+    """合并候选和 payload 上的恢复语义元数据。"""
+
+    if candidate is None:
+        return {}
+    metadata = (
+        dict(candidate.metadata)
+        if isinstance(candidate.metadata, dict)
+        else {}
+    )
+    payload = candidate.structured_payload or candidate.payload
+    if isinstance(payload, Plan):
+        payload_metadata = payload.metadata if isinstance(payload.metadata, dict) else {}
+        for key in (
+            "replan_mode",
+            "terminal_policy",
+            "terminal_reason",
+            "preserve_prefix_until_step_index",
+        ):
+            value = payload_metadata.get(key)
+            if value is not None and key not in metadata:
+                metadata[key] = value
+    return metadata
+
+
+def is_terminal_stop_candidate(candidate: PendingActionCandidate | None) -> bool:
+    metadata = extract_candidate_recovery_metadata(candidate)
+    terminal_policy = _normalize_text(metadata.get("terminal_policy"))
+    replan_mode = _normalize_text(metadata.get("replan_mode"))
+    return terminal_policy == "stop" or replan_mode == "terminal_stop"
+
+
+def resolve_terminal_stop_reason(
+    *,
+    failure_type: FailureType | str | None,
+    failure_code: str | None,
+) -> str:
+    """将 stop 候选映射到定稿约定的终止原因。"""
+
+    normalized_type = _normalize_failure_type(failure_type)
+    normalized_code = _normalize_text(failure_code) or ""
+    if normalized_type == FailureType.SAFETY_BLOCK or normalized_code.startswith("SAFETY_"):
+        return "unsafe_to_continue"
+    if normalized_code.startswith(("SCHEMA_", "IO_", "TOOL_")):
+        return "recovery_exhausted"
+    if normalized_type in _TERMINAL_STOP_REASON_BY_FAILURE_TYPE:
+        return _TERMINAL_STOP_REASON_BY_FAILURE_TYPE[normalized_type]
+    return "economic_stop"
 
 
 def resolve_s6_recovery_action(
@@ -284,7 +498,7 @@ def _normalize_selector_phase(value: str | None) -> str:
 
 def _normalize_workflow_action(value: str | None) -> str | None:
     normalized = _normalize_text(value)
-    if normalized in _WORKFLOW_ACTION_TO_FLOW:
+    if normalized in _WORKFLOW_ACTION_ROUTES:
         return normalized
     return None
 
@@ -313,6 +527,27 @@ def _safe_float(value: object, *, default: float) -> float:
         return default
 
 
+def _safe_optional_float(value: object) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_bool(value: object, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
 def _normalize_failure_type(value: FailureType | str | None) -> FailureType | None:
     if isinstance(value, FailureType):
         return value
@@ -321,6 +556,48 @@ def _normalize_failure_type(value: FailureType | str | None) -> FailureType | No
             return FailureType(value)
         except ValueError:
             return None
+    return None
+
+
+def _is_hard_blocked_suggestion(
+    *,
+    suggested_action: str,
+    safety_blocked: bool,
+) -> bool:
+    return safety_blocked and suggested_action == "continue"
+
+
+def _should_choose_stop(
+    *,
+    allowed_actions: frozenset[str],
+    allow_auto_stop: bool,
+    u_stop: float,
+    p_success: float,
+    budget_pressure: float,
+    recovery_margin: float,
+    intervention_value: float,
+) -> bool:
+    if "stop" not in allowed_actions:
+        return False
+    if allow_auto_stop and u_stop >= 0.72:
+        return True
+    return (
+        p_success <= 0.20
+        and budget_pressure >= 0.85
+        and recovery_margin <= 0.20
+        and intervention_value <= 0.35
+    )
+
+
+def _resolve_preserve_prefix_until_step_index(
+    plan: Plan,
+    step_id: str | None,
+) -> int | None:
+    if not step_id:
+        return None
+    for index, step in enumerate(plan.steps):
+        if step.id == step_id:
+            return index - 1 if index > 0 else None
     return None
 
 

--- a/tests/integration/test_workflow_action_selector.py
+++ b/tests/integration/test_workflow_action_selector.py
@@ -413,6 +413,46 @@ def test_workflow_action_selector_maps_stop_to_controlled_waiting_path():
     assert failed["action_name"] == "stop"
     assert context.status == InternalStatus.WAITING_REPLAN
     assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+    assert context.pending_action is not None
+    assert context.pending_action.default_recommendation is not None
+    assert context.pending_action.candidates[0].metadata["terminal_policy"] == "stop"
+    assert context.pending_action.candidates[0].metadata["terminal_reason"] == "economic_stop"
+
+
+@pytest.mark.integration
+def test_workflow_action_selector_maps_stop_to_waiting_even_without_explicit_confirm():
+    task_id = "int_workflow_action_stop_always_waiting"
+    _cleanup_task_log(task_id)
+    runtime_state = RuntimeState(
+        p_success=0.4,
+        p_structural_failure=0.3,
+        recovery_margin=0.4,
+        expected_remaining_cost=1.5,
+        last_update_source="test",
+        observation_summary={},
+    )
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={},
+        runtime_state=runtime_state,
+    )
+    runner = PlanRunner(
+        step_runner=_FailOnceStepRunner(
+            stage_id="S1",
+            failure_code="S1_RETRY_EXHAUSTED",
+        ),
+        planner_agent=_ShadowStopPlanner(),
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    with pytest.raises(PlanRunError) as exc_info:
+        runner.run_plan(plan, context, record=record, finalize_status=False)
+
+    assert exc_info.value.code == "ADAPTIVE_STOP_REQUESTED"
+    assert context.status == InternalStatus.WAITING_REPLAN
+    assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+    assert context.pending_action is not None
+    assert context.pending_action.candidates[0].metadata["terminal_policy"] == "stop"
 
 
 @pytest.mark.integration

--- a/tests/unit/test_decision_apply.py
+++ b/tests/unit/test_decision_apply.py
@@ -285,6 +285,69 @@ def test_replan_confirm_accept_transitions_to_planning(sample_task, sample_plan)
 
 
 @pytest.mark.unit
+def test_replan_confirm_accept_terminal_stop_transitions_to_failed(
+    sample_task,
+    sample_plan,
+):
+    stop_plan = sample_plan.model_copy(deep=True)
+    stop_plan.metadata = {
+        **(stop_plan.metadata if isinstance(stop_plan.metadata, dict) else {}),
+        "replan_mode": "suffix_replan",
+        "terminal_policy": "stop",
+        "terminal_reason": "economic_stop",
+    }
+    pending_action = PendingAction(
+        pending_action_id="pa_replan_terminal_stop",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.REPLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="terminal_stop_s1",
+                payload=stop_plan,
+                structured_payload=stop_plan,
+                metadata={
+                    "terminal_policy": "stop",
+                    "terminal_reason": "economic_stop",
+                    "replan_mode": "suffix_replan",
+                },
+            )
+        ],
+        default_recommendation="terminal_stop_s1",
+        explanation="terminal stop waiting",
+    )
+    decision = Decision(
+        decision_id="dec_terminal_stop",
+        task_id=sample_task.task_id,
+        pending_action_id=pending_action.pending_action_id,
+        choice=DecisionChoice.ACCEPT,
+        selected_candidate_id="terminal_stop_s1",
+        decided_by="user_1",
+    )
+    context = WorkflowContext(
+        task=sample_task,
+        status=InternalStatus.WAITING_REPLAN,
+        pending_action=pending_action,
+    )
+    record = _make_record(sample_task.task_id, InternalStatus.WAITING_REPLAN)
+    record.pending_action = pending_action
+
+    snapshots, snapshot_writer = _capture_snapshots()
+    result = apply_replan_confirm_decision(
+        context,
+        record,
+        decision,
+        snapshot_writer=snapshot_writer,
+    )
+
+    assert context.status == InternalStatus.FAILED
+    assert record.status == to_external_status(InternalStatus.FAILED)
+    assert result.plan is None
+    assert pending_action.status == PendingActionStatus.DECIDED
+    assert snapshots[0].artifacts[DECISION_SUMMARY_ARTIFACT_KEY]["terminal_policy"] == "stop"
+    assert snapshots[0].artifacts[DECISION_SUMMARY_ARTIFACT_KEY]["terminal_reason"] == "economic_stop"
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "internal_status,action_type,apply_func",
     [

--- a/tests/unit/test_recovery_selector.py
+++ b/tests/unit/test_recovery_selector.py
@@ -1,0 +1,61 @@
+import pytest
+
+from src.models.db import InternalStatus
+from src.workflow.errors import FailureType
+from src.workflow.recovery import (
+    WorkflowActionSelectorInput,
+    resolve_workflow_action_route,
+    select_workflow_action,
+)
+
+
+@pytest.mark.unit
+def test_selector_safety_block_overrides_continue_suggestion():
+    decision = select_workflow_action(
+        WorkflowActionSelectorInput(
+            phase="execution",
+            stage_id="S3",
+            failure_code="SAFETY_POST_BLOCK",
+            failure_type=FailureType.SAFETY_BLOCK,
+            safety_blocked=True,
+            suggested_action="continue",
+            runtime_state_summary={
+                "p_success": 0.61,
+                "p_structural_failure": 0.42,
+                "recovery_margin": 0.18,
+                "expected_remaining_cost": 1.7,
+            },
+        )
+    )
+
+    assert decision.action == "suffix_replan"
+    assert decision.mapped_flow == "replan"
+    assert decision.evidence_source["basis"] == "hard_priority"
+
+
+@pytest.mark.unit
+def test_selector_stop_route_maps_to_waiting_replan_and_failed_terminal():
+    decision = select_workflow_action(
+        WorkflowActionSelectorInput(
+            phase="execution",
+            stage_id="S2",
+            failure_code="S2_TIMEOUT",
+            failure_type=FailureType.RETRYABLE,
+            retry_exhausted=True,
+            runtime_state_summary={
+                "p_success": 0.12,
+                "p_structural_failure": 0.63,
+                "recovery_margin": 0.08,
+                "expected_remaining_cost": 4.7,
+                "budget_pressure": 0.91,
+                "intervention_value": 0.22,
+            },
+        )
+    )
+    route = resolve_workflow_action_route(decision.action)
+
+    assert decision.action == "stop"
+    assert decision.mapped_flow == "stop"
+    assert route.waiting_status == InternalStatus.WAITING_REPLAN
+    assert route.terminal_status == InternalStatus.FAILED
+    assert route.terminal_policy == "stop"


### PR DESCRIPTION
## 变更内容
- 在 workflow recovery 层统一动作选择器接口与动作到既有恢复闭环的映射
- 按冻结设计将 `stop` 落为 `terminal_stop` 候选，复用 `WAITING_REPLAN_CONFIRM -> Decision -> FAILED` 路径
- 补充 waiting 审计字段透传、单元测试、集成测试以及 issue 231 接入说明

## 设计对齐
- 对齐 2026-03-29 冻结设计中的统一动作空间与优先级约束
- 保持现有 FSM、HITL 与 `retry -> patch -> replan` 契约不变
- 不新增 FSM 状态

## 验证
- `uv run pytest tests/unit/test_recovery_selector.py tests/unit/test_decision_apply.py tests/integration/test_workflow_action_selector.py`
- `uv run pytest tests/unit/test_plan_runner.py tests/unit/test_patch_runner.py tests/unit/test_event_log.py`
- `uv run pytest tests/api/test_api_endpoints.py -k 'pending_action or replan or waiting_state'`

Closes #231
