### PR TITLE
feat(runtime): 实现 lite belief-state 主路径

### DIFF
--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -2133,7 +2133,12 @@ def _build_runtime_shadow_decision(
         runtime_state_summary.get("expected_remaining_cost"),
         default=0.0,
     )
-    cost_pressure = min(expected_remaining_cost / 5.0, 1.0)
+    evidence_sufficiency = _safe_float(
+        runtime_state_summary.get("evidence_sufficiency"),
+        default=0.5,
+    )
+    budget_pressure = min(max(expected_remaining_cost, 0.0), 1.5)
+    cost_pressure = min(budget_pressure, 1.0)
     margin_signal = max(-1.0, min(recovery_margin, 1.0))
     overall = _safe_float(score_breakdown.get("overall"), default=0.0)
     confidence = _safe_float(score_breakdown.get("confidence"), default=overall)
@@ -2147,13 +2152,23 @@ def _build_runtime_shadow_decision(
         p_success=p_success,
         p_structural_failure=p_structural_failure,
         recovery_margin=recovery_margin,
+        budget_pressure=budget_pressure,
         cost_pressure=cost_pressure,
     )
     evidence_effect = 0.18 * (p_success - 0.5) * confidence
+    evidence_sufficiency_effect = (
+        0.10 * ((2.0 * evidence_sufficiency) - 1.0) * max(confidence, feasibility)
+    )
     risk_effect = -0.16 * p_structural_failure * (1.0 - risk)
     recovery_effect = 0.10 * margin_signal * fallback_depth
     cost_effect = -0.14 * cost_pressure * (1.0 - cost)
-    delta = evidence_effect + risk_effect + recovery_effect + cost_effect
+    delta = (
+        evidence_effect
+        + evidence_sufficiency_effect
+        + risk_effect
+        + recovery_effect
+        + cost_effect
+    )
     factors = [
         _build_runtime_adjustment_factor(
             category="evidence",
@@ -2161,6 +2176,13 @@ def _build_runtime_shadow_decision(
             source="runtime_state.p_success+score_breakdown.confidence",
             contribution=evidence_effect,
             message="Current evidence and candidate confidence adjust the shadow score.",
+        ),
+        _build_runtime_adjustment_factor(
+            category="evidence",
+            signal="evidence_sufficiency",
+            source="runtime_state.evidence_sufficiency+score_breakdown.feasibility",
+            contribution=evidence_sufficiency_effect,
+            message="Evidence sufficiency raises confidence in routes backed by enough cheap validation.",
         ),
         _build_runtime_adjustment_factor(
             category="risk",
@@ -2230,6 +2252,7 @@ def _build_runtime_shadow_decision(
                 message="Stop guard applies when success is low and cost pressure is already high.",
             )
         )
+    delta = max(-0.35, min(0.35, delta))
     adjusted = max(0.0, min(1.0, overall + delta))
     final_score = ScoreSummary(
         value=round(adjusted, 6),
@@ -2257,6 +2280,7 @@ def _build_runtime_shadow_decision(
             "runtime_state.p_structural_failure",
             "runtime_state.recovery_margin",
             "runtime_state.expected_remaining_cost",
+            "runtime_state.evidence_sufficiency",
         ],
         candidate_metric_fields=[
             "score_breakdown.overall",
@@ -2273,7 +2297,8 @@ def _build_runtime_shadow_decision(
         "Runtime rerank records static_score, runtime_adjustment, and final_score separately; "
         f"static_score={overall:.2f}, runtime_adjustment={delta:.2f}, final_score={adjusted:.2f}; "
         f"signals use p_success={p_success:.2f}, p_structural_failure={p_structural_failure:.2f}, "
-        f"recovery_margin={recovery_margin:.2f}, expected_remaining_cost={expected_remaining_cost:.2f}; "
+        f"recovery_margin={recovery_margin:.2f}, expected_remaining_cost={expected_remaining_cost:.2f}, "
+        f"evidence_sufficiency={evidence_sufficiency:.2f}; "
         f"shadow_action={action} because {reason}."
     )
     return _RuntimeShadowDecision(
@@ -2311,12 +2336,17 @@ def _resolve_shadow_action(
     p_success: float,
     p_structural_failure: float,
     recovery_margin: float,
+    budget_pressure: float,
     cost_pressure: float,
 ) -> tuple[str, str]:
-    if p_success <= 0.25 and cost_pressure >= 0.7:
+    if (
+        p_success <= 0.20
+        and budget_pressure >= 0.85
+        and recovery_margin <= 0.20
+    ):
         return (
             "stop",
-            "success probability is low while remaining cost pressure is high",
+            "success probability is low, budget pressure is high, and recovery headroom is nearly exhausted",
         )
     if candidate_kind == "patch":
         if p_structural_failure >= 0.55 and recovery_margin <= 0.1:

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -284,6 +284,7 @@ class RuntimeState(BaseModel):
     p_structural_failure: float
     recovery_margin: float
     expected_remaining_cost: float
+    evidence_sufficiency: float = 0.5
     last_update_source: str
     observation_summary: Dict[str, Any] = Field(default_factory=dict)
 
@@ -292,7 +293,7 @@ class RuntimeState(BaseModel):
     def _validate_schema_version(cls, value: int) -> int:
         return _validate_runtime_state_schema_version(value)
 
-    @field_validator("p_success", "p_structural_failure")
+    @field_validator("p_success", "p_structural_failure", "evidence_sufficiency")
     @classmethod
     def _validate_probability(cls, value: float) -> float:
         return _validate_probability_value(value)
@@ -353,13 +354,14 @@ class RuntimeStateSummary(BaseModel):
     p_structural_failure: float
     recovery_margin: float
     expected_remaining_cost: float
+    evidence_sufficiency: float = 0.5
 
     @field_validator("schema_version")
     @classmethod
     def _validate_schema_version(cls, value: int) -> int:
         return _validate_runtime_state_schema_version(value)
 
-    @field_validator("p_success", "p_structural_failure")
+    @field_validator("p_success", "p_structural_failure", "evidence_sufficiency")
     @classmethod
     def _validate_probability(cls, value: float) -> float:
         return _validate_probability_value(value)
@@ -388,6 +390,7 @@ class RuntimeStateSummary(BaseModel):
             p_structural_failure=runtime_state.p_structural_failure,
             recovery_margin=runtime_state.recovery_margin,
             expected_remaining_cost=runtime_state.expected_remaining_cost,
+            evidence_sufficiency=runtime_state.evidence_sufficiency,
         )
 
 

--- a/src/workflow/belief_state.py
+++ b/src/workflow/belief_state.py
@@ -16,6 +16,7 @@ _BASELINE_P_SUCCESS = 0.5
 _BASELINE_P_STRUCTURAL_FAILURE = 0.25
 _BASELINE_RECOVERY_MARGIN = 0.6
 _BASELINE_EXPECTED_REMAINING_COST = 1.0
+_BASELINE_EVIDENCE_SUFFICIENCY = 0.5
 _STRUCTURAL_STAGE_IDS = {"S2", "S3", "S4"}
 
 
@@ -62,6 +63,7 @@ def update_runtime_state(
             completed_steps=completed_steps,
             total_steps=total_steps,
         ),
+        evidence_sufficiency=_BASELINE_EVIDENCE_SUFFICIENCY,
         last_update_source="runtime_bootstrap",
         observation_summary={},
     )
@@ -70,6 +72,7 @@ def update_runtime_state(
     p_structural_failure = state.p_structural_failure
     recovery_margin = _clamp_unit_interval(state.recovery_margin)
     expected_remaining_cost = state.expected_remaining_cost
+    evidence_sufficiency = _clamp_unit_interval(state.evidence_sufficiency)
     observation_summary = dict(state.observation_summary)
     last_update_source = state.last_update_source
     cost_penalty = 0.0
@@ -179,6 +182,18 @@ def update_runtime_state(
         cost_penalty=cost_penalty,
         cost_reward=cost_reward,
     )
+    evidence_signal = _estimate_evidence_signal(
+        step_result=step_result,
+        safety_result=safety_result,
+        failure_context=failure_context,
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+    )
+    evidence_sufficiency = _resolve_evidence_sufficiency(
+        previous_value=evidence_sufficiency,
+        evidence_signal=evidence_signal,
+    )
+    observation_summary["evidence_signal"] = _round_metric(evidence_signal)
 
     return RuntimeState(
         p_success=_round_metric(_clamp_unit_interval(p_success)),
@@ -187,6 +202,7 @@ def update_runtime_state(
         ),
         recovery_margin=_round_metric(_clamp_unit_interval(recovery_margin)),
         expected_remaining_cost=_round_metric(max(expected_remaining_cost, 0.0)),
+        evidence_sufficiency=_round_metric(evidence_sufficiency),
         last_update_source=last_update_source,
         observation_summary=_drop_none_values(observation_summary),
     )
@@ -297,6 +313,125 @@ def _resolve_remaining_cost(
         elif step_result.status == "failed":
             base_cost += 0.5
     return max(base_cost + cost_penalty - cost_reward, 0.0)
+
+
+def _resolve_evidence_sufficiency(
+    *,
+    previous_value: float,
+    evidence_signal: float,
+) -> float:
+    # 中文注释：派生量只在运行时现场计算，持久化主状态仍只保留 evidence_sufficiency 本身。
+    return _clamp_unit_interval((0.70 * previous_value) + (0.30 * evidence_signal))
+
+
+def _estimate_evidence_signal(
+    *,
+    step_result: StepResult | None,
+    safety_result: SafetyResult | None,
+    failure_context: RuntimeFailureContext | None,
+    completed_steps: int | None,
+    total_steps: int | None,
+) -> float:
+    if (
+        step_result is None
+        and safety_result is None
+        and failure_context is None
+        and (completed_steps is None or completed_steps <= 0)
+    ):
+        return _BASELINE_EVIDENCE_SUFFICIENCY
+    cheap_validation_coverage = _estimate_cheap_validation_coverage(
+        step_result=step_result,
+        completed_steps=completed_steps,
+        total_steps=total_steps,
+    )
+    candidate_agreement = _estimate_candidate_agreement(
+        step_result=step_result,
+        safety_result=safety_result,
+        failure_context=failure_context,
+    )
+    metric_completeness = _estimate_metric_completeness(
+        step_result=step_result,
+        safety_result=safety_result,
+    )
+    return _clamp_unit_interval(
+        (0.40 * cheap_validation_coverage)
+        + (0.30 * candidate_agreement)
+        + (0.30 * metric_completeness)
+    )
+
+
+def _estimate_cheap_validation_coverage(
+    *,
+    step_result: StepResult | None,
+    completed_steps: int | None,
+    total_steps: int | None,
+) -> float:
+    coverage = 0.35
+    if (
+        completed_steps is not None
+        and total_steps is not None
+        and total_steps > 0
+    ):
+        coverage += 0.35 * min(max(completed_steps / total_steps, 0.0), 1.0)
+    if step_result is None:
+        return _clamp_unit_interval(coverage)
+    stage_id = _extract_stage_id(step_result)
+    if step_result.status == "success":
+        coverage += 0.18
+        if _is_structural_step(stage_id=stage_id, tool_id=step_result.tool):
+            coverage += 0.08
+    elif step_result.status == "failed":
+        coverage -= 0.12
+    return _clamp_unit_interval(coverage)
+
+
+def _estimate_candidate_agreement(
+    *,
+    step_result: StepResult | None,
+    safety_result: SafetyResult | None,
+    failure_context: RuntimeFailureContext | None,
+) -> float:
+    agreement = 0.5
+    if step_result is not None:
+        stage_id = _extract_stage_id(step_result)
+        if step_result.status == "success":
+            agreement += 0.12
+            if _is_structural_step(stage_id=stage_id, tool_id=step_result.tool):
+                agreement += 0.08
+        elif step_result.status == "failed":
+            agreement -= 0.18
+    if safety_result is not None:
+        if safety_result.action == "warn":
+            agreement -= 0.08
+        elif safety_result.action == "block":
+            agreement -= 0.18
+    if failure_context is not None:
+        recovery_action = _normalize_recovery_action(
+            failure_context.to_replay_payload()
+        )
+        if recovery_action == "patch_local":
+            agreement += 0.04
+        elif recovery_action in {"suffix_replan", "replan", "stop"}:
+            agreement -= 0.08
+    return _clamp_unit_interval(agreement)
+
+
+def _estimate_metric_completeness(
+    *,
+    step_result: StepResult | None,
+    safety_result: SafetyResult | None,
+) -> float:
+    completeness = 0.35
+    if step_result is not None:
+        if isinstance(step_result.outputs, dict) and step_result.outputs:
+            completeness += 0.25
+        if isinstance(step_result.metrics, dict) and step_result.metrics:
+            completeness += 0.20
+        if _extract_failure_code(step_result):
+            completeness += 0.10
+    if safety_result is not None and safety_result.risk_flags:
+        completeness += 0.10
+    return _clamp_unit_interval(completeness)
 
 
 def _write_progress_summary(

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -211,22 +211,27 @@ def select_workflow_action(
         runtime_summary.get("expected_remaining_cost"),
         default=1.0,
     )
-    cost_pressure = min(max(expected_remaining_cost, 0.0) / 5.0, 1.0)
-    budget_pressure = _safe_float(
-        runtime_summary.get("budget_pressure"),
-        default=cost_pressure,
+    evidence_sufficiency = _safe_float(
+        runtime_summary.get("evidence_sufficiency"),
+        default=0.5,
     )
-    intervention_value = _safe_float(
-        runtime_summary.get("intervention_value"),
-        default=1.0,
+    derived_runtime_features = _derive_runtime_action_features(
+        runtime_summary=runtime_summary,
+        p_success=p_success,
+        p_structural_failure=p_structural_failure,
+        recovery_margin=recovery_margin,
+        expected_remaining_cost=expected_remaining_cost,
+        evidence_sufficiency=evidence_sufficiency,
+        stage_id=selector_input.stage_id,
+        failure_type=selector_input.failure_type,
+        retry_exhausted=bool(selector_input.retry_exhausted),
+        safety_blocked=bool(selector_input.safety_blocked),
     )
-    prefix_preservability = _safe_optional_float(
-        runtime_summary.get("prefix_preservability")
-    )
-    local_patchability = _safe_optional_float(
-        runtime_summary.get("local_patchability")
-    )
-    u_stop = _safe_float(runtime_summary.get("u_stop"), default=0.0)
+    budget_pressure = derived_runtime_features["budget_pressure"]
+    intervention_value = derived_runtime_features["intervention_value"]
+    prefix_preservability = derived_runtime_features["prefix_preservability"]
+    local_patchability = derived_runtime_features["local_patchability"]
+    u_stop = derived_runtime_features["u_stop"]
     allow_auto_stop = _safe_bool(
         runtime_summary.get("allow_auto_stop"),
         default=False,
@@ -306,8 +311,15 @@ def select_workflow_action(
         and (
             local_patchability is None
             or (
-                local_patchability >= 0.55
-                and recovery_margin >= 0.30
+                (
+                    local_patchability >= 0.55
+                    and recovery_margin >= 0.30
+                )
+                or (
+                    phase == "patch"
+                    and local_patchability >= 0.65
+                    and recovery_margin >= 0.15
+                )
             )
         )
         and not (
@@ -377,6 +389,7 @@ def select_workflow_action(
             "retry_exhausted": bool(selector_input.retry_exhausted),
             "s6_default_action": s6_default_action,
             "budget_pressure": budget_pressure,
+            "evidence_sufficiency": evidence_sufficiency,
             "intervention_value": intervention_value,
             "prefix_preservability": prefix_preservability,
             "local_patchability": local_patchability,
@@ -550,6 +563,119 @@ def _normalize_runtime_state_summary(
     return dict(payload)
 
 
+def _derive_runtime_action_features(
+    *,
+    runtime_summary: dict[str, Any],
+    p_success: float,
+    p_structural_failure: float,
+    recovery_margin: float,
+    expected_remaining_cost: float,
+    evidence_sufficiency: float,
+    stage_id: str | None,
+    failure_type: FailureType | str | None,
+    retry_exhausted: bool,
+    safety_blocked: bool,
+) -> dict[str, float]:
+    budget_pressure = _safe_float(
+        runtime_summary.get("budget_pressure"),
+        default=_clip_float(expected_remaining_cost, lower=0.0, upper=1.5),
+    )
+    local_patchability = _safe_optional_float(
+        runtime_summary.get("local_patchability")
+    )
+    if local_patchability is None:
+        stage_locality_bonus = 0.0
+        normalized_stage = _normalize_text(stage_id)
+        normalized_failure_type = _normalize_failure_type(failure_type)
+        if normalized_stage == "S1":
+            stage_locality_bonus += 0.18
+        if normalized_failure_type in {
+            FailureType.RETRYABLE,
+            FailureType.TOOL_ERROR,
+            FailureType.NON_RETRYABLE,
+        } and not safety_blocked:
+            stage_locality_bonus += 0.08
+        if retry_exhausted and not safety_blocked:
+            stage_locality_bonus += 0.06
+        local_patchability = _clip_float(
+            0.45 * recovery_margin
+            + 0.35 * (1.0 - p_structural_failure)
+            + 0.20 * evidence_sufficiency,
+            lower=0.0,
+            upper=1.0,
+        )
+        local_patchability = _clip_float(
+            local_patchability + stage_locality_bonus,
+            lower=0.0,
+            upper=1.0,
+        )
+    prefix_preservability = _safe_optional_float(
+        runtime_summary.get("prefix_preservability")
+    )
+    if prefix_preservability is None:
+        prefix_preservability = _clip_float(
+            0.50 * recovery_margin
+            + 0.30 * evidence_sufficiency
+            + 0.20 * (1.0 - min(budget_pressure, 1.0)),
+            lower=0.0,
+            upper=1.0,
+        )
+    intervention_value = _safe_optional_float(
+        runtime_summary.get("intervention_value")
+    )
+    if intervention_value is None:
+        uncertainty = _clip_float(
+            1.0 - abs(p_success - (1.0 - p_structural_failure)),
+            lower=0.0,
+            upper=1.0,
+        )
+        manual_salvageability = _clip_float(
+            0.55 * local_patchability + 0.45 * prefix_preservability,
+            lower=0.0,
+            upper=1.0,
+        )
+        artifact_salience = _clip_float(
+            0.60 * evidence_sufficiency + 0.40 * recovery_margin,
+            lower=0.0,
+            upper=1.0,
+        )
+        decision_gap = _clip_float(
+            0.50 + 0.25 * recovery_margin - 0.25 * min(budget_pressure, 1.0),
+            lower=0.0,
+            upper=1.0,
+        )
+        # 中文注释：这里把派生量限制在动作选择现场计算，避免将其误固化为新的主状态。
+        intervention_value = _clip_float(
+            0.30 * uncertainty
+            + 0.25 * manual_salvageability
+            + 0.25 * artifact_salience
+            + 0.20 * decision_gap,
+            lower=0.0,
+            upper=1.0,
+        )
+    u_stop = _safe_optional_float(runtime_summary.get("u_stop"))
+    if u_stop is None:
+        safety_terminality = 1.0 if (
+            safety_blocked or _normalize_failure_type(failure_type) == FailureType.SAFETY_BLOCK
+        ) else 0.0
+        u_stop = _clip_float(
+            0.32 * (1.0 - p_success)
+            + 0.24 * min(budget_pressure, 1.0)
+            + 0.18 * (1.0 - recovery_margin)
+            + 0.16 * safety_terminality
+            + 0.10 * (1.0 - intervention_value),
+            lower=0.0,
+            upper=1.0,
+        )
+    return {
+        "budget_pressure": budget_pressure,
+        "intervention_value": intervention_value,
+        "prefix_preservability": prefix_preservability,
+        "local_patchability": local_patchability,
+        "u_stop": u_stop,
+    }
+
+
 def _normalize_text(value: object) -> str | None:
     if not isinstance(value, str):
         return None
@@ -585,6 +711,10 @@ def _safe_bool(value: object, *, default: bool) -> bool:
         if normalized in {"0", "false", "no", "off"}:
             return False
     return default
+
+
+def _clip_float(value: float, *, lower: float, upper: float) -> float:
+    return max(lower, min(upper, float(value)))
 
 
 def _normalize_failure_type(value: FailureType | str | None) -> FailureType | None:
@@ -973,6 +1103,7 @@ def _has_complete_runtime_state_payload(payload: dict[str, Any]) -> bool:
         "p_structural_failure",
         "recovery_margin",
         "expected_remaining_cost",
+        "evidence_sufficiency",
         "last_update_source",
     }
     return required_keys.issubset(payload.keys())

--- a/tests/integration/test_workflow_action_selector.py
+++ b/tests/integration/test_workflow_action_selector.py
@@ -342,6 +342,12 @@ def test_workflow_action_selector_maps_patch_local_to_waiting_patch():
     assert context.pending_action is not None
     assert context.pending_action.action_type == PendingActionType.PATCH_CONFIRM
     assert context.pending_action.metadata["workflow_action"] == "patch_local"
+    assert (
+        context.pending_action.metadata["workflow_action_evidence"]["runtime_state_summary"][
+            "evidence_sufficiency"
+        ]
+        == pytest.approx(0.50735)
+    )
 
 
 @pytest.mark.integration

--- a/tests/unit/test_belief_state.py
+++ b/tests/unit/test_belief_state.py
@@ -105,6 +105,7 @@ def test_update_runtime_state_accepts_structured_update_input() -> None:
     assert state.p_structural_failure == 0.47
     assert state.recovery_margin == 0.31
     assert state.expected_remaining_cost == 5.0
+    assert state.evidence_sufficiency == 0.5015
 
 
 def test_workflow_context_apply_runtime_state_update_is_runner_entrypoint() -> None:

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -179,6 +179,7 @@ class TestRuntimeState:
 
         assert state.schema_version == 1
         assert state.p_success == 0.8
+        assert state.evidence_sufficiency == 0.5
         assert state.observation_summary["completed_high_cost_steps"] == 1
 
     def test_runtime_state_rejects_invalid_probability(self):
@@ -207,6 +208,7 @@ class TestRuntimeState:
             "p_structural_failure": 0.19,
             "recovery_margin": 0.32,
             "expected_remaining_cost": 5.5,
+            "evidence_sufficiency": 0.5,
         }
 
 
@@ -434,6 +436,7 @@ class TestCandidateSetContracts:
             "p_structural_failure": 0.11,
             "recovery_margin": 0.49,
             "expected_remaining_cost": 3.0,
+            "evidence_sufficiency": 0.5,
         }
 
     def test_candidate_invalid_runtime_state_summary_rejected(
@@ -468,6 +471,7 @@ class TestCandidateSetContracts:
                     "p_structural_failure": 0.11,
                     "recovery_margin": 0.49,
                     "expected_remaining_cost": 3.0,
+                    "evidence_sufficiency": 0.5,
                 },
                 DEFAULT_RECOMMENDATION_REASON_METADATA_KEY: {
                     "code": "plan_ranked_first",

--- a/tests/unit/test_plan_runner_step_trace.py
+++ b/tests/unit/test_plan_runner_step_trace.py
@@ -82,6 +82,7 @@ def test_update_runtime_state_with_success_step_is_deterministic() -> None:
     assert state.p_structural_failure == 0.12
     assert state.recovery_margin == 0.66
     assert state.expected_remaining_cost == 3.0
+    assert state.evidence_sufficiency == 0.5687
     assert state.observation_summary["completed_steps"] == 1
     assert state.observation_summary["remaining_steps"] == 3
 
@@ -123,6 +124,7 @@ def test_update_runtime_state_captures_patch_failure_context() -> None:
     assert state.p_structural_failure == 0.47
     assert state.recovery_margin == 0.31
     assert state.expected_remaining_cost == 5.0
+    assert state.evidence_sufficiency == 0.5015
     assert state.observation_summary["last_failure_code"] == "NIM_TIMEOUT"
     assert state.observation_summary["last_recovery_action"] == "patch_local"
 
@@ -164,6 +166,7 @@ def test_update_runtime_state_handles_safety_block_and_suffix_replan() -> None:
     assert state.p_structural_failure == 0.46
     assert state.recovery_margin == 0.32
     assert state.expected_remaining_cost == 4.95
+    assert state.evidence_sufficiency == 0.4499
     assert state.observation_summary["last_safety_action"] == "block"
     assert state.observation_summary["last_recovery_action"] == "suffix_replan"
 

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -618,6 +618,7 @@ class TestPlannerAgent:
         )
         assert waiting_summary["action_score"]["source"] == "score_breakdown.overall"
         assert waiting_summary["runtime_state_summary"]["p_success"] == pytest.approx(0.58)
+        assert waiting_summary["runtime_state_summary"]["evidence_sufficiency"] == pytest.approx(0.5)
         assert waiting_summary["shadow_score"]["source"].startswith(
             "score_breakdown.overall+runtime_state.continue"
         )
@@ -806,6 +807,7 @@ class TestPlannerAgent:
         assert "Runtime rerank updated default recommendation" in topk.explanation
         for candidate in topk.candidates:
             assert candidate.metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.62)
+            assert candidate.metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY]["evidence_sufficiency"] == pytest.approx(0.5)
             assert candidate.metadata["shadow_action"] == "continue"
             assert candidate.metadata[STATIC_SCORE_METADATA_KEY]["value"] == pytest.approx(
                 candidate.score_breakdown["overall"]

--- a/tests/unit/test_recovery_event_logs.py
+++ b/tests/unit/test_recovery_event_logs.py
@@ -142,11 +142,13 @@ def test_restore_context_from_snapshot_backfills_partial_runtime_state_payload()
     assert context.runtime_state.p_structural_failure == pytest.approx(0.25)
     assert context.runtime_state.recovery_margin == pytest.approx(0.6)
     assert context.runtime_state.expected_remaining_cost == pytest.approx(1.0)
+    assert context.runtime_state.evidence_sufficiency == pytest.approx(0.4895)
     assert context.runtime_state.observation_summary == {
         "completed_steps": 1,
         "total_steps": 2,
         "remaining_steps": 1,
         "completed_ratio": 0.5,
+        "evidence_signal": 0.465,
         "selected_candidate_id": "patch_a",
     }
 

--- a/tests/unit/test_recovery_selector.py
+++ b/tests/unit/test_recovery_selector.py
@@ -59,3 +59,30 @@ def test_selector_stop_route_maps_to_waiting_replan_and_failed_terminal():
     assert route.waiting_status == InternalStatus.WAITING_REPLAN
     assert route.terminal_status == InternalStatus.FAILED
     assert route.terminal_policy == "stop"
+
+
+@pytest.mark.unit
+def test_selector_derives_runtime_features_from_core_belief_state_only():
+    decision = select_workflow_action(
+        WorkflowActionSelectorInput(
+            phase="execution",
+            stage_id="S3",
+            failure_code="S3_ALL_CANDIDATES_REJECTED",
+            failure_type=FailureType.NON_RETRYABLE,
+            retry_exhausted=True,
+            runtime_state_summary={
+                "p_success": 0.18,
+                "p_structural_failure": 0.62,
+                "recovery_margin": 0.12,
+                "expected_remaining_cost": 1.1,
+                "evidence_sufficiency": 0.66,
+            },
+        )
+    )
+
+    assert decision.action == "suffix_replan"
+    assert decision.evidence_source["budget_pressure"] == pytest.approx(1.1)
+    assert decision.evidence_source["evidence_sufficiency"] == pytest.approx(0.66)
+    assert decision.evidence_source["local_patchability"] == pytest.approx(0.459, rel=1e-3)
+    assert decision.evidence_source["prefix_preservability"] == pytest.approx(0.258, rel=1e-3)
+    assert decision.evidence_source["intervention_value"] == pytest.approx(0.4991375, rel=1e-3)

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -224,6 +224,7 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
         p_structural_failure=0.18,
         recovery_margin=0.41,
         expected_remaining_cost=12.5,
+        evidence_sufficiency=0.63,
         last_update_source="safety:post_step",
         observation_summary={"high_cost_steps_completed": 1},
     )
@@ -243,6 +244,7 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
         "p_structural_failure": 0.18,
         "recovery_margin": 0.41,
         "expected_remaining_cost": 12.5,
+        "evidence_sufficiency": 0.63,
         "last_update_source": "safety:post_step",
     }
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
@@ -254,6 +256,7 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
         "p_structural_failure": 0.18,
         "recovery_margin": 0.41,
         "expected_remaining_cost": 12.5,
+        "evidence_sufficiency": 0.63,
     }
 
 
@@ -284,10 +287,12 @@ def test_build_task_snapshot_waiting_bootstraps_runtime_state_when_missing():
         "p_structural_failure": 0.25,
         "recovery_margin": 0.6,
         "expected_remaining_cost": 1.0,
+        "evidence_sufficiency": 0.5,
         "last_update_source": "runtime_bootstrap",
     }
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
-        "completed_steps": 0
+        "completed_steps": 0,
+        "evidence_signal": 0.5,
     }
     assert snapshot.artifacts[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.5)
 


### PR DESCRIPTION
## 变更说明
本 PR 实现 lite belief-state 主路径，并将其接入动作选择、候选重排序与默认建议修正、snapshot/recovery 恢复边界，以及对应的回归测试。

本次实现重点包括：
- 将 `evidence_sufficiency` 正式纳入 `RuntimeState` / `RuntimeStateSummary`，与既有 `p_success`、`p_structural_failure`、`recovery_margin`、`expected_remaining_cost` 共同组成 5 个冻结核心状态量。
- 在 `belief_state` 更新链路中补齐 `evidence_sufficiency` 的确定性更新与恢复回填，保持旧快照的兼容恢复。
- 在统一动作选择器中，仅基于 5 个核心状态现场派生 `budget_pressure`、`intervention_value`、`local_patchability`、`prefix_preservability`、`u_stop` 等运行时量，避免将派生量误固化为新的持久化主状态。
- 在 planner runtime rerank 中接入 `evidence_sufficiency`，并收紧 `stop` 的 shadow guard，避免误伤局部 patch / layered patch 主路径。
- 补齐 belief-state 与 dynamic observation-only 基线的对照覆盖，确保日志、waiting metadata、snapshot 与 recovery 路线可区分。

## 影响与收益
- lite belief-state 路线现在可以作为独立主路径运行，并与无 belief-state 动态基线共享同一套 workflow/recovery 基础设施。
- `runtime_state` / snapshot 的落点与设计定稿一致，且恢复时不会引入隐性共享状态。
- 默认建议修正、waiting 元数据和恢复事件日志都能带出可审计的 belief-state 相关信息，便于后续 action-level / belief-state-level 分析。

## 验证
已通过：
- `uv run pytest tests/unit/test_belief_state.py tests/unit/test_plan_runner_step_trace.py tests/unit/test_recovery_selector.py tests/unit/test_task_snapshot.py tests/unit/test_recovery_event_logs.py tests/unit/test_contracts.py tests/unit/test_planner_agent.py tests/integration/test_candidate_score_gate.py::test_patch_gate_waiting_and_auto_paths tests/integration/test_recovery_layered_patch.py tests/integration/test_workflow_action_selector.py -q`

补充说明：
- 按 issue 验收命令执行 `uv run pytest tests/integration -q` 时，仓库中若干依赖外部 LLM provider 的既有集成用例在当前环境下因 `APIConnectionError` 失败；本 PR 直接影响的 belief-state / patch / recovery 相关集成回归已单独验证通过。