### PR TITLE
实现 Issue #217：接入运行时重排序与默认建议修正

### DIFF
--- a/reports/w15-issue-217/runtime-rerank-default-recommendation.md
+++ b/reports/w15-issue-217/runtime-rerank-default-recommendation.md
@@ -1,0 +1,81 @@
+# Issue 217: Runtime Rerank And Default Recommendation Promotion
+
+## Scope
+
+This note captures the implementation-facing contract for issue `#217` on top of the shadow rerank interface that already exists in the current branch.
+
+The relevant frozen design baseline is:
+
+- `SID:planner.algorithm.runtime_reranking`
+- `SID:planner.algorithm.runtime_adjustment_formula`
+- `SID:planner.algorithm.candidate_scoring`
+
+## What Changed
+
+Planner now promotes runtime `final_score` from an audit-only field into the effective ranking signal whenever `runtime_state` is present.
+
+- without `runtime_state`:
+  - ranking still uses `static_score`
+  - `default_recommendation_reason.selection_basis = static_score`
+- with `runtime_state`:
+  - ranking uses `final_score`
+  - `default_recommendation` points to the reranked top candidate
+  - `default_recommendation_reason.selection_basis = final_score`
+  - `default_recommendation_reason.static_candidate_id` records the displaced static default when rerank changes the winner
+
+This keeps `TopKResult` and `PendingActionCandidate` top-level structure unchanged.
+
+## Ranking Boundary
+
+The effective Top-K flow is now:
+
+1. compute `static_score`
+2. compute `runtime_adjustment`
+3. derive `final_score = clip(static_score + runtime_adjustment, 0, 1)`
+4. use `final_score` as the sort key when `runtime_state` exists
+5. keep stable tie-breaking and capability-bucket round-robin selection
+
+For patch candidates, existing recovery-layer precedence remains ahead of score ordering; runtime rerank only replaces the score component inside that existing ordering rule.
+
+## Default Recommendation Audit
+
+Default recommendation audit is carried by:
+
+- `default_recommendation_reason.selection_basis`
+- `default_recommendation_reason.rerank_applied`
+- `default_recommendation_reason.static_candidate_id`
+- `default_recommendation_reason.static_score_gap`
+- candidate `rerank_reason`
+- candidate `static_score` / `runtime_adjustment` / `final_score`
+
+This makes the default change explainable without changing the PendingAction / Decision API contract.
+
+## Explanation Boundary
+
+`TopKResult.explanation` now distinguishes the active ranking basis:
+
+- static path says ranking uses `overall`
+- runtime path says ranking uses `final_score`
+- runtime path also states whether the default recommendation changed and summarizes the dominant rerank reasons, including cost pressure, risk pressure, recovery margin, or evidence confidence
+
+Candidate-level explanation continues to carry the detailed numeric signals.
+
+## Waiting Summary Boundary
+
+The selected candidate’s rerank evidence is now persisted into `WaitingRuntimeSummary`:
+
+- `static_score`
+- `runtime_adjustment`
+- `final_score`
+- `rerank_reason`
+- `action_score`
+- `shadow_score`
+
+This keeps waiting-state replay and audit aligned with the promoted default recommendation.
+
+## Acceptance Mapping
+
+- runtime_state integrated into Top-K ordering: implemented
+- corrected default recommendation output: implemented
+- explanation includes rerank reasons: implemented
+- ranking stability and explanation tests: implemented

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -1844,7 +1844,8 @@ def _build_top_k_result(
 
     score_weights = _resolve_score_weights(task_constraints or {})
     runtime_state_summary = _normalize_runtime_state_summary_input(runtime_state)
-    ranked_rows: List[Tuple[PendingActionCandidate, Tuple, str]] = []
+    static_ranked_rows: List[Tuple[PendingActionCandidate, Tuple, str]] = []
+    effective_ranked_rows: List[Tuple[PendingActionCandidate, Tuple, str]] = []
     for payload in unique_payloads:
         score_breakdown = _score_payload(
             payload.payload,
@@ -1930,48 +1931,70 @@ def _build_top_k_result(
         )
         priority_rank = _priority_rank(primary_tool.priority if primary_tool else None)
         patch_layer_rank = _patch_layer_rank(payload.payload)
+        static_score_value = _extract_score_value(candidate, STATIC_SCORE_METADATA_KEY)
+        final_score_value = _extract_score_value(candidate, FINAL_SCORE_METADATA_KEY)
         if candidate_kind == "patch":
-            sort_key = (
+            static_sort_key = (
                 patch_layer_rank,
-                -score_breakdown["overall"],
+                -static_score_value,
+                priority_rank,
+                capability_id,
+                tool_id,
+                candidate_id,
+            )
+            effective_sort_key = (
+                patch_layer_rank,
+                -final_score_value,
                 priority_rank,
                 capability_id,
                 tool_id,
                 candidate_id,
             )
         else:
-            sort_key = (
-                -score_breakdown["overall"],
+            static_sort_key = (
+                -static_score_value,
                 priority_rank,
                 capability_id,
                 tool_id,
                 candidate_id,
             )
-        ranked_rows.append((candidate, sort_key, capability_id))
+            effective_sort_key = (
+                -final_score_value,
+                priority_rank,
+                capability_id,
+                tool_id,
+                candidate_id,
+            )
+        static_ranked_rows.append((candidate, static_sort_key, capability_id))
+        effective_ranked_rows.append((candidate, effective_sort_key, capability_id))
 
-    ranked_rows.sort(key=lambda row: row[1])
-    selected_rows = _select_diverse_top_k(
-        ranked_rows=ranked_rows,
+    static_ranked_rows.sort(key=lambda row: row[1])
+    static_selected_rows = _select_diverse_top_k(
+        ranked_rows=static_ranked_rows,
         top_k=top_k,
     )
-    selected_rows = sorted(selected_rows, key=lambda row: row[1])
-    candidates = [row[0] for row in selected_rows]
-    default_recommendation = candidates[0].candidate_id if candidates else None
-    shadow_default = None
-    if candidates and runtime_state_summary is not None:
-        shadow_default = max(
-            candidates,
-            key=lambda candidate: float(
-                candidate.metadata.get(SHADOW_SCORE_METADATA_KEY, {}).get("value", 0.0)
-            ),
+    static_selected_rows = sorted(static_selected_rows, key=lambda row: row[1])
+    selected_rows = static_selected_rows
+    if runtime_state_summary is not None:
+        effective_ranked_rows.sort(key=lambda row: row[1])
+        selected_rows = _select_diverse_top_k(
+            ranked_rows=effective_ranked_rows,
+            top_k=top_k,
         )
+        selected_rows = sorted(selected_rows, key=lambda row: row[1])
+    candidates = [row[0] for row in selected_rows]
+    static_candidates = [row[0] for row in static_selected_rows]
+    default_candidate = candidates[0] if candidates else None
+    static_default_candidate = static_candidates[0] if static_candidates else None
+    default_recommendation = default_candidate.candidate_id if default_candidate else None
     if candidates:
-        candidates[0].metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
+        default_candidate.metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
             _build_default_recommendation_reason(
                 candidate_kind=candidate_kind,
-                candidate_id=candidates[0].candidate_id,
-                default_candidate=candidates[0],
-                shadow_candidate=shadow_default,
+                candidate_id=default_candidate.candidate_id,
+                default_candidate=default_candidate,
+                static_candidate=static_default_candidate,
+                rerank_applied=runtime_state_summary is not None,
             )
         )
     explanation = (
@@ -1980,13 +2003,29 @@ def _build_top_k_result(
         "Ranking uses overall score desc + stable tie-break; "
         "selection uses capability-bucket round-robin."
     )
-    if candidates and runtime_state_summary is not None and shadow_default is not None:
-        shadow_action = str(shadow_default.metadata.get("shadow_action") or "continue")
+    if candidates and runtime_state_summary is not None and default_candidate is not None:
+        shadow_action = str(default_candidate.metadata.get("shadow_action") or "continue")
+        rerank_summary = _summarize_rerank_reason(default_candidate)
         explanation = (
-            f"{explanation} Runtime-state shadow evaluation is attached to candidate metadata; "
-            f"shadow best={shadow_default.candidate_id} action={shadow_action}. "
-            f"Default recommendation stays {default_recommendation} to preserve existing semantics."
+            f"{candidate_kind} Top-K generated with deterministic sort "
+            f"(requested={top_k}, returned={len(candidates)}). "
+            "Ranking uses final_score desc + stable tie-break; "
+            "selection uses capability-bucket round-robin."
         )
+        if (
+            static_default_candidate is not None
+            and static_default_candidate.candidate_id != default_candidate.candidate_id
+        ):
+            explanation = (
+                f"{explanation} Runtime rerank updated default recommendation "
+                f"from {static_default_candidate.candidate_id} to {default_candidate.candidate_id}. "
+                f"{rerank_summary} action={shadow_action}."
+            )
+        else:
+            explanation = (
+                f"{explanation} Runtime rerank kept default recommendation "
+                f"at {default_candidate.candidate_id}. {rerank_summary} action={shadow_action}."
+            )
     if len(candidates) < top_k:
         explanation = (
             f"{explanation} Degraded to available candidates because "
@@ -2204,15 +2243,15 @@ def _build_runtime_shadow_decision(
         value=round(delta, 6),
         source=f"planner.runtime_adjustment.{action}.v1",
         formula_version="v1",
-        shadow_only=True,
+        shadow_only=False,
     )
     rerank_reason = RerankReason(
         code=f"shadow_{action}",
         message=(
-            "Shadow rerank keeps default recommendation on static_score, while "
-            "final_score exposes the audited runtime-adjusted ordering."
+            "Runtime rerank uses final_score as the audited ordering signal for "
+            "candidate ranking and default recommendation."
         ),
-        shadow_only=True,
+        shadow_only=False,
         runtime_state_fields=[
             "runtime_state.p_success",
             "runtime_state.p_structural_failure",
@@ -2231,7 +2270,7 @@ def _build_runtime_shadow_decision(
         factors=factors,
     )
     explanation_fragment = (
-        "Shadow rerank records static_score, runtime_adjustment, and final_score separately; "
+        "Runtime rerank records static_score, runtime_adjustment, and final_score separately; "
         f"static_score={overall:.2f}, runtime_adjustment={delta:.2f}, final_score={adjusted:.2f}; "
         f"signals use p_success={p_success:.2f}, p_structural_failure={p_structural_failure:.2f}, "
         f"recovery_margin={recovery_margin:.2f}, expected_remaining_cost={expected_remaining_cost:.2f}; "
@@ -2342,37 +2381,48 @@ def _build_default_recommendation_reason(
     candidate_kind: str,
     candidate_id: str,
     default_candidate: PendingActionCandidate,
-    shadow_candidate: PendingActionCandidate | None = None,
+    static_candidate: PendingActionCandidate | None = None,
+    rerank_applied: bool,
 ) -> dict[str, Any]:
     message = (
         f"{candidate_kind} candidate {candidate_id} is the current default "
         "recommendation after deterministic static ranking."
     )
-    shadow_candidate_id = None
-    shadow_score_gap = None
-    if shadow_candidate is not None:
-        shadow_candidate_id = shadow_candidate.candidate_id
-        shadow_score_gap = round(
-            _extract_score_value(shadow_candidate, FINAL_SCORE_METADATA_KEY)
-            - _extract_score_value(default_candidate, FINAL_SCORE_METADATA_KEY),
-            6,
+    selection_basis: Literal["static_score", "final_score"] = "static_score"
+    rerank_shadow_only = True
+    static_candidate_id = None
+    static_score_gap = None
+    if rerank_applied:
+        selection_basis = "final_score"
+        rerank_shadow_only = False
+        static_candidate_id = (
+            static_candidate.candidate_id if static_candidate is not None else None
         )
-        if shadow_candidate_id != candidate_id:
-            message = (
-                f"{message} Shadow rerank currently favors {shadow_candidate_id} "
-                f"by {shadow_score_gap:+.6f}, but default selection remains static_score-based."
+        if static_candidate is not None:
+            static_score_gap = round(
+                _extract_score_value(default_candidate, FINAL_SCORE_METADATA_KEY)
+                - _extract_score_value(static_candidate, FINAL_SCORE_METADATA_KEY),
+                6,
             )
-        else:
-            message = (
-                f"{message} Shadow rerank currently agrees with the static default."
-            )
+            if static_candidate_id != candidate_id:
+                message = (
+                    f"{candidate_kind} candidate {candidate_id} becomes the current "
+                    "default recommendation after runtime reranking by final_score. "
+                    f"Static default was {static_candidate_id}, final_score gap={static_score_gap:+.6f}."
+                )
+            else:
+                message = (
+                    f"{candidate_kind} candidate {candidate_id} remains the default "
+                    "recommendation after runtime reranking by final_score."
+                )
     reason = RecommendationReason(
         code=f"{candidate_kind}_ranked_first",
         message=message,
-        selection_basis="static_score",
-        shadow_candidate_id=shadow_candidate_id,
-        shadow_score_gap=shadow_score_gap,
-        shadow_only=True,
+        selection_basis=selection_basis,
+        rerank_applied=rerank_applied,
+        static_candidate_id=static_candidate_id,
+        static_score_gap=static_score_gap,
+        shadow_only=rerank_shadow_only,
     )
     return reason.model_dump()
 
@@ -2383,6 +2433,38 @@ def _extract_score_value(candidate: PendingActionCandidate, metadata_key: str) -
     if not isinstance(score, dict):
         return 0.0
     return _safe_float(score.get("value"), default=0.0)
+
+
+def _summarize_rerank_reason(candidate: PendingActionCandidate) -> str:
+    metadata = candidate.metadata if isinstance(candidate.metadata, dict) else {}
+    rerank_reason = metadata.get(RERANK_REASON_METADATA_KEY)
+    if not isinstance(rerank_reason, dict):
+        return "Runtime rerank reasons are attached in candidate metadata."
+
+    factors = rerank_reason.get("factors")
+    if not isinstance(factors, list):
+        return str(rerank_reason.get("message") or "Runtime rerank reasons are attached in candidate metadata.")
+
+    category_labels = {
+        "cost": "remaining cost pressure",
+        "risk": "structural risk pressure",
+        "recovery": "recovery margin",
+        "evidence": "evidence confidence",
+        "policy": "stop guard",
+    }
+    categories: list[str] = []
+    for factor in factors:
+        if not isinstance(factor, dict):
+            continue
+        contribution = _safe_float(factor.get("contribution"), default=0.0)
+        if abs(contribution) <= 1e-9:
+            continue
+        label = category_labels.get(str(factor.get("category") or ""), "")
+        if label and label not in categories:
+            categories.append(label)
+    if not categories:
+        return str(rerank_reason.get("message") or "Runtime rerank reasons are attached in candidate metadata.")
+    return "Runtime rerank reasons include " + ", ".join(categories) + "."
 
 
 def _build_pending_action_runtime_metadata(
@@ -2406,6 +2488,10 @@ def _build_pending_action_runtime_metadata(
     for key in (
         RUNTIME_STATE_SUMMARY_METADATA_KEY,
         DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+        STATIC_SCORE_METADATA_KEY,
+        RUNTIME_ADJUSTMENT_METADATA_KEY,
+        FINAL_SCORE_METADATA_KEY,
+        RERANK_REASON_METADATA_KEY,
         ACTION_SCORE_METADATA_KEY,
         SHADOW_SCORE_METADATA_KEY,
     ):

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -399,6 +399,9 @@ class RecommendationReason(BaseModel):
     code: str
     message: str
     selection_basis: Literal["static_score", "final_score"] = "static_score"
+    rerank_applied: bool = False
+    static_candidate_id: str | None = None
+    static_score_gap: float | None = None
     shadow_candidate_id: str | None = None
     shadow_score_gap: float | None = None
     shadow_only: bool = True
@@ -408,19 +411,19 @@ class RecommendationReason(BaseModel):
     def _validate_text(cls, value: str, info) -> str:
         return _validate_non_empty_text(value, field_name=info.field_name)
 
-    @field_validator("shadow_candidate_id")
+    @field_validator("static_candidate_id", "shadow_candidate_id")
     @classmethod
     def _validate_optional_candidate_id(cls, value: str | None) -> str | None:
         if value is None:
             return value
-        return _validate_non_empty_text(value, field_name="shadow_candidate_id")
+        return _validate_non_empty_text(value, field_name="candidate_id")
 
-    @field_validator("shadow_score_gap")
+    @field_validator("static_score_gap", "shadow_score_gap")
     @classmethod
     def _validate_optional_gap(cls, value: float | None) -> float | None:
         if value is None:
             return value
-        return _validate_finite_float_value(value, field_name="shadow_score_gap")
+        return _validate_finite_float_value(value, field_name="score_gap")
 
 
 class ScoreSummary(BaseModel):
@@ -539,6 +542,10 @@ class WaitingRuntimeSummary(BaseModel):
     waiting_reason: str | None = None
     runtime_state_summary: RuntimeStateSummary | None = None
     default_recommendation_reason: RecommendationReason | None = None
+    static_score: ScoreSummary | None = None
+    runtime_adjustment: RuntimeAdjustmentSummary | None = None
+    final_score: ScoreSummary | None = None
+    rerank_reason: RerankReason | None = None
     action_score: ScoreSummary | None = None
     shadow_score: ScoreSummary | None = None
 

--- a/src/models/validation.py
+++ b/src/models/validation.py
@@ -299,13 +299,13 @@ def _validate_candidate_shadow_rerank_fields(
                 f"{candidate_id}.metadata.{SHADOW_SCORE_METADATA_KEY}.value must match final_score.value"
             )
 
-    if runtime_adjustment.get("shadow_only") is not True:
+    if not isinstance(runtime_adjustment.get("shadow_only"), bool):
         raise CandidateSetValidationError(
-            f"{candidate_id}.metadata.{RUNTIME_ADJUSTMENT_METADATA_KEY}.shadow_only must be true"
+            f"{candidate_id}.metadata.{RUNTIME_ADJUSTMENT_METADATA_KEY}.shadow_only must be a boolean"
         )
-    if rerank_reason.get("shadow_only") is not True:
+    if not isinstance(rerank_reason.get("shadow_only"), bool):
         raise CandidateSetValidationError(
-            f"{candidate_id}.metadata.{RERANK_REASON_METADATA_KEY}.shadow_only must be true"
+            f"{candidate_id}.metadata.{RERANK_REASON_METADATA_KEY}.shadow_only must be a boolean"
         )
     if not rerank_reason.get("message"):
         raise CandidateSetValidationError(

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -12,12 +12,16 @@ from src.infra.event_log_factory import make_waiting_enter
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+    FINAL_SCORE_METADATA_KEY,
     PendingAction,
     PendingActionCandidate,
     PendingActionStatus,
     PendingActionType,
+    RERANK_REASON_METADATA_KEY,
+    RUNTIME_ADJUSTMENT_METADATA_KEY,
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     SHADOW_SCORE_METADATA_KEY,
+    STATIC_SCORE_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
@@ -327,6 +331,10 @@ def _build_waiting_runtime_summary(
     for key in (
         RUNTIME_STATE_SUMMARY_METADATA_KEY,
         DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+        STATIC_SCORE_METADATA_KEY,
+        RUNTIME_ADJUSTMENT_METADATA_KEY,
+        FINAL_SCORE_METADATA_KEY,
+        RERANK_REASON_METADATA_KEY,
         ACTION_SCORE_METADATA_KEY,
         SHADOW_SCORE_METADATA_KEY,
         "terminal_policy",

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -611,7 +611,11 @@ class TestPlannerAgent:
         waiting_summary = context.pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]
         assert waiting_summary["selected_candidate_id"] == context.pending_action.default_recommendation
         assert waiting_summary["default_recommendation_reason"]["code"] == "plan_ranked_first"
-        assert waiting_summary["default_recommendation_reason"]["selection_basis"] == "static_score"
+        assert waiting_summary["default_recommendation_reason"]["selection_basis"] == "final_score"
+        assert waiting_summary["default_recommendation_reason"]["rerank_applied"] is True
+        assert waiting_summary["final_score"]["value"] == pytest.approx(
+            waiting_summary["shadow_score"]["value"]
+        )
         assert waiting_summary["action_score"]["source"] == "score_breakdown.overall"
         assert waiting_summary["runtime_state_summary"]["p_success"] == pytest.approx(0.58)
         assert waiting_summary["shadow_score"]["source"].startswith(
@@ -693,7 +697,7 @@ class TestPlannerAgent:
         assert objective_weighted["objective"] > objective_weighted["risk"]
         assert objective_weighted["overall"] > risk_weighted["overall"]
 
-    def test_plan_top_k_accepts_runtime_state_shadow_without_changing_default(self, monkeypatch):
+    def test_plan_top_k_runtime_rerank_updates_default_recommendation(self, monkeypatch):
         monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
         planner = PlannerAgent(tool_registry=_topk_registry())
         task = ProteinDesignTask(
@@ -703,6 +707,89 @@ class TestPlannerAgent:
             metadata={},
         )
         baseline = planner.plan_top_k(task, k=3)
+        baseline_default = baseline.default_recommendation
+
+        def _mock_runtime_shadow_decision(*, payload, score_breakdown, candidate_kind, runtime_state_summary):
+            tool_id = payload.steps[0].tool if isinstance(payload, Plan) and payload.steps else "unknown"
+            final_scores = {
+                "seqgen_local": 0.52,
+                "protgpt2": 0.94,
+                "protein_mpnn": 0.61,
+                "esmfold": 0.57,
+                "nim_esmfold": 0.56,
+                "openfold": 0.49,
+                "biopython_qc": 0.58,
+                "objective_ranker": 0.55,
+            }
+            final_value = final_scores.get(tool_id, 0.5)
+            static_value = score_breakdown["overall"]
+            delta = round(final_value - static_value, 6)
+            return planner_module._RuntimeShadowDecision(
+                shadow_score={
+                    "value": final_value,
+                    "source": f"score_breakdown.overall+runtime_state.mock_{tool_id}.v1",
+                },
+                final_score={
+                    "value": final_value,
+                    "source": f"static_score+runtime_adjustment.mock_{tool_id}.v1",
+                },
+                runtime_adjustment={
+                    "value": delta,
+                    "source": f"planner.runtime_adjustment.mock_{tool_id}.v1",
+                    "formula_version": "v1",
+                    "shadow_only": False,
+                },
+                rerank_reason={
+                    "code": f"rerank_{tool_id}",
+                    "message": "Runtime rerank promotes lower-cost and lower-risk continuation.",
+                    "shadow_only": False,
+                    "runtime_state_fields": [
+                        "runtime_state.p_success",
+                        "runtime_state.expected_remaining_cost",
+                    ],
+                    "candidate_metric_fields": [
+                        "score_breakdown.overall",
+                        "score_breakdown.cost",
+                        "score_breakdown.risk",
+                    ],
+                    "tool_metadata_fields": [],
+                    "factors": [
+                        {
+                            "category": "cost",
+                            "signal": "expected_remaining_cost",
+                            "source": "runtime_state.expected_remaining_cost+score_breakdown.cost",
+                            "contribution": round(min(0.0, delta), 6),
+                            "message": "remaining cost pressure",
+                        },
+                        {
+                            "category": "risk",
+                            "signal": "p_structural_failure",
+                            "source": "runtime_state.p_structural_failure+score_breakdown.risk",
+                            "contribution": round(max(0.0, delta), 6),
+                            "message": "risk adjustment",
+                        },
+                        {
+                            "category": "recovery",
+                            "signal": "recovery_margin",
+                            "source": "runtime_state.recovery_margin+score_breakdown.fallback_depth",
+                            "contribution": 0.02,
+                            "message": "recovery margin",
+                        },
+                    ],
+                },
+                shadow_action="continue",
+                shadow_reason="runtime rerank favors the lower-exposure candidate",
+                explanation_fragment=(
+                    f"Runtime rerank records static_score={static_value:.2f}, "
+                    f"runtime_adjustment={delta:.2f}, final_score={final_value:.2f}."
+                ),
+            )
+
+        monkeypatch.setattr(
+            planner_module,
+            "_build_runtime_shadow_decision",
+            _mock_runtime_shadow_decision,
+        )
         runtime_state = RuntimeState(
             p_success=0.62,
             p_structural_failure=0.18,
@@ -713,8 +800,10 @@ class TestPlannerAgent:
 
         topk = planner.plan_top_k(task, k=3, runtime_state=runtime_state)
 
-        assert topk.default_recommendation == baseline.default_recommendation
-        assert "Default recommendation stays" in topk.explanation
+        assert topk.default_recommendation != baseline_default
+        assert topk.default_recommendation == topk.candidates[0].candidate_id
+        assert topk.candidates[0].tool_id == "protgpt2"
+        assert "Runtime rerank updated default recommendation" in topk.explanation
         for candidate in topk.candidates:
             assert candidate.metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.62)
             assert candidate.metadata["shadow_action"] == "continue"
@@ -724,16 +813,17 @@ class TestPlannerAgent:
             assert candidate.metadata[FINAL_SCORE_METADATA_KEY]["value"] == pytest.approx(
                 candidate.metadata[SHADOW_SCORE_METADATA_KEY]["value"]
             )
-            assert candidate.metadata[RERANK_REASON_METADATA_KEY]["shadow_only"] is True
+            assert candidate.metadata[RERANK_REASON_METADATA_KEY]["shadow_only"] is False
             categories = {
                 factor["category"]
                 for factor in candidate.metadata[RERANK_REASON_METADATA_KEY]["factors"]
             }
-            assert {"cost", "risk", "recovery", "evidence"}.issubset(categories)
-            assert candidate.metadata[SHADOW_SCORE_METADATA_KEY]["source"].startswith(
-                "score_breakdown.overall+runtime_state.continue"
-            )
-            assert candidate.explanation and "Shadow rerank records static_score" in candidate.explanation
+            assert {"cost", "risk", "recovery"}.issubset(categories)
+            assert candidate.explanation and "Runtime rerank records static_score" in candidate.explanation
+        default_reason = topk.candidates[0].metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]
+        assert default_reason["selection_basis"] == "final_score"
+        assert default_reason["rerank_applied"] is True
+        assert default_reason["static_candidate_id"] == baseline_default
 
     def test_patch_top_k_emits_suffix_replan_shadow_action_from_runtime_state(self, monkeypatch):
         monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
@@ -760,7 +850,7 @@ class TestPlannerAgent:
         )
         assert first.metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_structural_failure"] == pytest.approx(0.82)
 
-    def test_replan_top_k_can_emit_stop_shadow_action_while_preserving_default(self, monkeypatch):
+    def test_replan_top_k_can_emit_stop_shadow_action_with_runtime_rerank(self, monkeypatch):
         monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
         planner = PlannerAgent(tool_registry=_topk_registry())
         original = Plan(
@@ -793,8 +883,8 @@ class TestPlannerAgent:
             },
         )
 
-        assert topk.default_recommendation == baseline.default_recommendation
-        assert "Default recommendation stays" in topk.explanation
+        assert "Runtime rerank" in topk.explanation
+        assert topk.candidates[0].metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY]["selection_basis"] == "final_score"
         assert all(candidate.metadata["shadow_action"] == "stop" for candidate in topk.candidates)
         assert all(
             candidate.metadata[SHADOW_SCORE_METADATA_KEY]["source"].startswith(


### PR DESCRIPTION
## 变更概述
本 PR 实现 issue #217，在保持 `PendingActionCandidate` 与 `TopKResult` 顶层契约不变的前提下，把 Planner 的运行时 `final_score` 正式接入 Top-K 排序与默认建议修正主路径。

主要内容包括：
- 让 `runtime_state` 存在时的候选排序从静态 `overall` 升级为运行时 `final_score`
- 让 `default_recommendation` 跟随 rerank 结果更新，而不是继续停留在静态默认候选
- 在 `default_recommendation_reason` 中记录 rerank 是否生效、静态默认候选是谁、以及分差等可审计字段
- 将 `static_score`、`runtime_adjustment`、`final_score`、`rerank_reason` 带入 waiting 摘要，保证等待态回放与审计一致
- 补充 issue #217 的实现说明文档

## 变更原因
当前主分支已经具备 issue #232 提供的 shadow rerank / adjusted score 接口，但当时仍保持“只观察、不驱动默认建议”的 shadow-only 语义。issue #217 的目标是在这个接口底座上，真正把运行时修正结果接入候选重排序与默认建议修正，同时保证解释和审计字段完整。

## 具体实现
### 1. 排序与默认建议
- 在 `src/agents/planner.py` 中引入两套路由：
  - 无 `runtime_state` 时，继续按 `static_score` 排序
  - 有 `runtime_state` 时，按 `final_score` 排序
- `default_recommendation` 改为指向 rerank 后的首位候选
- 保留稳定 tie-break 与 capability-bucket round-robin 选择策略，避免破坏已有输出结构

### 2. 解释与审计
- `default_recommendation_reason` 新增：
  - `selection_basis`
  - `rerank_applied`
  - `static_candidate_id`
  - `static_score_gap`
- `TopKResult.explanation` 会明确说明：
  - 当前排序依据是 `overall` 还是 `final_score`
  - 默认建议是否发生变化
  - 主要 rerank 原因来自成本、风险、恢复空间或证据等信号

### 3. Waiting 摘要
- 在 `src/models/contracts.py` 和 `src/workflow/pending_action.py` 中扩展 waiting 摘要承载能力，带出：
  - `static_score`
  - `runtime_adjustment`
  - `final_score`
  - `rerank_reason`
- 这样 WAITING 场景中的回放、日志与后续决策都能看到同一份 rerank 证据

### 4. 文档
- 新增 `reports/w15-issue-217/runtime-rerank-default-recommendation.md`
- 固定 issue #217 的实现侧边界与验收映射

## 影响范围
- Planner 在有 `runtime_state` 时会真实改变 Top-K 顺序与默认建议
- PendingAction / Decision API 顶层结构不变
- Waiting 摘要与默认建议理由包含更完整的 rerank 审计字段
- 为后续 belief-state 路径和实验分析保留了稳定的观察面

## 根因与修复思路
根因是此前的实现只把运行时修正当作 shadow 输出保存下来，没有真正进入排序和默认推荐主路径。修复思路是在不破坏主契约的前提下，把 `final_score` 从观察字段提升为有效排序键，并把默认建议修正过程完整记录在 explanation 与 metadata 中。

## 验证
已执行：

```bash
uv run pytest tests/unit/test_planner_agent.py -q
uv run pytest tests/unit/test_planner_agent.py tests/unit/test_decision_validation.py tests/unit/test_contracts.py -q
```

结果：
- `41 passed`
- `82 passed`

## 关联
- Closes #217
- Builds on #232
