### PR TITLE
feat(workflow): 实现动态无 belief-state 动态基线

### DIFF
--- a/scripts/smoke_test_llm_providers.py
+++ b/scripts/smoke_test_llm_providers.py
@@ -134,6 +134,14 @@ def _provider_worker(
     result_queue.put(result)
 
 
+def _resolve_process_context() -> multiprocessing.context.BaseContext:
+    """Prefer fork where available so importlib-loaded test modules remain runnable."""
+    try:
+        return multiprocessing.get_context("fork")
+    except ValueError:
+        return multiprocessing.get_context()
+
+
 def run_provider_with_timeout(
     alias: str,
     catalog_path: Path,
@@ -141,8 +149,9 @@ def run_provider_with_timeout(
     target_length: int,
     timeout_seconds: int,
 ) -> dict[str, object]:
-    result_queue: multiprocessing.Queue = multiprocessing.Queue()
-    process = multiprocessing.Process(
+    process_context = _resolve_process_context()
+    result_queue: multiprocessing.Queue = process_context.Queue()
+    process = process_context.Process(
         target=_provider_worker,
         args=(alias, str(catalog_path), goal, target_length, result_queue),
     )

--- a/src/workflow/context.py
+++ b/src/workflow/context.py
@@ -27,6 +27,7 @@ from src.models.contracts import (
 )
 from src.models.db import InternalStatus
 from src.workflow.belief_state import extract_failure_context, update_runtime_state
+from src.workflow.runtime_policy import runtime_policy_uses_belief_state
 
 __all__ = ["WorkflowContext"]
 
@@ -97,6 +98,8 @@ class WorkflowContext(BaseModel):
             如果 step_id 已存在，会覆盖之前的结果
         """
         self.step_results[result.step_id] = result
+        if not runtime_policy_uses_belief_state(self.task):
+            return
         self.apply_runtime_state_update(
             step_result=result,
             failure_context=extract_failure_context(result),
@@ -109,6 +112,8 @@ class WorkflowContext(BaseModel):
             event: 安全检查结果事件
         """
         self.safety_events.append(event)
+        if not runtime_policy_uses_belief_state(self.task):
+            return
         self.apply_runtime_state_update(safety_result=event)
 
     def apply_runtime_state_update(
@@ -117,12 +122,14 @@ class WorkflowContext(BaseModel):
         step_result: StepResult | None = None,
         safety_result: SafetyResult | None = None,
         failure_context: RuntimeFailureContext | None = None,
-    ) -> RuntimeState:
+    ) -> RuntimeState | None:
         """通过稳定更新接口刷新 runtime_state。
 
         PlanRunner / PatchRunner / StepRunner 应通过 WorkflowContext helpers
         间接接入 belief-state 更新器，而不是散落地直接修改 runtime_state。
         """
+        if not runtime_policy_uses_belief_state(self.task):
+            return None
         completed_steps = len(self.step_results)
         total_steps = self._get_total_step_count()
         if total_steps is not None and total_steps < completed_steps:

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -39,6 +39,7 @@ from src.workflow.snapshots import (
     extract_pending_action_waiting_summary,
 )
 from src.workflow.status import StatusLogger, transition_task_status
+from src.workflow.runtime_policy import runtime_policy_trace
 
 EventLogger = Callable[[dict], None]
 
@@ -597,6 +598,7 @@ def _emit_decision_applied_event(
         if selected_candidate is not None
         else {}
     )
+    runtime_trace = runtime_policy_trace(context.task)
     decision_event = make_decision_applied(
         task_id=context.task.task_id,
         decision_id=decision.decision_id,
@@ -635,6 +637,8 @@ def _emit_decision_applied_event(
             "evidence_source": candidate_meta.get("default_recommendation_reason"),
             "terminal_policy": candidate_meta.get("terminal_policy"),
             "terminal_reason": candidate_meta.get("terminal_reason"),
+            "runtime_policy": runtime_trace["runtime_policy"],
+            "belief_state_enabled": runtime_trace["belief_state_enabled"],
             "runtime_state_summary": build_context_runtime_state_summary(
                 context,
                 require_runtime_state=True,
@@ -671,6 +675,7 @@ def _emit_waiting_exit_event(
         if selected_candidate is not None
         else {}
     )
+    runtime_trace = runtime_policy_trace(context.task)
     exit_event = make_waiting_exit(
         task_id=context.task.task_id,
         prev_status=prev_status,
@@ -691,6 +696,8 @@ def _emit_waiting_exit_event(
             "evidence_source": candidate_meta.get("default_recommendation_reason"),
             "terminal_policy": candidate_meta.get("terminal_policy"),
             "terminal_reason": candidate_meta.get("terminal_reason"),
+            "runtime_policy": runtime_trace["runtime_policy"],
+            "belief_state_enabled": runtime_trace["belief_state_enabled"],
             "runtime_state_summary": build_context_runtime_state_summary(
                 context,
                 require_runtime_state=True,

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -29,6 +29,7 @@ from src.workflow.snapshots import build_context_runtime_state_summary
 from src.workflow.step_runner import StepRunner
 from src.workflow.status import transition_task_status
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
+from src.workflow.runtime_policy import resolve_runtime_policy, runtime_policy_uses_belief_state
 
 
 class StepRunnerLike(Protocol):
@@ -427,6 +428,8 @@ class PatchRunner:
         context: WorkflowContext,
         result: StepResult,
     ):
+        if not runtime_policy_uses_belief_state(context.task):
+            return None
         completed_steps = len(context.step_results)
         if result.step_id not in context.step_results:
             completed_steps += 1
@@ -470,7 +473,12 @@ class PatchRunner:
                 failure_type=result.failure_type,
                 retry_exhausted=retry_exhausted,
                 safety_blocked=result.failure_type == FailureType.SAFETY_BLOCK,
-                runtime_state_summary=runtime_state_preview.to_summary_payload(),
+                runtime_state_summary=(
+                    runtime_state_preview.to_summary_payload()
+                    if runtime_state_preview is not None
+                    else None
+                ),
+                runtime_policy=resolve_runtime_policy(context.task),
             )
         )
         _attach_workflow_action_meta(result, decision)
@@ -500,9 +508,14 @@ class PatchRunner:
                 failure_type=result.failure_type,
                 retry_exhausted=bool(result.metrics.get("retry_exhausted")),
                 safety_blocked=result.failure_type == FailureType.SAFETY_BLOCK,
-                runtime_state_summary=runtime_state_preview.to_summary_payload(),
+                runtime_state_summary=(
+                    runtime_state_preview.to_summary_payload()
+                    if runtime_state_preview is not None
+                    else None
+                ),
                 suggested_action=suggested_action if isinstance(suggested_action, str) else None,
                 suggested_reason=suggested_reason if isinstance(suggested_reason, str) else None,
+                runtime_policy=resolve_runtime_policy(context.task),
             )
         )
         _attach_workflow_action_meta(result, decision)

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -35,6 +35,7 @@ from src.workflow.snapshots import (
     build_task_snapshot,
     default_snapshot_writer,
 )
+from src.workflow.runtime_policy import runtime_policy_trace
 
 EventLogger = Callable[[dict], None]
 
@@ -178,6 +179,7 @@ def enter_waiting_state(
         require_runtime_state=True,
         external_state=new_status,
     )
+    runtime_trace = runtime_policy_trace(context.task)
     waiting_enter_event = make_waiting_enter(
         task_id=context.task.task_id,
         pending_action_id=pending_action.pending_action_id,
@@ -235,6 +237,8 @@ def enter_waiting_state(
                 if isinstance(selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY), dict)
                 else None
             ),
+            "runtime_policy": runtime_trace["runtime_policy"],
+            "belief_state_enabled": runtime_trace["belief_state_enabled"],
             "runtime_state_summary": runtime_state_summary,
         },
     )

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -43,6 +43,7 @@ from src.workflow.errors import (
     classify_exception,
     is_retryable_failure,
 )
+from src.workflow.runtime_policy import resolve_runtime_policy, runtime_policy_trace
 
 
 class StepRunnerLike(Protocol):
@@ -612,6 +613,7 @@ class PlanRunner:
                 retry_exhausted=bool(step_result.metrics.get("retry_exhausted")),
                 safety_blocked=step_result.failure_type == FailureType.SAFETY_BLOCK,
                 runtime_state_summary=runtime_state_summary,
+                runtime_policy=resolve_runtime_policy(context.task),
             )
         )
         metrics = dict(step_result.metrics)
@@ -938,6 +940,7 @@ class PlanRunner:
             "external_status": to_external_status(context.status).value,
         }
         event_data = _build_step_trace_data(step_result)
+        event_data.update(runtime_policy_trace(context.task))
         runtime_state_summary = build_context_runtime_state_summary(context)
         if runtime_state_summary is not None:
             event_data["runtime_state_summary"] = runtime_state_summary

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -36,6 +36,10 @@ from src.storage.snapshot_store import read_latest_snapshot, DEFAULT_SNAPSHOT_DI
 from src.workflow.belief_state import update_runtime_state
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
+from src.workflow.runtime_policy import (
+    DYNAMIC_OBSERVATION_ONLY_POLICY,
+    resolve_runtime_policy,
+)
 
 __all__ = [
     "restore_context_from_snapshot",
@@ -154,6 +158,7 @@ class WorkflowActionSelectorInput:
     runtime_state_summary: dict[str, Any] | None = None
     suggested_action: str | None = None
     suggested_reason: str | None = None
+    runtime_policy: str | None = None
 
 
 @dataclass(frozen=True)
@@ -185,6 +190,10 @@ def select_workflow_action(
     suggested_action = _normalize_workflow_action(selector_input.suggested_action)
     if suggested_action not in allowed_actions:
         suggested_action = None
+    runtime_policy = resolve_runtime_policy(
+        {"runtime_policy": selector_input.runtime_policy}
+    )
+    observation_only = runtime_policy == DYNAMIC_OBSERVATION_ONLY_POLICY
 
     runtime_summary = _normalize_runtime_state_summary(
         selector_input.runtime_state_summary
@@ -267,8 +276,15 @@ def select_workflow_action(
         basis = "suggested_action"
     elif not has_failure_signal:
         action = "continue"
-        reason = "no failure or safety signal is present in the current execution step"
-        basis = "default_continue"
+        if observation_only:
+            reason = (
+                "observation-only runtime policy saw no failure or safety signal "
+                "in the current execution step"
+            )
+            basis = "observation_only"
+        else:
+            reason = "no failure or safety signal is present in the current execution step"
+            basis = "default_continue"
     elif _should_choose_stop(
         allowed_actions=allowed_actions,
         allow_auto_stop=allow_auto_stop,
@@ -300,8 +316,15 @@ def select_workflow_action(
         )
     ):
         action = "patch_local"
-        reason = "failure still looks local and existing recovery order prefers patch"
-        basis = "action_priority"
+        if observation_only:
+            reason = (
+                "observation-only runtime policy routes the local failure "
+                "through patch_local"
+            )
+            basis = "observation_only"
+        else:
+            reason = "failure still looks local and existing recovery order prefers patch"
+            basis = "action_priority"
     elif (
         "suffix_replan" in allowed_actions
         and (
@@ -313,14 +336,28 @@ def select_workflow_action(
         )
     ):
         action = "suffix_replan"
-        reason = (
-            "structural failure pressure is high or trigger matrix already prefers replan"
-        )
-        basis = "action_priority"
+        if observation_only:
+            reason = (
+                "observation-only runtime policy escalates to suffix_replan "
+                "from the current failure signal"
+            )
+            basis = "observation_only"
+        else:
+            reason = (
+                "structural failure pressure is high or trigger matrix already prefers replan"
+            )
+            basis = "action_priority"
     else:
         action = "continue"
-        reason = "current context does not justify escalating beyond the existing path"
-        basis = "default_continue"
+        if observation_only:
+            reason = (
+                "observation-only runtime policy keeps the current path because "
+                "the present signal does not justify escalation"
+            )
+            basis = "observation_only"
+        else:
+            reason = "current context does not justify escalating beyond the existing path"
+            basis = "default_continue"
 
     route = resolve_workflow_action_route(action)
     return WorkflowActionSelectorResult(
@@ -345,6 +382,8 @@ def select_workflow_action(
             "local_patchability": local_patchability,
             "allow_auto_stop": allow_auto_stop,
             "u_stop": u_stop,
+            "runtime_policy": runtime_policy,
+            "belief_state_enabled": not observation_only,
             "runtime_state_summary": runtime_summary or None,
         },
     )

--- a/src/workflow/runtime_policy.py
+++ b/src/workflow/runtime_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from src.models.contracts import ProteinDesignTask
+
+__all__ = [
+    "DYNAMIC_OBSERVATION_ONLY_POLICY",
+    "LITE_BELIEF_STATE_POLICY",
+    "resolve_runtime_policy",
+    "runtime_policy_trace",
+    "runtime_policy_uses_belief_state",
+]
+
+DYNAMIC_OBSERVATION_ONLY_POLICY = "dynamic_observation_only"
+LITE_BELIEF_STATE_POLICY = "lite_belief_state"
+_NO_BELIEF_STATE_POLICIES = frozenset(
+    {
+        DYNAMIC_OBSERVATION_ONLY_POLICY,
+        "static_single_candidate",
+        "static_threshold_gate",
+        "none",
+        "disabled",
+        "off",
+    }
+)
+
+
+def resolve_runtime_policy(
+    task_or_constraints: ProteinDesignTask | Mapping[str, Any] | None,
+) -> str:
+    constraints = _extract_constraints(task_or_constraints)
+    raw_value = constraints.get("runtime_policy")
+    if not isinstance(raw_value, str):
+        return LITE_BELIEF_STATE_POLICY
+    normalized = raw_value.strip().lower()
+    if not normalized:
+        return LITE_BELIEF_STATE_POLICY
+    return normalized
+
+
+def runtime_policy_uses_belief_state(
+    task_or_constraints: ProteinDesignTask | Mapping[str, Any] | None,
+) -> bool:
+    return resolve_runtime_policy(task_or_constraints) not in _NO_BELIEF_STATE_POLICIES
+
+
+def runtime_policy_trace(
+    task_or_constraints: ProteinDesignTask | Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    policy = resolve_runtime_policy(task_or_constraints)
+    return {
+        "runtime_policy": policy,
+        "belief_state_enabled": policy not in _NO_BELIEF_STATE_POLICIES,
+    }
+
+
+def _extract_constraints(
+    task_or_constraints: ProteinDesignTask | Mapping[str, Any] | None,
+) -> Mapping[str, Any]:
+    if task_or_constraints is None:
+        return {}
+    if isinstance(task_or_constraints, ProteinDesignTask):
+        return (
+            task_or_constraints.constraints
+            if isinstance(task_or_constraints.constraints, Mapping)
+            else {}
+        )
+    if isinstance(task_or_constraints, Mapping):
+        return task_or_constraints
+    return {}

--- a/src/workflow/snapshots.py
+++ b/src/workflow/snapshots.py
@@ -16,6 +16,7 @@ from src.models.db import ExternalStatus, to_external_status
 from src.storage.snapshot_store import append_snapshot
 from src.workflow.belief_state import update_runtime_state
 from src.workflow.context import WorkflowContext
+from src.workflow.runtime_policy import runtime_policy_uses_belief_state
 
 SnapshotWriter = Callable[[TaskSnapshot], None]
 
@@ -142,6 +143,8 @@ def _resolve_runtime_state_for_snapshot(
     external_state: ExternalStatus,
     require_runtime_state: bool,
 ) -> RuntimeState | None:
+    if not runtime_policy_uses_belief_state(context.task):
+        return None
     if context.runtime_state is not None:
         return context.runtime_state
     if not (

--- a/tests/integration/test_workflow_action_selector.py
+++ b/tests/integration/test_workflow_action_selector.py
@@ -184,6 +184,15 @@ class _PatchOnlyPlanner:
         return request.original_plan
 
 
+class _ObservationOnlyPatchPlanner(_PatchOnlyPlanner):
+    def __init__(self) -> None:
+        self.last_runtime_state = object()
+
+    def patch_top_k(self, request, *, k=3, runtime_state=None):  # type: ignore[override]
+        self.last_runtime_state = runtime_state
+        raise RuntimeError("fallback planner.patch path only")
+
+
 class _AllowSafetyAgent:
     def check_task_input(self, task, plan):
         return SafetyResult(
@@ -333,6 +342,46 @@ def test_workflow_action_selector_maps_patch_local_to_waiting_patch():
     assert context.pending_action is not None
     assert context.pending_action.action_type == PendingActionType.PATCH_CONFIRM
     assert context.pending_action.metadata["workflow_action"] == "patch_local"
+
+
+@pytest.mark.integration
+def test_dynamic_observation_only_policy_skips_runtime_state_but_keeps_patch_flow():
+    task_id = "int_workflow_action_observation_only"
+    _cleanup_task_log(task_id)
+    planner = _ObservationOnlyPatchPlanner()
+    plan, context, record = _build_runtime_objects(
+        task_id=task_id,
+        constraints={
+            "require_patch_confirm": True,
+            "runtime_policy": "dynamic_observation_only",
+        },
+    )
+    runner = PlanRunner(
+        step_runner=_FailOnceStepRunner(
+            stage_id="S1",
+            failure_code="S1_RETRY_EXHAUSTED",
+        ),
+        planner_agent=planner,
+        safety_agent=_AllowSafetyAgent(),
+    )
+
+    runner.run_plan(plan, context, record=record, finalize_status=False)
+
+    events = read_timeline_events(task_id)
+    waiting = next(entry for entry in events if entry.get("event_type") == "WAITING_ENTER")
+    assert context.status == InternalStatus.WAITING_PATCH
+    assert context.runtime_state is None
+    assert planner.last_runtime_state is None
+    assert waiting["action_name"] == "patch"
+    assert waiting["data"]["runtime_policy"] == "dynamic_observation_only"
+    assert waiting["data"]["belief_state_enabled"] is False
+    assert waiting["runtime_state_summary"] is None
+    assert context.pending_action is not None
+    assert context.pending_action.metadata["workflow_action"] == "patch_local"
+    assert (
+        context.pending_action.metadata["workflow_action_evidence"]["runtime_policy"]
+        == "dynamic_observation_only"
+    )
 
 
 @pytest.mark.integration

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -290,3 +290,29 @@ def test_build_task_snapshot_waiting_bootstraps_runtime_state_when_missing():
         "completed_steps": 0
     }
     assert snapshot.artifacts[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.5)
+
+
+@pytest.mark.unit
+def test_build_task_snapshot_observation_only_policy_does_not_bootstrap_runtime_state():
+    task = ProteinDesignTask(
+        task_id="task_observation_only_snapshot_001",
+        goal="keep dynamic baseline free of belief-state artifacts",
+        constraints={"runtime_policy": "dynamic_observation_only"},
+    )
+    context = WorkflowContext(
+        task=task,
+        plan=None,
+        runtime_state=None,
+        status=InternalStatus.WAITING_PLAN_CONFIRM,
+    )
+
+    snapshot = build_task_snapshot(
+        context,
+        state_override=ExternalStatus.WAITING_PLAN_CONFIRM,
+        require_runtime_state=True,
+    )
+
+    assert context.runtime_state is None
+    assert RUNTIME_STATE_ARTIFACT_KEY not in snapshot.artifacts
+    assert RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY not in snapshot.artifacts
+    assert RUNTIME_STATE_SUMMARY_METADATA_KEY not in snapshot.artifacts


### PR DESCRIPTION
## 关联 Issue
- Closes #218

## 变更概述
本 PR 实现了 `dynamic_observation_only` 运行时策略，用于落地 issue #218 要求的“动态无 belief-state”基线。

该实现复用了现有 Week15 的动作选择器与 recovery 映射，没有引入新的执行路径；与 Lite belief-state 路线共享同一套 workflow / patch / waiting / decision 基础设施，仅在状态估计层做差异化处理。

## 对照 Issue Checkpoint
- [x] 实现直接基于观测的动态动作选择逻辑
  - 在 observation-only 模式下，动作选择仍走统一 `select_workflow_action` 接口，但不再依赖持久化 `runtime_state_summary`，而是仅基于当前失败观测与既有 S6 trigger / recovery 语义做决策。
- [x] 与现有动作选择接入层对齐
  - 已接入 `plan_runner`、`patch_runner`、`pending_action`、`decision_apply`、`snapshots` 相关路径，复用原有 WAITING / PATCH / REPLAN 闭环。
- [x] 补充配置开关和最小测试
  - 新增 `runtime_policy` 解析与共享 helper；支持 `dynamic_observation_only` 模式。
  - 补充 observation-only 的集成测试和 snapshot 单测，覆盖“能运行、可区分、不偷偷携带 belief-state”。
- [x] 明确与 Lite belief-state 版本的实现差异
  - Lite 路线仍允许更新、传递和持久化 `runtime_state`。
  - dynamic_no_belief_state 路线在同一执行框架下关闭 `runtime_state` 更新、摘要传播和 snapshot 落盘，仅保留动作选择与恢复闭环复用。

## 交付与验收对照
- [x] 动态无 belief-state 路线可运行
- [x] 与主执行框架兼容
- [x] 测试与配置开关可区分该基线
- [x] 配置和日志可区分该基线

## 主要改动
- 新增 `src/workflow/runtime_policy.py`，统一解析运行时策略并区分是否启用 belief-state。
- 在 workflow 主路径中接入 observation-only 策略，确保该模式下不自动更新或补写 `runtime_state`。
- 在事件、waiting、decision 审计中补充 `runtime_policy` / `belief_state_enabled`，用于实验分组与日志区分。
- 补充 observation-only 对照测试。
- 顺带修复 `scripts/smoke_test_llm_providers.py` 在当前平台下的 multiprocessing 兼容性问题，以保证 unit 验收命令稳定通过。

## 验证
- `uv run pytest tests/unit/test_task_snapshot.py tests/unit/test_recovery_selector.py tests/integration/test_workflow_action_selector.py -q`
- `uv run pytest tests/unit -q`

## 说明
本 PR 不改变静态 Top-1 / 固定阈值 gate 基线定义，也不在本 PR 中给出最终实验结论。