### PR TITLE
feat(evaluation): expand issue230 belief-state metrics

### DIFF
--- a/reports/w16-issue230/action-belief-aggregation-metrics.md
+++ b/reports/w16-issue230/action-belief-aggregation-metrics.md
@@ -1,0 +1,87 @@
+# Issue #230 Action / Belief-State Aggregation Metrics
+
+## Design Baseline
+
+- Core belief-state fields: `p_success`, `p_structural_failure`, `recovery_margin`, `expected_remaining_cost`, `evidence_sufficiency`.
+- Derived audit fields: `budget_pressure`, `intervention_value`, `goal_misalignment`, `local_patchability`, `prefix_preservability`.
+- Action space: `continue`, `patch_local`, `suffix_replan`, `stop`.
+- Canonical internal paper groups: `static_top1`, `fixed_threshold_gate`, `dynamic_no_belief_state`, `lite_belief_state`.
+- External comparison groups keep canonical ids `E0`, `E1`, `E2`.
+
+## Naming Contract
+
+`src/infra/w12_vertical_experiment.py` now emits:
+
+- `group_id`: the current aggregation key, which may be a historical id or canonical paper id depending on `group_order`.
+- `canonical_group_id`: normalized paper-facing id.
+- `group_alias`: run-level back link from historical alias to canonical id.
+- `group_aliases`: group-level list of historical aliases folded into a canonical group.
+
+Historical mappings:
+
+- `A0 -> static_top1`
+- `A3 -> fixed_threshold_gate`
+- `A4/A5 -> dynamic_no_belief_state`
+- `A6 -> lite_belief_state`
+- `react_single_trajectory/tot_multi_branch/reflexion_recovery -> E0/E1/E2`
+
+## Run-Level Fields
+
+Action fields:
+
+- `action_continue_count`
+- `action_patch_local_count`
+- `action_suffix_replan_count`
+- `action_stop_count`
+
+Shadow/actual fields:
+
+- `shadow_action_observation_count`
+- `shadow_action_agreement_count`
+- `shadow_action_agreement_rate`
+- `shadow_actual_bias_count`
+- `shadow_actual_bias_rate`
+
+Belief-state observability fields:
+
+- `belief_state_observation_count`
+- `belief_state_core_observed_count`
+- `belief_state_core_completeness`
+- `belief_state_core_complete`
+- `belief_state_derived_observed_count`
+- `belief_state_derived_completeness`
+- `belief_state_sources`
+
+For each core and derived field, the run row also includes:
+
+- `belief_state_<field>`
+- `belief_state_<field>_observed`
+
+## Group-Level Fields
+
+Summary rows include:
+
+- `belief_state_observable_rate`
+- `belief_state_core_complete_rate`
+- `belief_state_core_completeness_mean`
+- `belief_state_derived_completeness_mean`
+- `belief_state_<core_field>_observable_rate`
+- `belief_state_<derived_field>_observable_rate`
+- `action_<action>_mean`
+- `action_<action>_rate`
+- `shadow_action_agreement_rate`
+- `shadow_actual_bias_rate`
+
+`action_distribution_breakdown.csv` includes action totals/rates plus shadow/actual agreement and bias.
+
+`belief_state_observability_breakdown.csv` includes group-level core-field and derived-field observable rates.
+
+## Source Mapping
+
+The unified aggregation script reads all baselines through the same inputs:
+
+- Event log: `data.runtime_state_summary`, `data.waiting_runtime_summary.runtime_state_summary`, `data.recovery.runtime_state_summary`, logged action names, shadow action, and shadow score.
+- Snapshot: `artifacts.runtime_state` and `artifacts.decision_summary`.
+- Summary row: optional `runtime_state` or `runtime_state_summary` fields already present in a manifest row.
+
+No separate aggregation script is needed for internal A0-A6 groups, canonical paper groups, or external E0/E1/E2 comparisons.

--- a/scripts/evaluate_w12_vertical_issue171.py
+++ b/scripts/evaluate_w12_vertical_issue171.py
@@ -153,6 +153,8 @@ def main() -> int:
     summary_rows = aggregated["summary_rows"]
     patch_rows = aggregated["patch_rows"]
     high_cost_rows = aggregated["high_cost_rows"]
+    action_rows = aggregated["action_rows"]
+    belief_state_rows = aggregated["belief_state_rows"]
     requirement2_rows = aggregated["requirement2_rows"]
     abnormal_rows = aggregated["abnormal_rows"]
     gate_rows = aggregated["gate_rows"]
@@ -161,6 +163,8 @@ def main() -> int:
 
     summary_fields = [
         "group_id",
+        "canonical_group_id",
+        "group_aliases",
         "runs",
         "success_rate",
         "success_ci_low",
@@ -176,6 +180,13 @@ def main() -> int:
         "executable_ci_high",
         "waiting_chain_complete_rate",
         "failure_traceable_rate",
+        "snapshot_linked_rate",
+        "runtime_state_observable_rate",
+        "shadow_output_observable_rate",
+        "belief_state_observable_rate",
+        "belief_state_core_complete_rate",
+        "belief_state_core_completeness_mean",
+        "belief_state_derived_completeness_mean",
         "patch_events_mean",
         "patch_events_ci_low",
         "patch_events_ci_high",
@@ -196,6 +207,21 @@ def main() -> int:
         "high_cost_failure_ci_high",
         "patch_minimality_hit_rate",
         "suffix_replan_prefix_preservation_rate",
+        "action_continue_mean",
+        "action_continue_rate",
+        "action_patch_local_mean",
+        "action_patch_local_rate",
+        "action_suffix_replan_mean",
+        "action_suffix_replan_rate",
+        "action_stop_mean",
+        "action_stop_rate",
+        "shadow_action_agreement_rate",
+        "shadow_actual_bias_rate",
+        "belief_state_p_success_observable_rate",
+        "belief_state_p_structural_failure_observable_rate",
+        "belief_state_recovery_margin_observable_rate",
+        "belief_state_expected_remaining_cost_observable_rate",
+        "belief_state_evidence_sufficiency_observable_rate",
         "requirement2_sequence_core",
         "requirement2_quality_qc",
         "requirement2_objective_scoring",
@@ -225,6 +251,53 @@ def main() -> int:
         "high_cost_rule_hits",
     ]
     write_csv(output_dir / "high_cost_breakdown.csv", high_cost_rows, high_cost_fields)
+
+    action_fields = [
+        "group_id",
+        "canonical_group_id",
+        "group_aliases",
+        "action_total",
+        "action_continue_total",
+        "action_continue_rate",
+        "action_patch_local_total",
+        "action_patch_local_rate",
+        "action_suffix_replan_total",
+        "action_suffix_replan_rate",
+        "action_stop_total",
+        "action_stop_rate",
+        "shadow_action_observation_total",
+        "shadow_action_agreement_total",
+        "shadow_action_agreement_rate",
+        "shadow_actual_bias_total",
+        "shadow_actual_bias_rate",
+    ]
+    write_csv(output_dir / "action_distribution_breakdown.csv", action_rows, action_fields)
+
+    belief_state_fields = [
+        "group_id",
+        "canonical_group_id",
+        "group_aliases",
+        "runs",
+        "belief_state_observable_rate",
+        "belief_state_core_complete_rate",
+        "belief_state_core_completeness_mean",
+        "belief_state_derived_completeness_mean",
+        "p_success_observable_rate",
+        "p_structural_failure_observable_rate",
+        "recovery_margin_observable_rate",
+        "expected_remaining_cost_observable_rate",
+        "evidence_sufficiency_observable_rate",
+        "budget_pressure_observable_rate",
+        "intervention_value_observable_rate",
+        "goal_misalignment_observable_rate",
+        "local_patchability_observable_rate",
+        "prefix_preservability_observable_rate",
+    ]
+    write_csv(
+        output_dir / "belief_state_observability_breakdown.csv",
+        belief_state_rows,
+        belief_state_fields,
+    )
 
     requirement2_fields = ["group_id", "slice_type", "name", "covered", "usage_count"]
     write_csv(
@@ -269,6 +342,8 @@ def main() -> int:
             "run_id": row.get("run_id"),
             "task_id": row.get("task_id"),
             "group_id": row.get("group_id"),
+            "canonical_group_id": row.get("canonical_group_id"),
+            "group_alias": row.get("group_alias"),
             "replicate": row.get("replicate"),
             "task_key": row.get("task_key"),
             "final_status": row.get("final_status"),
@@ -283,6 +358,8 @@ def main() -> int:
         "run_id",
         "task_id",
         "group_id",
+        "canonical_group_id",
+        "group_alias",
         "replicate",
         "task_key",
         "final_status",

--- a/src/infra/w12_vertical_experiment.py
+++ b/src/infra/w12_vertical_experiment.py
@@ -61,6 +61,38 @@ _PATCH_EVENT_NAMES = {"PARAM_TWEAK", "REPLACE_TOOL", "STRUCTURE_PATCH"}
 DEFAULT_REPLAY_SAMPLE_DIR = (
     Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "w14_issue215"
 )
+ACTION_SPACE = ("continue", "patch_local", "suffix_replan", "stop")
+BELIEF_STATE_CORE_FIELDS = (
+    "p_success",
+    "p_structural_failure",
+    "recovery_margin",
+    "expected_remaining_cost",
+    "evidence_sufficiency",
+)
+BELIEF_STATE_DERIVED_FIELDS = (
+    "budget_pressure",
+    "intervention_value",
+    "goal_misalignment",
+    "local_patchability",
+    "prefix_preservability",
+)
+CANONICAL_GROUP_ALIASES: dict[str, str] = {
+    "A0": "static_top1",
+    "A3": "fixed_threshold_gate",
+    "A4": "dynamic_no_belief_state",
+    "A5": "dynamic_no_belief_state",
+    "A6": "lite_belief_state",
+    "static_top1": "static_top1",
+    "fixed_threshold_gate": "fixed_threshold_gate",
+    "dynamic_no_belief_state": "dynamic_no_belief_state",
+    "lite_belief_state": "lite_belief_state",
+    "E0": "E0",
+    "E1": "E1",
+    "E2": "E2",
+    "react_single_trajectory": "E0",
+    "tot_multi_branch": "E1",
+    "reflexion_recovery": "E2",
+}
 
 
 def now_iso() -> str:
@@ -430,22 +462,51 @@ def _nested(row: dict[str, Any], *path: str) -> Any:
     return current
 
 
-def _has_runtime_state_observation(row: dict[str, Any]) -> bool:
+def canonicalize_group_id(group_id: Any) -> str:
+    """把历史实现组和外部别名映射为论文主结果组。"""
+    if not isinstance(group_id, str) or not group_id.strip():
+        return ""
+    text = group_id.strip()
+    return CANONICAL_GROUP_ALIASES.get(text, text)
+
+
+def _numeric(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _runtime_state_candidates(row: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
     data = row.get("data")
     if not isinstance(data, dict):
         data = {}
-    if isinstance(data.get("runtime_state_summary"), dict):
-        return True
+
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    direct = data.get("runtime_state_summary")
+    if isinstance(direct, dict):
+        candidates.append(("event_log:data.runtime_state_summary", direct))
+
     waiting_summary = data.get("waiting_runtime_summary")
-    if isinstance(waiting_summary, dict) and isinstance(
-        waiting_summary.get("runtime_state_summary"),
-        dict,
-    ):
-        return True
+    if isinstance(waiting_summary, dict):
+        waiting_state = waiting_summary.get("runtime_state_summary")
+        if isinstance(waiting_state, dict):
+            candidates.append(
+                ("event_log:data.waiting_runtime_summary.runtime_state_summary", waiting_state)
+            )
+
     recovery = data.get("recovery")
-    if isinstance(recovery, dict) and isinstance(recovery.get("runtime_state_summary"), dict):
-        return True
-    return False
+    if isinstance(recovery, dict):
+        recovery_state = recovery.get("runtime_state_summary")
+        if isinstance(recovery_state, dict):
+            candidates.append(("event_log:data.recovery.runtime_state_summary", recovery_state))
+
+    return candidates
+
+
+def _has_runtime_state_observation(row: dict[str, Any]) -> bool:
+    return bool(_runtime_state_candidates(row))
 
 
 def _has_shadow_output(row: dict[str, Any]) -> bool:
@@ -569,6 +630,80 @@ def _load_snapshot_payload(path: Path) -> dict[str, Any] | None:
     except Exception:
         return None
     return None
+
+
+def _collect_belief_state_metrics(
+    *,
+    rows: list[dict[str, Any]],
+    snapshot_artifacts: dict[str, Any],
+    run: dict[str, Any],
+) -> dict[str, Any]:
+    latest_values: dict[str, float | None] = {
+        field: None for field in (*BELIEF_STATE_CORE_FIELDS, *BELIEF_STATE_DERIVED_FIELDS)
+    }
+    core_observation_counts: Counter[str] = Counter()
+    derived_observation_counts: Counter[str] = Counter()
+    source_hits: set[str] = set()
+    observation_count = 0
+
+    def consume(source: str, payload: dict[str, Any]) -> None:
+        nonlocal observation_count
+        observed_any = False
+        for field in BELIEF_STATE_CORE_FIELDS:
+            value = _numeric(payload.get(field))
+            if value is not None:
+                latest_values[field] = value
+                core_observation_counts[field] += 1
+                observed_any = True
+        for field in BELIEF_STATE_DERIVED_FIELDS:
+            value = _numeric(payload.get(field))
+            if value is not None:
+                latest_values[field] = value
+                derived_observation_counts[field] += 1
+                observed_any = True
+        if observed_any:
+            observation_count += 1
+            source_hits.add(source)
+
+    for row in rows:
+        for source, payload in _runtime_state_candidates(row):
+            consume(source, payload)
+
+    snapshot_state = snapshot_artifacts.get("runtime_state")
+    if isinstance(snapshot_state, dict):
+        consume("snapshot:artifacts.runtime_state", snapshot_state)
+
+    run_runtime_state = run.get("runtime_state")
+    if isinstance(run_runtime_state, dict):
+        consume("summary_row:runtime_state", run_runtime_state)
+    run_runtime_summary = run.get("runtime_state_summary")
+    if isinstance(run_runtime_summary, dict):
+        consume("summary_row:runtime_state_summary", run_runtime_summary)
+
+    core_observed = {
+        field: core_observation_counts.get(field, 0) > 0 for field in BELIEF_STATE_CORE_FIELDS
+    }
+    derived_observed = {
+        field: derived_observation_counts.get(field, 0) > 0
+        for field in BELIEF_STATE_DERIVED_FIELDS
+    }
+    core_observed_count = sum(1 for observed in core_observed.values() if observed)
+    derived_observed_count = sum(1 for observed in derived_observed.values() if observed)
+
+    return {
+        "belief_state_observation_count": observation_count,
+        "belief_state_core_observed_count": core_observed_count,
+        "belief_state_core_completeness": core_observed_count / len(BELIEF_STATE_CORE_FIELDS),
+        "belief_state_core_complete": core_observed_count == len(BELIEF_STATE_CORE_FIELDS),
+        "belief_state_derived_observed_count": derived_observed_count,
+        "belief_state_derived_completeness": (
+            derived_observed_count / len(BELIEF_STATE_DERIVED_FIELDS)
+        ),
+        "belief_state_sources": sorted(source_hits),
+        "belief_state_core_observed": core_observed,
+        "belief_state_derived_observed": derived_observed,
+        "belief_state_latest": latest_values,
+    }
 
 
 def _optional_path(value: Any) -> Path | None:
@@ -813,17 +948,32 @@ def extract_run_metrics(
         if isinstance(decision_summary.get("shadow_action"), str) and decision_summary.get("shadow_action"):
             shadow_output_observable = True
 
+    belief_state_metrics = _collect_belief_state_metrics(
+        rows=rows,
+        snapshot_artifacts=snapshot_artifacts,
+        run=run,
+    )
+
     shadow_action_agreement_rate = None
     if shadow_action_observation_count > 0:
         shadow_action_agreement_rate = (
             shadow_action_agreement_count / shadow_action_observation_count
         )
+    shadow_actual_bias_count = shadow_action_observation_count - shadow_action_agreement_count
+    shadow_actual_bias_rate = None
+    if shadow_action_observation_count > 0:
+        shadow_actual_bias_rate = shadow_actual_bias_count / shadow_action_observation_count
 
-    return {
+    original_group_id = run.get("group_id")
+    canonical_group_id = canonicalize_group_id(original_group_id)
+
+    metrics = {
         "run_id": run.get("run_id"),
         "task_id": run.get("task_id"),
         "task_key": run.get("task_key"),
-        "group_id": run.get("group_id"),
+        "group_id": original_group_id,
+        "canonical_group_id": canonical_group_id,
+        "group_alias": original_group_id if original_group_id != canonical_group_id else "",
         "replicate": run.get("replicate"),
         "freeze_id": run.get("freeze_id"),
         "event_log_path": str(event_log_path) if str(event_log_path) != "." else "",
@@ -856,6 +1006,8 @@ def extract_run_metrics(
         "shadow_action_agreement_count": shadow_action_agreement_count,
         "shadow_action_observation_count": shadow_action_observation_count,
         "shadow_action_agreement_rate": shadow_action_agreement_rate,
+        "shadow_actual_bias_count": shadow_actual_bias_count,
+        "shadow_actual_bias_rate": shadow_actual_bias_rate,
         "layer_counter": dict(layer_counter),
         "tool_usage": dict(tool_usage),
         "capability_usage": dict(capability_usage),
@@ -869,6 +1021,22 @@ def extract_run_metrics(
         "replay_sample_id": run.get("replay_sample_id"),
         "replay_source_freeze_id": run.get("replay_source_freeze_id"),
     }
+    metrics.update(belief_state_metrics)
+    for field in BELIEF_STATE_CORE_FIELDS:
+        metrics[f"belief_state_{field}"] = belief_state_metrics["belief_state_latest"].get(
+            field
+        )
+        metrics[f"belief_state_{field}_observed"] = belief_state_metrics[
+            "belief_state_core_observed"
+        ].get(field, False)
+    for field in BELIEF_STATE_DERIVED_FIELDS:
+        metrics[f"belief_state_{field}"] = belief_state_metrics["belief_state_latest"].get(
+            field
+        )
+        metrics[f"belief_state_{field}_observed"] = belief_state_metrics[
+            "belief_state_derived_observed"
+        ].get(field, False)
+    return metrics
 
 
 def _proportion_summary(flags: list[bool]) -> dict[str, Any]:
@@ -908,15 +1076,20 @@ def aggregate_group_metrics(
     requirement2_capability_map: dict[str, list[str]],
 ) -> dict[str, Any]:
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    group_order_set = set(group_order)
     for row in runs:
         group_id = row.get("group_id")
-        if isinstance(group_id, str):
+        canonical_group_id = row.get("canonical_group_id") or canonicalize_group_id(group_id)
+        if isinstance(canonical_group_id, str) and canonical_group_id in group_order_set:
+            grouped[canonical_group_id].append(row)
+        elif isinstance(group_id, str):
             grouped[group_id].append(row)
 
     summary_rows: list[dict[str, Any]] = []
     patch_rows: list[dict[str, Any]] = []
     high_cost_rows: list[dict[str, Any]] = []
     action_rows: list[dict[str, Any]] = []
+    belief_state_rows: list[dict[str, Any]] = []
     requirement2_rows: list[dict[str, Any]] = []
     abnormal_rows: list[dict[str, Any]] = []
     gate_rows: list[dict[str, Any]] = []
@@ -958,6 +1131,13 @@ def aggregate_group_metrics(
             float(item.get("action_suffix_replan_count", 0) or 0) for item in rows
         ]
         action_stop_counts = [float(item.get("action_stop_count", 0) or 0) for item in rows]
+        action_totals_by_name = {
+            "continue": sum(action_continue_counts),
+            "patch_local": sum(action_patch_counts),
+            "suffix_replan": sum(action_suffix_replan_counts),
+            "stop": sum(action_stop_counts),
+        }
+        action_total = sum(action_totals_by_name.values())
 
         patch_summary = _mean_summary(patch_counts, iterations=iterations, seed=seed + idx * 11 + 1)
         replan_summary = _mean_summary(replan_counts, iterations=iterations, seed=seed + idx * 11 + 2)
@@ -1002,6 +1182,13 @@ def aggregate_group_metrics(
         total_patch_events_with_layer = 0
         shadow_action_agreement_total = 0
         shadow_action_observation_total = 0
+        aliases = sorted(
+            {
+                str(row.get("group_id"))
+                for row in rows
+                if isinstance(row.get("group_id"), str) and row.get("group_id") != group_id
+            }
+        )
 
         for row in rows:
             for layer, count in (row.get("layer_counter") or {}).items():
@@ -1040,6 +1227,42 @@ def aggregate_group_metrics(
             shadow_action_agreement_rate = (
                 shadow_action_agreement_total / shadow_action_observation_total
             )
+        shadow_actual_bias_total = shadow_action_observation_total - shadow_action_agreement_total
+        shadow_actual_bias_rate = None
+        if shadow_action_observation_total > 0:
+            shadow_actual_bias_rate = shadow_actual_bias_total / shadow_action_observation_total
+
+        belief_core_observed_rates = {
+            field: _proportion_summary(
+                [bool(item.get(f"belief_state_{field}_observed")) for item in rows]
+            )
+            for field in BELIEF_STATE_CORE_FIELDS
+        }
+        belief_derived_observed_rates = {
+            field: _proportion_summary(
+                [bool(item.get(f"belief_state_{field}_observed")) for item in rows]
+            )
+            for field in BELIEF_STATE_DERIVED_FIELDS
+        }
+        belief_state_observable = _proportion_summary(
+            [int(item.get("belief_state_observation_count", 0) or 0) > 0 for item in rows]
+        )
+        belief_state_core_complete = _proportion_summary(
+            [bool(item.get("belief_state_core_complete")) for item in rows]
+        )
+        belief_core_completeness = _mean_summary(
+            [float(item.get("belief_state_core_completeness", 0.0) or 0.0) for item in rows],
+            iterations=iterations,
+            seed=seed + idx * 11 + 11,
+        )
+        belief_derived_completeness = _mean_summary(
+            [
+                float(item.get("belief_state_derived_completeness", 0.0) or 0.0)
+                for item in rows
+            ],
+            iterations=iterations,
+            seed=seed + idx * 11 + 12,
+        )
 
         requirement2_bucket_status: dict[str, bool] = {}
         for bucket, capabilities in requirement2_capability_map.items():
@@ -1049,6 +1272,8 @@ def aggregate_group_metrics(
 
         summary_row = {
             "group_id": group_id,
+            "canonical_group_id": canonicalize_group_id(group_id),
+            "group_aliases": aliases,
             "runs": len(rows),
             "success_rate": success["rate"],
             "success_ci_low": success["ci_low"],
@@ -1067,6 +1292,10 @@ def aggregate_group_metrics(
             "snapshot_linked_rate": snapshot_linked["rate"],
             "runtime_state_observable_rate": runtime_state_observable["rate"],
             "shadow_output_observable_rate": shadow_output_observable["rate"],
+            "belief_state_observable_rate": belief_state_observable["rate"],
+            "belief_state_core_complete_rate": belief_state_core_complete["rate"],
+            "belief_state_core_completeness_mean": belief_core_completeness["mean"],
+            "belief_state_derived_completeness_mean": belief_derived_completeness["mean"],
             "patch_events_mean": patch_summary["mean"],
             "patch_events_ci_low": patch_summary["ci_low"],
             "patch_events_ci_high": patch_summary["ci_high"],
@@ -1100,11 +1329,20 @@ def aggregate_group_metrics(
             "action_stop_ci_low": stop_action_summary["ci_low"],
             "action_stop_ci_high": stop_action_summary["ci_high"],
             "shadow_action_agreement_rate": shadow_action_agreement_rate,
+            "shadow_actual_bias_rate": shadow_actual_bias_rate,
             "requirement2_sequence_core": requirement2_bucket_status.get("sequence_core", False),
             "requirement2_quality_qc": requirement2_bucket_status.get("quality_qc", False),
             "requirement2_objective_scoring": requirement2_bucket_status.get("objective_scoring", False),
             "requirement2_structure_prediction": requirement2_bucket_status.get("structure_prediction", False),
         }
+        for action_name, total in action_totals_by_name.items():
+            summary_row[f"action_{action_name}_rate"] = (
+                total / action_total if action_total > 0 else None
+            )
+        for field, field_summary in belief_core_observed_rates.items():
+            summary_row[f"belief_state_{field}_observable_rate"] = field_summary["rate"]
+        for field, field_summary in belief_derived_observed_rates.items():
+            summary_row[f"belief_state_{field}_observable_rate"] = field_summary["rate"]
         for bucket, covered in requirement2_bucket_status.items():
             summary_row[f"requirement2_{bucket}"] = covered
         summary_rows.append(summary_row)
@@ -1136,13 +1374,51 @@ def aggregate_group_metrics(
         action_rows.append(
             {
                 "group_id": group_id,
+                "canonical_group_id": canonicalize_group_id(group_id),
+                "group_aliases": aliases,
+                "action_total": action_total,
                 "action_continue_total": sum(action_continue_counts),
+                "action_continue_rate": (
+                    action_totals_by_name["continue"] / action_total if action_total > 0 else None
+                ),
                 "action_patch_local_total": sum(action_patch_counts),
+                "action_patch_local_rate": (
+                    action_totals_by_name["patch_local"] / action_total if action_total > 0 else None
+                ),
                 "action_suffix_replan_total": sum(action_suffix_replan_counts),
+                "action_suffix_replan_rate": (
+                    action_totals_by_name["suffix_replan"] / action_total if action_total > 0 else None
+                ),
                 "action_stop_total": sum(action_stop_counts),
+                "action_stop_rate": (
+                    action_totals_by_name["stop"] / action_total if action_total > 0 else None
+                ),
                 "shadow_action_observation_total": shadow_action_observation_total,
                 "shadow_action_agreement_total": shadow_action_agreement_total,
                 "shadow_action_agreement_rate": shadow_action_agreement_rate,
+                "shadow_actual_bias_total": shadow_actual_bias_total,
+                "shadow_actual_bias_rate": shadow_actual_bias_rate,
+            }
+        )
+
+        belief_state_rows.append(
+            {
+                "group_id": group_id,
+                "canonical_group_id": canonicalize_group_id(group_id),
+                "group_aliases": aliases,
+                "runs": len(rows),
+                "belief_state_observable_rate": belief_state_observable["rate"],
+                "belief_state_core_complete_rate": belief_state_core_complete["rate"],
+                "belief_state_core_completeness_mean": belief_core_completeness["mean"],
+                "belief_state_derived_completeness_mean": belief_derived_completeness["mean"],
+                **{
+                    f"{field}_observable_rate": field_summary["rate"]
+                    for field, field_summary in belief_core_observed_rates.items()
+                },
+                **{
+                    f"{field}_observable_rate": field_summary["rate"]
+                    for field, field_summary in belief_derived_observed_rates.items()
+                },
             }
         )
 
@@ -1222,6 +1498,7 @@ def aggregate_group_metrics(
         "patch_rows": patch_rows,
         "high_cost_rows": high_cost_rows,
         "action_rows": action_rows,
+        "belief_state_rows": belief_state_rows,
         "requirement2_rows": requirement2_rows,
         "abnormal_rows": abnormal_rows,
         "gate_rows": gate_rows,
@@ -1237,9 +1514,13 @@ def compute_increment_deltas(
     seed: int,
 ) -> list[dict[str, Any]]:
     by_group: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    group_order_set = set(group_order)
     for row in runs:
         group_id = row.get("group_id")
-        if isinstance(group_id, str):
+        canonical_group_id = row.get("canonical_group_id") or canonicalize_group_id(group_id)
+        if isinstance(canonical_group_id, str) and canonical_group_id in group_order_set:
+            by_group[canonical_group_id].append(row)
+        elif isinstance(group_id, str):
             by_group[group_id].append(row)
 
     rows: list[dict[str, Any]] = []
@@ -1401,5 +1682,8 @@ def build_markdown_report(
     lines.append("- Mechanism increment evidence: provided in `mechanism_increment_deltas.csv` with CI.")
     lines.append("- Offline thresholds: checked in `offline_gate_assessment.json`; unmet items include reasons.")
     lines.append("- Requirement2: tool/capability slices exported in `requirement2_tool_capability_slices.csv`.")
+    lines.append("- Action-level metrics: `action_distribution_breakdown.csv` exports `continue / patch_local / suffix_replan / stop` totals, rates, and shadow/actual bias.")
+    lines.append("- Belief-state metrics: `belief_state_observability_breakdown.csv` exports the five frozen core-state observable rates and derived-field completeness.")
+    lines.append("- Naming: `canonical_group_id` preserves the paper group name while `group_aliases` links back to historical `A0-A6` or external aliases.")
 
     return "\n".join(lines) + "\n"

--- a/tests/unit/test_w12_vertical_experiment.py
+++ b/tests/unit/test_w12_vertical_experiment.py
@@ -150,6 +150,16 @@ def test_replay_sample_materialization_extracts_runtime_snapshot_and_shadow_fiel
     assert metrics["report_linked"] is True
     assert metrics["runtime_state_observable"] is True
     assert metrics["shadow_output_observable"] is True
+    assert metrics["canonical_group_id"] == "fixed_threshold_gate"
+    assert metrics["group_alias"] == "A3"
+    assert metrics["belief_state_p_success"] == 0.74
+    assert metrics["belief_state_p_structural_failure"] == 0.18
+    assert metrics["belief_state_expected_remaining_cost"] == 1.1
+    assert metrics["belief_state_evidence_sufficiency"] is None
+    assert metrics["belief_state_core_observed_count"] == 4
+    assert metrics["belief_state_core_completeness"] == 0.8
+    assert metrics["belief_state_core_complete"] is False
+    assert "snapshot:artifacts.runtime_state" in metrics["belief_state_sources"]
     assert metrics["replay_sample_id"] == "runtime_shadow_success_sample"
     assert metrics["replay_source_freeze_id"] == "issue209-baseline-freeze-smoke"
 
@@ -377,6 +387,8 @@ def test_extract_run_metrics_tracks_action_counts_and_shadow_agreement(
     assert metrics["shadow_action_observation_count"] == 4
     assert metrics["shadow_action_agreement_count"] == 3
     assert metrics["shadow_action_agreement_rate"] == 0.75
+    assert metrics["shadow_actual_bias_count"] == 1
+    assert metrics["shadow_actual_bias_rate"] == 0.25
 
 
 def test_aggregate_and_deltas(tmp_path: Path) -> None:
@@ -414,6 +426,18 @@ def test_aggregate_and_deltas(tmp_path: Path) -> None:
             "shadow_action_agreement_count": 1 if success else 0,
             "shadow_action_observation_count": 1,
             "shadow_action_agreement_rate": 1.0 if success else 0.0,
+            "shadow_actual_bias_count": 0 if success else 1,
+            "shadow_actual_bias_rate": 0.0 if success else 1.0,
+            "belief_state_observation_count": 1 if group_id == "A1" else 0,
+            "belief_state_core_complete": group_id == "A1",
+            "belief_state_core_completeness": 1.0 if group_id == "A1" else 0.0,
+            "belief_state_derived_completeness": 0.2 if group_id == "A1" else 0.0,
+            "belief_state_p_success_observed": group_id == "A1",
+            "belief_state_p_structural_failure_observed": group_id == "A1",
+            "belief_state_recovery_margin_observed": group_id == "A1",
+            "belief_state_expected_remaining_cost_observed": group_id == "A1",
+            "belief_state_evidence_sufficiency_observed": group_id == "A1",
+            "belief_state_budget_pressure_observed": group_id == "A1",
             "layer_counter": {"parameter_level": patch_count} if patch_count else {},
             "tool_usage": {"protgpt2": 1},
             "capability_usage": {"sequence_generation": 1},
@@ -460,6 +484,19 @@ def test_aggregate_and_deltas(tmp_path: Path) -> None:
     assert summary["A0"]["action_patch_local_mean"] == 1.0
     assert summary["A0"]["action_suffix_replan_mean"] == 0.5
     assert summary["A1"]["shadow_action_agreement_rate"] == 1.0
+    assert summary["A0"]["shadow_actual_bias_rate"] == 0.5
+    assert summary["A1"]["belief_state_core_complete_rate"] == 1.0
+    assert summary["A1"]["belief_state_p_success_observable_rate"] == 1.0
+    assert summary["A1"]["belief_state_budget_pressure_observable_rate"] == 1.0
+    assert summary["A0"]["action_patch_local_rate"] == 0.5
+
+    action_rows = {row["group_id"]: row for row in aggregated["action_rows"]}
+    assert action_rows["A0"]["action_total"] == 4.0
+    assert action_rows["A0"]["shadow_actual_bias_total"] == 1
+
+    belief_rows = {row["group_id"]: row for row in aggregated["belief_state_rows"]}
+    assert belief_rows["A1"]["belief_state_core_complete_rate"] == 1.0
+    assert belief_rows["A1"]["budget_pressure_observable_rate"] == 1.0
 
     deltas = compute_increment_deltas(
         runs,
@@ -474,6 +511,68 @@ def test_aggregate_and_deltas(tmp_path: Path) -> None:
     assert row["to_group"] == "A1"
     assert row["delta"] is not None
     assert row["pairing"] == "paired"
+
+
+def test_aggregate_group_metrics_supports_canonical_group_naming() -> None:
+    runs = [
+        {
+            "run_id": "a0_r1",
+            "task_id": "task_a0",
+            "task_key": "k1",
+            "group_id": "A0",
+            "canonical_group_id": "static_top1",
+            "replicate": 1,
+            "success": True,
+            "first_pass_success": True,
+            "schema_valid": True,
+            "executable_plan": True,
+            "waiting_chain_complete": True,
+            "failure_traceable": True,
+            "snapshot_linked": False,
+            "runtime_state_observable": False,
+            "shadow_output_observable": False,
+            "belief_state_core_complete": False,
+        },
+        {
+            "run_id": "a6_r1",
+            "task_id": "task_a6",
+            "task_key": "k1",
+            "group_id": "A6",
+            "canonical_group_id": "lite_belief_state",
+            "replicate": 1,
+            "success": True,
+            "first_pass_success": False,
+            "schema_valid": True,
+            "executable_plan": True,
+            "waiting_chain_complete": True,
+            "failure_traceable": True,
+            "snapshot_linked": True,
+            "runtime_state_observable": True,
+            "shadow_output_observable": True,
+            "belief_state_core_complete": True,
+            "belief_state_core_completeness": 1.0,
+            "belief_state_derived_completeness": 0.0,
+            "belief_state_p_success_observed": True,
+            "belief_state_p_structural_failure_observed": True,
+            "belief_state_recovery_margin_observed": True,
+            "belief_state_expected_remaining_cost_observed": True,
+            "belief_state_evidence_sufficiency_observed": True,
+        },
+    ]
+
+    aggregated = aggregate_group_metrics(
+        runs,
+        group_order=["static_top1", "lite_belief_state"],
+        iterations=100,
+        seed=17,
+        thresholds={},
+        requirement2_capability_map=DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    )
+
+    summary = {row["group_id"]: row for row in aggregated["summary_rows"]}
+    assert summary["static_top1"]["group_aliases"] == ["A0"]
+    assert summary["lite_belief_state"]["group_aliases"] == ["A6"]
+    assert summary["lite_belief_state"]["belief_state_core_complete_rate"] == 1.0
 
 
 def test_requirement2_rows_include_new_similarity_and_secondary_structure_tools(


### PR DESCRIPTION
## 背景

本 PR 完成 #230 的实现交付：将 2026-03-29 已冻结的 action-level / belief-state-level 聚合指标接入统一聚合脚本，使内部四组论文主线、历史 A0-A6 增量组，以及外部 E0/E1/E2 对照可以复用同一 run-level / group-level 输出结构。

该 PR **视为 #230 的完成指示**，但 **不应在合并后立即关闭 #230**。#230 明确声明 hard blocked by #231、#232、#248、#249；其中 #248、#249 当前仍未完成。因此 issue 关闭动作应等待 hard block issue 全部完成后再执行。

## 主要变更

### 1. 统一 action / belief-state 聚合字段

在 `src/infra/w12_vertical_experiment.py` 中补齐统一聚合字段：

- run-level action 计数：
  - `action_continue_count`
  - `action_patch_local_count`
  - `action_suffix_replan_count`
  - `action_stop_count`
- run-level shadow/actual 偏差：
  - `shadow_action_observation_count`
  - `shadow_action_agreement_count`
  - `shadow_action_agreement_rate`
  - `shadow_actual_bias_count`
  - `shadow_actual_bias_rate`
- run-level belief-state 核心字段：
  - `belief_state_p_success`
  - `belief_state_p_structural_failure`
  - `belief_state_recovery_margin`
  - `belief_state_expected_remaining_cost`
  - `belief_state_evidence_sufficiency`
- 每个核心字段对应 `_observed` 标记，并新增核心字段完整率：
  - `belief_state_core_observed_count`
  - `belief_state_core_completeness`
  - `belief_state_core_complete`

同时区分派生审计字段：

- `budget_pressure`
- `intervention_value`
- `goal_misalignment`
- `local_patchability`
- `prefix_preservability`

这些派生量只作为可观测率/完整率聚合，不混入持久化核心状态量口径。

### 2. group-level 扩展指标

`aggregate_group_metrics()` 现在输出：

- group-level action 分布：
  - `action_<action>_mean`
  - `action_<action>_rate`
- group-level belief-state 可观测率与完整率：
  - `belief_state_observable_rate`
  - `belief_state_core_complete_rate`
  - `belief_state_core_completeness_mean`
  - `belief_state_derived_completeness_mean`
  - `belief_state_<field>_observable_rate`
- group-level shadow/actual 偏差：
  - `shadow_action_agreement_rate`
  - `shadow_actual_bias_rate`

同时新增结构化输出：

- `action_rows`
- `belief_state_rows`

### 3. canonical group naming 与 alias 回链

新增 canonical mapping：

- `A0 -> static_top1`
- `A3 -> fixed_threshold_gate`
- `A4/A5 -> dynamic_no_belief_state`
- `A6 -> lite_belief_state`
- `react_single_trajectory -> E0`
- `tot_multi_branch -> E1`
- `reflexion_recovery -> E2`

run-level 输出保留：

- `group_id`
- `canonical_group_id`
- `group_alias`

group-level 输出保留：

- `group_id`
- `canonical_group_id`
- `group_aliases`

这样图表、报告模板和历史 issue 对账可以同时使用 canonical group 与历史 alias。

### 4. 评估脚本输出扩展

`scripts/evaluate_w12_vertical_issue171.py` 增加：

- `vertical_metrics_summary.csv` 的 action / belief-state / alias 扩展字段
- `action_distribution_breakdown.csv`
- `belief_state_observability_breakdown.csv`
- `run_log_index.csv` 中的 canonical/alias 回链字段

这些输出可以直接服务 #221、#222、#223、#224 的实验矩阵与图表消费。

### 5. 指标说明文档

新增：

- `reports/w16-issue230/action-belief-aggregation-metrics.md`

内容覆盖：

- 设计基线
- naming contract
- run-level 字段清单
- group-level 字段清单
- event log / snapshot / summary row 的取数映射

## 设计一致性

本实现按设计文档冻结口径实现：

- belief-state 核心状态量：
  - `p_success`
  - `p_structural_failure`
  - `recovery_margin`
  - `expected_remaining_cost`
  - `evidence_sufficiency`
- 动作空间：
  - `continue`
  - `patch_local`
  - `suffix_replan`
  - `stop`
- canonical 论文主结果组：
  - `static_top1`
  - `fixed_threshold_gate`
  - `dynamic_no_belief_state`
  - `lite_belief_state`

## 验收对照

- [x] 已形成 run-level action / belief-state 聚合字段清单
- [x] 已形成 group-level 扩展指标清单
- [x] 已形成 canonical naming / alias 字段约定
- [x] 内容与 2026-03-29 设计定稿一致
- [x] 映射到 `src/infra/w12_vertical_experiment.py`
- [x] 内部四组与外部 E0/E1/E2 复用同一聚合脚本与相同字段结构
- [x] 保留历史 alias 回链
- [x] 可供 #221、#222、#223、#224 引用

## 注意事项

本 PR 是 #230 的完成指示，但不自动关闭 #230。#230 的 hard block 依赖为：

- #231
- #232
- #248
- #249

其中 #248、#249 仍需完成后，才建议关闭 #230。

## 验证

已运行：

```bash
uv run pytest tests/unit/test_w12_vertical_experiment.py -q
uv run pytest tests/unit/test_w12_vertical_experiment.py tests/unit/test_w16_issue221_experiment_matrix.py tests/unit/test_run_w16_issue221_experiment_matrix.py -q
```

结果：

- `tests/unit/test_w12_vertical_experiment.py`: 10 passed
- 相关 W12/W16 聚合与实验矩阵测试：23 passed
