### PR TITLE
test(runtime): 完成 issue #220 并修复 OpenFold3 远程集成链路

### DIFF
--- a/services/openfold3_rest_server/README.md
+++ b/services/openfold3_rest_server/README.md
@@ -77,6 +77,7 @@ pip install fastapi uvicorn pydantic
 - `OPENFOLD3_REST_API_TOKEN`: Bearer token（可选）
 - `OPENFOLD3_MODEL_DIR`: 模型目录（默认 `/root/autodl-tmp/models/openfold3`）
 - `OPENFOLD3_PREDICT_BIN`: 推理命令（默认 `run_openfold`）
+- `OPENFOLD3_RUNNER_YAML`: 传给 `run_openfold predict` 的 runner 配置文件（可选）
 - `OPENFOLD3_PREDICT_CMD`: 自定义完整命令模板（可选）  
   支持占位符：`{query_json}`、`{output_dir}`、`{model_dir}`、`{predict_bin}`
 - `OPENFOLD3_EXTRA_ARGS`: 额外命令参数（可选，例如 `--num_recycles=3`）
@@ -121,3 +122,8 @@ export OPENFOLD3_PREDICT_BIN=run_openfold
 ```
 - 若真实命令与默认封装不一致，优先使用 `OPENFOLD3_PREDICT_CMD` 完整覆盖。
 - 当你仅做端到端联调时，可以先设置 `OPENFOLD3_MOCK_MODE=1` 验证调用链路，再切换到真实推理。
+- 若当前 GPU/DeepSpeed 环境无法兼容 `evoformer_attn` JIT，可设置：
+```bash
+export OPENFOLD3_RUNNER_YAML=/root/projects/2022112879/remote-model-rest/services/openfold3_rest_server/config/openfold3_no_deepspeed_evo_attention.yml
+```
+  该配置会关闭 `use_deepspeed_evo_attention`，优先保证真实推理链路可用。

--- a/services/openfold3_rest_server/app.py
+++ b/services/openfold3_rest_server/app.py
@@ -22,6 +22,13 @@ from services.openfold3_rest_server.jobs import (
 from services.openfold3_rest_server.schemas import PredictRequest
 
 
+def _iter_artifact_files(artifact_dir: Path) -> list[Path]:
+    """递归收集作业产物文件，兼容 OpenFold3 嵌套输出目录。"""
+    if not artifact_dir.exists():
+        return []
+    return sorted(path for path in artifact_dir.rglob("*") if path.is_file())
+
+
 def _error_response(
     *,
     status_code: int,
@@ -144,33 +151,32 @@ def _build_app(
 
         artifact_dir = job_dir(base_dir, job_id) / "artifacts"
         artifacts = []
-        if artifact_dir.exists():
-            for file_path in sorted(artifact_dir.iterdir()):
-                if file_path.is_file():
-                    artifacts.append(
-                        {
-                            "name": file_path.name,
-                            "url": str(
-                                request.url_for(
-                                    "download_artifact",
-                                    job_id=job_id,
-                                    filename=file_path.name,
-                                )
-                            ),
-                            "type": "file",
-                        }
-                    )
+        for file_path in _iter_artifact_files(artifact_dir):
+            relative_path = file_path.relative_to(artifact_dir).as_posix()
+            artifacts.append(
+                {
+                    "name": relative_path,
+                    "url": str(
+                        request.url_for(
+                            "download_artifact",
+                            job_id=job_id,
+                            artifact_path=relative_path,
+                        )
+                    ),
+                    "type": "file",
+                }
+            )
         payload["artifacts"] = artifacts
         return payload
 
-    @app.get("/files/{job_id}/{filename}", name="download_artifact")
-    def download_artifact(job_id: str, filename: str) -> FileResponse:
-        path = job_dir(base_dir, job_id) / "artifacts" / filename
+    @app.get("/files/{job_id}/{artifact_path:path}", name="download_artifact")
+    def download_artifact(job_id: str, artifact_path: str) -> FileResponse:
+        path = job_dir(base_dir, job_id) / "artifacts" / artifact_path
         if not path.exists() or not path.is_file():
             return _error_response(
                 status_code=404,
                 code="ARTIFACT_NOT_FOUND",
-                message=f"Artifact '{filename}' does not exist for job '{job_id}'",
+                message=f"Artifact '{artifact_path}' does not exist for job '{job_id}'",
                 retryable=False,
             )
         return FileResponse(path=path)

--- a/services/openfold3_rest_server/config/openfold3_no_deepspeed_evo_attention.yml
+++ b/services/openfold3_rest_server/config/openfold3_no_deepspeed_evo_attention.yml
@@ -1,0 +1,11 @@
+model_update:
+  presets:
+    - predict
+    - pae_enabled
+  custom:
+    settings:
+      memory:
+        eval:
+          use_deepspeed_evo_attention: false
+          use_cueq_triangle_kernels: false
+          use_lma: false

--- a/services/openfold3_rest_server/openfold3_runner.py
+++ b/services/openfold3_rest_server/openfold3_runner.py
@@ -14,6 +14,7 @@ DEFAULT_MODEL_DIR = "/root/autodl-tmp/models/openfold3"
 DEFAULT_PREDICT_BIN = "run_openfold"
 DEFAULT_DEVICE = "cuda"
 _HELP_TEXT_CACHE: dict[str, str] = {}
+_RUNNER_YAML_ENV = "OPENFOLD3_RUNNER_YAML"
 
 
 def run_openfold3_prediction(
@@ -62,11 +63,11 @@ def run_openfold3_prediction(
         plddt = 0.0
 
     outputs: Dict[str, Any] = {
-        "pdb_path": structure_path.name,
+        "pdb_path": str(structure_path.relative_to(artifact_dir).as_posix()),
         "plddt": plddt,
     }
     if structure_path.suffix.lower() in {".cif", ".mmcif"}:
-        outputs["cif_path"] = structure_path.name
+        outputs["cif_path"] = str(structure_path.relative_to(artifact_dir).as_posix())
 
     metrics = {
         "device_used": device,
@@ -213,6 +214,10 @@ def _build_predict_command(
             command.append(model_arg)
             model_arg_mode = model_arg.split("=", 1)[0]
 
+    runner_yaml_arg = _build_runner_yaml_arg(predict_bin=predict_bin)
+    if runner_yaml_arg is not None:
+        command.append(runner_yaml_arg)
+
     extra = str(os.getenv("OPENFOLD3_EXTRA_ARGS", "")).strip()
     if extra:
         command.extend(shlex.split(extra))
@@ -221,6 +226,8 @@ def _build_predict_command(
         "query_arg": query_opt,
         "output_arg": output_opt,
         "model_arg": model_arg_mode,
+        "runner_yaml_arg": runner_yaml_arg.split("=", 1)[0] if runner_yaml_arg else "none",
+        "runner_yaml_path": runner_yaml_arg.split("=", 1)[1] if runner_yaml_arg else None,
     }
 
 
@@ -271,6 +278,30 @@ def _build_model_arg(*, predict_bin: str, model_dir: str) -> str | None:
     if not path.exists():
         return None
     return f"{ckpt_opt}={model_dir}"
+
+
+def _build_runner_yaml_arg(*, predict_bin: str) -> str | None:
+    configured = str(os.getenv(_RUNNER_YAML_ENV, "")).strip()
+    if not configured:
+        return None
+
+    runner_yaml = Path(configured)
+    if not runner_yaml.exists() or not runner_yaml.is_file():
+        raise RuntimeError(
+            f"{_RUNNER_YAML_ENV} does not exist or is not a file: {runner_yaml}"
+        )
+
+    runner_opt = _pick_supported_option(
+        predict_bin,
+        ("--runner-yaml", "--runner_yaml"),
+        default="--runner_yaml",
+    )
+    if runner_opt is None:
+        raise RuntimeError(
+            f"{predict_bin} predict does not support --runner-yaml/--runner_yaml"
+        )
+
+    return f"{runner_opt}={runner_yaml}"
 
 
 def _pick_supported_option(
@@ -337,14 +368,14 @@ def _resolve_predict_bin(predict_bin: str) -> str:
 def _find_structure_file(artifact_dir: Path) -> Path | None:
     patterns = ("*.pdb", "*.cif", "*.mmcif")
     for pattern in patterns:
-        files = sorted(artifact_dir.glob(pattern))
+        files = sorted(artifact_dir.rglob(pattern))
         if files:
             return files[0]
     return None
 
 
 def _extract_plddt_from_artifacts(artifact_dir: Path) -> float | None:
-    for json_file in sorted(artifact_dir.glob("*.json")):
+    for json_file in sorted(artifact_dir.rglob("*.json")):
         try:
             payload = json.loads(json_file.read_text(encoding="utf-8"))
         except Exception:

--- a/src/engines/remote_model_service.py
+++ b/src/engines/remote_model_service.py
@@ -329,6 +329,7 @@ class RESTModelInvocationService(RemoteModelInvocationService):
 
                 # 下载文件
                 artifact_path = output_dir / artifact_name
+                artifact_path.parent.mkdir(parents=True, exist_ok=True)
                 self._download_file(artifact_url, artifact_path)
                 local_path = str(artifact_path.resolve())
                 downloaded_artifacts.append(local_path)

--- a/tests/services/test_openfold3_rest_server_contract.py
+++ b/tests/services/test_openfold3_rest_server_contract.py
@@ -90,6 +90,51 @@ def test_contract_failure_path(tmp_path: Path) -> None:
     assert err["code"] == "REMOTE_RESULTS_NOT_READY"
 
 
+def test_contract_lists_and_downloads_nested_artifacts(tmp_path: Path) -> None:
+    def fake_run_job(
+        base_dir: Path,
+        job_id: str,
+        *,
+        model_dir: str,
+        predict_bin: str,
+        device: str,
+    ) -> None:
+        job_path = base_dir / job_id
+        nested = job_path / "artifacts" / "openfold3_request" / "seed_42"
+        nested.mkdir(parents=True, exist_ok=True)
+        (job_path / "outputs.json").write_text(
+            '{"pdb_path":"openfold3_request/seed_42/prediction_model.cif","plddt":81.2}',
+            encoding="utf-8",
+        )
+        (nested / "prediction_model.cif").write_text("data_test\n", encoding="utf-8")
+        (job_path / "status.json").write_text(
+            '{"job_id":"%s","status":"completed"}' % job_id,
+            encoding="utf-8",
+        )
+
+    app = create_app(remote_base_dir=tmp_path, run_job_func=fake_run_job)
+    client = TestClient(app)
+    resp = client.post(
+        "/predict",
+        json={
+            "task_id": "task_nested",
+            "step_id": "S2",
+            "inputs": {"sequence": "ACDEFGHIKLMNPQRSTVWY"},
+        },
+    )
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+
+    results_resp = client.get(f"/results/{job_id}")
+    assert results_resp.status_code == 200
+    payload = results_resp.json()
+    assert payload["outputs"]["pdb_path"] == "openfold3_request/seed_42/prediction_model.cif"
+    assert payload["artifacts"][0]["name"] == "openfold3_request/seed_42/prediction_model.cif"
+
+    file_resp = client.get(payload["artifacts"][0]["url"])
+    assert file_resp.status_code == 200
+
+
 def test_contract_error_envelope_and_auth(tmp_path: Path) -> None:
     app = create_app(remote_base_dir=tmp_path, api_token="token-123")
     client = TestClient(app)

--- a/tests/services/test_openfold3_runner_compat.py
+++ b/tests/services/test_openfold3_runner_compat.py
@@ -60,6 +60,55 @@ def test_build_predict_command_supports_legacy_underscore_flags(
     assert meta["model_arg"] == "--model_dir"
 
 
+def test_build_predict_command_appends_runner_yaml_from_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    help_text = """
+    Usage: run_openfold predict [OPTIONS]
+      --query-json FILE
+      --output-dir PATH
+      --runner-yaml FILE
+    """
+    runner_yaml = tmp_path / "runner.yml"
+    runner_yaml.write_text("model_update: {}\n", encoding="utf-8")
+    monkeypatch.setattr(runner, "_get_predict_help_text", lambda _bin: help_text)
+    monkeypatch.setenv("OPENFOLD3_RUNNER_YAML", str(runner_yaml))
+
+    command, meta = runner._build_predict_command(
+        query_json_path=tmp_path / "query.json",
+        output_dir=tmp_path / "artifacts",
+        model_dir="/models/openfold3",
+        predict_bin="run_openfold",
+    )
+
+    assert any(part == f"--runner-yaml={runner_yaml}" for part in command)
+    assert meta["runner_yaml_arg"] == "--runner-yaml"
+    assert meta["runner_yaml_path"] == str(runner_yaml)
+
+
+def test_build_predict_command_rejects_missing_runner_yaml(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    help_text = """
+    Usage: run_openfold predict [OPTIONS]
+      --query-json FILE
+      --output-dir PATH
+      --runner-yaml FILE
+    """
+    monkeypatch.setattr(runner, "_get_predict_help_text", lambda _bin: help_text)
+    monkeypatch.setenv("OPENFOLD3_RUNNER_YAML", str(tmp_path / "missing.yml"))
+
+    with pytest.raises(RuntimeError, match="OPENFOLD3_RUNNER_YAML"):
+        runner._build_predict_command(
+            query_json_path=tmp_path / "query.json",
+            output_dir=tmp_path / "artifacts",
+            model_dir="/models/openfold3",
+            predict_bin="run_openfold",
+        )
+
+
 def test_prepare_query_json_uses_queries_format_when_runtime_requires_queries(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -95,6 +144,30 @@ def test_prepare_query_json_respects_env_override_inputs(
     assert query_format == "inputs"
     assert "inputs" in payload
     assert payload["inputs"][0]["molecules"][0]["sequence"] == "ACDEFG"
+
+
+def test_find_structure_file_supports_nested_artifact_paths(tmp_path: Path) -> None:
+    nested = tmp_path / "openfold3_request" / "seed_42"
+    nested.mkdir(parents=True, exist_ok=True)
+    model_path = nested / "prediction_model.cif"
+    model_path.write_text("data_test\n", encoding="utf-8")
+
+    found = runner._find_structure_file(tmp_path)
+
+    assert found == model_path
+
+
+def test_extract_plddt_supports_nested_artifact_paths(tmp_path: Path) -> None:
+    nested = tmp_path / "openfold3_request" / "seed_42"
+    nested.mkdir(parents=True, exist_ok=True)
+    (nested / "prediction_confidences.json").write_text(
+        json.dumps({"plddt": 81.25}),
+        encoding="utf-8",
+    )
+
+    plddt = runner._extract_plddt_from_artifacts(tmp_path)
+
+    assert plddt == pytest.approx(81.25)
 
 
 def test_resolve_predict_bin_prefers_which(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_plan_runner.py
+++ b/tests/unit/test_plan_runner.py
@@ -1280,3 +1280,36 @@ def test_failed_step_builds_replan_pending_action_with_nim_option() -> None:
         for event in context.safety_events
         for flag in event.risk_flags
     )
+
+
+def test_run_plan_stops_after_entering_waiting_patch(
+    multi_step_plan: Plan,
+    planned_context: WorkflowContext,
+) -> None:
+    """进入 WAITING_PATCH 后，PlanRunner 不应继续推进后续步骤。"""
+
+    class WaitingPatchRunner:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def run_step_with_patch(self, plan, step_index, context, record=None):
+            self.calls.append(plan.steps[step_index].id)
+            context.status = InternalStatus.WAITING_PATCH
+            return PatchRunOutcome(
+                plan=plan,
+                step_results=[],
+                next_step_index=step_index,
+            )
+
+    patch_runner = WaitingPatchRunner()
+    plan_runner = PlanRunner(
+        step_runner=DummyStepRunner(),
+        patch_runner=patch_runner,
+    )
+
+    result = plan_runner.run_plan(multi_step_plan, planned_context)
+
+    assert result is multi_step_plan
+    assert planned_context.status == InternalStatus.WAITING_PATCH
+    assert patch_runner.calls == ["S1"]
+    assert planned_context.step_results == {}

--- a/tests/unit/test_remote_model_service.py
+++ b/tests/unit/test_remote_model_service.py
@@ -304,6 +304,44 @@ def test_download_results_path_mapping(service: RESTModelInvocationService, tmp_
     assert str((output_dir / "esmfold.log").resolve()) in outputs["artifacts"]
 
 
+def test_download_results_preserves_nested_artifact_paths(
+    service: RESTModelInvocationService,
+    tmp_path: Path,
+) -> None:
+    """测试嵌套产物路径会被正确下载并映射。"""
+    output_dir = tmp_path / "output"
+
+    mock_results_response = Mock()
+    mock_results_response.json.return_value = {
+        "job_id": "job123",
+        "outputs": {
+            "pdb_path": "openfold3_request/seed_42/prediction_model.cif",
+            "plddt": 88.0,
+        },
+        "artifacts": [
+            {
+                "name": "openfold3_request/seed_42/prediction_model.cif",
+                "url": "http://localhost:8000/files/job123/openfold3_request/seed_42/prediction_model.cif",
+            }
+        ],
+    }
+    mock_results_response.raise_for_status = Mock()
+
+    mock_file_response = Mock()
+    mock_file_response.raise_for_status = Mock()
+    mock_file_response.iter_bytes = Mock(return_value=[b"data_test"])
+
+    with patch.object(service.client, "get", return_value=mock_results_response):
+        with patch.object(service.client, "stream") as mock_stream:
+            mock_stream.return_value.__enter__.return_value = mock_file_response
+            outputs = service.download_results("job123", output_dir)
+
+    expected_path = (output_dir / "openfold3_request" / "seed_42" / "prediction_model.cif").resolve()
+    assert outputs["pdb_path"] == str(expected_path)
+    assert outputs["artifacts"] == [str(expected_path)]
+    assert expected_path.exists()
+
+
 def test_download_results_stream_includes_default_headers(tmp_path: Path) -> None:
     service = RESTModelInvocationService(
         base_url="http://localhost:8000",

--- a/tests/unit/test_status_transition.py
+++ b/tests/unit/test_status_transition.py
@@ -70,6 +70,48 @@ class TestTaskStatusTransition:
     @pytest.mark.parametrize(
         "from_status,to_status",
         [
+            (InternalStatus.DONE, InternalStatus.RUNNING),
+            (InternalStatus.FAILED, InternalStatus.PLANNING),
+            (InternalStatus.CANCELLED, InternalStatus.WAITING_REPLAN),
+        ],
+    )
+    def test_transition_rejects_changes_from_terminal_states(
+        self, sample_task, from_status: InternalStatus, to_status: InternalStatus
+    ):
+        record = self._make_record(sample_task.task_id, from_status)
+        context = WorkflowContext(task=sample_task, status=from_status)
+
+        with pytest.raises(ValueError, match="terminal status"):
+            transition_task_status(context, record, to_status)
+
+        assert context.status == from_status
+        assert record.status == to_external_status(from_status)
+        assert record.internal_status == from_status
+
+    @pytest.mark.parametrize(
+        "from_status,to_status",
+        [
+            (InternalStatus.WAITING_PATCH, InternalStatus.RUNNING),
+            (InternalStatus.WAITING_REPLAN, InternalStatus.PATCHING),
+            (InternalStatus.SUMMARIZING, InternalStatus.RUNNING),
+        ],
+    )
+    def test_transition_rejects_illegal_waiting_or_terminal_bypass_jumps(
+        self, sample_task, from_status: InternalStatus, to_status: InternalStatus
+    ):
+        record = self._make_record(sample_task.task_id, from_status)
+        context = WorkflowContext(task=sample_task, status=from_status)
+
+        with pytest.raises(ValueError, match="Invalid task status transition"):
+            transition_task_status(context, record, to_status)
+
+        assert context.status == from_status
+        assert record.status == to_external_status(from_status)
+        assert record.internal_status == from_status
+
+    @pytest.mark.parametrize(
+        "from_status,to_status",
+        [
             (InternalStatus.CREATED, InternalStatus.PLANNING),
             (InternalStatus.PLANNING, InternalStatus.PLANNED),
             (InternalStatus.PLANNING, InternalStatus.WAITING_PLAN_CONFIRM),


### PR DESCRIPTION
## 背景

本 PR 包含两部分相关改动：

1. 完成 issue #220 要求的恢复 FSM / WAITING 行为测试补充。
2. 修复在 issue #220 验收过程中暴露出来的 OpenFold3 远程集成链路问题，并将本地与远程使用的配置保持同步。

之所以把这两部分放在同一个 PR，是因为 issue #220 的验收命令包含 `tests/integration -q`。在实际验收时，虽然新增的 FSM 测试已经通过，但 OpenFold3 远程链路存在环境与服务包装层的兼容问题，导致整体验收无法通过。因此需要一并修复，才能使该 issue 的实现和验收口径闭环。

## 为什么要做这些改动

### 1. 补齐恢复 FSM 的边界测试

issue #220 关注的是 recovery / waiting 相关状态机边界。如果这些边界没有被测试锁住，后续重构时很容易出现两类回归：

- 终态被错误地继续迁移，破坏任务生命周期不变量。
- 进入 `WAITING_PATCH` 或其他 waiting 相关状态后，plan runner 仍继续向后执行步骤，导致恢复流程与执行流程串线。

因此本 PR 在单测层明确覆盖：

- 终态不可继续迁移。
- `WAITING` / `SUMMARIZING` 的非法跳转会被拒绝。
- 一旦进入 `WAITING_PATCH`，当前计划执行必须立即停住，而不是继续消费后续步骤。

这些测试的目的不是引入新行为，而是把已有设计意图固定下来，避免 recovery FSM 边界在后续修改中被悄悄破坏。

### 2. 修复 OpenFold3 远程链路，否则 issue #220 无法按验收标准完成

在按 issue 验收要求执行 `tests/integration -q` 时，最初失败并不是来自新加的 FSM 测试，而是来自 OpenFold3 远程服务链路。具体问题有两层：

#### 2.1 OpenFold3 默认启用了当前环境不兼容的 DeepSpeed evo attention kernel

远程日志显示推理阶段报错：

- `Unable to JIT load the evoformer_attn op due to hardware/software issue`

这意味着当前远程 GPU / CUDA / torch / deepspeed 组合下，OpenFold3 默认使用的 fused kernel 无法稳定工作。结果是：

- 任务状态被标记为失败。
- 集成测试误以为 OpenFold3 功能不可用。
- 全流程测试会进一步掉进 recovery fallback，继而触发与本 issue 无关的后续错误。

所以这里必须显式关闭 `use_deepspeed_evo_attention`，先保证远程推理链路稳定可用。这个改动本质上是“兼容性修复”，不是模型语义变更。

#### 2.2 OpenFold3 实际产物位于嵌套目录，服务包装层原先只识别顶层文件

修掉 kernel 问题后，远程任务实际上已经成功产出了 `.cif` 文件，但产物位于类似如下路径：

- `openfold3_request/seed_42/..._model.cif`

原先的服务包装层和下载逻辑有三个假设与真实输出不一致：

- 只在 artifacts 顶层查找结构文件。
- `/results` 只列出顶层文件。
- client 下载结果时默认所有 artifact 都是平铺文件名，没有为嵌套路径创建父目录。

这会导致“任务实际上成功，但服务端/客户端把它误判成失败”。因此必须补上递归发现、递归列举和嵌套路径下载保存。

## 具体改动

### A. issue #220 测试补充

- `tests/unit/test_status_transition.py`
  - 补充终态不可迁移测试。
  - 补充 `WAITING` / `SUMMARIZING` 非法跳转测试。

- `tests/unit/test_plan_runner.py`
  - 补充进入 `WAITING_PATCH` 后 plan runner 必须立即停住的测试。

### B. OpenFold3 REST 兼容性修复

- `services/openfold3_rest_server/openfold3_runner.py`
  - 支持通过 `OPENFOLD3_RUNNER_YAML` 注入 runner yaml。
  - 在执行命令元信息中记录 runner yaml 相关字段，便于排查。
  - 递归查找结构文件与置信度 JSON，不再假设产物平铺在顶层。

- `services/openfold3_rest_server/app.py`
  - `/results` 改为递归列举 artifact。
  - `/files/{job_id}/...` 支持嵌套路径下载，而不是只接受单层文件名。

- `src/engines/remote_model_service.py`
  - 下载远程 artifact 时自动创建父目录，兼容嵌套路径。

### C. 配置同步

新增：

- `services/openfold3_rest_server/config/openfold3_no_deepspeed_evo_attention.yml`

该配置显式关闭：

- `use_deepspeed_evo_attention: false`
- `use_cueq_triangle_kernels: false`
- `use_lma: false`

选择这样配置的原因：

- 当前目标是优先消除与 fused/JIT kernel 相关的不兼容，恢复远程链路可用性。
- 用户已明确表示当前不担心 OOM，因此优先选择最保守、最稳定的兼容路径。
- 该配置同时放入仓库中，便于本地和远程使用同一份 runner 配置，避免“本地修了但远程仍跑旧配置”。

同时更新：

- `services/openfold3_rest_server/README.md`

文档中补充了 `OPENFOLD3_RUNNER_YAML` 的使用方式，明确建议服务启动时指向上述 yaml，以保证部署方式可复现。

## 配置变更说明

这次配置改动需要特别说明：

1. 这不是功能开关的随意调整，而是为了解决已在远程环境中实际复现的 kernel 不兼容问题。
2. 该配置不会改变工作流对 OpenFold3 的调用契约，只是改变 OpenFold3 内部推理所采用的内存/加速实现路径。
3. 代价主要是潜在的推理速度下降；收益是恢复稳定性和可验收性。
4. 将配置文件纳入仓库后，本地与远程都可以引用同一路径，减少环境漂移。

远程服务启动时建议使用：

```bash
export OPENFOLD3_RUNNER_YAML=/root/projects/2022112879/remote-model-rest/services/openfold3_rest_server/config/openfold3_no_deepspeed_evo_attention.yml
python -m uvicorn services.openfold3_rest_server.app:app --host 0.0.0.0 --port 8200
```

## 验证结果

已通过的关键验证包括：

- `tests/unit/test_status_transition.py`
- `tests/unit/test_plan_runner.py`
- `tests/services/test_openfold3_runner_compat.py`
- `tests/services/test_openfold3_rest_server_contract.py`
- `tests/unit/test_remote_model_service.py`
- `tests/integration/test_openfold3_remote_e2e.py`
- `tests/integration/test_remote_rest_full_e2e.py`
- `tests/integration -q`

全量集成结果：

- `56 passed, 7 skipped, 1 warning`

## 提交拆分

本 PR 按两个提交组织，便于审阅：

1. `test(runtime): cover recovery fsm waiting edges`
2. `fix(openfold3-rest): support nested artifacts and runner config`

这样 reviewer 可以先看 issue #220 的直接实现，再看为通过验收而补上的 OpenFold3 远程兼容修复。