### PR TITLE
实现 Issue #232：接入 Planner shadow rerank 与 adjusted score 接口

### DIFF
--- a/reports/w15-issue-232/planner-shadow-rerank-interface.md
+++ b/reports/w15-issue-232/planner-shadow-rerank-interface.md
@@ -1,0 +1,70 @@
+# Issue 232: Planner Shadow Rerank And Adjusted Score Interface
+
+## Scope
+
+This note captures the implementation-facing contract for issue `#232` and aligns the current code path with the 2026-03-29 frozen design:
+
+- `SID:planner.algorithm.candidate_scoring`
+- `SID:planner.algorithm.runtime_reranking`
+- `SID:planner.algorithm.runtime_adjustment_formula`
+- `SID:algo.schema.cost`
+- `SID:algo.schema.risk`
+- `SID:algo.schema.recovery`
+- `SID:tools.metadata.active_table`
+- `SID:tools.metadata.derived_metrics`
+
+## Candidate Interface
+
+The Planner keeps `TopKResult` and `PendingActionCandidate` unchanged at the top level and lands the shadow rerank interface in candidate metadata:
+
+- `static_score`: static prior score summary, mapped from `score_breakdown.overall`
+- `runtime_adjustment`: bounded runtime correction, always marked `shadow_only=true`
+- `final_score`: audited `clip(static_score + runtime_adjustment, 0, 1)` result
+- `rerank_reason`: structured audit payload for cost / risk / recovery / evidence-facing reasons
+- `action_score`: compatibility alias for the static score summary
+- `shadow_score`: compatibility alias for the shadow `final_score`
+
+The required implementation points are:
+
+- [`src/agents/planner.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/agents/planner.py)
+- [`src/models/validation.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/models/validation.py)
+- [`src/models/contracts.py`](/Users/yurikon/workspace/thesis/thesis-project.dev/src/models/contracts.py)
+
+## Default Recommendation Boundary
+
+Default recommendation remains static-first in this issue.
+
+- `default_recommendation` is still chosen by deterministic static ranking.
+- `default_recommendation_reason.selection_basis` is fixed to `static_score`.
+- `default_recommendation_reason.shadow_candidate_id` records the shadow-best candidate when runtime_state is present.
+- `default_recommendation_reason.shadow_only=true` makes it explicit that shadow rerank has not yet been promoted into control flow.
+
+This makes `#217` able to promote `final_score` later without changing the candidate contract again.
+
+## Runtime State Boundary
+
+The shadow rerank path consumes only the current four stable runtime summary fields already present in code:
+
+- `runtime_state.p_success`
+- `runtime_state.p_structural_failure`
+- `runtime_state.recovery_margin`
+- `runtime_state.expected_remaining_cost`
+
+No new persistent runtime state is introduced here. Future belief-state work in `#219` can extend the adjustment logic additively, but it should continue to flow through `runtime_adjustment` and `rerank_reason` instead of creating a parallel score channel.
+
+## Tool Metadata Boundary
+
+Planner does not read the active-tool profile table directly in this issue.
+
+- Planner consumes candidate-level score signals such as `score_breakdown.cost`, `score_breakdown.risk`, `score_breakdown.confidence`, `score_breakdown.fallback_depth`, and `score_breakdown.feasibility`.
+- `#248` should own the canonical mapping from active tool priors and derived `step_cost` / `step_risk` into those candidate-level signals.
+- `rerank_reason.tool_metadata_fields` is intentionally empty today, which documents that raw tool priors have not yet been wired in at the Planner boundary.
+
+This keeps the consumption seam explicit and avoids duplicating tool-prior formulas inside Planner.
+
+## Acceptance Mapping
+
+- shadow rerank / adjusted score interface: implemented via candidate metadata and validation
+- default recommendation correction and explanation boundary: implemented via enriched `default_recommendation_reason`
+- runtime_state seam: implemented and limited to current summary fields
+- active tool metadata seam: documented as a Planner read boundary for future `#248` integration

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -15,6 +15,7 @@ from src.agents.task_goal_parser import enrich_task_from_goal
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+    FINAL_SCORE_METADATA_KEY,
     PatchRequest,
     PendingActionType,
     PendingActionCandidate,
@@ -24,10 +25,17 @@ from src.models.contracts import (
     PlanPatchOpType,
     PlanStep,
     ProteinDesignTask,
+    RERANK_REASON_METADATA_KEY,
+    RecommendationReason,
+    RerankReason,
     ReplanRequest,
     RuntimeState,
+    RuntimeAdjustmentFactor,
+    RuntimeAdjustmentSummary,
     RuntimeStateSummary,
     ScoreSummary,
+    STATIC_SCORE_METADATA_KEY,
+    RUNTIME_ADJUSTMENT_METADATA_KEY,
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     StepResult,
     SHADOW_SCORE_METADATA_KEY,
@@ -89,6 +97,9 @@ class CandidateGateDecision:
 @dataclass(frozen=True)
 class _RuntimeShadowDecision:
     shadow_score: dict[str, Any]
+    final_score: dict[str, Any]
+    runtime_adjustment: dict[str, Any]
+    rerank_reason: dict[str, Any]
     shadow_action: str
     shadow_reason: str
     explanation_fragment: str
@@ -373,6 +384,9 @@ class PlannerAgent:
         )
         return {
             **score_breakdown,
+            "static_score": float(score_breakdown.get("overall", 0.0)),
+            "runtime_adjustment": float(shadow.runtime_adjustment["value"]),
+            "final_score": float(shadow.final_score["value"]),
             "shadow_overall": float(shadow.shadow_score["value"]),
         }
 
@@ -672,6 +686,7 @@ class PlannerAgent:
             validate_candidate_set_output(
                 pending_action,
                 require_s5_fields=True,
+                require_shadow_rerank_fields=True,
             )
             enter_waiting_state(
                 context,
@@ -1858,6 +1873,7 @@ def _build_top_k_result(
             "adapter_mode": adapter_mode,
             "generation_note": payload.note,
             "s5_contract": _build_s5_scoring_contract(score_weights),
+            STATIC_SCORE_METADATA_KEY: _build_static_score_summary(score_breakdown),
             ACTION_SCORE_METADATA_KEY: _build_action_score_summary(score_breakdown),
         }
         explanation = (
@@ -1882,7 +1898,7 @@ def _build_top_k_result(
                 metadata.update(s1_metadata)
                 metadata["sequence_confidence"] = score_breakdown.get("confidence")
         if runtime_state_summary is None:
-            metadata[SHADOW_SCORE_METADATA_KEY] = _build_shadow_score_summary(score_breakdown)
+            shadow = _build_shadow_passthrough_decision(score_breakdown)
         else:
             metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = dict(runtime_state_summary)
             shadow = _build_runtime_shadow_decision(
@@ -1891,10 +1907,13 @@ def _build_top_k_result(
                 score_breakdown=score_breakdown,
                 runtime_state_summary=runtime_state_summary,
             )
-            metadata[SHADOW_SCORE_METADATA_KEY] = shadow.shadow_score
             metadata["shadow_action"] = shadow.shadow_action
             metadata["shadow_action_reason"] = shadow.shadow_reason
             explanation = f"{explanation} {shadow.explanation_fragment}"
+        metadata[RUNTIME_ADJUSTMENT_METADATA_KEY] = shadow.runtime_adjustment
+        metadata[FINAL_SCORE_METADATA_KEY] = shadow.final_score
+        metadata[RERANK_REASON_METADATA_KEY] = shadow.rerank_reason
+        metadata[SHADOW_SCORE_METADATA_KEY] = shadow.shadow_score
         candidate = PendingActionCandidate(
             candidate_id=candidate_id,
             structured_payload=payload.payload,
@@ -1938,11 +1957,21 @@ def _build_top_k_result(
     selected_rows = sorted(selected_rows, key=lambda row: row[1])
     candidates = [row[0] for row in selected_rows]
     default_recommendation = candidates[0].candidate_id if candidates else None
+    shadow_default = None
+    if candidates and runtime_state_summary is not None:
+        shadow_default = max(
+            candidates,
+            key=lambda candidate: float(
+                candidate.metadata.get(SHADOW_SCORE_METADATA_KEY, {}).get("value", 0.0)
+            ),
+        )
     if candidates:
         candidates[0].metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
             _build_default_recommendation_reason(
                 candidate_kind=candidate_kind,
                 candidate_id=candidates[0].candidate_id,
+                default_candidate=candidates[0],
+                shadow_candidate=shadow_default,
             )
         )
     explanation = (
@@ -1951,13 +1980,7 @@ def _build_top_k_result(
         "Ranking uses overall score desc + stable tie-break; "
         "selection uses capability-bucket round-robin."
     )
-    if candidates and runtime_state_summary is not None:
-        shadow_default = max(
-            candidates,
-            key=lambda candidate: float(
-                candidate.metadata.get(SHADOW_SCORE_METADATA_KEY, {}).get("value", 0.0)
-            ),
-        )
+    if candidates and runtime_state_summary is not None and shadow_default is not None:
         shadow_action = str(shadow_default.metadata.get("shadow_action") or "continue")
         explanation = (
             f"{explanation} Runtime-state shadow evaluation is attached to candidate metadata; "
@@ -1984,6 +2007,14 @@ def _build_action_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     return summary.model_dump()
 
 
+def _build_static_score_summary(score_breakdown: dict[str, float]) -> dict[str, Any]:
+    summary = ScoreSummary(
+        value=float(score_breakdown.get("overall", 0.0)),
+        source="score_breakdown.overall.static.v1",
+    )
+    return summary.model_dump()
+
+
 def _build_shadow_score_summary(score_breakdown: dict[str, float]) -> dict[str, Any]:
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
@@ -2004,6 +2035,46 @@ def _normalize_runtime_state_summary_input(
     if isinstance(runtime_state, dict):
         return RuntimeStateSummary.model_validate(runtime_state).model_dump()
     raise ValueError("runtime_state must be RuntimeState, RuntimeStateSummary, or mapping")
+
+
+def _build_shadow_passthrough_decision(
+    score_breakdown: dict[str, float],
+) -> _RuntimeShadowDecision:
+    static_value = round(float(score_breakdown.get("overall", 0.0)), 6)
+    final_score = ScoreSummary(
+        value=static_value,
+        source="static_score+runtime_adjustment.shadow_passthrough.v1",
+    )
+    runtime_adjustment = RuntimeAdjustmentSummary(
+        value=0.0,
+        source="planner.runtime_adjustment.shadow_passthrough.v1",
+        formula_version="v1",
+        shadow_only=True,
+    )
+    rerank_reason = RerankReason(
+        code="shadow_passthrough",
+        message=(
+            "No runtime_state was provided, so final_score mirrors static_score "
+            "and remains shadow-only."
+        ),
+        shadow_only=True,
+        runtime_state_fields=[],
+        candidate_metric_fields=["score_breakdown.overall"],
+        tool_metadata_fields=[],
+        factors=[],
+    )
+    return _RuntimeShadowDecision(
+        shadow_score=_build_shadow_score_summary(score_breakdown),
+        final_score=final_score.model_dump(),
+        runtime_adjustment=runtime_adjustment.model_dump(),
+        rerank_reason=rerank_reason.model_dump(),
+        shadow_action="continue",
+        shadow_reason="runtime_state is not available",
+        explanation_fragment=(
+            "Shadow rerank is in passthrough mode; "
+            f"static_score={static_value:.2f}, runtime_adjustment=0.00, final_score={static_value:.2f}."
+        ),
+    )
 
 
 def _build_runtime_shadow_decision(
@@ -2030,6 +2101,7 @@ def _build_runtime_shadow_decision(
     risk = _safe_float(score_breakdown.get("risk"), default=overall)
     cost = _safe_float(score_breakdown.get("cost"), default=overall)
     fallback_depth = _safe_float(score_breakdown.get("fallback_depth"), default=0.5)
+    feasibility = _safe_float(score_breakdown.get("feasibility"), default=0.5)
     action, reason = _resolve_shadow_action(
         candidate_kind=candidate_kind,
         payload=payload,
@@ -2038,35 +2110,158 @@ def _build_runtime_shadow_decision(
         recovery_margin=recovery_margin,
         cost_pressure=cost_pressure,
     )
-    delta = (
-        0.18 * (p_success - 0.5) * confidence
-        - 0.16 * p_structural_failure * (1.0 - risk)
-        + 0.10 * margin_signal * fallback_depth
-        - 0.14 * cost_pressure * (1.0 - cost)
-    )
+    evidence_effect = 0.18 * (p_success - 0.5) * confidence
+    risk_effect = -0.16 * p_structural_failure * (1.0 - risk)
+    recovery_effect = 0.10 * margin_signal * fallback_depth
+    cost_effect = -0.14 * cost_pressure * (1.0 - cost)
+    delta = evidence_effect + risk_effect + recovery_effect + cost_effect
+    factors = [
+        _build_runtime_adjustment_factor(
+            category="evidence",
+            signal="p_success*confidence",
+            source="runtime_state.p_success+score_breakdown.confidence",
+            contribution=evidence_effect,
+            message="Current evidence and candidate confidence adjust the shadow score.",
+        ),
+        _build_runtime_adjustment_factor(
+            category="risk",
+            signal="p_structural_failure",
+            source="runtime_state.p_structural_failure+score_breakdown.risk",
+            contribution=risk_effect,
+            message="Structural failure pressure reduces the shadow score.",
+        ),
+        _build_runtime_adjustment_factor(
+            category="recovery",
+            signal="recovery_margin*fallback_depth",
+            source="runtime_state.recovery_margin+score_breakdown.fallback_depth",
+            contribution=recovery_effect,
+            message="Recovery headroom and fallback depth shape the shadow rerank bonus.",
+        ),
+        _build_runtime_adjustment_factor(
+            category="cost",
+            signal="expected_remaining_cost",
+            source="runtime_state.expected_remaining_cost+score_breakdown.cost",
+            contribution=cost_effect,
+            message="Remaining cost pressure penalizes expensive suffixes.",
+        ),
+    ]
     if action == "patch_local":
-        delta += 0.04 * fallback_depth
+        patch_bonus = 0.04 * fallback_depth
+        delta += patch_bonus
+        factors.append(
+            _build_runtime_adjustment_factor(
+                category="recovery",
+                signal="fallback_depth",
+                source="score_breakdown.fallback_depth",
+                contribution=patch_bonus,
+                message="Local patchability keeps more recovery options available.",
+            )
+        )
     elif action == "suffix_replan":
-        delta += 0.02 * score_breakdown.get("feasibility", 0.5)
-        delta -= 0.03 * cost_pressure
+        replan_recovery_bonus = 0.02 * feasibility
+        replan_cost_penalty = -0.03 * cost_pressure
+        delta += replan_recovery_bonus + replan_cost_penalty
+        factors.append(
+            _build_runtime_adjustment_factor(
+                category="recovery",
+                signal="feasibility",
+                source="score_breakdown.feasibility",
+                contribution=replan_recovery_bonus,
+                message="Feasible suffix replacement preserves validated prefix value.",
+            )
+        )
+        factors.append(
+            _build_runtime_adjustment_factor(
+                category="cost",
+                signal="cost_pressure",
+                source="runtime_state.expected_remaining_cost",
+                contribution=replan_cost_penalty,
+                message="Suffix replan still carries residual budget pressure.",
+            )
+        )
     elif action == "stop":
-        delta -= 0.12 + 0.06 * cost_pressure
+        stop_penalty = -(0.12 + 0.06 * cost_pressure)
+        delta += stop_penalty
+        factors.append(
+            _build_runtime_adjustment_factor(
+                category="policy",
+                signal="stop_guard",
+                source="runtime_state.p_success+runtime_state.expected_remaining_cost",
+                contribution=stop_penalty,
+                message="Stop guard applies when success is low and cost pressure is already high.",
+            )
+        )
     adjusted = max(0.0, min(1.0, overall + delta))
-    summary = ScoreSummary(
+    final_score = ScoreSummary(
+        value=round(adjusted, 6),
+        source=f"static_score+runtime_adjustment.{action}.v1",
+    )
+    shadow_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"score_breakdown.overall+runtime_state.{action}.v1",
     )
+    runtime_adjustment = RuntimeAdjustmentSummary(
+        value=round(delta, 6),
+        source=f"planner.runtime_adjustment.{action}.v1",
+        formula_version="v1",
+        shadow_only=True,
+    )
+    rerank_reason = RerankReason(
+        code=f"shadow_{action}",
+        message=(
+            "Shadow rerank keeps default recommendation on static_score, while "
+            "final_score exposes the audited runtime-adjusted ordering."
+        ),
+        shadow_only=True,
+        runtime_state_fields=[
+            "runtime_state.p_success",
+            "runtime_state.p_structural_failure",
+            "runtime_state.recovery_margin",
+            "runtime_state.expected_remaining_cost",
+        ],
+        candidate_metric_fields=[
+            "score_breakdown.overall",
+            "score_breakdown.confidence",
+            "score_breakdown.risk",
+            "score_breakdown.cost",
+            "score_breakdown.fallback_depth",
+            "score_breakdown.feasibility",
+        ],
+        tool_metadata_fields=[],
+        factors=factors,
+    )
     explanation_fragment = (
-        "Runtime correction combines static overall score with "
-        f"p_success={p_success:.2f}, p_structural_failure={p_structural_failure:.2f}, "
+        "Shadow rerank records static_score, runtime_adjustment, and final_score separately; "
+        f"static_score={overall:.2f}, runtime_adjustment={delta:.2f}, final_score={adjusted:.2f}; "
+        f"signals use p_success={p_success:.2f}, p_structural_failure={p_structural_failure:.2f}, "
         f"recovery_margin={recovery_margin:.2f}, expected_remaining_cost={expected_remaining_cost:.2f}; "
         f"shadow_action={action} because {reason}."
     )
     return _RuntimeShadowDecision(
-        shadow_score=summary.model_dump(),
+        shadow_score=shadow_score.model_dump(),
+        final_score=final_score.model_dump(),
+        runtime_adjustment=runtime_adjustment.model_dump(),
+        rerank_reason=rerank_reason.model_dump(),
         shadow_action=action,
         shadow_reason=reason,
         explanation_fragment=explanation_fragment,
+    )
+
+
+def _build_runtime_adjustment_factor(
+    *,
+    category: Literal["cost", "risk", "recovery", "evidence", "policy"],
+    signal: str,
+    source: str,
+    contribution: float,
+    message: str,
+) -> RuntimeAdjustmentFactor:
+    return RuntimeAdjustmentFactor(
+        category=category,
+        signal=signal,
+        source=source,
+        contribution=round(contribution, 6),
+        message=message,
     )
 
 
@@ -2146,14 +2341,48 @@ def _build_default_recommendation_reason(
     *,
     candidate_kind: str,
     candidate_id: str,
-) -> dict[str, str]:
-    return {
-        "code": f"{candidate_kind}_ranked_first",
-        "message": (
-            f"{candidate_kind} candidate {candidate_id} is the current default "
-            "recommendation after deterministic ranking."
-        ),
-    }
+    default_candidate: PendingActionCandidate,
+    shadow_candidate: PendingActionCandidate | None = None,
+) -> dict[str, Any]:
+    message = (
+        f"{candidate_kind} candidate {candidate_id} is the current default "
+        "recommendation after deterministic static ranking."
+    )
+    shadow_candidate_id = None
+    shadow_score_gap = None
+    if shadow_candidate is not None:
+        shadow_candidate_id = shadow_candidate.candidate_id
+        shadow_score_gap = round(
+            _extract_score_value(shadow_candidate, FINAL_SCORE_METADATA_KEY)
+            - _extract_score_value(default_candidate, FINAL_SCORE_METADATA_KEY),
+            6,
+        )
+        if shadow_candidate_id != candidate_id:
+            message = (
+                f"{message} Shadow rerank currently favors {shadow_candidate_id} "
+                f"by {shadow_score_gap:+.6f}, but default selection remains static_score-based."
+            )
+        else:
+            message = (
+                f"{message} Shadow rerank currently agrees with the static default."
+            )
+    reason = RecommendationReason(
+        code=f"{candidate_kind}_ranked_first",
+        message=message,
+        selection_basis="static_score",
+        shadow_candidate_id=shadow_candidate_id,
+        shadow_score_gap=shadow_score_gap,
+        shadow_only=True,
+    )
+    return reason.model_dump()
+
+
+def _extract_score_value(candidate: PendingActionCandidate, metadata_key: str) -> float:
+    metadata = candidate.metadata if isinstance(candidate.metadata, dict) else {}
+    score = metadata.get(metadata_key)
+    if not isinstance(score, dict):
+        return 0.0
+    return _safe_float(score.get("value"), default=0.0)
 
 
 def _build_pending_action_runtime_metadata(

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -21,6 +21,10 @@ RUNTIME_STATE_SUMMARY_METADATA_KEY = "runtime_state_summary"
 DEFAULT_RECOMMENDATION_REASON_METADATA_KEY = "default_recommendation_reason"
 ACTION_SCORE_METADATA_KEY = "action_score"
 SHADOW_SCORE_METADATA_KEY = "shadow_score"
+STATIC_SCORE_METADATA_KEY = "static_score"
+FINAL_SCORE_METADATA_KEY = "final_score"
+RUNTIME_ADJUSTMENT_METADATA_KEY = "runtime_adjustment"
+RERANK_REASON_METADATA_KEY = "rerank_reason"
 WAITING_RUNTIME_SUMMARY_METADATA_KEY = "waiting_runtime_summary"
 DECISION_SUMMARY_ARTIFACT_KEY = "decision_summary"
 
@@ -394,11 +398,29 @@ class RecommendationReason(BaseModel):
 
     code: str
     message: str
+    selection_basis: Literal["static_score", "final_score"] = "static_score"
+    shadow_candidate_id: str | None = None
+    shadow_score_gap: float | None = None
+    shadow_only: bool = True
 
     @field_validator("code", "message")
     @classmethod
     def _validate_text(cls, value: str, info) -> str:
         return _validate_non_empty_text(value, field_name=info.field_name)
+
+    @field_validator("shadow_candidate_id")
+    @classmethod
+    def _validate_optional_candidate_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return _validate_non_empty_text(value, field_name="shadow_candidate_id")
+
+    @field_validator("shadow_score_gap")
+    @classmethod
+    def _validate_optional_gap(cls, value: float | None) -> float | None:
+        if value is None:
+            return value
+        return _validate_finite_float_value(value, field_name="shadow_score_gap")
 
 
 class ScoreSummary(BaseModel):
@@ -421,6 +443,90 @@ class ScoreSummary(BaseModel):
     @classmethod
     def _validate_source(cls, value: str) -> str:
         return _validate_non_empty_text(value, field_name="source")
+
+
+class RuntimeAdjustmentFactor(BaseModel):
+    """runtime_adjustment 的可审计单因子。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    category: Literal["cost", "risk", "recovery", "evidence", "policy"]
+    signal: str
+    source: str
+    contribution: float
+    message: str
+
+    @field_validator("signal", "source", "message")
+    @classmethod
+    def _validate_text(cls, value: str, info) -> str:
+        return _validate_non_empty_text(value, field_name=info.field_name)
+
+    @field_validator("contribution")
+    @classmethod
+    def _validate_contribution(cls, value: float) -> float:
+        return _validate_finite_float_value(value, field_name="contribution")
+
+
+class RuntimeAdjustmentSummary(BaseModel):
+    """运行时修正摘要。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    value: float
+    source: str
+    formula_version: str = "v1"
+    shadow_only: bool = True
+
+    @field_validator("value")
+    @classmethod
+    def _validate_value(cls, value: float) -> float:
+        normalized = _validate_finite_float_value(value, field_name="value")
+        if not -1.0 <= normalized <= 1.0:
+            raise ValueError("value must be between -1 and 1")
+        return normalized
+
+    @field_validator("source", "formula_version")
+    @classmethod
+    def _validate_text(cls, value: str, info) -> str:
+        return _validate_non_empty_text(value, field_name=info.field_name)
+
+
+class RerankReason(BaseModel):
+    """shadow rerank 的最小可审计说明。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    message: str
+    shadow_only: bool = True
+    runtime_state_fields: List[str] = Field(default_factory=list)
+    candidate_metric_fields: List[str] = Field(default_factory=list)
+    tool_metadata_fields: List[str] = Field(default_factory=list)
+    factors: List[RuntimeAdjustmentFactor] = Field(default_factory=list)
+
+    @field_validator("code", "message")
+    @classmethod
+    def _validate_text(cls, value: str, info) -> str:
+        return _validate_non_empty_text(value, field_name=info.field_name)
+
+    @field_validator(
+        "runtime_state_fields",
+        "candidate_metric_fields",
+        "tool_metadata_fields",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_string_list(cls, value: Any, info) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError(f"{info.field_name} must be a list")
+        normalized: list[str] = []
+        for item in value:
+            if not isinstance(item, str):
+                raise ValueError(f"{info.field_name} items must be strings")
+            normalized.append(_validate_non_empty_text(item, field_name=info.field_name))
+        return normalized
 
 
 class WaitingRuntimeSummary(BaseModel):
@@ -578,7 +684,9 @@ class PendingActionCandidate(BaseModel):
         metadata: 额外元数据。
             - `runtime_state_summary` 可承载候选展示所需的轻量状态摘要。
             - `default_recommendation_reason` 可承载默认建议理由。
-            - `action_score` / `shadow_score` 用于承载动作分摘要。
+            - `action_score` / `shadow_score` 用于承载兼容动作分摘要。
+            - `static_score` / `runtime_adjustment` / `final_score` / `rerank_reason`
+              用于承载 shadow rerank 接口。
     """
 
     candidate_id: str
@@ -774,6 +882,24 @@ def _normalize_recommendation_reason(reason_payload: Any) -> Dict[str, Any]:
     )
 
 
+def _normalize_runtime_adjustment_summary(summary_payload: Any) -> Dict[str, Any]:
+    if isinstance(summary_payload, RuntimeAdjustmentSummary):
+        return summary_payload.model_dump()
+    if isinstance(summary_payload, dict):
+        return RuntimeAdjustmentSummary.model_validate(summary_payload).model_dump()
+    raise ValueError(
+        f"metadata.{RUNTIME_ADJUSTMENT_METADATA_KEY} must be a mapping"
+    )
+
+
+def _normalize_rerank_reason(reason_payload: Any) -> Dict[str, Any]:
+    if isinstance(reason_payload, RerankReason):
+        return reason_payload.model_dump()
+    if isinstance(reason_payload, dict):
+        return RerankReason.model_validate(reason_payload).model_dump()
+    raise ValueError(f"metadata.{RERANK_REASON_METADATA_KEY} must be a mapping")
+
+
 def _normalize_score_summary(score_payload: Any, *, field_name: str) -> Dict[str, Any]:
     if isinstance(score_payload, ScoreSummary):
         return score_payload.model_dump()
@@ -808,6 +934,32 @@ def _normalize_candidate_runtime_contracts(
         metadata[SHADOW_SCORE_METADATA_KEY] = _normalize_score_summary(
             shadow_score_payload,
             field_name=SHADOW_SCORE_METADATA_KEY,
+        )
+
+    static_score_payload = metadata.get(STATIC_SCORE_METADATA_KEY)
+    if static_score_payload is not None:
+        metadata[STATIC_SCORE_METADATA_KEY] = _normalize_score_summary(
+            static_score_payload,
+            field_name=STATIC_SCORE_METADATA_KEY,
+        )
+
+    final_score_payload = metadata.get(FINAL_SCORE_METADATA_KEY)
+    if final_score_payload is not None:
+        metadata[FINAL_SCORE_METADATA_KEY] = _normalize_score_summary(
+            final_score_payload,
+            field_name=FINAL_SCORE_METADATA_KEY,
+        )
+
+    runtime_adjustment_payload = metadata.get(RUNTIME_ADJUSTMENT_METADATA_KEY)
+    if runtime_adjustment_payload is not None:
+        metadata[RUNTIME_ADJUSTMENT_METADATA_KEY] = _normalize_runtime_adjustment_summary(
+            runtime_adjustment_payload
+        )
+
+    rerank_reason_payload = metadata.get(RERANK_REASON_METADATA_KEY)
+    if rerank_reason_payload is not None:
+        metadata[RERANK_REASON_METADATA_KEY] = _normalize_rerank_reason(
+            rerank_reason_payload
         )
 
 

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import math
 from typing import Any, Callable, Optional
 
-from src.models.contracts import (Decision, DecisionChoice, PendingAction,
-                                  PendingActionCandidate, PendingActionType,
-                                  Plan, PlanStep, ProteinDesignTask)
+from src.models.contracts import (ACTION_SCORE_METADATA_KEY, Decision,
+                                  DecisionChoice, FINAL_SCORE_METADATA_KEY,
+                                  PendingAction, PendingActionCandidate,
+                                  PendingActionType, Plan, PlanStep,
+                                  ProteinDesignTask,
+                                  RERANK_REASON_METADATA_KEY,
+                                  RUNTIME_ADJUSTMENT_METADATA_KEY,
+                                  SHADOW_SCORE_METADATA_KEY,
+                                  STATIC_SCORE_METADATA_KEY)
 from src.kg.kg_client import ToolKGError, load_tool_kg
 from src.adapters.registry import get_adapter
 
@@ -38,6 +45,14 @@ class CandidateSetValidationError(ValueError):
 
 REQUIRED_SCORE_BREAKDOWN_FIELDS = frozenset(
     {"feasibility", "objective", "risk", "cost", "overall"}
+)
+REQUIRED_SHADOW_RERANK_METADATA_FIELDS = frozenset(
+    {
+        STATIC_SCORE_METADATA_KEY,
+        RUNTIME_ADJUSTMENT_METADATA_KEY,
+        FINAL_SCORE_METADATA_KEY,
+        RERANK_REASON_METADATA_KEY,
+    }
 )
 REQUIRED_S5_INPUT_FIELDS = frozenset({"candidates", "metrics"})
 REQUIRED_S5_OUTPUT_FIELDS = frozenset(
@@ -105,6 +120,7 @@ def validate_candidate_set_output(
     require_v1_fields: bool = True,
     require_default_recommendation: bool = True,
     require_s5_fields: bool = False,
+    require_shadow_rerank_fields: bool = False,
 ) -> None:
     """校验 CandidateSetOutput 契约（用于 Planner/HITL 输出）。
 
@@ -133,6 +149,8 @@ def validate_candidate_set_output(
             _validate_candidate_v1_fields(candidate, candidate_id)
         if require_s5_fields:
             _validate_candidate_s5_fields(candidate, candidate_id)
+        if require_shadow_rerank_fields:
+            _validate_candidate_shadow_rerank_fields(candidate, candidate_id)
 
     default_id = (
         pending_action.default_recommendation or pending_action.default_suggestion
@@ -196,6 +214,119 @@ def _validate_candidate_tool_fields(
         raise CandidateSetValidationError(
             f"{candidate_id}.metadata missing tool keys: {missing}"
         )
+
+
+def _validate_candidate_shadow_rerank_fields(
+    candidate: PendingActionCandidate, candidate_id: str
+) -> None:
+    metadata = candidate.metadata or {}
+    missing = [
+        key for key in REQUIRED_SHADOW_RERANK_METADATA_FIELDS if key not in metadata
+    ]
+    if missing:
+        missing_keys = ", ".join(sorted(missing))
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata missing shadow rerank keys: {missing_keys}"
+        )
+
+    static_score = metadata[STATIC_SCORE_METADATA_KEY]
+    final_score = metadata[FINAL_SCORE_METADATA_KEY]
+    runtime_adjustment = metadata[RUNTIME_ADJUSTMENT_METADATA_KEY]
+    rerank_reason = metadata[RERANK_REASON_METADATA_KEY]
+
+    if not isinstance(static_score, dict) or not isinstance(final_score, dict):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata static/final score must be mappings"
+        )
+    if not isinstance(runtime_adjustment, dict):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{RUNTIME_ADJUSTMENT_METADATA_KEY} must be a mapping"
+        )
+    if not isinstance(rerank_reason, dict):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{RERANK_REASON_METADATA_KEY} must be a mapping"
+        )
+
+    static_value = _coerce_float(
+        static_score.get("value"),
+        field_name=f"{candidate_id}.metadata.{STATIC_SCORE_METADATA_KEY}.value",
+    )
+    final_value = _coerce_float(
+        final_score.get("value"),
+        field_name=f"{candidate_id}.metadata.{FINAL_SCORE_METADATA_KEY}.value",
+    )
+    adjustment_value = _coerce_float(
+        runtime_adjustment.get("value"),
+        field_name=f"{candidate_id}.metadata.{RUNTIME_ADJUSTMENT_METADATA_KEY}.value",
+    )
+    overall = _coerce_float(
+        candidate.score_breakdown.get("overall"),
+        field_name=f"{candidate_id}.score_breakdown.overall",
+    )
+    if not math.isclose(static_value, overall, rel_tol=1e-6, abs_tol=1e-6):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{STATIC_SCORE_METADATA_KEY}.value must match score_breakdown.overall"
+        )
+    if not math.isclose(
+        final_value,
+        max(0.0, min(1.0, static_value + adjustment_value)),
+        rel_tol=1e-6,
+        abs_tol=1e-6,
+    ):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{FINAL_SCORE_METADATA_KEY}.value must equal clip(static_score + runtime_adjustment, 0, 1)"
+        )
+
+    action_score = metadata.get(ACTION_SCORE_METADATA_KEY)
+    if isinstance(action_score, dict):
+        action_value = _coerce_float(
+            action_score.get("value"),
+            field_name=f"{candidate_id}.metadata.{ACTION_SCORE_METADATA_KEY}.value",
+        )
+        if not math.isclose(action_value, static_value, rel_tol=1e-6, abs_tol=1e-6):
+            raise CandidateSetValidationError(
+                f"{candidate_id}.metadata.{ACTION_SCORE_METADATA_KEY}.value must match static_score.value"
+            )
+
+    shadow_score = metadata.get(SHADOW_SCORE_METADATA_KEY)
+    if isinstance(shadow_score, dict):
+        shadow_value = _coerce_float(
+            shadow_score.get("value"),
+            field_name=f"{candidate_id}.metadata.{SHADOW_SCORE_METADATA_KEY}.value",
+        )
+        if not math.isclose(shadow_value, final_value, rel_tol=1e-6, abs_tol=1e-6):
+            raise CandidateSetValidationError(
+                f"{candidate_id}.metadata.{SHADOW_SCORE_METADATA_KEY}.value must match final_score.value"
+            )
+
+    if runtime_adjustment.get("shadow_only") is not True:
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{RUNTIME_ADJUSTMENT_METADATA_KEY}.shadow_only must be true"
+        )
+    if rerank_reason.get("shadow_only") is not True:
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{RERANK_REASON_METADATA_KEY}.shadow_only must be true"
+        )
+    if not rerank_reason.get("message"):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{RERANK_REASON_METADATA_KEY}.message is required"
+        )
+    if abs(adjustment_value) > 1e-9 and not rerank_reason.get("runtime_state_fields"):
+        raise CandidateSetValidationError(
+            f"{candidate_id}.metadata.{RERANK_REASON_METADATA_KEY}.runtime_state_fields is required when runtime_adjustment is non-zero"
+        )
+
+
+def _coerce_float(value: Any, *, field_name: str) -> float:
+    if isinstance(value, bool):
+        raise CandidateSetValidationError(f"{field_name} must be numeric")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise CandidateSetValidationError(f"{field_name} must be numeric") from exc
+    if not math.isfinite(parsed):
+        raise CandidateSetValidationError(f"{field_name} must be finite")
+    return parsed
 
 
 def _validate_candidate_s5_fields(

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -246,6 +246,7 @@ class PatchRunner:
                 pending_action,
                 require_v1_fields=candidate_set_v1_ready,
                 require_s5_fields=candidate_set_v1_ready,
+                require_shadow_rerank_fields=candidate_set_v1_ready,
             )
             enter_waiting_state(
                 context,

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -4,14 +4,18 @@ from pydantic import ValidationError
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+    FINAL_SCORE_METADATA_KEY,
     PendingAction,
     PendingActionCandidate,
     PendingActionType,
     ProteinDesignTask,
     Plan,
     PlanStep,
+    RERANK_REASON_METADATA_KEY,
+    RUNTIME_ADJUSTMENT_METADATA_KEY,
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     SHADOW_SCORE_METADATA_KEY,
+    STATIC_SCORE_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     RuntimeState,
     StepResult,
@@ -473,16 +477,51 @@ class TestCandidateSetContracts:
                     "value": 0.81,
                     "source": "score_breakdown.overall",
                 },
-                SHADOW_SCORE_METADATA_KEY: {
+                STATIC_SCORE_METADATA_KEY: {
                     "value": 0.81,
-                    "source": "score_breakdown.overall_passthrough",
+                    "source": "score_breakdown.overall.static.v1",
+                },
+                RUNTIME_ADJUSTMENT_METADATA_KEY: {
+                    "value": -0.03,
+                    "source": "planner.runtime_adjustment.continue.v1",
+                    "formula_version": "v1",
+                    "shadow_only": True,
+                },
+                FINAL_SCORE_METADATA_KEY: {
+                    "value": 0.78,
+                    "source": "static_score+runtime_adjustment.continue.v1",
+                },
+                RERANK_REASON_METADATA_KEY: {
+                    "code": "shadow_continue",
+                    "message": "shadow explanation",
+                    "shadow_only": True,
+                    "runtime_state_fields": ["runtime_state.p_success"],
+                    "candidate_metric_fields": ["score_breakdown.overall"],
+                    "tool_metadata_fields": [],
+                    "factors": [
+                        {
+                            "category": "risk",
+                            "signal": "p_structural_failure",
+                            "source": "runtime_state.p_structural_failure+score_breakdown.risk",
+                            "contribution": -0.03,
+                            "message": "risk penalty",
+                        }
+                    ],
+                },
+                SHADOW_SCORE_METADATA_KEY: {
+                    "value": 0.78,
+                    "source": "score_breakdown.overall+runtime_state.continue.v1",
                 },
             },
         )
 
         assert candidate.metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]["code"] == "plan_ranked_first"
         assert candidate.metadata[ACTION_SCORE_METADATA_KEY]["value"] == pytest.approx(0.81)
-        assert candidate.metadata[SHADOW_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall_passthrough"
+        assert candidate.metadata[STATIC_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall.static.v1"
+        assert candidate.metadata[RUNTIME_ADJUSTMENT_METADATA_KEY]["value"] == pytest.approx(-0.03)
+        assert candidate.metadata[FINAL_SCORE_METADATA_KEY]["value"] == pytest.approx(0.78)
+        assert candidate.metadata[RERANK_REASON_METADATA_KEY]["factors"][0]["category"] == "risk"
+        assert candidate.metadata[SHADOW_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall+runtime_state.continue.v1"
 
     def test_pending_action_waiting_runtime_summary_is_normalized(
         self, sample_task: ProteinDesignTask, sample_plan: Plan

--- a/tests/unit/test_decision_validation.py
+++ b/tests/unit/test_decision_validation.py
@@ -1,6 +1,10 @@
 import pytest
 
 from src.models.contracts import (
+    FINAL_SCORE_METADATA_KEY,
+    RERANK_REASON_METADATA_KEY,
+    RUNTIME_ADJUSTMENT_METADATA_KEY,
+    STATIC_SCORE_METADATA_KEY,
     Decision,
     DecisionChoice,
     PendingAction,
@@ -142,6 +146,145 @@ def test_candidate_set_v1_validation_passes(sample_task, sample_plan):
     )
 
     validate_candidate_set_output(pending_action)
+
+
+@pytest.mark.unit
+def test_candidate_set_shadow_rerank_validation_passes(sample_task, sample_plan):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_shadow_ok",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.4,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a is balanced",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                io_type="sequence_to_structure",
+                adapter_mode="remote",
+                metadata={
+                    STATIC_SCORE_METADATA_KEY: {
+                        "value": 0.85,
+                        "source": "score_breakdown.overall.static.v1",
+                    },
+                    RUNTIME_ADJUSTMENT_METADATA_KEY: {
+                        "value": -0.05,
+                        "source": "planner.runtime_adjustment.continue.v1",
+                        "formula_version": "v1",
+                        "shadow_only": True,
+                    },
+                    FINAL_SCORE_METADATA_KEY: {
+                        "value": 0.8,
+                        "source": "static_score+runtime_adjustment.continue.v1",
+                    },
+                    RERANK_REASON_METADATA_KEY: {
+                        "code": "shadow_continue",
+                        "message": "runtime-adjusted shadow ordering",
+                        "shadow_only": True,
+                        "runtime_state_fields": [
+                            "runtime_state.p_success",
+                            "runtime_state.p_structural_failure",
+                        ],
+                        "candidate_metric_fields": ["score_breakdown.overall"],
+                        "tool_metadata_fields": [],
+                        "factors": [
+                            {
+                                "category": "risk",
+                                "signal": "p_structural_failure",
+                                "source": "runtime_state.p_structural_failure+score_breakdown.risk",
+                                "contribution": -0.05,
+                                "message": "risk penalty",
+                            }
+                        ],
+                    },
+                },
+            )
+        ],
+        default_recommendation="plan_a",
+        explanation="test",
+    )
+
+    validate_candidate_set_output(
+        pending_action,
+        require_shadow_rerank_fields=True,
+    )
+
+
+@pytest.mark.unit
+def test_candidate_set_shadow_rerank_requires_consistent_final_score(
+    sample_task, sample_plan
+):
+    pending_action = PendingAction(
+        pending_action_id="pa_candidate_set_shadow_bad",
+        task_id=sample_task.task_id,
+        action_type=PendingActionType.PLAN_CONFIRM,
+        candidates=[
+            PendingActionCandidate(
+                candidate_id="plan_a",
+                structured_payload=sample_plan,
+                score_breakdown={
+                    "feasibility": 1.0,
+                    "objective": 0.8,
+                    "risk": 0.2,
+                    "cost": 0.4,
+                    "overall": 0.85,
+                },
+                risk_level="low",
+                cost_estimate="medium",
+                explanation="candidate a is balanced",
+                tool_id="esmfold",
+                capability_id="structure_prediction",
+                io_type="sequence_to_structure",
+                adapter_mode="remote",
+                metadata={
+                    STATIC_SCORE_METADATA_KEY: {
+                        "value": 0.85,
+                        "source": "score_breakdown.overall.static.v1",
+                    },
+                    RUNTIME_ADJUSTMENT_METADATA_KEY: {
+                        "value": -0.05,
+                        "source": "planner.runtime_adjustment.continue.v1",
+                        "formula_version": "v1",
+                        "shadow_only": True,
+                    },
+                    FINAL_SCORE_METADATA_KEY: {
+                        "value": 0.83,
+                        "source": "static_score+runtime_adjustment.continue.v1",
+                    },
+                    RERANK_REASON_METADATA_KEY: {
+                        "code": "shadow_continue",
+                        "message": "runtime-adjusted shadow ordering",
+                        "shadow_only": True,
+                        "runtime_state_fields": ["runtime_state.p_success"],
+                        "candidate_metric_fields": ["score_breakdown.overall"],
+                        "tool_metadata_fields": [],
+                        "factors": [],
+                    },
+                },
+            )
+        ],
+        default_recommendation="plan_a",
+        explanation="test",
+    )
+
+    with pytest.raises(
+        CandidateSetValidationError,
+        match="final_score\\.value must equal clip\\(static_score \\+ runtime_adjustment, 0, 1\\)",
+    ):
+        validate_candidate_set_output(
+            pending_action,
+            require_shadow_rerank_fields=True,
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -9,16 +9,20 @@ from src.kg.kg_client import ToolKGError
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+    FINAL_SCORE_METADATA_KEY,
     PatchRequest,
     PendingActionType,
     Plan,
     PlanPatch,
     PlanStep,
     ProteinDesignTask,
+    RERANK_REASON_METADATA_KEY,
     ReplanRequest,
     RuntimeState,
+    RUNTIME_ADJUSTMENT_METADATA_KEY,
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     SHADOW_SCORE_METADATA_KEY,
+    STATIC_SCORE_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     StepResult,
     now_iso,
@@ -551,7 +555,16 @@ class TestPlannerAgent:
         assert len(capability_buckets) >= 2
         default_metadata = first.candidates[0].metadata
         assert default_metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]["code"] == "plan_ranked_first"
+        assert default_metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]["selection_basis"] == "static_score"
         assert default_metadata[ACTION_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall"
+        assert default_metadata[STATIC_SCORE_METADATA_KEY]["value"] == pytest.approx(
+            first.candidates[0].score_breakdown["overall"]
+        )
+        assert default_metadata[RUNTIME_ADJUSTMENT_METADATA_KEY]["value"] == pytest.approx(0.0)
+        assert default_metadata[FINAL_SCORE_METADATA_KEY]["value"] == pytest.approx(
+            first.candidates[0].score_breakdown["overall"]
+        )
+        assert default_metadata[RERANK_REASON_METADATA_KEY]["code"] == "shadow_passthrough"
         assert default_metadata[SHADOW_SCORE_METADATA_KEY]["source"] == "score_breakdown.overall_passthrough"
 
     def test_plan_with_status_waiting_metadata_keeps_runtime_summary_fields(self, monkeypatch):
@@ -598,6 +611,7 @@ class TestPlannerAgent:
         waiting_summary = context.pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]
         assert waiting_summary["selected_candidate_id"] == context.pending_action.default_recommendation
         assert waiting_summary["default_recommendation_reason"]["code"] == "plan_ranked_first"
+        assert waiting_summary["default_recommendation_reason"]["selection_basis"] == "static_score"
         assert waiting_summary["action_score"]["source"] == "score_breakdown.overall"
         assert waiting_summary["runtime_state_summary"]["p_success"] == pytest.approx(0.58)
         assert waiting_summary["shadow_score"]["source"].startswith(
@@ -704,10 +718,22 @@ class TestPlannerAgent:
         for candidate in topk.candidates:
             assert candidate.metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.62)
             assert candidate.metadata["shadow_action"] == "continue"
+            assert candidate.metadata[STATIC_SCORE_METADATA_KEY]["value"] == pytest.approx(
+                candidate.score_breakdown["overall"]
+            )
+            assert candidate.metadata[FINAL_SCORE_METADATA_KEY]["value"] == pytest.approx(
+                candidate.metadata[SHADOW_SCORE_METADATA_KEY]["value"]
+            )
+            assert candidate.metadata[RERANK_REASON_METADATA_KEY]["shadow_only"] is True
+            categories = {
+                factor["category"]
+                for factor in candidate.metadata[RERANK_REASON_METADATA_KEY]["factors"]
+            }
+            assert {"cost", "risk", "recovery", "evidence"}.issubset(categories)
             assert candidate.metadata[SHADOW_SCORE_METADATA_KEY]["source"].startswith(
                 "score_breakdown.overall+runtime_state.continue"
             )
-            assert candidate.explanation and "Runtime correction combines static overall score" in candidate.explanation
+            assert candidate.explanation and "Shadow rerank records static_score" in candidate.explanation
 
     def test_patch_top_k_emits_suffix_replan_shadow_action_from_runtime_state(self, monkeypatch):
         monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())


### PR DESCRIPTION
## 变更概述
本 PR 实现 issue #232，按 2026-03-29 冻结设计把 Planner 的 shadow rerank / adjusted score 接口落到当前代码路径中，并保持 `TopKResult` 与 `PendingActionCandidate` 顶层契约不变。

主要内容包括：
- 在候选 metadata 中显式补齐 `static_score`、`runtime_adjustment`、`final_score`、`rerank_reason`
- 保留 `action_score` / `shadow_score` 作为兼容摘要字段
- 将默认建议边界固定为 `static_score` 驱动，并记录 shadow 最优候选与分差，供后续 #217 升级使用
- 为 runtime_state 消费边界、活跃工具元数据消费边界补充实现侧说明

## 变更原因
issue #232 的目标不是重新设计静态评分与运行时修正，而是把已经冻结的设计基线转换成 Planner 可直接接入的接口。当前代码已经有 shadow 输出雏形，但还缺少明确的字段分层、可审计修正理由，以及对后续 #217 / #219 / #248 可复用的实现边界。

## 具体实现
### 1. 契约与校验
- 在 `src/models/contracts.py` 中增加 shadow rerank 相关元数据模型与归一化逻辑
- 在 `src/models/validation.py` 中增加 `require_shadow_rerank_fields` 校验，确保：
  - `static_score` 与 `score_breakdown.overall` 一致
  - `final_score = clip(static_score + runtime_adjustment, 0, 1)`
  - `rerank_reason` 与 `runtime_adjustment` 保持 shadow-only 审计语义

### 2. Planner 输出
- 在 `src/agents/planner.py` 中让 Planner 在候选 metadata 中稳定产出：
  - `static_score`
  - `runtime_adjustment`
  - `final_score`
  - `rerank_reason`
- 无 `runtime_state` 时走 shadow passthrough，仍显式给出三段分数接口
- 有 `runtime_state` 时将成本、风险、恢复空间、证据信号拆成可审计因子写入 `rerank_reason.factors`
- `default_recommendation_reason` 新增静态/最终分数边界说明，明确当前默认推荐仍由静态排序决定

### 3. 交付说明
- 新增 `reports/w15-issue-232/planner-shadow-rerank-interface.md`
- 说明 shadow-only 字段、默认建议修正边界、runtime_state 接缝，以及与活跃工具画像的消费边界

## 影响范围
- Planner Top-K 候选 metadata 更完整，可直接支撑后续 shadow rerank 升级
- 不改变现有 PendingAction / Decision API 顶层结构
- 为 #217 提供默认建议修正的升级入口
- 为 #219 保留 runtime_state 扩展接口
- 为 #248 明确工具画像与派生 `step_cost` / `step_risk` 的接缝位置

## 根因与修复思路
根因是现有实现只有 shadow 可见性，没有把静态分、运行时修正分、最终分拆开，也缺少可追溯到风险/成本/恢复来源的结构化理由。修复思路是采用向后兼容扩展：不升级主契约版本，只在 metadata 中补足 frozen design 所要求的 shadow rerank 接口，并用验证器把这些关系固定下来。

## 验证
已执行：

```bash
uv run pytest tests/unit/test_contracts.py tests/unit/test_decision_validation.py tests/unit/test_planner_agent.py -q
```

结果：`82 passed`

## 关联
- Closes #232
- Soft sync: #217, #219, #248
