### PR TITLE
feat(evaluation): add issue222 integration analysis

### DIFF
--- a/scripts/evaluate_w16_issue222_integration_analysis.py
+++ b/scripts/evaluate_w16_issue222_integration_analysis.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.infra.w16_issue222_integration_analysis import (
+    DEFAULT_ISSUE222_KG_PATH,
+    load_and_analyze_issue222_results,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate issue #222 overall and stratified integration analysis."
+    )
+    parser.add_argument(
+        "--run-manifest-path",
+        type=Path,
+        required=True,
+        help="Path to issue #221 runs_manifest.json.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory for issue #222 artifacts. Defaults to run manifest directory.",
+    )
+    parser.add_argument(
+        "--kg-path",
+        type=Path,
+        default=DEFAULT_ISSUE222_KG_PATH,
+        help="ProteinToolKG path for tool->capability mapping.",
+    )
+    parser.add_argument(
+        "--bootstrap-iterations",
+        type=int,
+        default=10000,
+        help="Bootstrap iterations for confidence intervals.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=20260417,
+        help="Random seed for bootstrap resampling.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = args.output_dir or args.run_manifest_path.parent / "issue222-analysis"
+    result = load_and_analyze_issue222_results(
+        run_manifest_path=args.run_manifest_path,
+        output_dir=output_dir,
+        kg_path=args.kg_path,
+        bootstrap_iterations=args.bootstrap_iterations,
+        seed=args.seed,
+    )
+
+    print(f"[issue222] analyzed_runs={len(result['run_level_results'])}")
+    print(f"[issue222] output_dir={output_dir}")
+    print(f"[issue222] overall_csv={output_dir / 'overall_metrics.csv'}")
+    print(
+        f"[issue222] stratified_csv={output_dir / 'difficulty_stratified_metrics.csv'}"
+    )
+    print(f"[issue222] chart_rows={output_dir / 'chart_summary_rows.csv'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/infra/w16_issue222_integration_analysis.py
+++ b/src/infra/w16_issue222_integration_analysis.py
@@ -1,0 +1,590 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from src.infra.w12_vertical_experiment import (
+    DEFAULT_REQUIREMENT2_CAPABILITY_MAP,
+    aggregate_group_metrics,
+    compute_increment_deltas,
+    load_json,
+    now_iso,
+    write_csv,
+    write_json,
+    write_jsonl,
+)
+from src.infra.w16_issue221_experiment_matrix import (
+    DEFAULT_ISSUE221_KG_PATH,
+    evaluate_issue221_run_manifest,
+)
+
+__all__ = [
+    "DEFAULT_ISSUE222_KG_PATH",
+    "analyze_issue222_results",
+    "load_and_analyze_issue222_results",
+]
+
+DEFAULT_ISSUE222_KG_PATH = DEFAULT_ISSUE221_KG_PATH
+_CORE_GROUP_ORDER = (
+    "static_top1",
+    "fixed_threshold_gate",
+    "dynamic_no_belief_state",
+    "lite_belief_state",
+)
+_CHART_METRICS = (
+    ("success", "success_rate"),
+    ("success", "first_pass_success_rate"),
+    ("cost", "duration_ms_mean"),
+    ("cost", "high_cost_call_mean"),
+    ("cost", "high_cost_failure_mean"),
+    ("recovery", "patch_events_mean"),
+    ("recovery", "replan_events_mean"),
+    ("recovery", "suffix_replan_events_mean"),
+    ("recovery", "patch_minimality_hit_rate"),
+    ("recovery", "suffix_replan_prefix_preservation_rate"),
+)
+
+
+def analyze_issue222_results(
+    *,
+    manifest: Mapping[str, Any],
+    output_dir: Path,
+    kg_path: Path = DEFAULT_ISSUE222_KG_PATH,
+    bootstrap_iterations: int = 10000,
+    seed: int = 20260417,
+) -> dict[str, Any]:
+    """生成 issue222 的总体与难度分层聚合分析。
+
+    Args:
+        manifest: issue221 运行清单。
+        output_dir: issue222 分析产物目录。
+        kg_path: Tool KG 路径。
+        bootstrap_iterations: bootstrap 轮数。
+        seed: 随机种子。
+
+    Returns:
+        包含 run-level、总体、分层、恢复复杂度和图表行的分析结果。
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_eval_dir = output_dir / "source_issue221_evaluation"
+    source_result = evaluate_issue221_run_manifest(
+        manifest=manifest,
+        output_dir=source_eval_dir,
+        kg_path=kg_path,
+        bootstrap_iterations=bootstrap_iterations,
+        seed=seed,
+    )
+    run_level_results = list(source_result["run_level_results"])
+    group_order = _resolve_group_order(manifest)
+    requirement2_map = _resolve_requirement2_map(manifest)
+    thresholds = _numeric_thresholds(manifest.get("offline_thresholds"))
+
+    overall = aggregate_group_metrics(
+        run_level_results,
+        group_order=group_order,
+        iterations=max(100, bootstrap_iterations),
+        seed=seed + 101,
+        thresholds=thresholds,
+        requirement2_capability_map=requirement2_map,
+    )
+    overall_rows = [
+        _summary_projection(row, slice_type="overall", slice_value="all")
+        for row in overall["summary_rows"]
+    ]
+
+    stratified_rows: list[dict[str, Any]] = []
+    for offset, difficulty in enumerate(_ordered_values(run_level_results, "difficulty")):
+        slice_runs = [
+            row for row in run_level_results if str(row.get("difficulty") or "unknown") == difficulty
+        ]
+        aggregated = aggregate_group_metrics(
+            slice_runs,
+            group_order=group_order,
+            iterations=max(100, bootstrap_iterations),
+            seed=seed + 201 + offset,
+            thresholds=thresholds,
+            requirement2_capability_map=requirement2_map,
+        )
+        stratified_rows.extend(
+            _summary_projection(row, slice_type="difficulty", slice_value=difficulty)
+            for row in aggregated["summary_rows"]
+        )
+
+    recovery_rows = _build_recovery_complexity_rows(
+        overall_rows=overall_rows,
+        stratified_rows=stratified_rows,
+    )
+    chart_rows = _build_chart_summary_rows(overall_rows + stratified_rows)
+    delta_rows = _build_issue222_delta_rows(
+        run_level_results=run_level_results,
+        group_order=group_order,
+        iterations=max(100, bootstrap_iterations),
+        seed=seed + 401,
+    )
+    metric_definitions = _metric_definitions()
+    statistical_summary = {
+        "generated_at": now_iso(),
+        "issue_id": 222,
+        "source_issue_id": int(manifest.get("issue_id") or 221),
+        "run_count": len(run_level_results),
+        "group_order": group_order,
+        "difficulty_values": _ordered_values(run_level_results, "difficulty"),
+        "source_run_manifest_path": manifest.get("run_manifest_path"),
+        "source_evaluation_dir": str(source_eval_dir),
+        "metric_dimensions": ["success", "cost", "recovery"],
+        "delta_metrics": sorted({row["metric"] for row in delta_rows}),
+    }
+
+    write_jsonl(output_dir / "run_level_results.jsonl", run_level_results)
+    write_json(output_dir / "run_level_results.json", run_level_results)
+    write_csv(output_dir / "overall_metrics.csv", overall_rows, _analysis_fieldnames())
+    write_json(output_dir / "overall_metrics.json", overall_rows)
+    write_csv(
+        output_dir / "difficulty_stratified_metrics.csv",
+        stratified_rows,
+        _analysis_fieldnames(),
+    )
+    write_json(output_dir / "difficulty_stratified_metrics.json", stratified_rows)
+    write_csv(
+        output_dir / "recovery_complexity_high_cost.csv",
+        recovery_rows,
+        [
+            "slice_type",
+            "slice_value",
+            "group_id",
+            "runs",
+            "patch_events_mean",
+            "replan_events_mean",
+            "suffix_replan_events_mean",
+            "recovery_event_mean",
+            "patch_minimality_hit_rate",
+            "suffix_replan_prefix_preservation_rate",
+            "high_cost_call_mean",
+            "high_cost_failure_mean",
+        ],
+    )
+    write_csv(
+        output_dir / "chart_summary_rows.csv",
+        chart_rows,
+        ["slice_type", "slice_value", "group_id", "metric_dimension", "metric", "value"],
+    )
+    write_json(output_dir / "chart_summary_rows.json", chart_rows)
+    write_csv(
+        output_dir / "statistical_deltas.csv",
+        delta_rows,
+        [
+            "slice_type",
+            "slice_value",
+            "from_group",
+            "to_group",
+            "metric",
+            "delta",
+            "ci_low",
+            "ci_high",
+            "sample_size",
+            "pairing",
+        ],
+    )
+    write_json(output_dir / "metric_definitions.json", metric_definitions)
+    write_csv(
+        output_dir / "metric_definitions.csv",
+        metric_definitions,
+        ["metric", "dimension", "definition", "source", "table"],
+    )
+    write_json(output_dir / "statistical_summary.json", statistical_summary)
+    (output_dir / "issue222_analysis_report.md").write_text(
+        _build_markdown_report(
+            generated_at=statistical_summary["generated_at"],
+            manifest=manifest,
+            overall_rows=overall_rows,
+            stratified_rows=stratified_rows,
+            recovery_rows=recovery_rows,
+            delta_rows=delta_rows,
+        ),
+        encoding="utf-8",
+    )
+
+    return {
+        "run_level_results": run_level_results,
+        "overall_rows": overall_rows,
+        "stratified_rows": stratified_rows,
+        "recovery_rows": recovery_rows,
+        "chart_rows": chart_rows,
+        "delta_rows": delta_rows,
+        "metric_definitions": metric_definitions,
+        "statistical_summary": statistical_summary,
+    }
+
+
+def _resolve_group_order(manifest: Mapping[str, Any]) -> list[str]:
+    groups = [
+        str(group.get("id"))
+        for group in manifest.get("groups", [])
+        if isinstance(group, dict) and isinstance(group.get("id"), str)
+    ]
+    if groups:
+        return groups
+    return list(_CORE_GROUP_ORDER)
+
+
+def _resolve_requirement2_map(manifest: Mapping[str, Any]) -> dict[str, list[str]]:
+    raw = manifest.get("requirement2_capability_map")
+    if not isinstance(raw, dict):
+        return dict(DEFAULT_REQUIREMENT2_CAPABILITY_MAP)
+    return {
+        str(key): [str(item) for item in value if isinstance(item, str)]
+        for key, value in raw.items()
+        if isinstance(value, list)
+    }
+
+
+def _numeric_thresholds(value: Any) -> dict[str, float]:
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(key): float(raw)
+        for key, raw in value.items()
+        if isinstance(raw, (int, float)) and not isinstance(raw, bool)
+    }
+
+
+def _ordered_values(rows: Iterable[Mapping[str, Any]], field: str) -> list[str]:
+    preferred = ["easy", "medium", "hard", "unknown"]
+    values = {str(row.get(field) or "unknown") for row in rows}
+    ordered = [value for value in preferred if value in values]
+    ordered.extend(sorted(values - set(ordered)))
+    return ordered
+
+
+def _summary_projection(
+    row: Mapping[str, Any],
+    *,
+    slice_type: str,
+    slice_value: str,
+) -> dict[str, Any]:
+    projected = {
+        "slice_type": slice_type,
+        "slice_value": slice_value,
+        "group_id": row.get("group_id"),
+        "runs": row.get("runs"),
+        "success_rate": row.get("success_rate"),
+        "success_ci_low": row.get("success_ci_low"),
+        "success_ci_high": row.get("success_ci_high"),
+        "first_pass_success_rate": row.get("first_pass_success_rate"),
+        "schema_valid_rate": row.get("schema_valid_rate"),
+        "executable_plan_rate": row.get("executable_plan_rate"),
+        "waiting_chain_complete_rate": row.get("waiting_chain_complete_rate"),
+        "failure_traceable_rate": row.get("failure_traceable_rate"),
+        "duration_ms_mean": row.get("duration_ms_mean"),
+        "duration_ms_ci_low": row.get("duration_ms_ci_low"),
+        "duration_ms_ci_high": row.get("duration_ms_ci_high"),
+        "high_cost_call_mean": row.get("high_cost_call_mean"),
+        "high_cost_call_ci_low": row.get("high_cost_call_ci_low"),
+        "high_cost_call_ci_high": row.get("high_cost_call_ci_high"),
+        "high_cost_failure_mean": row.get("high_cost_failure_mean"),
+        "patch_events_mean": row.get("patch_events_mean"),
+        "replan_events_mean": row.get("replan_events_mean"),
+        "suffix_replan_events_mean": row.get("suffix_replan_events_mean"),
+        "patch_minimality_hit_rate": row.get("patch_minimality_hit_rate"),
+        "suffix_replan_prefix_preservation_rate": row.get(
+            "suffix_replan_prefix_preservation_rate"
+        ),
+        "action_continue_mean": row.get("action_continue_mean"),
+        "action_patch_local_mean": row.get("action_patch_local_mean"),
+        "action_suffix_replan_mean": row.get("action_suffix_replan_mean"),
+        "action_stop_mean": row.get("action_stop_mean"),
+        "shadow_action_agreement_rate": row.get("shadow_action_agreement_rate"),
+    }
+    projected["recovery_event_mean"] = _sum_numeric(
+        projected.get("patch_events_mean"),
+        projected.get("replan_events_mean"),
+        projected.get("suffix_replan_events_mean"),
+    )
+    return projected
+
+
+def _sum_numeric(*values: Any) -> float | None:
+    total = 0.0
+    observed = False
+    for value in values:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            total += float(value)
+            observed = True
+    return total if observed else None
+
+
+def _build_recovery_complexity_rows(
+    *,
+    overall_rows: list[dict[str, Any]],
+    stratified_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "slice_type": row["slice_type"],
+            "slice_value": row["slice_value"],
+            "group_id": row["group_id"],
+            "runs": row["runs"],
+            "patch_events_mean": row["patch_events_mean"],
+            "replan_events_mean": row["replan_events_mean"],
+            "suffix_replan_events_mean": row["suffix_replan_events_mean"],
+            "recovery_event_mean": row["recovery_event_mean"],
+            "patch_minimality_hit_rate": row["patch_minimality_hit_rate"],
+            "suffix_replan_prefix_preservation_rate": row[
+                "suffix_replan_prefix_preservation_rate"
+            ],
+            "high_cost_call_mean": row["high_cost_call_mean"],
+            "high_cost_failure_mean": row["high_cost_failure_mean"],
+        }
+        for row in [*overall_rows, *stratified_rows]
+    ]
+
+
+def _build_chart_summary_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    chart_rows: list[dict[str, Any]] = []
+    for row in rows:
+        for dimension, metric in _CHART_METRICS:
+            chart_rows.append(
+                {
+                    "slice_type": row["slice_type"],
+                    "slice_value": row["slice_value"],
+                    "group_id": row["group_id"],
+                    "metric_dimension": dimension,
+                    "metric": metric,
+                    "value": row.get(metric),
+                }
+            )
+    return chart_rows
+
+
+def _build_issue222_delta_rows(
+    *,
+    run_level_results: list[dict[str, Any]],
+    group_order: list[str],
+    iterations: int,
+    seed: int,
+) -> list[dict[str, Any]]:
+    metric_keys = [
+        "success",
+        "first_pass_success",
+        "duration_ms",
+        "high_cost_call_count",
+        "patch_event_count",
+        "replan_event_count",
+        "suffix_replan_event_count",
+    ]
+    rows: list[dict[str, Any]] = []
+    slices = [("overall", "all", run_level_results)]
+    for difficulty in _ordered_values(run_level_results, "difficulty"):
+        slices.append(
+            (
+                "difficulty",
+                difficulty,
+                [
+                    row
+                    for row in run_level_results
+                    if str(row.get("difficulty") or "unknown") == difficulty
+                ],
+            )
+        )
+
+    counter = 0
+    for slice_type, slice_value, slice_runs in slices:
+        for metric in metric_keys:
+            for delta in compute_increment_deltas(
+                slice_runs,
+                group_order=group_order,
+                metric_key=metric,
+                iterations=iterations,
+                seed=seed + counter,
+            ):
+                enriched = dict(delta)
+                enriched["slice_type"] = slice_type
+                enriched["slice_value"] = slice_value
+                rows.append(enriched)
+            counter += 1
+    return rows
+
+
+def _analysis_fieldnames() -> list[str]:
+    return [
+        "slice_type",
+        "slice_value",
+        "group_id",
+        "runs",
+        "success_rate",
+        "success_ci_low",
+        "success_ci_high",
+        "first_pass_success_rate",
+        "schema_valid_rate",
+        "executable_plan_rate",
+        "waiting_chain_complete_rate",
+        "failure_traceable_rate",
+        "duration_ms_mean",
+        "duration_ms_ci_low",
+        "duration_ms_ci_high",
+        "high_cost_call_mean",
+        "high_cost_call_ci_low",
+        "high_cost_call_ci_high",
+        "high_cost_failure_mean",
+        "patch_events_mean",
+        "replan_events_mean",
+        "suffix_replan_events_mean",
+        "recovery_event_mean",
+        "patch_minimality_hit_rate",
+        "suffix_replan_prefix_preservation_rate",
+        "action_continue_mean",
+        "action_patch_local_mean",
+        "action_suffix_replan_mean",
+        "action_stop_mean",
+        "shadow_action_agreement_rate",
+    ]
+
+
+def _metric_definitions() -> list[dict[str, str]]:
+    return [
+        {
+            "metric": "success_rate",
+            "dimension": "success",
+            "definition": "DONE runs divided by all runs in the slice.",
+            "source": "extract_run_metrics.final_status from event log or manifest status_external",
+            "table": "overall_metrics.csv, difficulty_stratified_metrics.csv",
+        },
+        {
+            "metric": "first_pass_success_rate",
+            "dimension": "success",
+            "definition": "DONE runs without patch, replan, or waiting entry.",
+            "source": "extract_run_metrics patch/replan/waiting counters",
+            "table": "overall_metrics.csv, difficulty_stratified_metrics.csv",
+        },
+        {
+            "metric": "duration_ms_mean",
+            "dimension": "cost",
+            "definition": "Mean end-to-end run duration in milliseconds.",
+            "source": "manifest duration_ms or started_at/finished_at/event timestamps",
+            "table": "overall_metrics.csv, difficulty_stratified_metrics.csv",
+        },
+        {
+            "metric": "high_cost_call_mean",
+            "dimension": "cost",
+            "definition": "Mean matched high-cost tool calls per run.",
+            "source": "STEP_FINISHED/STEP_FAILED rows matched against high_cost_rules",
+            "table": "overall_metrics.csv, recovery_complexity_high_cost.csv",
+        },
+        {
+            "metric": "patch_events_mean",
+            "dimension": "recovery",
+            "definition": "Mean parameter/tool/structure patch events per run.",
+            "source": "PARAM_TWEAK, REPLACE_TOOL, STRUCTURE_PATCH event rows",
+            "table": "overall_metrics.csv, recovery_complexity_high_cost.csv",
+        },
+        {
+            "metric": "replan_events_mean",
+            "dimension": "recovery",
+            "definition": "Mean replanning transitions per run.",
+            "source": "TASK_STATUS_CHANGED rows whose to_status is REPLANNING",
+            "table": "overall_metrics.csv, recovery_complexity_high_cost.csv",
+        },
+        {
+            "metric": "suffix_replan_prefix_preservation_rate",
+            "dimension": "recovery",
+            "definition": "Share of suffix replan samples that preserve the successful prefix.",
+            "source": "data.recovery.prefix_preserved samples",
+            "table": "overall_metrics.csv, recovery_complexity_high_cost.csv",
+        },
+    ]
+
+
+def _build_markdown_report(
+    *,
+    generated_at: str,
+    manifest: Mapping[str, Any],
+    overall_rows: list[dict[str, Any]],
+    stratified_rows: list[dict[str, Any]],
+    recovery_rows: list[dict[str, Any]],
+    delta_rows: list[dict[str, Any]],
+) -> str:
+    lines = [
+        "# Issue #222 Integration Analysis",
+        "",
+        f"- generated_at: `{generated_at}`",
+        f"- source_issue: `#{int(manifest.get('issue_id') or 221)}`",
+        f"- source_run_manifest: `{manifest.get('run_manifest_path') or 'UNKNOWN'}`",
+        "- comparison_scope: `static_top1 / fixed_threshold_gate / dynamic_no_belief_state / lite_belief_state`",
+        "",
+        "## Overall Metrics",
+        "",
+        "| group | runs | success | first_pass | high_cost_mean | patch_mean | replan_mean | recovery_mean |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in overall_rows:
+        lines.append(
+            "| {group_id} | {runs} | {success:.4f} | {first_pass:.4f} | {high_cost:.4f} | {patch:.4f} | {replan:.4f} | {recovery:.4f} |".format(
+                group_id=row.get("group_id"),
+                runs=int(row.get("runs") or 0),
+                success=float(row.get("success_rate") or 0.0),
+                first_pass=float(row.get("first_pass_success_rate") or 0.0),
+                high_cost=float(row.get("high_cost_call_mean") or 0.0),
+                patch=float(row.get("patch_events_mean") or 0.0),
+                replan=float(row.get("replan_events_mean") or 0.0),
+                recovery=float(row.get("recovery_event_mean") or 0.0),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Difficulty Stratification",
+            "",
+            "| difficulty | group | runs | success | high_cost_mean | recovery_mean |",
+            "| --- | --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for row in stratified_rows:
+        lines.append(
+            "| {difficulty} | {group_id} | {runs} | {success:.4f} | {high_cost:.4f} | {recovery:.4f} |".format(
+                difficulty=row.get("slice_value"),
+                group_id=row.get("group_id"),
+                runs=int(row.get("runs") or 0),
+                success=float(row.get("success_rate") or 0.0),
+                high_cost=float(row.get("high_cost_call_mean") or 0.0),
+                recovery=float(row.get("recovery_event_mean") or 0.0),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Output Contract",
+            "",
+            "- `overall_metrics.csv`: overall success/cost/recovery summary rows.",
+            "- `difficulty_stratified_metrics.csv`: difficulty x group stratified summary rows.",
+            "- `recovery_complexity_high_cost.csv`: patch/replan/prefix/high-cost focused rows.",
+            "- `chart_summary_rows.csv`: long-form chart/table rows.",
+            "- `metric_definitions.json`: metric definitions and source mappings.",
+            "- `statistical_deltas.csv`: paired or unpaired bootstrap deltas for core metrics.",
+            "",
+            f"- recovery_rows: `{len(recovery_rows)}`",
+            f"- delta_rows: `{len(delta_rows)}`",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def load_and_analyze_issue222_results(
+    *,
+    run_manifest_path: Path,
+    output_dir: Path,
+    kg_path: Path = DEFAULT_ISSUE222_KG_PATH,
+    bootstrap_iterations: int = 10000,
+    seed: int = 20260417,
+) -> dict[str, Any]:
+    """从 run manifest 路径加载并执行 issue222 分析。"""
+
+    return analyze_issue222_results(
+        manifest=load_json(run_manifest_path),
+        output_dir=output_dir,
+        kg_path=kg_path,
+        bootstrap_iterations=bootstrap_iterations,
+        seed=seed,
+    )

--- a/tests/unit/test_w16_issue222_integration_analysis.py
+++ b/tests/unit/test_w16_issue222_integration_analysis.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.infra.w16_issue222_integration_analysis import analyze_issue222_results
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False))
+            handle.write("\n")
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def test_issue222_analysis_writes_overall_stratified_and_definition_outputs(
+    tmp_path: Path,
+) -> None:
+    kg_path = tmp_path / "protein_tool_kg.json"
+    _write_json(
+        kg_path,
+        {
+            "tools": [
+                {"id": "esmfold", "capabilities": ["structure_prediction"]},
+                {"id": "seqgen_local", "capabilities": ["sequence_generation"]},
+            ]
+        },
+    )
+
+    success_log = tmp_path / "logs" / "lite_success.jsonl"
+    _write_jsonl(
+        success_log,
+        [
+            {
+                "event": "STEP_FINISHED",
+                "task_id": "task_lite_success",
+                "step_id": "S2",
+                "tool": "esmfold",
+                "status": "success",
+                "timestamp": "2026-04-17T10:00:01+00:00",
+                "data": {"action_name": "continue", "shadow_action": "continue"},
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": "task_lite_success",
+                "from_status": "SUMMARIZING",
+                "to_status": "DONE",
+                "timestamp": "2026-04-17T10:00:02+00:00",
+            },
+        ],
+    )
+    success_snapshot = tmp_path / "snapshots" / "lite_success.jsonl"
+    _write_jsonl(success_snapshot, [{"artifacts": {"runtime_state": {"p_success": 0.8}}}])
+    success_report = tmp_path / "reports" / "lite_success.json"
+    _write_json(success_report, {})
+
+    patch_log = tmp_path / "logs" / "dynamic_patch.jsonl"
+    _write_jsonl(
+        patch_log,
+        [
+            {
+                "event": "PARAM_TWEAK",
+                "task_id": "task_dynamic_patch",
+                "step_id": "S1",
+                "timestamp": "2026-04-17T11:00:01+00:00",
+                "data": {"recovery": {"recovery_layer": "parameter_level"}},
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": "task_dynamic_patch",
+                "from_status": "RUNNING",
+                "to_status": "REPLANNING",
+                "reason": "suffix_replan_requested",
+                "timestamp": "2026-04-17T11:00:02+00:00",
+            },
+            {
+                "event": "RECOVERY_ESCALATED",
+                "task_id": "task_dynamic_patch",
+                "step_id": "S2",
+                "timestamp": "2026-04-17T11:00:03+00:00",
+                "data": {
+                    "action_name": "replan",
+                    "recovery": {
+                        "replan_mode": "suffix_replan",
+                        "prefix_preserved": True,
+                    },
+                },
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": "task_dynamic_patch",
+                "from_status": "RUNNING",
+                "to_status": "FAILED",
+                "timestamp": "2026-04-17T11:00:04+00:00",
+            },
+        ],
+    )
+    static_log = tmp_path / "logs" / "static_success.jsonl"
+    _write_jsonl(
+        static_log,
+        [
+            {
+                "event": "STEP_FINISHED",
+                "task_id": "task_static_success",
+                "step_id": "S1",
+                "tool": "seqgen_local",
+                "status": "success",
+                "timestamp": "2026-04-17T09:00:01+00:00",
+            },
+            {
+                "event": "TASK_STATUS_CHANGED",
+                "task_id": "task_static_success",
+                "from_status": "SUMMARIZING",
+                "to_status": "DONE",
+                "timestamp": "2026-04-17T09:00:02+00:00",
+            },
+        ],
+    )
+
+    run_config = tmp_path / "run_configs" / "placeholder.json"
+    _write_json(run_config, {})
+    manifest = {
+        "issue_id": 221,
+        "run_manifest_path": str(tmp_path / "runs_manifest.json"),
+        "config_path": str(tmp_path / "config.json"),
+        "freeze_id": "issue209-baseline-freeze-20260326",
+        "high_cost_rules": [
+            {
+                "rule_id": "structure_mapping",
+                "tool_ids": ["esmfold"],
+                "capability_ids": ["structure_prediction"],
+            }
+        ],
+        "groups": [
+            {"id": "static_top1"},
+            {"id": "dynamic_no_belief_state"},
+            {"id": "lite_belief_state"},
+        ],
+        "artifact_policy": {
+            "all_runs_required": ["run_config_path", "event_log_path"],
+            "success_runs_required": ["snapshot_path", "report_path"],
+            "waiting_runs_required": ["snapshot_path"],
+            "failed_runs_required": [],
+        },
+        "runs": [
+            {
+                "run_id": "static_easy",
+                "task_id": "task_static_success",
+                "task_key": "easy_task",
+                "group_id": "static_top1",
+                "replicate": 1,
+                "freeze_id": "issue209-baseline-freeze-20260326",
+                "task_set_version": "issue209-taskset-v1",
+                "difficulty": "easy",
+                "budget_tier": "standard",
+                "runtime_policy": "static_single_candidate",
+                "run_config_path": str(run_config),
+                "event_log_path": str(static_log),
+                "snapshot_path": "",
+                "report_path": "",
+                "status_external": "DONE",
+            },
+            {
+                "run_id": "dynamic_hard",
+                "task_id": "task_dynamic_patch",
+                "task_key": "hard_task",
+                "group_id": "dynamic_no_belief_state",
+                "replicate": 1,
+                "freeze_id": "issue209-baseline-freeze-20260326",
+                "task_set_version": "issue209-taskset-v1",
+                "difficulty": "hard",
+                "budget_tier": "high_cost_sensitive",
+                "runtime_policy": "dynamic_observation_only",
+                "run_config_path": str(run_config),
+                "event_log_path": str(patch_log),
+                "snapshot_path": "",
+                "report_path": "",
+                "status_external": "FAILED",
+            },
+            {
+                "run_id": "lite_hard",
+                "task_id": "task_lite_success",
+                "task_key": "hard_task",
+                "group_id": "lite_belief_state",
+                "replicate": 1,
+                "freeze_id": "issue209-baseline-freeze-20260326",
+                "task_set_version": "issue209-taskset-v1",
+                "difficulty": "hard",
+                "budget_tier": "high_cost_sensitive",
+                "runtime_policy": "lite_belief_state",
+                "run_config_path": str(run_config),
+                "event_log_path": str(success_log),
+                "snapshot_path": str(success_snapshot),
+                "report_path": str(success_report),
+                "status_external": "DONE",
+            },
+        ],
+    }
+
+    result = analyze_issue222_results(
+        manifest=manifest,
+        output_dir=tmp_path / "issue222",
+        kg_path=kg_path,
+        bootstrap_iterations=100,
+        seed=23,
+    )
+
+    overall = {row["group_id"]: row for row in result["overall_rows"]}
+    assert overall["lite_belief_state"]["success_rate"] == 1.0
+    assert overall["dynamic_no_belief_state"]["recovery_event_mean"] == 4.0
+    assert overall["lite_belief_state"]["high_cost_call_mean"] == 1.0
+
+    hard_rows = {
+        row["group_id"]: row
+        for row in result["stratified_rows"]
+        if row["slice_value"] == "hard"
+    }
+    assert hard_rows["lite_belief_state"]["success_rate"] == 1.0
+    assert hard_rows["dynamic_no_belief_state"]["success_rate"] == 0.0
+
+    output_dir = tmp_path / "issue222"
+    assert (output_dir / "overall_metrics.csv").exists()
+    assert (output_dir / "difficulty_stratified_metrics.csv").exists()
+    assert (output_dir / "recovery_complexity_high_cost.csv").exists()
+    assert (output_dir / "chart_summary_rows.csv").exists()
+    assert (output_dir / "metric_definitions.json").exists()
+    assert (output_dir / "issue222_analysis_report.md").exists()
+    definitions = json.loads((output_dir / "metric_definitions.json").read_text())
+    assert {row["dimension"] for row in definitions} >= {"success", "cost", "recovery"}


### PR DESCRIPTION
## 背景

本 PR 完成 #222 的实现交付：在 #221 四组方法 run-level 结果基础上，增加总体指标、难度分层、恢复复杂度和高代价调用的可复算聚合分析。

#222 的唯一 hard block 是 #221，当前 #221 已关闭。因此本 PR 合并到 `dev` 后，可作为 #222 的关闭依据。

## 主要变更

### 1. 新增 issue222 分析模块

新增 `src/infra/w16_issue222_integration_analysis.py`，以 #221 产出的 `runs_manifest.json` 为输入，复用现有 run-level 评估与聚合能力，并额外生成 #222 所需分析产物。

核心入口：

- `analyze_issue222_results(...)`
- `load_and_analyze_issue222_results(...)`

该实现不新增实验分组，不重新执行实验，只基于 #221 的可追溯 run-level 结果进行复算聚合。

### 2. 覆盖 success / cost / recovery 三类指标

总体与分层分析覆盖：

- success：
  - `success_rate`
  - `first_pass_success_rate`
  - `schema_valid_rate`
  - `executable_plan_rate`
- cost：
  - `duration_ms_mean`
  - `high_cost_call_mean`
  - `high_cost_failure_mean`
- recovery：
  - `patch_events_mean`
  - `replan_events_mean`
  - `suffix_replan_events_mean`
  - `recovery_event_mean`
  - `patch_minimality_hit_rate`
  - `suffix_replan_prefix_preservation_rate`
  - action 分配相关均值

### 3. 输出总体与难度分层表

新增输出：

- `overall_metrics.csv`
- `overall_metrics.json`
- `difficulty_stratified_metrics.csv`
- `difficulty_stratified_metrics.json`

分层字段使用 #221 / #209 任务集中的 `difficulty`，当前口径兼容 `easy / medium / hard / unknown`，并保留扩展值。

### 4. 输出恢复复杂度与高代价调用分析

新增输出：

- `recovery_complexity_high_cost.csv`

该表集中呈现：

- patch/replan/suffix_replan 均值
- 汇总恢复事件均值
- patch minimality
- suffix_replan prefix preservation
- high-cost call / failure 均值

### 5. 输出图表与报告可直接消费的 summary rows

新增长表输出：

- `chart_summary_rows.csv`
- `chart_summary_rows.json`

格式为：

- `slice_type`
- `slice_value`
- `group_id`
- `metric_dimension`
- `metric`
- `value`

该结构可直接被后续图表、表格模板和章节材料消费。

### 6. 输出指标定义与统计摘要

新增：

- `metric_definitions.csv`
- `metric_definitions.json`
- `statistical_summary.json`
- `statistical_deltas.csv`
- `issue222_analysis_report.md`

其中 `metric_definitions.*` 明确每个核心指标的：

- 指标名
- 维度
- 定义
- 来源
- 所在输出表

`statistical_deltas.csv` 使用已有 paired/unpaired bootstrap delta 逻辑，按总体和 difficulty 分层输出核心指标组间差异。

### 7. 新增 CLI 入口

新增 `scripts/evaluate_w16_issue222_integration_analysis.py`：

```bash
uv run python scripts/evaluate_w16_issue222_integration_analysis.py \
  --run-manifest-path <path-to-issue221-runs_manifest.json> \
  --output-dir <output-dir>
```

默认输出目录为 run manifest 所在目录下的 `issue222-analysis/`。

## 验收对照

- [x] 聚合四组方法的总体指标
- [x] 生成按难度分层的分析表
- [x] 统计高代价调用、patch/replan、prefix preservation 等指标
- [x] 输出可被图表直接消费的 summary rows
- [x] 聚合结果可复算
- [x] 每个指标字段有来源与定义
- [x] 输出格式兼容后续图表与报告模板

## 测试

已运行：

```bash
uv run pytest tests/unit/test_w16_issue222_integration_analysis.py tests/unit/test_w16_issue221_experiment_matrix.py tests/unit/test_run_w16_issue221_experiment_matrix.py tests/unit/test_w12_vertical_experiment.py -q
```

结果：

- `24 passed`

## 备注

本 PR 合并后，#222 的实现交付即可视为完成。#223 和 #224 可以继续消费本 PR 生成的分层分析、chart summary rows、metric definitions 和统计摘要。

Closes #222
