### PR TITLE
feat(llm): harden MiniMax structured planning for issue #273

### DIFF
--- a/configs/llm_providers.json
+++ b/configs/llm_providers.json
@@ -88,7 +88,7 @@
       "timeout": 60,
       "max_tokens": 4000,
       "temperature": 0.2,
-      "tool_strategy": "emit_plan",
+      "tool_strategy": "two_stage_plan",
       "structured_output_mode": "tool_call",
       "anthropic_version": "2023-06-01"
     },

--- a/configs/llm_providers.json
+++ b/configs/llm_providers.json
@@ -79,10 +79,10 @@
         }
       }
     },
-    "minimax-m2.5": {
+    "minimax-m2.7": {
       "provider_type": "anthropic_messages",
-      "description": "MiniMax M2.5 via Anthropic-compatible Messages API",
-      "model_name": "MiniMax-M2.5",
+      "description": "MiniMax M2.7 via Anthropic-compatible Messages API",
+      "model_name": "MiniMax-M2.7",
       "api_key_env": "ANTHROPIC_API_KEY",
       "endpoint_env": "ANTHROPIC_BASE_URL",
       "timeout": 60,

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -11,6 +11,7 @@ from src.adapters.registry import get_adapter
 from src.kg.kg_client import ToolKGError, load_tool_kg
 from src.llm.base_llm_provider import BaseProvider, ProviderConfig
 from src.llm.baseline_provider import BaselineProvider
+from src.llm.provider_payload_parser import ProviderPayloadValidationError
 from src.llm.provider_registry import create_provider, load_provider_catalog
 from src.agents.task_goal_parser import enrich_task_from_goal
 from src.models.contracts import (
@@ -501,7 +502,15 @@ class PlannerAgent:
         *,
         provider: BaseProvider,
     ) -> Plan:
-        plan_dict = provider.call_planner(task=task, tool_registry=self._tool_registry)
+        try:
+            plan_dict = provider.call_planner(task=task, tool_registry=self._tool_registry)
+        except ProviderPayloadValidationError as exc:
+            _append_provider_validation_failure_event(
+                task_id=task.task_id,
+                provider_name=_provider_name(provider),
+                error=exc,
+            )
+            raise
         plan = Plan.model_validate(plan_dict)
         plan = _normalize_plan_input_contract_references(
             plan,
@@ -808,6 +817,13 @@ class PlannerAgent:
             return []
         try:
             patch_dict = provider.call_patch(request, self._tool_registry)
+        except ProviderPayloadValidationError as exc:
+            _append_provider_validation_failure_event(
+                task_id=request.task_id,
+                provider_name=_provider_name(provider),
+                error=exc,
+            )
+            return []
         except Exception:
             return []
         if not isinstance(patch_dict, dict):
@@ -851,6 +867,13 @@ class PlannerAgent:
             return []
         try:
             plan_dict = provider.call_replan(request, self._tool_registry)
+        except ProviderPayloadValidationError as exc:
+            _append_provider_validation_failure_event(
+                task_id=request.task_id,
+                provider_name=_provider_name(provider),
+                error=exc,
+            )
+            return []
         except Exception:
             return []
         if not isinstance(plan_dict, dict):
@@ -892,6 +915,28 @@ def _provider_name(provider: BaseProvider) -> str:
     if isinstance(model_name, str) and model_name.strip():
         return model_name.strip()
     return provider.__class__.__name__
+
+
+def _append_provider_validation_failure_event(
+    *,
+    task_id: str,
+    provider_name: str,
+    error: ProviderPayloadValidationError,
+) -> None:
+    append_event(
+        task_id,
+        {
+            "event": "PROVIDER_VALIDATION_FAILED",
+            "task_id": task_id,
+            "timestamp": now_iso(),
+            "tool": provider_name,
+            "failure_code": error.failure_type,
+            "data": {
+                "provider_name": provider_name,
+                **error.as_event_payload(),
+            },
+        },
+    )
 
 
 def _normalized_planner_provider_env() -> str | None:

--- a/src/llm/anthropic_messages_provider.py
+++ b/src/llm/anthropic_messages_provider.py
@@ -5,7 +5,7 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type
 
 from anthropic import Anthropic
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from src.llm.base_llm_provider import BaseProvider, ProviderConfig
 from src.llm.provider_payload_parser import (
@@ -31,6 +31,43 @@ if TYPE_CHECKING:
 
 
 _MAX_PROVIDER_REPAIR_RETRIES = 2
+_TWO_STAGE_PLAN_STRATEGY = "two_stage_plan"
+
+
+class PlanSkeletonStep(BaseModel):
+    """两阶段规划中的单步骨架。
+
+    Attributes:
+        id: 可选步骤 ID，provider 层会归一化为 S1/S2/...。
+        tool: 该步骤选择的工具 ID。
+        metadata: 步骤级附加说明，不承载执行结果。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str | None = None
+    tool: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PlanSkeleton(BaseModel):
+    """两阶段规划第一阶段输出的计划骨架。
+
+    Attributes:
+        task_id: 任务 ID，可由 provider 层补齐。
+        steps: 只包含步骤顺序和工具选择，不包含 inputs。
+        constraints: 任务约束透传字段。
+        metadata: 骨架生成元信息。
+        explanation: 可选解释。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str | None = None
+    steps: List[PlanSkeletonStep]
+    constraints: Dict[str, Any] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    explanation: str | None = None
 
 
 class AnthropicMessagesProvider(BaseProvider):
@@ -48,6 +85,9 @@ class AnthropicMessagesProvider(BaseProvider):
     def call_planner(
         self, task: ProteinDesignTask, tool_registry: List["ToolSpec"]
     ) -> Dict:
+        if self._uses_two_stage_plan():
+            return self._call_two_stage_planner(task, tool_registry)
+
         payload = self._request_tool_payload(
             system_prompt=self._build_plan_system_prompt(),
             user_prompt=self._build_plan_user_prompt(task, tool_registry),
@@ -70,6 +110,60 @@ class AnthropicMessagesProvider(BaseProvider):
                 "provider": "anthropic_messages",
                 "model": self.config.model_name,
                 "endpoint": self.endpoint,
+            }
+        )
+        if not self.validate_plan(payload):
+            raise ValueError(f"LLM 生成的 Plan 无效: {payload}")
+        return payload
+
+    def _call_two_stage_planner(
+        self, task: ProteinDesignTask, tool_registry: List["ToolSpec"]
+    ) -> Dict[str, Any]:
+        skeleton = self._request_tool_payload(
+            system_prompt=self._build_plan_skeleton_system_prompt(),
+            user_prompt=self._build_plan_skeleton_user_prompt(task, tool_registry),
+            tool_name="emit_plan_skeleton",
+            tool_description="Emit a PlanSkeleton JSON object with steps and tools only.",
+            schema_model=PlanSkeleton,
+            candidate_kind="plan_skeleton",
+            tool_registry=tool_registry,
+            validator=lambda candidate, parse_result: self._validate_plan_skeleton_candidate(
+                candidate,
+                parse_result=parse_result,
+                task=task,
+                tool_registry=tool_registry,
+            ),
+        )
+        skeleton_plan = PlanSkeleton.model_validate(skeleton)
+        payload = self._request_tool_payload(
+            system_prompt=self._build_plan_system_prompt(),
+            user_prompt=self._build_plan_inputs_user_prompt(
+                task,
+                tool_registry,
+                skeleton=skeleton_plan,
+            ),
+            tool_name="emit_plan",
+            tool_description="Emit a single Plan JSON object aligned with the provided skeleton.",
+            schema_model=Plan,
+            candidate_kind="plan",
+            tool_registry=tool_registry,
+            validator=lambda candidate, parse_result: self._validate_plan_candidate(
+                candidate,
+                parse_result=parse_result,
+                task=task,
+                tool_registry=tool_registry,
+                materialize_inputs=True,
+                skeleton=skeleton_plan,
+            ),
+        )
+        metadata = payload.setdefault("metadata", {})
+        metadata.update(
+            {
+                "provider": "anthropic_messages",
+                "model": self.config.model_name,
+                "endpoint": self.endpoint,
+                "provider_generation_mode": _TWO_STAGE_PLAN_STRATEGY,
+                "provider_plan_skeleton": self._skeleton_summary(skeleton_plan),
             }
         )
         if not self.validate_plan(payload):
@@ -154,7 +248,7 @@ class AnthropicMessagesProvider(BaseProvider):
         user_prompt: str,
         tool_name: str,
         tool_description: str,
-        schema_model: Type[Plan] | Type[PlanPatch],
+        schema_model: Type[BaseModel],
         candidate_kind: str,
         tool_registry: List["ToolSpec"],
         validator: Callable[[dict[str, Any], ProviderPayloadParseResult], dict[str, Any]],
@@ -250,6 +344,14 @@ class AnthropicMessagesProvider(BaseProvider):
             "CANDIDATES 之类裸占位符。"
         )
 
+    def _build_plan_skeleton_system_prompt(self) -> str:
+        return (
+            "你是一个蛋白质设计规划助手。必须调用 emit_plan_skeleton 工具输出计划骨架，"
+            "只决定步骤顺序和 tool，不要填写 inputs，不要输出执行结果。"
+            "steps 必须是 JSON array；step id 必须是 S1/S2/...；"
+            "tool 必须来自可用工具列表。"
+        )
+
     def _build_plan_user_prompt(
         self, task: ProteinDesignTask, tool_registry: List["ToolSpec"]
     ) -> str:
@@ -262,6 +364,50 @@ class AnthropicMessagesProvider(BaseProvider):
             "要求：\n"
             "- steps must be a JSON array, never a string\n"
             "- all step ids must be S1/S2/... in execution order\n"
+            "- all cross-step references must be S<n>.field\n"
+            "- do not emit ${...}, $CANDIDATES, $STEP_2, <generated_sequence>, <predicted_pdb>, auto\n"
+        )
+
+    def _build_plan_skeleton_user_prompt(
+        self, task: ProteinDesignTask, tool_registry: List["ToolSpec"]
+    ) -> str:
+        return (
+            f"任务 ID: {task.task_id}\n"
+            f"目标: {task.goal}\n"
+            f"约束: {json.dumps(task.constraints, ensure_ascii=False, indent=2)}\n"
+            f"可用工具:\n{self._format_tool_registry(tool_registry)}\n"
+            "请先生成 PlanSkeleton。\n"
+            "要求：\n"
+            "- steps must be a JSON array, never a string\n"
+            "- each step must contain only id/tool/metadata, no inputs\n"
+            "- all step ids must be S1/S2/... in execution order\n"
+            "- tool must be selected from the available tools\n"
+            "- do not emit execution outputs, placeholders, or cross-step references\n"
+        )
+
+    def _build_plan_inputs_user_prompt(
+        self,
+        task: ProteinDesignTask,
+        tool_registry: List["ToolSpec"],
+        *,
+        skeleton: PlanSkeleton,
+    ) -> str:
+        skeleton_json = json.dumps(
+            skeleton.model_dump(mode="json"),
+            ensure_ascii=False,
+            indent=2,
+        )
+        return (
+            f"任务 ID: {task.task_id}\n"
+            f"目标: {task.goal}\n"
+            f"约束: {json.dumps(task.constraints, ensure_ascii=False, indent=2)}\n"
+            f"可用工具:\n{self._format_tool_registry(tool_registry)}\n"
+            f"已确认 PlanSkeleton:\n{skeleton_json}\n"
+            "请基于该 skeleton 生成完整 Plan。\n"
+            "要求：\n"
+            "- keep exactly the same step count, ids, order, and tools as PlanSkeleton\n"
+            "- fill only executable inputs and metadata; do not invent execution outputs\n"
+            "- steps must be a JSON array, never a string\n"
             "- all cross-step references must be S<n>.field\n"
             "- do not emit ${...}, $CANDIDATES, $STEP_2, <generated_sequence>, <predicted_pdb>, auto\n"
         )
@@ -374,6 +520,7 @@ class AnthropicMessagesProvider(BaseProvider):
         tool_registry: List["ToolSpec"],
         materialize_inputs: bool,
         constraints_override: dict[str, Any] | None = None,
+        skeleton: PlanSkeleton | None = None,
     ) -> dict[str, Any]:
         candidate = dict(candidate)
         candidate.setdefault("task_id", task.task_id)
@@ -392,6 +539,13 @@ class AnthropicMessagesProvider(BaseProvider):
                 normalized_payload=candidate,
                 parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
             ) from exc
+
+        if skeleton is not None:
+            self._raise_on_skeleton_mismatch(
+                plan=plan,
+                skeleton=skeleton,
+                parse_result=parse_result,
+            )
 
         try:
             plan = self._prepare_plan_for_validation(
@@ -426,6 +580,56 @@ class AnthropicMessagesProvider(BaseProvider):
                 parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
             ) from exc
         return plan.model_dump(mode="json")
+
+    def _validate_plan_skeleton_candidate(
+        self,
+        candidate: dict[str, Any],
+        *,
+        parse_result: ProviderPayloadParseResult,
+        task: ProteinDesignTask,
+        tool_registry: List["ToolSpec"],
+    ) -> dict[str, Any]:
+        candidate = dict(candidate)
+        candidate.setdefault("task_id", task.task_id)
+        candidate.setdefault("constraints", task.constraints)
+        candidate.setdefault("metadata", {})
+        self._raise_on_syntax_issues(
+            candidate_kind="plan_skeleton",
+            parse_result=parse_result,
+        )
+        try:
+            skeleton = PlanSkeleton.model_validate(candidate)
+        except ValidationError as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="plan_skeleton",
+                failure_type="SCHEMA_INVALID",
+                issues=self._build_schema_issues(exc),
+                normalized_payload=candidate,
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
+
+        registry_ids = {tool.id for tool in tool_registry}
+        issues: list[dict[str, Any]] = []
+        for index, step in enumerate(skeleton.steps):
+            if step.tool not in registry_ids:
+                issues.append(
+                    {
+                        "code": "SKELETON_TOOL_UNKNOWN",
+                        "path": f"$.steps[{index}].tool",
+                        "message": f"tool '{step.tool}' is not in registry",
+                        "observed": step.tool,
+                        "repair_hint": "choose a tool id from the available tool registry",
+                    }
+                )
+        if issues:
+            raise ProviderPayloadValidationError(
+                candidate_kind="plan_skeleton",
+                failure_type="SCHEMA_INVALID",
+                issues=issues,
+                normalized_payload=skeleton.model_dump(mode="json"),
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            )
+        return skeleton.model_dump(mode="json")
 
     def _validate_patch_candidate(
         self,
@@ -545,6 +749,70 @@ class AnthropicMessagesProvider(BaseProvider):
             normalized_payload=parse_result.normalized_payload,
             parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
         )
+
+    def _raise_on_skeleton_mismatch(
+        self,
+        *,
+        plan: Plan,
+        skeleton: PlanSkeleton,
+        parse_result: ProviderPayloadParseResult,
+    ) -> None:
+        issues: list[dict[str, Any]] = []
+        if len(plan.steps) != len(skeleton.steps):
+            issues.append(
+                {
+                    "code": "PLAN_SKELETON_STEP_COUNT_MISMATCH",
+                    "path": "$.steps",
+                    "message": "final Plan must keep the same step count as PlanSkeleton",
+                    "observed": len(plan.steps),
+                    "repair_hint": "keep exactly the skeleton steps and fill only inputs",
+                }
+            )
+        for index, skeleton_step in enumerate(skeleton.steps):
+            if index >= len(plan.steps):
+                break
+            plan_step = plan.steps[index]
+            if plan_step.id != skeleton_step.id:
+                issues.append(
+                    {
+                        "code": "PLAN_SKELETON_STEP_ID_MISMATCH",
+                        "path": f"$.steps[{index}].id",
+                        "message": "final Plan step id must match PlanSkeleton",
+                        "observed": plan_step.id,
+                        "repair_hint": f"use {skeleton_step.id}",
+                    }
+                )
+            if plan_step.tool != skeleton_step.tool:
+                issues.append(
+                    {
+                        "code": "PLAN_SKELETON_TOOL_MISMATCH",
+                        "path": f"$.steps[{index}].tool",
+                        "message": "final Plan tool must match PlanSkeleton",
+                        "observed": plan_step.tool,
+                        "repair_hint": f"use {skeleton_step.tool}",
+                    }
+                )
+        if not issues:
+            return
+        raise ProviderPayloadValidationError(
+            candidate_kind="plan",
+            failure_type="SCHEMA_INVALID",
+            issues=issues,
+            normalized_payload=plan.model_dump(mode="json"),
+            parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+        )
+
+    def _uses_two_stage_plan(self) -> bool:
+        return self.config.tool_strategy == _TWO_STAGE_PLAN_STRATEGY
+
+    def _skeleton_summary(self, skeleton: PlanSkeleton) -> dict[str, Any]:
+        return {
+            "step_count": len(skeleton.steps),
+            "steps": [
+                {"id": step.id, "tool": step.tool}
+                for step in skeleton.steps
+            ],
+        }
 
     def _build_repair_user_prompt(
         self,

--- a/src/llm/anthropic_messages_provider.py
+++ b/src/llm/anthropic_messages_provider.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import json
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type
 
 from anthropic import Anthropic
+from pydantic import ValidationError
 
 from src.llm.base_llm_provider import BaseProvider, ProviderConfig
+from src.llm.provider_payload_parser import (
+    ProviderPayloadParseResult,
+    ProviderPayloadParser,
+    ProviderPayloadValidationError,
+)
 from src.models.contracts import (
     PatchRequest,
     Plan,
@@ -14,9 +20,17 @@ from src.models.contracts import (
     ProteinDesignTask,
     ReplanRequest,
 )
+from src.models.validation import (
+    CandidateExecutionValidationError,
+    validate_plan_executability,
+)
+from src.workflow.patch import apply_patch
 
 if TYPE_CHECKING:
     from src.agents.planner import ToolSpec
+
+
+_MAX_PROVIDER_REPAIR_RETRIES = 2
 
 
 class AnthropicMessagesProvider(BaseProvider):
@@ -40,8 +54,16 @@ class AnthropicMessagesProvider(BaseProvider):
             tool_name="emit_plan",
             tool_description="Emit a single Plan JSON object.",
             schema_model=Plan,
+            candidate_kind="plan",
+            tool_registry=tool_registry,
+            validator=lambda candidate, parse_result: self._validate_plan_candidate(
+                candidate,
+                parse_result=parse_result,
+                task=task,
+                tool_registry=tool_registry,
+                materialize_inputs=True,
+            ),
         )
-        payload.setdefault("task_id", task.task_id)
         metadata = payload.setdefault("metadata", {})
         metadata.update(
             {
@@ -65,8 +87,15 @@ class AnthropicMessagesProvider(BaseProvider):
             tool_name="emit_patch",
             tool_description="Emit a single PlanPatch JSON object.",
             schema_model=PlanPatch,
+            candidate_kind="patch",
+            tool_registry=tool_registry,
+            validator=lambda candidate, parse_result: self._validate_patch_candidate(
+                candidate,
+                parse_result=parse_result,
+                request=request,
+                tool_registry=tool_registry,
+            ),
         )
-        payload.setdefault("task_id", request.task_id)
         metadata = payload.setdefault("metadata", {})
         metadata.update(
             {
@@ -91,8 +120,20 @@ class AnthropicMessagesProvider(BaseProvider):
             tool_name="emit_replan",
             tool_description="Emit a single Plan JSON object for replan.",
             schema_model=Plan,
+            candidate_kind="replan",
+            tool_registry=tool_registry,
+            validator=lambda candidate, parse_result: self._validate_plan_candidate(
+                candidate,
+                parse_result=parse_result,
+                task=self._build_validation_task(
+                    task_id=request.task_id,
+                    constraints=request.original_plan.constraints,
+                ),
+                tool_registry=tool_registry,
+                materialize_inputs=False,
+                constraints_override=request.original_plan.constraints,
+            ),
         )
-        payload.setdefault("task_id", request.task_id)
         metadata = payload.setdefault("metadata", {})
         metadata.update(
             {
@@ -114,46 +155,64 @@ class AnthropicMessagesProvider(BaseProvider):
         tool_name: str,
         tool_description: str,
         schema_model: Type[Plan] | Type[PlanPatch],
+        candidate_kind: str,
+        tool_registry: List["ToolSpec"],
+        validator: Callable[[dict[str, Any], ProviderPayloadParseResult], dict[str, Any]],
     ) -> Dict[str, Any]:
         started_at = time.time()
-        response = self._post_messages(
-            {
-                "model": self.config.model_name,
-                "system": system_prompt,
-                "messages": [{"role": "user", "content": user_prompt}],
-                "max_tokens": self.config.max_tokens or 4000,
-                "temperature": self.config.temperature,
-                "tools": [
-                    {
-                        "name": tool_name,
-                        "description": tool_description,
-                        "input_schema": schema_model.model_json_schema(),
-                    }
-                ],
-                "tool_choice": {"type": "tool", "name": tool_name},
+        parser = ProviderPayloadParser(tool_registry)
+        last_error: ProviderPayloadValidationError | None = None
+
+        for attempt in range(_MAX_PROVIDER_REPAIR_RETRIES + 1):
+            current_user_prompt = user_prompt
+            if last_error is not None:
+                current_user_prompt = self._build_repair_user_prompt(
+                    base_user_prompt=user_prompt,
+                    candidate_kind=candidate_kind,
+                    tool_name=tool_name,
+                    error=last_error,
+                )
+            response = self._post_messages(
+                {
+                    "model": self.config.model_name,
+                    "system": system_prompt,
+                    "messages": [{"role": "user", "content": current_user_prompt}],
+                    "max_tokens": self.config.max_tokens or 4000,
+                    "temperature": self.config.temperature,
+                    "tools": [
+                        {
+                            "name": tool_name,
+                            "description": tool_description,
+                            "input_schema": schema_model.model_json_schema(),
+                        }
+                    ],
+                    "tool_choice": {"type": "tool", "name": tool_name},
+                }
+            )
+            tool_input = self._extract_tool_input(response, tool_name=tool_name)
+            parse_result = parser.parse(tool_input, candidate_kind=candidate_kind)
+            try:
+                validated = validator(
+                    parse_result.normalized_payload or {},
+                    parse_result,
+                )
+            except ProviderPayloadValidationError as exc:
+                last_error = exc.with_attempts(attempt + 1)
+                if attempt >= _MAX_PROVIDER_REPAIR_RETRIES:
+                    raise last_error
+                continue
+
+            metadata = validated.setdefault("metadata", {})
+            metadata["elapsed_seconds"] = time.time() - started_at
+            metadata["provider_validation"] = {
+                "candidate_kind": candidate_kind,
+                "repair_attempts": attempt,
+                "total_attempts": attempt + 1,
+                "syntax_repairs": [repair.as_dict() for repair in parse_result.repairs],
             }
-        )
-        content = response.get("content")
-        if not isinstance(content, list):
-            raise ValueError("Anthropic 响应缺少 content 列表")
+            return validated
 
-        tool_input = None
-        for block in content:
-            if (
-                isinstance(block, dict)
-                and block.get("type") == "tool_use"
-                and block.get("name") == tool_name
-            ):
-                tool_input = block.get("input")
-                break
-
-        if not isinstance(tool_input, dict):
-            raise ValueError("Anthropic 响应缺少结构化 tool_use payload")
-
-        tool_input = _normalize_tool_payload(tool_input)
-        metadata = tool_input.setdefault("metadata", {})
-        metadata["elapsed_seconds"] = time.time() - started_at
-        return tool_input
+        raise ValueError(f"{candidate_kind} provider validation failed without details")
 
     def _post_messages(self, payload: dict[str, Any]) -> dict[str, Any]:
         try:
@@ -186,6 +245,9 @@ class AnthropicMessagesProvider(BaseProvider):
         return (
             "你是一个蛋白质设计规划助手。必须调用 emit_plan 工具输出单个结构化 Plan，"
             "不要输出自由文本 JSON，不要补执行结果。"
+            "steps 必须是 JSON array，不能是字符串；step id 必须是 S1/S2/...；"
+            "跨步引用只能写成 S<n>.field；严禁输出 ${...}、$...、<...>、auto、"
+            "CANDIDATES 之类裸占位符。"
         )
 
     def _build_plan_user_prompt(
@@ -196,13 +258,20 @@ class AnthropicMessagesProvider(BaseProvider):
             f"目标: {task.goal}\n"
             f"约束: {json.dumps(task.constraints, ensure_ascii=False, indent=2)}\n"
             f"可用工具:\n{self._format_tool_registry(tool_registry)}\n"
-            "请生成完整 Plan。"
+            "请生成完整 Plan。\n"
+            "要求：\n"
+            "- steps must be a JSON array, never a string\n"
+            "- all step ids must be S1/S2/... in execution order\n"
+            "- all cross-step references must be S<n>.field\n"
+            "- do not emit ${...}, $CANDIDATES, $STEP_2, <generated_sequence>, <predicted_pdb>, auto\n"
         )
 
     def _build_patch_system_prompt(self) -> str:
         return (
             "你是一个蛋白质设计恢复规划助手。必须调用 emit_patch 工具输出最小 PlanPatch，"
             "优先参数级，其次工具级，最后结构级。"
+            "operations 必须是 JSON array；所有引用只能写成 S<n>.field；"
+            "严禁输出 ${...}、$...、<...>、auto、裸占位符。"
         )
 
     def _build_patch_user_prompt(
@@ -221,13 +290,20 @@ class AnthropicMessagesProvider(BaseProvider):
             f"原始计划: {json.dumps(request.original_plan.model_dump(mode='json'), ensure_ascii=False, indent=2)}\n"
             f"失败上下文: {json.dumps(failed_payload, ensure_ascii=False, indent=2)}\n"
             f"可用工具:\n{self._format_tool_registry(tool_registry)}\n"
-            "请生成最小 PlanPatch。"
+            "请生成最小 PlanPatch。\n"
+            "要求：\n"
+            "- operations must be a JSON array\n"
+            "- replace_step must keep the same target id\n"
+            "- all references must use S<n>.field\n"
+            "- do not emit ${...}, $STEP_2, $CANDIDATES, <...>, auto\n"
         )
 
     def _build_replan_system_prompt(self) -> str:
         return (
             "你是一个蛋白质设计再规划助手。必须调用 emit_replan 工具输出完整 Plan，"
             "优先 suffix_replan，保留成功前缀。"
+            "steps 必须是 JSON array；step id 必须是 S1/S2/...；"
+            "所有跨步引用只能使用 S<n>.field；严禁 ${...}、$...、<...>、auto。"
         )
 
     def _build_replan_user_prompt(
@@ -243,7 +319,13 @@ class AnthropicMessagesProvider(BaseProvider):
             f"原始计划: {json.dumps(request.original_plan.model_dump(mode='json'), ensure_ascii=False, indent=2)}\n"
             f"再规划上下文: {json.dumps(payload, ensure_ascii=False, indent=2)}\n"
             f"可用工具:\n{self._format_tool_registry(tool_registry)}\n"
-            "请生成新的 Plan。"
+            "请生成新的 Plan。\n"
+            "要求：\n"
+            "- keep the successful prefix whenever possible\n"
+            "- steps must be a JSON array, never a string\n"
+            "- all step ids must be S1/S2/... in order\n"
+            "- all references must use S<n>.field\n"
+            "- do not emit ${...}, $..., <...>, auto, or bare placeholders\n"
         )
 
     def _format_tool_registry(self, tool_registry: List["ToolSpec"]) -> str:
@@ -259,340 +341,280 @@ class AnthropicMessagesProvider(BaseProvider):
             ]
         )
 
+    def _extract_tool_input(
+        self,
+        response: dict[str, Any],
+        *,
+        tool_name: str,
+    ) -> dict[str, Any]:
+        content = response.get("content")
+        if not isinstance(content, list):
+            raise ValueError("Anthropic 响应缺少 content 列表")
 
-def _normalize_tool_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
-    normalized = _normalize_json_like_value(payload)
-    if not isinstance(normalized, dict):
-        raise ValueError("Anthropic tool_use payload 归一化后不是 dict")
-    return _normalize_plan_like_payload(normalized)
+        tool_input = None
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("name") == tool_name
+            ):
+                tool_input = block.get("input")
+                break
 
+        if not isinstance(tool_input, dict):
+            raise ValueError("Anthropic 响应缺少结构化 tool_use payload")
+        return tool_input
 
-def _normalize_plan_like_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
-    normalized = dict(payload)
-    if isinstance(normalized.get("steps"), list):
-        normalized["steps"] = _normalize_plan_steps(normalized["steps"])
-    if isinstance(normalized.get("operations"), list):
-        normalized["operations"] = _normalize_patch_operations(normalized["operations"])
-    return normalized
-
-
-def _normalize_plan_steps(steps: list[Any]) -> list[Any]:
-    step_id_map, tool_reference_map = _build_step_reference_maps(steps)
-    normalized_steps: list[Any] = []
-    for index, raw_step in enumerate(steps, start=1):
-        if not isinstance(raw_step, dict):
-            normalized_steps.append(raw_step)
-            continue
-        step = dict(raw_step)
-        step["id"] = f"S{index}"
-        inputs = step.get("inputs")
-        if isinstance(inputs, dict):
-            step["inputs"] = {
-                key: _normalize_reference_value(
-                    value,
-                    input_key=key,
-                    step_id_map=step_id_map,
-                    tool_reference_map=tool_reference_map,
-                )
-                for key, value in inputs.items()
-            }
-        normalized_steps.append(step)
-    return normalized_steps
-
-
-def _normalize_patch_operations(operations: list[Any]) -> list[Any]:
-    pseudo_steps: list[dict[str, Any]] = []
-    for operation in operations:
-        if not isinstance(operation, dict):
-            continue
-        step = operation.get("step")
-        if not isinstance(step, dict):
-            continue
-        target = operation.get("target")
-        pseudo_step = dict(step)
-        if "id" not in pseudo_step and isinstance(target, str):
-            pseudo_step["id"] = target
-        pseudo_steps.append(pseudo_step)
-
-    step_id_map, tool_reference_map = _build_step_reference_maps(pseudo_steps)
-    normalized_operations: list[Any] = []
-    for operation in operations:
-        if not isinstance(operation, dict):
-            normalized_operations.append(operation)
-            continue
-        normalized = dict(operation)
-        target = normalized.get("target")
-        if isinstance(target, str):
-            normalized["target"] = _normalize_step_identifier(
-                target,
-                step_id_map=step_id_map,
-            )
-        step = normalized.get("step")
-        if isinstance(step, dict):
-            normalized_step = dict(step)
-            step_id = normalized_step.get("id")
-            if isinstance(step_id, str):
-                normalized_step["id"] = _normalize_step_identifier(
-                    step_id,
-                    step_id_map=step_id_map,
-                )
-            inputs = normalized_step.get("inputs")
-            if isinstance(inputs, dict):
-                normalized_step["inputs"] = {
-                    key: _normalize_reference_value(
-                        value,
-                        input_key=key,
-                        step_id_map=step_id_map,
-                        tool_reference_map=tool_reference_map,
-                    )
-                    for key, value in inputs.items()
-                }
-            normalized["step"] = normalized_step
-        normalized_operations.append(normalized)
-    return normalized_operations
-
-
-def _build_step_reference_maps(
-    steps: list[Any],
-) -> tuple[dict[str, str], dict[str, str]]:
-    step_id_map: dict[str, str] = {}
-    tool_to_step_ids: dict[str, list[str]] = {}
-    for index, raw_step in enumerate(steps, start=1):
-        if not isinstance(raw_step, dict):
-            continue
-        canonical_id = f"S{index}"
-        raw_id = raw_step.get("id")
-        if isinstance(raw_id, str):
-            step_id_map[raw_id] = canonical_id
-            compact = raw_id.strip()
-            if compact:
-                step_id_map[compact] = canonical_id
-                if compact.isdigit():
-                    step_id_map[f"step_{compact}"] = canonical_id
-        step_id_map[str(index)] = canonical_id
-        step_id_map[f"step_{index}"] = canonical_id
-
-        tool_name = raw_step.get("tool")
-        if isinstance(tool_name, str) and tool_name.strip():
-            tool_to_step_ids.setdefault(tool_name.strip(), []).append(canonical_id)
-
-    tool_reference_map = {
-        tool_name: step_ids[0]
-        for tool_name, step_ids in tool_to_step_ids.items()
-        if len(step_ids) == 1
-    }
-    return step_id_map, tool_reference_map
-
-
-def _normalize_reference_value(
-    value: Any,
-    *,
-    input_key: str | None,
-    step_id_map: dict[str, str],
-    tool_reference_map: dict[str, str],
-) -> Any:
-    if isinstance(value, list):
-        return [
-            _normalize_reference_value(
-                item,
-                input_key=input_key,
-                step_id_map=step_id_map,
-                tool_reference_map=tool_reference_map,
-            )
-            for item in value
-        ]
-    if isinstance(value, dict):
-        return {
-            key: _normalize_reference_value(
-                item,
-                input_key=key,
-                step_id_map=step_id_map,
-                tool_reference_map=tool_reference_map,
-            )
-            for key, item in value.items()
-        }
-    if not isinstance(value, str):
-        return value
-
-    normalized = _normalize_symbolic_reference(
-        value,
-        input_key=input_key,
-        step_id_map=step_id_map,
-        tool_reference_map=tool_reference_map,
-    )
-    if normalized is not None:
-        return _normalize_reference_field_for_input_key(
-            normalized,
-            input_key=input_key,
+    def _validate_plan_candidate(
+        self,
+        candidate: dict[str, Any],
+        *,
+        parse_result: ProviderPayloadParseResult,
+        task: ProteinDesignTask,
+        tool_registry: List["ToolSpec"],
+        materialize_inputs: bool,
+        constraints_override: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        candidate = dict(candidate)
+        candidate.setdefault("task_id", task.task_id)
+        candidate.setdefault("metadata", {})
+        self._raise_on_syntax_issues(
+            candidate_kind="plan" if materialize_inputs else "replan",
+            parse_result=parse_result,
         )
-    return value
-
-
-def _normalize_symbolic_reference(
-    value: str,
-    *,
-    input_key: str | None,
-    step_id_map: dict[str, str],
-    tool_reference_map: dict[str, str],
-) -> str | None:
-    placeholder = _normalize_placeholder_reference(
-        value,
-        input_key=input_key,
-        step_id_map=step_id_map,
-    )
-    if placeholder is not None:
-        return placeholder
-
-    head, sep, tail = value.partition(".")
-    if not sep or not tail:
-        return None
-
-    normalized_head = step_id_map.get(head.strip())
-    normalized_field = tail.strip()
-    if normalized_head is None and normalized_field.startswith("output."):
-        normalized_head = tool_reference_map.get(head.strip())
-        normalized_field = normalized_field.removeprefix("output.").strip()
-    if normalized_head is None:
-        return None
-    if not normalized_field:
-        return None
-    return f"{normalized_head}.{normalized_field}"
-
-
-def _normalize_placeholder_reference(
-    value: str,
-    *,
-    input_key: str | None,
-    step_id_map: dict[str, str],
-) -> str | None:
-    payload = value.strip()
-    if not (payload.startswith("<from_step_") and payload.endswith(">")):
-        return None
-    body = payload[len("<from_step_") : -1]
-    step_token, sep, suffix = body.partition("_")
-    canonical_step = step_id_map.get(step_token)
-    if canonical_step is None:
-        return None
-
-    field = suffix.strip() if sep else ""
-    if field == "output":
-        field = ""
-    if not field:
-        field = _infer_reference_field(input_key)
-    if not field:
-        return None
-    return f"{canonical_step}.{field}"
-
-
-def _infer_reference_field(input_key: str | None) -> str | None:
-    if not isinstance(input_key, str):
-        return None
-    lookup = {
-        "sequence": "sequence",
-        "pdb_path": "pdb_path",
-        "candidates": "candidates",
-        "structure_results": "structure_results",
-        "qc_metrics": "qc_metrics",
-        "score_table": "score_table",
-        "top_k": "top_k",
-    }
-    return lookup.get(input_key.strip())
-
-
-def _normalize_reference_field_for_input_key(
-    value: str,
-    *,
-    input_key: str | None,
-) -> str:
-    head, sep, tail = value.partition(".")
-    if not sep or not tail:
-        return value
-    expected_field = _infer_reference_field(input_key)
-    if expected_field is None:
-        return value
-    normalized_field = tail.strip()
-    if normalized_field == expected_field:
-        return value
-    if not _should_rewrite_reference_field(
-        input_key=input_key,
-        current_field=normalized_field,
-        expected_field=expected_field,
-    ):
-        return value
-    return f"{head.strip()}.{expected_field}"
-
-
-def _should_rewrite_reference_field(
-    *,
-    input_key: str | None,
-    current_field: str,
-    expected_field: str,
-) -> bool:
-    if not isinstance(input_key, str):
-        return False
-    normalized_key = input_key.strip()
-    if normalized_key == "sequence" and current_field in {"candidates", "sequence_candidates"}:
-        return True
-    if normalized_key == "candidates" and current_field == "sequence":
-        return True
-    if normalized_key == "pdb_path" and current_field in {"structure_pdb", "structure_path", "cif_path"}:
-        return True
-    if normalized_key == "structure_results" and current_field in {"pdb_path", "sequence", "plddt"}:
-        return True
-    return current_field == expected_field
-
-
-def _normalize_step_identifier(
-    value: str,
-    *,
-    step_id_map: dict[str, str],
-) -> str:
-    return step_id_map.get(value.strip(), value)
-
-
-def _normalize_json_like_value(value: Any) -> Any:
-    parsed = _parse_json_like_string(value)
-    if parsed is not value:
-        return _normalize_json_like_value(parsed)
-    if isinstance(value, list):
-        return [_normalize_json_like_value(item) for item in value]
-    if isinstance(value, dict):
-        return {
-            key: _normalize_json_like_value(item)
-            for key, item in value.items()
-        }
-    return value
-
-
-def _parse_json_like_string(value: Any) -> Any:
-    if not isinstance(value, str):
-        return value
-    payload = _strip_markdown_json_fence(value).strip()
-    if not payload or payload[0] not in "[{":
-        return value
-
-    candidates = [payload]
-    if '""' in payload:
-        candidates.append(payload.replace('""', '"'))
-
-    for candidate in candidates:
         try:
-            return json.loads(candidate)
-        except json.JSONDecodeError:
-            continue
-    return value
+            plan = Plan.model_validate(candidate)
+        except ValidationError as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="plan" if materialize_inputs else "replan",
+                failure_type="SCHEMA_INVALID",
+                issues=self._build_schema_issues(exc),
+                normalized_payload=candidate,
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
 
+        try:
+            plan = self._prepare_plan_for_validation(
+                plan,
+                task=task,
+                tool_registry=tool_registry,
+                materialize_inputs=materialize_inputs,
+                constraints_override=constraints_override,
+            )
+        except Exception as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="plan" if materialize_inputs else "replan",
+                failure_type="EXECUTABILITY_INVALID",
+                issues=[
+                    {
+                        "code": "PLAN_PREPARATION_INVALID",
+                        "path": "$.steps",
+                        "message": str(exc),
+                    }
+                ],
+                normalized_payload=plan.model_dump(mode="json"),
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
+        try:
+            validate_plan_executability(plan, task)
+        except CandidateExecutionValidationError as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="plan" if materialize_inputs else "replan",
+                failure_type="EXECUTABILITY_INVALID",
+                issues=[issue.as_dict() for issue in exc.issues],
+                normalized_payload=plan.model_dump(mode="json"),
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
+        return plan.model_dump(mode="json")
 
-def _strip_markdown_json_fence(content: str) -> str:
-    payload = content.strip()
-    if not payload.startswith("```"):
-        return payload
+    def _validate_patch_candidate(
+        self,
+        candidate: dict[str, Any],
+        *,
+        parse_result: ProviderPayloadParseResult,
+        request: PatchRequest,
+        tool_registry: List["ToolSpec"],
+    ) -> dict[str, Any]:
+        candidate = dict(candidate)
+        candidate.setdefault("task_id", request.task_id)
+        candidate.setdefault("metadata", {})
+        self._raise_on_syntax_issues(candidate_kind="patch", parse_result=parse_result)
+        try:
+            patch = PlanPatch.model_validate(candidate)
+        except ValidationError as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="patch",
+                failure_type="SCHEMA_INVALID",
+                issues=self._build_schema_issues(exc),
+                normalized_payload=candidate,
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
 
-    lines = payload.splitlines()
-    if not lines:
-        return payload
-    if lines[0].startswith("```"):
-        lines = lines[1:]
-    if lines and lines[-1].strip() == "```":
-        lines = lines[:-1]
-    return "\n".join(lines).strip()
+        from src.agents.planner import _normalize_patch_input_contract_references
+
+        patch = _normalize_patch_input_contract_references(
+            patch,
+            registry=tool_registry,
+        )
+        try:
+            patched_plan = apply_patch(request.original_plan, patch)
+            validation_task = self._build_validation_task(
+                task_id=request.task_id,
+                constraints=request.original_plan.constraints,
+            )
+            patched_plan = self._prepare_plan_for_validation(
+                patched_plan,
+                task=validation_task,
+                tool_registry=tool_registry,
+                materialize_inputs=False,
+                constraints_override=request.original_plan.constraints,
+            )
+            validate_plan_executability(patched_plan, validation_task)
+        except CandidateExecutionValidationError as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="patch",
+                failure_type="EXECUTABILITY_INVALID",
+                issues=[issue.as_dict() for issue in exc.issues],
+                normalized_payload=patch.model_dump(mode="json"),
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
+        except Exception as exc:
+            raise ProviderPayloadValidationError(
+                candidate_kind="patch",
+                failure_type="EXECUTABILITY_INVALID",
+                issues=[
+                    {
+                        "code": "PATCH_APPLICATION_INVALID",
+                        "path": "$.operations",
+                        "message": str(exc),
+                    }
+                ],
+                normalized_payload=patch.model_dump(mode="json"),
+                parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+            ) from exc
+
+        return patch.model_dump(mode="json")
+
+    def _prepare_plan_for_validation(
+        self,
+        plan: Plan,
+        *,
+        task: ProteinDesignTask,
+        tool_registry: List["ToolSpec"],
+        materialize_inputs: bool,
+        constraints_override: dict[str, Any] | None = None,
+    ) -> Plan:
+        from src.agents.planner import (
+            _ensure_plan_tools_in_registry,
+            _materialize_missing_plan_inputs,
+            _normalize_plan_input_contract_references,
+            _resolve_plan_tools,
+        )
+
+        constraints = constraints_override if isinstance(constraints_override, dict) else task.constraints
+        prepared = _normalize_plan_input_contract_references(
+            plan,
+            registry=tool_registry,
+        )
+        prepared = _resolve_plan_tools(
+            prepared,
+            tool_registry,
+            constraints,
+        )
+        if materialize_inputs:
+            prepared = _materialize_missing_plan_inputs(
+                prepared,
+                tool_registry,
+                task,
+            )
+        _ensure_plan_tools_in_registry(prepared, tool_registry)
+        return prepared
+
+    def _raise_on_syntax_issues(
+        self,
+        *,
+        candidate_kind: str,
+        parse_result: ProviderPayloadParseResult,
+    ) -> None:
+        if parse_result.is_compliant:
+            return
+        raise ProviderPayloadValidationError(
+            candidate_kind=candidate_kind,
+            failure_type="SYNTAX_INVALID",
+            issues=[issue.as_dict() for issue in parse_result.issues],
+            normalized_payload=parse_result.normalized_payload,
+            parser_repairs=[repair.as_dict() for repair in parse_result.repairs],
+        )
+
+    def _build_repair_user_prompt(
+        self,
+        *,
+        base_user_prompt: str,
+        candidate_kind: str,
+        tool_name: str,
+        error: ProviderPayloadValidationError,
+    ) -> str:
+        issue_lines = []
+        for index, issue in enumerate(error.issues[:8], start=1):
+            line = f"{index}. {issue.get('path', '$')}: {issue.get('message', error.failure_type)}"
+            observed = issue.get("observed")
+            if observed is not None:
+                line += f" | observed={json.dumps(observed, ensure_ascii=False)}"
+            repair_hint = issue.get("repair_hint")
+            if isinstance(repair_hint, str) and repair_hint:
+                line += f" | fix={repair_hint}"
+            issue_lines.append(line)
+
+        return (
+            f"{base_user_prompt}\n\n"
+            "上一次输出未通过 provider 校验，请仅修复结构、字段和引用表达，"
+            "不要改变任务意图，不要新增未请求步骤，不要填造假的执行结果。\n"
+            f"目标工具调用: {tool_name}\n"
+            f"候选类型: {candidate_kind}\n"
+            f"失败分类: {error.failure_type}\n"
+            f"修复轮次: {error.attempts}\n"
+            "错误摘要:\n"
+            + "\n".join(f"- {line}" for line in issue_lines)
+            + "\n必须遵守:\n"
+            "- 只输出一次对应工具调用\n"
+            "- steps / operations 必须是真正的 JSON array，不能是字符串\n"
+            "- 跨步引用只能使用 S<n>.field\n"
+            "- 禁止 ${...}、$...、<...>、auto、裸 token（如 CANDIDATES）\n"
+            "- 若是 patch，replace_step 必须保持 target id 不变\n"
+        )
+
+    def _build_schema_issues(self, exc: ValidationError) -> list[dict[str, Any]]:
+        issues: list[dict[str, Any]] = []
+        for error in exc.errors():
+            loc = error.get("loc") or ()
+            path = "$"
+            if isinstance(loc, tuple):
+                segments: list[str] = ["$"]
+                for item in loc:
+                    if isinstance(item, int):
+                        segments[-1] = f"{segments[-1]}[{item}]"
+                    else:
+                        segments.append(str(item))
+                path = ".".join(segments)
+            issues.append(
+                {
+                    "code": "SCHEMA_FIELD_INVALID",
+                    "path": path,
+                    "message": error.get("msg", "schema validation failed"),
+                    "observed": error.get("input"),
+                }
+            )
+        return issues
+
+    def _build_validation_task(
+        self,
+        *,
+        task_id: str,
+        constraints: dict[str, Any] | None,
+    ) -> ProteinDesignTask:
+        return ProteinDesignTask(
+            task_id=task_id,
+            goal="provider_validation_probe",
+            constraints=constraints or {},
+            metadata={},
+        )

--- a/src/llm/provider_payload_parser.py
+++ b/src/llm/provider_payload_parser.py
@@ -1,0 +1,891 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol, Sequence
+
+
+_CANONICAL_REFERENCE_RE = re.compile(r"^(S\d+)\.([A-Za-z_][A-Za-z0-9_]*)$")
+_INDEXED_REFERENCE_RE = re.compile(
+    r"^(S\d+)\.([A-Za-z_][A-Za-z0-9_]*)\[\d+\](?:\.([A-Za-z_][A-Za-z0-9_]*))?$"
+)
+_STEP_REFERENCE_RE = re.compile(
+    r"^\$?(?:(?:step|STEP)[_.-]?|S)?(\d+)(?:\.([A-Za-z_][A-Za-z0-9_]*))?$"
+)
+_TEMPLATE_REFERENCE_RE = re.compile(r"^\$\{([^{}]+)\}$")
+_PLACEHOLDER_STEP_RE = re.compile(r"^<from_step_(\d+)(?:_([A-Za-z0-9_]+))?>$")
+_TOOL_OUTPUT_RE = re.compile(
+    r"^([A-Za-z_][A-Za-z0-9_-]*)\.output\.([A-Za-z_][A-Za-z0-9_]*)$"
+)
+
+_FORBIDDEN_LITERAL_FIELDS = {
+    "sequence",
+    "candidates",
+    "pdb_path",
+    "structure_results",
+    "qc_metrics",
+    "score_table",
+    "top_k",
+}
+_PLACEHOLDER_FIELD_ALIASES = {
+    "generated_sequence": "sequence",
+    "predicted_pdb": "pdb_path",
+    "predicted_structure": "structure_results",
+    "structure": "structure_results",
+    "pdb": "pdb_path",
+    "seq": "sequence",
+}
+
+
+class ToolSpecLike(Protocol):
+    """Provider 解析器所需的最小工具定义接口。"""
+
+    id: str
+    outputs: Sequence[str]
+
+
+@dataclass(frozen=True)
+class PayloadRepair:
+    """一次已应用的轻量修复记录。"""
+
+    path: str
+    original: Any
+    normalized: Any
+    reason: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "original": self.original,
+            "normalized": self.normalized,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class PayloadIssue:
+    """一次无法自动修复的 payload 问题。"""
+
+    code: str
+    path: str
+    message: str
+    observed: Any = None
+    repair_hint: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+            "observed": self.observed,
+        }
+        if self.repair_hint:
+            payload["repair_hint"] = self.repair_hint
+        return payload
+
+
+@dataclass(frozen=True)
+class ProviderPayloadParseResult:
+    """Provider 输出的语法解析结果。"""
+
+    normalized_payload: dict[str, Any] | None
+    repairs: tuple[PayloadRepair, ...]
+    issues: tuple[PayloadIssue, ...]
+
+    @property
+    def is_compliant(self) -> bool:
+        return not self.issues
+
+
+class ProviderPayloadParser:
+    """Provider 输出语法解析器。
+
+    负责：
+    1. 解析 JSON-like 字符串；
+    2. 识别并归一化常见占位符 / 模板引用；
+    3. 收集无法自动修复的语法违规项。
+    """
+
+    def __init__(self, tool_registry: Sequence[ToolSpecLike] | None = None):
+        self._registry_outputs = {
+            spec.id: tuple(spec.outputs)
+            for spec in (tool_registry or ())
+            if getattr(spec, "id", None)
+        }
+
+    def parse(
+        self,
+        payload: Any,
+        *,
+        candidate_kind: str,
+    ) -> ProviderPayloadParseResult:
+        repairs: list[PayloadRepair] = []
+        issues: list[PayloadIssue] = []
+
+        normalized = _normalize_json_like_value(payload, path="$", repairs=repairs)
+        if not isinstance(normalized, dict):
+            issues.append(
+                PayloadIssue(
+                    code="PAYLOAD_NOT_OBJECT",
+                    path="$",
+                    message="provider payload must be a JSON object after syntax normalization",
+                    observed=type(normalized).__name__,
+                    repair_hint="return a single JSON object instead of text or arrays",
+                )
+            )
+            return ProviderPayloadParseResult(
+                normalized_payload=None,
+                repairs=tuple(repairs),
+                issues=tuple(issues),
+            )
+
+        normalized_payload = dict(normalized)
+        if candidate_kind in {"plan", "replan"}:
+            normalized_payload = self._normalize_plan_payload(
+                normalized_payload,
+                repairs=repairs,
+                issues=issues,
+            )
+        elif candidate_kind == "patch":
+            normalized_payload = self._normalize_patch_payload(
+                normalized_payload,
+                repairs=repairs,
+                issues=issues,
+            )
+
+        return ProviderPayloadParseResult(
+            normalized_payload=normalized_payload,
+            repairs=tuple(repairs),
+            issues=tuple(issues),
+        )
+
+    def _normalize_plan_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        repairs: list[PayloadRepair],
+        issues: list[PayloadIssue],
+    ) -> dict[str, Any]:
+        normalized = dict(payload)
+        steps = normalized.get("steps")
+        if isinstance(steps, list):
+            normalized["steps"] = self._normalize_plan_steps(
+                steps,
+                path="$.steps",
+                repairs=repairs,
+                issues=issues,
+            )
+        elif "steps" in normalized:
+            issues.append(
+                PayloadIssue(
+                    code="STEPS_NOT_ARRAY",
+                    path="$.steps",
+                    message="steps must be a JSON array",
+                    observed=steps,
+                    repair_hint="emit steps as an array of step objects, never as a string",
+                )
+            )
+        return normalized
+
+    def _normalize_patch_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        repairs: list[PayloadRepair],
+        issues: list[PayloadIssue],
+    ) -> dict[str, Any]:
+        normalized = dict(payload)
+        operations = normalized.get("operations")
+        if isinstance(operations, list):
+            normalized["operations"] = self._normalize_patch_operations(
+                operations,
+                path="$.operations",
+                repairs=repairs,
+                issues=issues,
+            )
+        elif "operations" in normalized:
+            issues.append(
+                PayloadIssue(
+                    code="OPERATIONS_NOT_ARRAY",
+                    path="$.operations",
+                    message="operations must be a JSON array",
+                    observed=operations,
+                    repair_hint="emit operations as an array of PlanPatchOp objects",
+                )
+            )
+        return normalized
+
+    def _normalize_plan_steps(
+        self,
+        steps: list[Any],
+        *,
+        path: str,
+        repairs: list[PayloadRepair],
+        issues: list[PayloadIssue],
+    ) -> list[Any]:
+        step_id_map, tool_reference_map = _build_step_reference_maps(steps)
+        normalized_steps: list[Any] = []
+        field_source_map: dict[str, str] = {}
+
+        for index, raw_step in enumerate(steps, start=1):
+            step_path = f"{path}[{index - 1}]"
+            if not isinstance(raw_step, dict):
+                normalized_steps.append(raw_step)
+                continue
+
+            step = dict(raw_step)
+            canonical_id = f"S{index}"
+            if step.get("id") != canonical_id:
+                repairs.append(
+                    PayloadRepair(
+                        path=f"{step_path}.id",
+                        original=step.get("id"),
+                        normalized=canonical_id,
+                        reason="canonicalize sequential step id",
+                    )
+                )
+            step["id"] = canonical_id
+
+            inputs = step.get("inputs")
+            if isinstance(inputs, dict):
+                normalized_inputs: dict[str, Any] = {}
+                for key, value in inputs.items():
+                    normalized_inputs[key] = self._normalize_input_value(
+                        value,
+                        path=f"{step_path}.inputs.{key}",
+                        input_key=key,
+                        step_id_map=step_id_map,
+                        tool_reference_map=tool_reference_map,
+                        field_source_map=field_source_map,
+                        repairs=repairs,
+                        issues=issues,
+                    )
+                step["inputs"] = normalized_inputs
+            elif "inputs" in step and inputs is not None:
+                issues.append(
+                    PayloadIssue(
+                        code="INPUTS_NOT_OBJECT",
+                        path=f"{step_path}.inputs",
+                        message="step inputs must be an object",
+                        observed=inputs,
+                        repair_hint="emit each step.inputs as a JSON object",
+                    )
+                )
+
+            normalized_steps.append(step)
+            for output_name in self._collect_output_fields(step):
+                field_source_map.setdefault(output_name, canonical_id)
+
+        return normalized_steps
+
+    def _normalize_patch_operations(
+        self,
+        operations: list[Any],
+        *,
+        path: str,
+        repairs: list[PayloadRepair],
+        issues: list[PayloadIssue],
+    ) -> list[Any]:
+        pseudo_steps: list[dict[str, Any]] = []
+        for operation in operations:
+            if not isinstance(operation, dict):
+                continue
+            step = operation.get("step")
+            if not isinstance(step, dict):
+                continue
+            pseudo_step = dict(step)
+            target = operation.get("target")
+            if "id" not in pseudo_step and isinstance(target, str):
+                pseudo_step["id"] = target
+            pseudo_steps.append(pseudo_step)
+
+        step_id_map, tool_reference_map = _build_step_reference_maps(pseudo_steps)
+        normalized_operations: list[Any] = []
+        field_source_map: dict[str, str] = {}
+
+        for index, raw_operation in enumerate(operations, start=1):
+            op_path = f"{path}[{index - 1}]"
+            if not isinstance(raw_operation, dict):
+                normalized_operations.append(raw_operation)
+                continue
+
+            operation = dict(raw_operation)
+            target = operation.get("target")
+            if isinstance(target, str):
+                normalized_target = _normalize_step_identifier(
+                    target,
+                    step_id_map=step_id_map,
+                )
+                if normalized_target != target:
+                    repairs.append(
+                        PayloadRepair(
+                            path=f"{op_path}.target",
+                            original=target,
+                            normalized=normalized_target,
+                            reason="canonicalize patch target step id",
+                        )
+                    )
+                operation["target"] = normalized_target
+
+            step = operation.get("step")
+            if isinstance(step, dict):
+                normalized_step = dict(step)
+                step_id = normalized_step.get("id")
+                if isinstance(step_id, str):
+                    normalized_step_id = _normalize_step_identifier(
+                        step_id,
+                        step_id_map=step_id_map,
+                    )
+                    if normalized_step_id != step_id:
+                        repairs.append(
+                            PayloadRepair(
+                                path=f"{op_path}.step.id",
+                                original=step_id,
+                                normalized=normalized_step_id,
+                                reason="canonicalize patch step id",
+                            )
+                        )
+                    normalized_step["id"] = normalized_step_id
+
+                inputs = normalized_step.get("inputs")
+                if isinstance(inputs, dict):
+                    normalized_inputs: dict[str, Any] = {}
+                    for key, value in inputs.items():
+                        normalized_inputs[key] = self._normalize_input_value(
+                            value,
+                            path=f"{op_path}.step.inputs.{key}",
+                            input_key=key,
+                            step_id_map=step_id_map,
+                            tool_reference_map=tool_reference_map,
+                            field_source_map=field_source_map,
+                            repairs=repairs,
+                            issues=issues,
+                        )
+                    normalized_step["inputs"] = normalized_inputs
+                operation["step"] = normalized_step
+
+                normalized_step_id = normalized_step.get("id")
+                if isinstance(normalized_step_id, str):
+                    for output_name in self._collect_output_fields(normalized_step):
+                        field_source_map.setdefault(output_name, normalized_step_id)
+
+            normalized_operations.append(operation)
+        return normalized_operations
+
+    def _normalize_input_value(
+        self,
+        value: Any,
+        *,
+        path: str,
+        input_key: str | None,
+        step_id_map: dict[str, str],
+        tool_reference_map: dict[str, str],
+        field_source_map: dict[str, str],
+        repairs: list[PayloadRepair],
+        issues: list[PayloadIssue],
+    ) -> Any:
+        normalized = _normalize_json_like_value(value, path=path, repairs=repairs)
+
+        if isinstance(normalized, list):
+            return [
+                self._normalize_input_value(
+                    item,
+                    path=f"{path}[{index}]",
+                    input_key=input_key,
+                    step_id_map=step_id_map,
+                    tool_reference_map=tool_reference_map,
+                    field_source_map=field_source_map,
+                    repairs=repairs,
+                    issues=issues,
+                )
+                for index, item in enumerate(normalized)
+            ]
+
+        if isinstance(normalized, dict):
+            return {
+                key: self._normalize_input_value(
+                    item,
+                    path=f"{path}.{key}",
+                    input_key=key,
+                    step_id_map=step_id_map,
+                    tool_reference_map=tool_reference_map,
+                    field_source_map=field_source_map,
+                    repairs=repairs,
+                    issues=issues,
+                )
+                for key, item in normalized.items()
+            }
+
+        if not isinstance(normalized, str):
+            return normalized
+
+        parsed = self._parse_reference_token(
+            normalized,
+            input_key=input_key,
+            step_id_map=step_id_map,
+            tool_reference_map=tool_reference_map,
+            field_source_map=field_source_map,
+        )
+        if parsed is not None:
+            if parsed != normalized:
+                repairs.append(
+                    PayloadRepair(
+                        path=path,
+                        original=normalized,
+                        normalized=parsed,
+                        reason="normalize non-canonical reference token",
+                    )
+                )
+            return parsed
+
+        if _looks_like_forbidden_reference(normalized):
+            issues.append(
+                PayloadIssue(
+                    code="REFERENCE_SYNTAX_INVALID",
+                    path=path,
+                    message="reference token is not compliant with S<n>.field grammar",
+                    observed=normalized,
+                    repair_hint=(
+                        "rewrite the value using S<n>.field and remove "
+                        "${...}, $..., <...>, auto, or bare placeholder tokens"
+                    ),
+                )
+            )
+        return normalized
+
+    def _parse_reference_token(
+        self,
+        value: str,
+        *,
+        input_key: str | None,
+        step_id_map: dict[str, str],
+        tool_reference_map: dict[str, str],
+        field_source_map: dict[str, str],
+    ) -> str | None:
+        text = value.strip()
+        if not text:
+            return None
+
+        canonical = _CANONICAL_REFERENCE_RE.fullmatch(text)
+        if canonical is not None:
+            return _normalize_reference_field_for_input_key(
+                text,
+                input_key=input_key,
+            )
+
+        indexed = _INDEXED_REFERENCE_RE.fullmatch(text)
+        if indexed is not None:
+            head = indexed.group(1)
+            field = indexed.group(3) or indexed.group(2)
+            return _normalize_reference_field_for_input_key(
+                f"{head}.{field}",
+                input_key=input_key,
+            )
+
+        symbolic = _normalize_symbolic_reference(
+            text,
+            input_key=input_key,
+            step_id_map=step_id_map,
+            tool_reference_map=tool_reference_map,
+        )
+        if symbolic is not None:
+            return _normalize_reference_field_for_input_key(
+                symbolic,
+                input_key=input_key,
+            )
+
+        template = _TEMPLATE_REFERENCE_RE.fullmatch(text)
+        if template is not None:
+            inner = template.group(1).strip()
+            if inner.lower().startswith("step."):
+                inner = "S" + inner.split(".", 1)[1]
+            elif inner.lower().startswith("step_"):
+                inner = "S" + inner.split("_", 1)[1]
+            parsed_inner = self._parse_reference_token(
+                inner,
+                input_key=input_key,
+                step_id_map=step_id_map,
+                tool_reference_map=tool_reference_map,
+                field_source_map=field_source_map,
+            )
+            if parsed_inner is not None:
+                return parsed_inner
+
+        placeholder = _PLACEHOLDER_STEP_RE.fullmatch(text)
+        if placeholder is not None:
+            step_token = placeholder.group(1)
+            field = placeholder.group(2)
+            canonical_step = step_id_map.get(step_token)
+            if canonical_step is None:
+                return None
+            resolved_field = _normalize_placeholder_field(
+                field,
+                input_key=input_key,
+            )
+            if resolved_field is None:
+                return None
+            return f"{canonical_step}.{resolved_field}"
+
+        field_placeholder = None
+        if text.startswith("<") and text.endswith(">"):
+            field_placeholder = _normalize_placeholder_field(
+                text[1:-1],
+                input_key=input_key,
+            )
+        if field_placeholder:
+            return _infer_reference_from_field(
+                field_placeholder,
+                field_source_map=field_source_map,
+            )
+
+        step_token = _STEP_REFERENCE_RE.fullmatch(text)
+        if step_token is not None:
+            canonical_step = step_id_map.get(step_token.group(1))
+            if canonical_step is None:
+                return None
+            field = step_token.group(2) or _infer_reference_field(input_key)
+            if field is None:
+                return None
+            return f"{canonical_step}.{field}"
+
+        tool_output = _TOOL_OUTPUT_RE.fullmatch(text)
+        if tool_output is not None:
+            tool_name = tool_output.group(1).strip()
+            field = tool_output.group(2).strip()
+            step_id = tool_reference_map.get(tool_name)
+            if step_id is None:
+                return None
+            return _normalize_reference_field_for_input_key(
+                f"{step_id}.{field}",
+                input_key=input_key,
+            )
+
+        normalized_token = text.strip("$")
+        if normalized_token.lower() == "auto":
+            expected_field = _infer_reference_field(input_key)
+            if expected_field is None:
+                return None
+            return _infer_reference_from_field(
+                expected_field,
+                field_source_map=field_source_map,
+            )
+
+        field_token = _normalize_placeholder_field(
+            normalized_token,
+            input_key=input_key,
+        )
+        if field_token is not None and normalized_token.upper() == normalized_token:
+            return _infer_reference_from_field(
+                field_token,
+                field_source_map=field_source_map,
+            )
+
+        return None
+
+    def _collect_output_fields(self, step: dict[str, Any]) -> tuple[str, ...]:
+        tool_name = step.get("tool")
+        if not isinstance(tool_name, str):
+            return ()
+        outputs = self._registry_outputs.get(tool_name)
+        if outputs:
+            return outputs
+        return ()
+
+
+class ProviderPayloadValidationError(ValueError):
+    """Provider 输出在 syntax/schema/executability 任一阶段失败。"""
+
+    def __init__(
+        self,
+        *,
+        candidate_kind: str,
+        failure_type: str,
+        issues: Sequence[dict[str, Any]],
+        normalized_payload: dict[str, Any] | None = None,
+        parser_repairs: Sequence[dict[str, Any]] | None = None,
+        attempts: int = 1,
+    ) -> None:
+        self.candidate_kind = candidate_kind
+        self.failure_type = failure_type
+        self.issues = [dict(issue) for issue in issues]
+        self.normalized_payload = (
+            dict(normalized_payload) if isinstance(normalized_payload, dict) else None
+        )
+        self.parser_repairs = [dict(repair) for repair in (parser_repairs or ())]
+        self.attempts = attempts
+        summary = self.issues[0]["message"] if self.issues else failure_type
+        super().__init__(f"{candidate_kind}:{failure_type}: {summary}")
+
+    def with_attempts(self, attempts: int) -> "ProviderPayloadValidationError":
+        return ProviderPayloadValidationError(
+            candidate_kind=self.candidate_kind,
+            failure_type=self.failure_type,
+            issues=self.issues,
+            normalized_payload=self.normalized_payload,
+            parser_repairs=self.parser_repairs,
+            attempts=attempts,
+        )
+
+    def as_event_payload(self) -> dict[str, Any]:
+        return {
+            "failure_code": self.failure_type,
+            "failures": list(self.issues),
+            "candidate_kind": self.candidate_kind,
+            "attempts": self.attempts,
+            "parser_repairs": list(self.parser_repairs),
+        }
+
+
+def _build_step_reference_maps(
+    steps: Sequence[Any],
+) -> tuple[dict[str, str], dict[str, str]]:
+    step_id_map: dict[str, str] = {}
+    tool_to_step_ids: dict[str, list[str]] = {}
+    for index, raw_step in enumerate(steps, start=1):
+        if not isinstance(raw_step, dict):
+            continue
+        canonical_id = f"S{index}"
+        raw_id = raw_step.get("id")
+        if isinstance(raw_id, str):
+            compact = raw_id.strip()
+            if compact:
+                step_id_map[compact] = canonical_id
+                step_id_map[compact.lower()] = canonical_id
+                if compact.isdigit():
+                    step_id_map[f"step_{compact}"] = canonical_id
+        step_id_map[str(index)] = canonical_id
+        step_id_map[f"step_{index}"] = canonical_id
+        step_id_map[f"s{index}"] = canonical_id
+
+        tool_name = raw_step.get("tool")
+        if isinstance(tool_name, str) and tool_name.strip():
+            tool_to_step_ids.setdefault(tool_name.strip(), []).append(canonical_id)
+
+    tool_reference_map = {
+        tool_name: step_ids[0]
+        for tool_name, step_ids in tool_to_step_ids.items()
+        if len(step_ids) == 1
+    }
+    return step_id_map, tool_reference_map
+
+
+def _normalize_step_identifier(
+    value: str,
+    *,
+    step_id_map: dict[str, str],
+) -> str:
+    normalized = step_id_map.get(value.strip())
+    if normalized is not None:
+        return normalized
+    return step_id_map.get(value.strip().lower(), value)
+
+
+def _normalize_symbolic_reference(
+    value: str,
+    *,
+    input_key: str | None,
+    step_id_map: dict[str, str],
+    tool_reference_map: dict[str, str],
+) -> str | None:
+    head, sep, tail = value.partition(".")
+    if not sep or not tail:
+        return None
+
+    normalized_head = step_id_map.get(head.strip()) or step_id_map.get(head.strip().lower())
+    normalized_field = tail.strip()
+    if normalized_head is None and normalized_field.startswith("output."):
+        normalized_head = tool_reference_map.get(head.strip())
+        normalized_field = normalized_field.removeprefix("output.").strip()
+    if normalized_head is None or not normalized_field:
+        return None
+    return _normalize_reference_field_for_input_key(
+        f"{normalized_head}.{normalized_field}",
+        input_key=input_key,
+    )
+
+
+def _infer_reference_field(input_key: str | None) -> str | None:
+    if not isinstance(input_key, str):
+        return None
+    lookup = {
+        "sequence": "sequence",
+        "pdb_path": "pdb_path",
+        "candidates": "candidates",
+        "structure_results": "structure_results",
+        "qc_metrics": "qc_metrics",
+        "score_table": "score_table",
+        "top_k": "top_k",
+    }
+    return lookup.get(input_key.strip())
+
+
+def _normalize_reference_field_for_input_key(
+    value: str,
+    *,
+    input_key: str | None,
+) -> str:
+    head, sep, tail = value.partition(".")
+    if not sep or not tail:
+        return value
+    expected_field = _infer_reference_field(input_key)
+    if expected_field is None:
+        return value
+    normalized_field = tail.strip()
+    if normalized_field == expected_field:
+        return value
+    if not _should_rewrite_reference_field(
+        input_key=input_key,
+        current_field=normalized_field,
+        expected_field=expected_field,
+    ):
+        return value
+    return f"{head.strip()}.{expected_field}"
+
+
+def _should_rewrite_reference_field(
+    *,
+    input_key: str | None,
+    current_field: str,
+    expected_field: str,
+) -> bool:
+    if not isinstance(input_key, str):
+        return False
+    normalized_key = input_key.strip()
+    if normalized_key == "sequence" and current_field in {"candidates", "sequence_candidates"}:
+        return True
+    if normalized_key == "candidates" and current_field == "sequence":
+        return True
+    if normalized_key == "pdb_path" and current_field in {"structure_pdb", "structure_path", "cif_path"}:
+        return True
+    if normalized_key == "structure_results" and current_field in {"pdb_path", "sequence", "plddt"}:
+        return True
+    return current_field == expected_field
+
+
+def _normalize_json_like_value(
+    value: Any,
+    *,
+    path: str,
+    repairs: list[PayloadRepair],
+) -> Any:
+    parsed = _parse_json_like_string(value)
+    if parsed is not value:
+        repairs.append(
+            PayloadRepair(
+                path=path,
+                original=value,
+                normalized=parsed,
+                reason="parse JSON-like string payload",
+            )
+        )
+        return _normalize_json_like_value(parsed, path=path, repairs=repairs)
+    if isinstance(value, list):
+        return [
+            _normalize_json_like_value(
+                item,
+                path=f"{path}[{index}]",
+                repairs=repairs,
+            )
+            for index, item in enumerate(value)
+        ]
+    if isinstance(value, dict):
+        return {
+            key: _normalize_json_like_value(
+                item,
+                path=f"{path}.{key}",
+                repairs=repairs,
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _parse_json_like_string(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    payload = _strip_markdown_json_fence(value).strip()
+    if not payload or payload[0] not in "[{":
+        return value
+
+    candidates = [payload]
+    if '""' in payload:
+        candidates.append(payload.replace('""', '"'))
+
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return value
+
+
+def _strip_markdown_json_fence(content: str) -> str:
+    payload = content.strip()
+    if not payload.startswith("```"):
+        return payload
+
+    lines = payload.splitlines()
+    if not lines:
+        return payload
+    if lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _normalize_placeholder_field(
+    token: str | None,
+    *,
+    input_key: str | None,
+) -> str | None:
+    if not isinstance(token, str):
+        return _infer_reference_field(input_key)
+    compact = token.strip().strip("$").strip()
+    if not compact:
+        return _infer_reference_field(input_key)
+
+    lowered = compact.lower()
+    if lowered.startswith("step_") or lowered.startswith("step."):
+        return _infer_reference_field(input_key)
+    if lowered in {"output", "value"}:
+        return _infer_reference_field(input_key)
+    if lowered in _PLACEHOLDER_FIELD_ALIASES:
+        return _PLACEHOLDER_FIELD_ALIASES[lowered]
+    if lowered in _FORBIDDEN_LITERAL_FIELDS:
+        return lowered
+    return _infer_reference_field(input_key)
+
+
+def _infer_reference_from_field(
+    field: str,
+    *,
+    field_source_map: dict[str, str],
+) -> str | None:
+    source_step = field_source_map.get(field)
+    if source_step is None:
+        return None
+    return f"{source_step}.{field}"
+
+
+def _looks_like_forbidden_reference(value: str) -> bool:
+    compact = value.strip()
+    if not compact:
+        return False
+    if compact == "auto":
+        return True
+    if compact.startswith("${") or compact.startswith("<") or compact.startswith("$"):
+        return True
+    if _STEP_REFERENCE_RE.fullmatch(compact) is not None:
+        return True
+    upper = compact.upper()
+    if upper == compact and upper in {
+        "CANDIDATES",
+        "SEQUENCE",
+        "PDB_PATH",
+        "STRUCTURE_RESULTS",
+        "QC_METRICS",
+    }:
+        return True
+    return False

--- a/src/llm/provider_payload_parser.py
+++ b/src/llm/provider_payload_parser.py
@@ -141,7 +141,7 @@ class ProviderPayloadParser:
             )
 
         normalized_payload = dict(normalized)
-        if candidate_kind in {"plan", "replan"}:
+        if candidate_kind in {"plan", "replan", "plan_skeleton"}:
             normalized_payload = self._normalize_plan_payload(
                 normalized_payload,
                 repairs=repairs,

--- a/tests/unit/test_anthropic_messages_provider.py
+++ b/tests/unit/test_anthropic_messages_provider.py
@@ -186,6 +186,300 @@ def test_anthropic_provider_generates_plan_via_tool_use(monkeypatch):
     assert calls["kwargs"]["extra_headers"]["anthropic-version"] == "2023-06-01"
 
 
+def test_anthropic_provider_generates_two_stage_plan_when_configured(monkeypatch):
+    calls = {"tool_names": [], "prompts": []}
+    payloads = {
+        "emit_plan_skeleton": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan_skeleton",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {"id": "1", "tool": "protgpt2", "metadata": {}},
+                            {"id": "2", "tool": "openfold", "metadata": {}},
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+        "emit_plan": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {
+                                "id": "S1",
+                                "tool": "protgpt2",
+                                "inputs": {"goal": "design a stable protein"},
+                                "metadata": {},
+                            },
+                            {
+                                "id": "S2",
+                                "tool": "openfold",
+                                "inputs": {"sequence": "S1.sequence"},
+                                "metadata": {},
+                            },
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+    }
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            tool_name = kwargs["tools"][0]["name"]
+            calls["tool_names"].append(tool_name)
+            calls["prompts"].append(kwargs["messages"][0]["content"])
+            return _fake_response(payloads[tool_name])
+
+    class FakeAnthropic:
+        def __init__(self, *, api_key, base_url, timeout):
+            del api_key, base_url, timeout
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_provider_module, "Anthropic", FakeAnthropic)
+    provider = AnthropicMessagesProvider(
+        ProviderConfig(
+            model_name="MiniMax-M2.7",
+            api_key="secret",
+            tool_strategy="two_stage_plan",
+        )
+    )
+
+    plan = provider.call_planner(_sample_task(), _sample_registry())
+
+    assert calls["tool_names"] == ["emit_plan_skeleton", "emit_plan"]
+    assert "已确认 PlanSkeleton" in calls["prompts"][1]
+    assert [step["tool"] for step in plan["steps"]] == ["protgpt2", "openfold"]
+    assert plan["steps"][0]["id"] == "S1"
+    assert plan["metadata"]["provider_generation_mode"] == "two_stage_plan"
+    assert plan["metadata"]["provider_plan_skeleton"]["step_count"] == 2
+
+
+def test_anthropic_provider_repairs_skeleton_with_inputs(monkeypatch):
+    calls = {"tool_names": [], "prompts": []}
+    skeleton_payloads = [
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan_skeleton",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {
+                                "id": "S1",
+                                "tool": "protgpt2",
+                                "inputs": {"goal": "design"},
+                                "metadata": {},
+                            }
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan_skeleton",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [{"id": "S1", "tool": "protgpt2", "metadata": {}}],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+    ]
+
+    class FakeMessages:
+        def __init__(self):
+            self.skeleton_count = 0
+
+        def create(self, **kwargs):
+            tool_name = kwargs["tools"][0]["name"]
+            calls["tool_names"].append(tool_name)
+            calls["prompts"].append(kwargs["messages"][0]["content"])
+            if tool_name == "emit_plan_skeleton":
+                index = min(self.skeleton_count, len(skeleton_payloads) - 1)
+                self.skeleton_count += 1
+                return _fake_response(skeleton_payloads[index])
+            return _fake_response(
+                {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "emit_plan",
+                            "input": {
+                                "task_id": "task_001",
+                                "steps": [
+                                    {
+                                        "id": "S1",
+                                        "tool": "protgpt2",
+                                        "inputs": {"goal": "design"},
+                                        "metadata": {},
+                                    }
+                                ],
+                                "constraints": {},
+                                "metadata": {},
+                            },
+                        }
+                    ]
+                }
+            )
+
+    class FakeAnthropic:
+        def __init__(self, *, api_key, base_url, timeout):
+            del api_key, base_url, timeout
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_provider_module, "Anthropic", FakeAnthropic)
+    provider = AnthropicMessagesProvider(
+        ProviderConfig(
+            model_name="MiniMax-M2.7",
+            api_key="secret",
+            tool_strategy="two_stage_plan",
+        )
+    )
+
+    plan = provider.call_planner(_sample_task(), _sample_registry())
+
+    assert calls["tool_names"] == [
+        "emit_plan_skeleton",
+        "emit_plan_skeleton",
+        "emit_plan",
+    ]
+    assert "失败分类: SCHEMA_INVALID" in calls["prompts"][1]
+    assert plan["steps"][0]["tool"] == "protgpt2"
+
+
+def test_anthropic_provider_repairs_two_stage_plan_when_skeleton_mismatches(monkeypatch):
+    calls = {"tool_names": [], "prompts": []}
+    final_payloads = [
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {
+                                "id": "S1",
+                                "tool": "protgpt2",
+                                "inputs": {"goal": "design"},
+                                "metadata": {},
+                            },
+                            {
+                                "id": "S2",
+                                "tool": "esmfold",
+                                "inputs": {"sequence": "S1.sequence"},
+                                "metadata": {},
+                            },
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {
+                                "id": "S1",
+                                "tool": "protgpt2",
+                                "inputs": {"goal": "design"},
+                                "metadata": {},
+                            },
+                            {
+                                "id": "S2",
+                                "tool": "openfold",
+                                "inputs": {"sequence": "S1.sequence"},
+                                "metadata": {},
+                            },
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+    ]
+
+    class FakeMessages:
+        def __init__(self):
+            self.final_count = 0
+
+        def create(self, **kwargs):
+            tool_name = kwargs["tools"][0]["name"]
+            calls["tool_names"].append(tool_name)
+            calls["prompts"].append(kwargs["messages"][0]["content"])
+            if tool_name == "emit_plan_skeleton":
+                return _fake_response(
+                    {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "emit_plan_skeleton",
+                                "input": {
+                                    "task_id": "task_001",
+                                    "steps": [
+                                        {"id": "S1", "tool": "protgpt2", "metadata": {}},
+                                        {"id": "S2", "tool": "openfold", "metadata": {}},
+                                    ],
+                                    "constraints": {},
+                                    "metadata": {},
+                                },
+                            }
+                        ]
+                    }
+                )
+            index = min(self.final_count, len(final_payloads) - 1)
+            self.final_count += 1
+            return _fake_response(final_payloads[index])
+
+    class FakeAnthropic:
+        def __init__(self, *, api_key, base_url, timeout):
+            del api_key, base_url, timeout
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_provider_module, "Anthropic", FakeAnthropic)
+    provider = AnthropicMessagesProvider(
+        ProviderConfig(
+            model_name="MiniMax-M2.7",
+            api_key="secret",
+            tool_strategy="two_stage_plan",
+        )
+    )
+
+    plan = provider.call_planner(_sample_task(), _sample_registry())
+
+    assert calls["tool_names"] == ["emit_plan_skeleton", "emit_plan", "emit_plan"]
+    assert "final Plan tool must match PlanSkeleton" in calls["prompts"][2]
+    assert plan["steps"][1]["tool"] == "openfold"
+    assert plan["metadata"]["provider_validation"]["repair_attempts"] == 1
+
+
 def test_anthropic_provider_generates_patch_and_replan(monkeypatch):
     payloads = {
         "emit_patch": {

--- a/tests/unit/test_anthropic_messages_provider.py
+++ b/tests/unit/test_anthropic_messages_provider.py
@@ -1,14 +1,26 @@
 from types import SimpleNamespace
 
+import pytest
+
 from src.agents.planner import ToolSpec
 import src.llm.anthropic_messages_provider as anthropic_provider_module
 from src.llm.anthropic_messages_provider import AnthropicMessagesProvider
 from src.llm.base_llm_provider import ProviderConfig
+from src.llm.provider_payload_parser import ProviderPayloadValidationError
 from src.models.contracts import PatchRequest, Plan, PlanStep, ProteinDesignTask, ReplanRequest, StepResult, now_iso
+from src.models.validation import CandidateExecutionIssue, CandidateExecutionValidationError
 
 
 def _sample_registry():
     return [
+        ToolSpec(
+            id="protgpt2",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence", "candidates"),
+            cost=1,
+            safety_level=0,
+        ),
         ToolSpec(
             id="esmfold",
             capabilities=("structure_prediction",),
@@ -25,7 +37,40 @@ def _sample_registry():
             cost=1,
             safety_level=0,
         ),
+        ToolSpec(
+            id="openfold",
+            capabilities=("structure_prediction",),
+            inputs=("sequence",),
+            outputs=("pdb_path", "structure_results"),
+            cost=1,
+            safety_level=0,
+        ),
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("ranking",),
+            inputs=("candidates",),
+            outputs=("score_table", "top_k"),
+            cost=1,
+            safety_level=0,
+        ),
+        ToolSpec(
+            id="biopython_qc",
+            capabilities=("quality_control",),
+            inputs=("sequence", "pdb_path"),
+            outputs=("qc_metrics",),
+            cost=1,
+            safety_level=0,
+        ),
     ]
+
+
+@pytest.fixture(autouse=True)
+def _stub_candidate_validation(monkeypatch):
+    monkeypatch.setattr(
+        anthropic_provider_module,
+        "validate_plan_executability",
+        lambda plan, task: None,
+    )
 
 
 def _sample_task():
@@ -535,3 +580,233 @@ def test_anthropic_provider_rewrites_semantically_wrong_reference_fields(monkeyp
 
     assert plan["steps"][1]["inputs"]["sequence"] == "S1.sequence"
     assert plan["steps"][2]["inputs"]["candidates"] == "S1.candidates"
+
+
+def test_anthropic_provider_retries_plan_when_syntax_invalid(monkeypatch):
+    calls = {"count": 0, "prompts": []}
+    payloads = [
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {
+                                "id": "S1",
+                                "tool": "esmfold",
+                                "inputs": {"sequence": "AAA"},
+                                "metadata": {},
+                            },
+                            {
+                                "id": "S2",
+                                "tool": "protein_mpnn",
+                                "inputs": {"pdb_path": "$STEP_9"},
+                                "metadata": {},
+                            },
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_plan",
+                    "input": {
+                        "task_id": "task_001",
+                        "steps": [
+                            {
+                                "id": "S1",
+                                "tool": "esmfold",
+                                "inputs": {"sequence": "AAA"},
+                                "metadata": {},
+                            },
+                            {
+                                "id": "S2",
+                                "tool": "protein_mpnn",
+                                "inputs": {"pdb_path": "S1.pdb_path"},
+                                "metadata": {},
+                            },
+                        ],
+                        "constraints": {},
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+    ]
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls["prompts"].append(kwargs["messages"][0]["content"])
+            index = min(calls["count"], len(payloads) - 1)
+            calls["count"] += 1
+            return _fake_response(payloads[index])
+
+    class FakeAnthropic:
+        def __init__(self, *, api_key, base_url, timeout):
+            del api_key, base_url, timeout
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_provider_module, "Anthropic", FakeAnthropic)
+    provider = AnthropicMessagesProvider(
+        ProviderConfig(model_name="glm-5", api_key="secret")
+    )
+
+    plan = provider.call_planner(_sample_task(), _sample_registry())
+
+    assert calls["count"] == 2
+    assert "失败分类: SYNTAX_INVALID" in calls["prompts"][1]
+    assert plan["steps"][1]["inputs"]["pdb_path"] == "S1.pdb_path"
+    assert plan["metadata"]["provider_validation"]["repair_attempts"] == 1
+
+
+def test_anthropic_provider_retries_patch_when_executability_invalid(monkeypatch):
+    calls = {"count": 0, "prompts": []}
+    payloads = [
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_patch",
+                    "input": {
+                        "task_id": "task_patch",
+                        "operations": [
+                            {
+                                "op": "replace_step",
+                                "target": "S1",
+                                "step": {
+                                    "tool": "protein_mpnn",
+                                    "inputs": {},
+                                    "metadata": {},
+                                },
+                            }
+                        ],
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "emit_patch",
+                    "input": {
+                        "task_id": "task_patch",
+                        "operations": [
+                            {
+                                "op": "replace_step",
+                                "target": "S1",
+                                "step": {
+                                    "tool": "protein_mpnn",
+                                    "inputs": {"pdb_path": "input.pdb"},
+                                    "metadata": {},
+                                },
+                            }
+                        ],
+                        "metadata": {},
+                    },
+                }
+            ]
+        },
+    ]
+
+    def fake_validate(plan, task):
+        del task
+        step = plan.steps[0]
+        if step.tool == "protein_mpnn" and "pdb_path" not in step.inputs:
+            raise CandidateExecutionValidationError(
+                [
+                    CandidateExecutionIssue(
+                        code="CANDIDATE_PARAMS_INVALID",
+                        message="required input 'pdb_path' is missing",
+                        step_id=step.id,
+                        tool_id=step.tool,
+                    )
+                ]
+            )
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            calls["prompts"].append(kwargs["messages"][0]["content"])
+            index = min(calls["count"], len(payloads) - 1)
+            calls["count"] += 1
+            return _fake_response(payloads[index])
+
+    class FakeAnthropic:
+        def __init__(self, *, api_key, base_url, timeout):
+            del api_key, base_url, timeout
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_provider_module, "Anthropic", FakeAnthropic)
+    monkeypatch.setattr(
+        anthropic_provider_module,
+        "validate_plan_executability",
+        fake_validate,
+    )
+    provider = AnthropicMessagesProvider(
+        ProviderConfig(model_name="glm-5", api_key="secret")
+    )
+
+    patch = provider.call_patch(_sample_patch_request(), _sample_registry())
+
+    assert patch is not None
+    assert calls["count"] == 2
+    assert "失败分类: EXECUTABILITY_INVALID" in calls["prompts"][1]
+    assert patch["operations"][0]["step"]["inputs"]["pdb_path"] == "input.pdb"
+    assert patch["metadata"]["provider_validation"]["repair_attempts"] == 1
+
+
+def test_anthropic_provider_raises_typed_error_after_retry_exhausted(monkeypatch):
+    calls = {"count": 0}
+    payload = {
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "emit_replan",
+                "input": {
+                    "task_id": "task_replan",
+                    "steps": [
+                        {
+                            "id": "S1",
+                            "tool": "protein_mpnn",
+                            "inputs": {"pdb_path": "$STEP_9"},
+                            "metadata": {},
+                        }
+                    ],
+                    "constraints": {},
+                    "metadata": {},
+                },
+            }
+        ]
+    }
+
+    class FakeMessages:
+        def create(self, **kwargs):
+            del kwargs
+            calls["count"] += 1
+            return _fake_response(payload)
+
+    class FakeAnthropic:
+        def __init__(self, *, api_key, base_url, timeout):
+            del api_key, base_url, timeout
+            self.messages = FakeMessages()
+
+    monkeypatch.setattr(anthropic_provider_module, "Anthropic", FakeAnthropic)
+    provider = AnthropicMessagesProvider(
+        ProviderConfig(model_name="glm-5", api_key="secret")
+    )
+
+    with pytest.raises(ProviderPayloadValidationError) as exc_info:
+        provider.call_replan(_sample_replan_request(), _sample_registry())
+
+    assert calls["count"] == 3
+    assert exc_info.value.failure_type == "SYNTAX_INVALID"
+    assert exc_info.value.candidate_kind == "replan"
+    assert exc_info.value.attempts == 3

--- a/tests/unit/test_planner_with_provider.py
+++ b/tests/unit/test_planner_with_provider.py
@@ -6,7 +6,9 @@ from typing import Dict, List
 from src.agents.planner import PlannerAgent, ToolSpec
 from src.llm.base_llm_provider import BaseProvider, ProviderConfig
 from src.llm.baseline_provider import BaselineProvider
+from src.llm.provider_payload_parser import ProviderPayloadValidationError
 from src.models.contracts import ProteinDesignTask, Plan, PatchRequest, StepResult, now_iso
+import src.agents.planner as planner_module
 
 
 @pytest.fixture(autouse=True)
@@ -118,6 +120,42 @@ class TestPlannerWithoutProvider:
         plan = planner.plan(sample_task)
 
         assert plan.steps[0].inputs["sequence"] == sample_task.constraints["sequence"]
+
+
+def test_planner_logs_provider_validation_failure(sample_task, monkeypatch):
+    events = []
+
+    class BrokenProvider(BaseProvider):
+        def __init__(self):
+            self.config = ProviderConfig(model_name="broken-provider")
+
+        def call_planner(self, task, tool_registry):
+            del task, tool_registry
+            raise ProviderPayloadValidationError(
+                candidate_kind="plan",
+                failure_type="SYNTAX_INVALID",
+                issues=[
+                    {
+                        "code": "REFERENCE_SYNTAX_INVALID",
+                        "path": "$.steps[1].inputs.sequence",
+                        "message": "reference token is not compliant",
+                    }
+                ],
+                attempts=3,
+            )
+
+    monkeypatch.setattr(planner_module, "append_event", lambda task_id, event: events.append((task_id, event)))
+    planner = PlannerAgent(llm_provider=BrokenProvider())
+
+    with pytest.raises(ProviderPayloadValidationError):
+        planner.plan(sample_task)
+
+    assert events
+    task_id, event = events[0]
+    assert task_id == sample_task.task_id
+    assert event["event"] == "PROVIDER_VALIDATION_FAILED"
+    assert event["failure_code"] == "SYNTAX_INVALID"
+    assert event["data"]["provider_name"] == "broken-provider"
 
 
 class TestPlannerWithBaselineProvider:

--- a/tests/unit/test_provider_payload_parser.py
+++ b/tests/unit/test_provider_payload_parser.py
@@ -1,0 +1,118 @@
+from src.agents.planner import ToolSpec
+from src.llm.provider_payload_parser import ProviderPayloadParser
+
+
+def _parser_registry():
+    return [
+        ToolSpec(
+            id="protgpt2",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence", "candidates"),
+            cost=1,
+            safety_level=0,
+        ),
+        ToolSpec(
+            id="openfold",
+            capabilities=("structure_prediction",),
+            inputs=("sequence",),
+            outputs=("pdb_path", "structure_results"),
+            cost=1,
+            safety_level=0,
+        ),
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("ranking",),
+            inputs=("candidates",),
+            outputs=("score_table", "top_k"),
+            cost=1,
+            safety_level=0,
+        ),
+        ToolSpec(
+            id="biopython_qc",
+            capabilities=("quality_control",),
+            inputs=("sequence", "pdb_path"),
+            outputs=("qc_metrics",),
+            cost=1,
+            safety_level=0,
+        ),
+    ]
+
+
+def test_provider_payload_parser_repairs_stringified_steps_and_reference_variants():
+    parser = ProviderPayloadParser(_parser_registry())
+    payload = {
+        "task_id": "task_001",
+        "steps": (
+            '[{"id":"step_1","tool":"protgpt2","inputs":{"goal":"design"},"metadata":{}},'
+            '{"id":"step_2","tool":"openfold","inputs":{"sequence":"${step.1.sequence}"},"metadata":{}},'
+            '{"id":"step_3","tool":"objective_ranker","inputs":{"candidates":"$CANDIDATES"},"metadata":{}},'
+            '{"id":"step_4","tool":"biopython_qc","inputs":{"sequence":"auto","pdb_path":"<predicted_pdb>"},"metadata":{}}]'
+        ),
+        "constraints": "{}",
+        "metadata": "{}",
+    }
+
+    result = parser.parse(payload, candidate_kind="plan")
+
+    assert result.is_compliant
+    assert isinstance(result.normalized_payload, dict)
+    assert [step["id"] for step in result.normalized_payload["steps"]] == ["S1", "S2", "S3", "S4"]
+    assert result.normalized_payload["steps"][1]["inputs"]["sequence"] == "S1.sequence"
+    assert result.normalized_payload["steps"][2]["inputs"]["candidates"] == "S1.candidates"
+    assert result.normalized_payload["steps"][3]["inputs"]["sequence"] == "S1.sequence"
+    assert result.normalized_payload["steps"][3]["inputs"]["pdb_path"] == "S2.pdb_path"
+    assert result.repairs
+
+
+def test_provider_payload_parser_reports_unresolved_reference_tokens():
+    parser = ProviderPayloadParser(_parser_registry())
+    payload = {
+        "task_id": "task_001",
+        "steps": [
+            {
+                "id": "S1",
+                "tool": "openfold",
+                "inputs": {"sequence": "$STEP_9"},
+                "metadata": {},
+            }
+        ],
+        "constraints": {},
+        "metadata": {},
+    }
+
+    result = parser.parse(payload, candidate_kind="plan")
+
+    assert not result.is_compliant
+    assert result.issues
+    assert result.issues[0].code == "REFERENCE_SYNTAX_INVALID"
+    assert result.issues[0].path == "$.steps[0].inputs.sequence"
+
+
+def test_provider_payload_parser_normalizes_indexed_candidate_reference_for_sequence_input():
+    parser = ProviderPayloadParser(_parser_registry())
+    payload = {
+        "task_id": "task_001",
+        "steps": [
+            {
+                "id": "S1",
+                "tool": "protgpt2",
+                "inputs": {"goal": "design"},
+                "metadata": {},
+            },
+            {
+                "id": "S2",
+                "tool": "openfold",
+                "inputs": {"sequence": "S1.candidates[0]"},
+                "metadata": {},
+            },
+        ],
+        "constraints": {},
+        "metadata": {},
+    }
+
+    result = parser.parse(payload, candidate_kind="plan")
+
+    assert result.is_compliant
+    assert result.normalized_payload["steps"][1]["inputs"]["sequence"] == "S1.sequence"
+    assert any(repair.path == "$.steps[1].inputs.sequence" for repair in result.repairs)

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -54,7 +54,7 @@ def test_create_provider_baseline():
 def test_create_provider_anthropic_messages():
     settings = ProviderSettings(
         provider_type="anthropic_messages",
-        model_name="MiniMax-M2.5",
+        model_name="MiniMax-M2.7",
         api_key="secret",
         endpoint="https://api.minimaxi.com/anthropic",
         anthropic_version="2023-06-01",
@@ -80,7 +80,7 @@ def test_create_provider_zai_chat():
 def test_resolve_endpoint_from_env(monkeypatch):
     settings = ProviderSettings(
         provider_type="anthropic_messages",
-        model_name="MiniMax-M2.5",
+        model_name="MiniMax-M2.7",
         endpoint_env="ANTHROPIC_BASE_URL",
     )
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.minimaxi.com/anthropic")
@@ -106,9 +106,10 @@ def test_load_provider_catalog_keeps_minimax_entry():
         Path(__file__).resolve().parents[2] / "configs" / "llm_providers.json"
     )
 
-    assert "minimax-m2.5" in catalog.providers
-    assert catalog.providers["minimax-m2.5"].provider_type == "anthropic_messages"
-    assert catalog.providers["minimax-m2.5"].endpoint_env == "ANTHROPIC_BASE_URL"
+    assert "minimax-m2.7" in catalog.providers
+    assert catalog.providers["minimax-m2.7"].provider_type == "anthropic_messages"
+    assert catalog.providers["minimax-m2.7"].model_name == "MiniMax-M2.7"
+    assert catalog.providers["minimax-m2.7"].endpoint_env == "ANTHROPIC_BASE_URL"
 
 
 def test_load_provider_catalog_keeps_glm_entries():


### PR DESCRIPTION
# feat(llm): harden MiniMax structured planning for issue #273

## 背景

该 PR 面向 `dev` 合并 issue #273 的修复。#273 是从 #172 外部横向实验 live run 中拆出的 P0 blocker：在 `MiniMax + Anthropic-compatible Messages API + 远端 PLM/OpenFold3` 已经打通后，剩余主要失败不再来自远端服务可达性，而是来自 planner provider 的结构化输出不稳定。

在 #172 的 E0/E1/E2 live run 中，MiniMax 虽然走的是 tool calling，但 `plan / patch / replan` 输出仍多次出现不合规 payload，导致 schema 校验、candidate executability 校验或后续 runtime recovery 被污染。典型脏输出包括：

- `steps` 被整体字符串化，甚至局部 JSON/list 结构损坏。
- `${step.1.sequence}`、`$STEP_2`、`$CANDIDATES` 等模板/占位符引用。
- `<generated_sequence>`、`<predicted_pdb>`、`auto`、裸 `CANDIDATES` 等不可执行 token。
- `S1.candidates[0]` 这类接近正确但不符合本仓库引用契约的表达。
- patch/replan 也会出现同类问题，因此不是单一初始 Plan 的解析问题。

如果不先修复该问题，#172 的横向实验结论会被 provider structured output instability 污染，无法清晰区分方法学失败、工具执行失败和 provider 格式失败。

## 推进过程中的阻塞与定位

推进过程中先排除了基础设施问题：

- MiniMax provider 路由可用。
- 本地 SSH tunnel 到远端 PLM/OpenFold3 服务可用。
- PLM REST 与 OpenFold3 REST 能被 issue172 runner 调用。
- `biopython_qc` 手工回放真实 `sequence + pdb_path` 时可通过。

随后 live probe 暴露了真正阻塞点：

- 仅靠 tool calling 不足以保证 provider payload 合规。
- 初始 Plan、PlanPatch、Replan 都可能返回 schema-invalid 或 executability-invalid payload。
- 错误如果直接进入 runtime，会放大为 WAITING_REPLAN / CANCELLED，使 #172 指标失真。
- MiniMax-M2.5 需要替换为 MiniMax-M2.7，并在 provider 层建立更强的结构化闭环。

后续 two-stage live probe 中仍观察到远程 OpenFold3 执行失败和 `nim_esmfold` 长度限制问题，但这些属于远程工具/执行恢复路径，不再属于 #273 的 provider structured output blocker。

## 解决方法

### 1. Provider 级鲁棒性闭环

新增 provider payload parser，并将 `plan / patch / replan` 统一纳入：

- syntax parsing / light repair
- `Plan` / `PlanPatch` schema validation
- executability validation
- structured error feedback
- bounded repair retry

失败分类现在明确为：

- `SYNTAX_INVALID`
- `SCHEMA_INVALID`
- `EXECUTABILITY_INVALID`

这使 provider 格式问题被拦截在 provider 层，而不是继续污染 runtime。

### 2. 语法解析与轻量修复

新增 `src/llm/provider_payload_parser.py`，覆盖 #273 中已观测到的主要脏格式：

- 字符串化 JSON / list / dict。
- 非标准 step id 归一化为 `S1/S2/...`。
- `${...}`、`$...`、`<...>`、`auto`、裸占位符的识别。
- tool output 风格引用归一化为 `S<n>.field`。
- `S1.candidates[0]` 在 sequence input 下归一化为 `S1.sequence`。
- 无法安全修复的内容进入 repair loop，而不是静默放行。

### 3. Plan / Patch / Replan repair loop

`AnthropicMessagesProvider` 中的 planner、patch、replan 路径现在共用 `_request_tool_payload`：

- 每次调用后先解析，再 schema 校验，再执行前可执行性校验。
- 校验失败会生成结构化错误摘要，反馈给模型进行修复。
- 最多进行有限次数 repair retry，避免无限循环。
- patch 路径会先应用 patch，再校验 patched plan 的 executability。

### 4. Prompt 强化

MiniMax 的 plan / patch / replan prompt 中显式要求：

- `steps` / `operations` 必须是真正 JSON array，不能是字符串。
- step id 必须是 `S1/S2/...`。
- 跨步引用只能是 `S<n>.field`。
- 禁止 `${...}`、`$...`、`<...>`、`auto`、裸 token。
- patch 的 `replace_step` 必须保持 target id。

### 5. MiniMax-M2.7 与两阶段生成

配置中将 MiniMax 从原先 2.5 替换为 MiniMax-M2.7：

- provider alias: `minimax-m2.7`
- model: `MiniMax-M2.7`

同时为 MiniMax 启用 `two_stage_plan`：

- 阶段一：`PlanSkeleton`，只生成 step ids + tools。
- 阶段二：基于 skeleton 填充完整 Plan inputs / references。

`PlanSkeleton` 使用严格 schema：

- 禁止 skeleton step 携带 `inputs` 等多余字段。
- tool 必须来自当前 registry。
- 最终 Plan 必须与 skeleton 的 step count / id / order / tool 完全一致。
- 若最终 Plan 偏离 skeleton，会进入 provider repair loop。

该设计保留了 PlannerAgent 对外契约，不改变 FSM，也不改变 agent 边界。

### 6. 可观测性

PlannerAgent 现在会捕获 `ProviderPayloadValidationError` 并写入：

- `PROVIDER_VALIDATION_FAILED`
- failure code
- issue list
- parser repairs
- provider name
- attempts

这为 #172 后续实验和论文失败模式分析保留了可追溯证据。

## 验证

本地 focused tests：

```bash
uv run pytest tests/unit/test_provider_payload_parser.py tests/unit/test_anthropic_messages_provider.py tests/unit/test_planner_with_provider.py tests/unit/test_provider_registry.py -q
```

结果：

```text
49 passed
```

live regression probe：

- provider: `minimax-m2.7`
- mode: `two_stage_plan`
- task: `issue172 high_solubility`
- groups: E0/E1/E2
- tunnel: `38100:8100`, `38200:8200`

结果：

- E1: `DONE`
- E2: `DONE`
- E0: `CANCELLED`

E0 失败原因为远程结构预测恢复路径问题：

- OpenFold3 remote job failure 后 patch 到 `nim_esmfold`
- 部分样本序列长度超过 NIM limit

该失败不是 provider schema / structured output 回归。probe 中未观察到：

- `PROVIDER_VALIDATION_FAILED`
- `CANDIDATE_VALIDATION_FAILED`
- skeleton mismatch

额外 MiniMax provider live smoke：

- 真实 MiniMax-M2.7 两阶段输出可通过 provider parser/schema/executability 闭环。
- smoke 中真实触发了 repair loop，并最终生成可执行 Plan。
- metadata 正确写入 `provider_generation_mode: two_stage_plan` 与 `provider_plan_skeleton`。

## 影响范围

主要影响：

- MiniMax Anthropic-compatible provider 的 plan / patch / replan 结构化鲁棒性。
- issue172 外部横向实验的 planner payload 稳定性。
- provider validation failure 的日志可观测性。

不改变：

- FSM 状态机。
- PlannerAgent / ExecutorAgent / SafetyAgent / SummarizerAgent 的职责边界。
- Plan / PlanPatch 既有字段语义。
- runtime recovery 顺序。

## Issue 状态判断

该 PR 覆盖 #273 的 P0 blocker 和验收标准：

- `plan / patch / replan` 均进入 repair loop。
- 已观测脏占位符要么被归一化，要么进入修复回合。
- schema/executability 失败不会直接污染 runtime。
- provider validation failure 有结构化日志。
- MiniMax-M2.7 已启用两阶段 Plan 生成。

stepwise generation 属于更强稳态方案，不是当前 #273 blocker 的关闭条件。如果未来 patch/replan 仍需要两阶段或 stepwise 生成，建议另开 follow-up issue。

Closes #273

