### PR TITLE
docs: add issue 233 action runtime audit evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ docs/*
 !docs/algorithm-and-llm/
 docs/algorithm-and-llm/*
 !docs/algorithm-and-llm/requirement2-similarity-secondary-structure-tools.md
+!docs/evidence/
+docs/evidence/*
+!docs/evidence/issue-233-action-runtime-audit-output-evidence.md
 plan/
 shared/
 drafts/

--- a/docs/evidence/issue-233-action-runtime-audit-output-evidence.md
+++ b/docs/evidence/issue-233-action-runtime-audit-output-evidence.md
@@ -1,0 +1,184 @@
+# Issue #233 action/runtime audit evidence
+
+## Scope
+
+This note summarizes repository evidence for GitHub issue
+[#233](https://github.com/Yuri-Kon/thesis-project/issues/233),
+`W14-Observability-3b: action/runtime 审计事件字段补齐`.
+
+The issue asked for action/runtime audit fields covering at least step,
+recovery escalation, `TASK_STATUS_CHANGED`, and WAITING-related events, with
+fields consumable by experiment scripts without manual stitching.
+
+## Verification date
+
+Checked on 2026-04-25 from branch `issue-233-output-evidence`.
+
+## Summary conclusion
+
+Evidence exists, but it is split across two layers:
+
+- `output/` contains experiment-facing derived columns and summaries that are
+  directly consumed by the analysis scripts.
+- Raw per-event audit fields are in `data/logs/*.jsonl`, referenced from
+  `output/**/run_level_results.json*` by `event_log_path`.
+
+No `output/issue233*` artifact was found. The evidence is therefore traceable
+through the experiment outputs and their linked event logs, rather than through
+a single issue-specific output file.
+
+## Output-layer evidence
+
+Representative output file:
+
+- `output/experiment/w16-expr-1/issue270-rerun-20260419b/run_level_results.json`
+
+Representative fields observed in run-level rows:
+
+- `runtime_state_observable`
+- `shadow_output_observable`
+- `action_continue_count`
+- `action_patch_local_count`
+- `action_suffix_replan_count`
+- `action_stop_count`
+- `event_log_path`
+- `snapshot_path`
+- `run_config_path`
+
+Example rows in that file show `runtime_state_observable: true`,
+`shadow_output_observable: true`, and action-count columns for
+`lite_belief_state` runs. The same rows point back to raw event logs, for
+example:
+
+- `data/logs/issue270-rerun-20260419b_lite_belief_state_enzyme_like_fold_r01.jsonl`
+- `data/logs/issue270-rerun-20260419b_lite_belief_state_enzyme_like_fold_r02.jsonl`
+
+Representative aggregate output:
+
+- `output/experiment/w16-expr-1/issue270-rerun-20260419b/matrix_metrics_summary.json`
+
+This aggregate includes direct experiment metrics such as:
+
+- `runtime_state_observable_rate`
+- `shadow_output_observable_rate`
+- `action_continue_mean`
+- `action_patch_local_mean`
+- `action_suffix_replan_mean`
+- `action_stop_mean`
+- `shadow_action_agreement_rate`
+
+For the `lite_belief_state` group in this artifact, the observed values include
+`runtime_state_observable_rate: 1.0` and
+`shadow_output_observable_rate: 0.8571428571428571`.
+
+## Raw event-log evidence
+
+Representative raw event log:
+
+- `data/logs/issue270-rerun-20260419b_lite_belief_state_high_solubility_r02.jsonl`
+
+Observed event coverage in that log:
+
+- `STEP_FINISHED` carries `data.action_name`,
+  `data.evidence_source`, `data.runtime_policy`,
+  `data.belief_state_enabled`, and `data.runtime_state_summary`.
+- `REPLACE_TOOL` and `STRUCTURE_PATCH` carry `data.action_name`,
+  `data.action_score`, `data.shadow_score`, `data.evidence_source`,
+  `data.recovery`, and `data.runtime_state_summary`.
+- `RECOVERY_ESCALATED` carries `data.action_name`,
+  `data.action_score`, `data.shadow_score`, `data.evidence_source`,
+  `data.recovery`, and `data.runtime_state_summary`.
+- `WAITING_ENTER` carries `data.action_type`, `data.action_name`,
+  `data.action_score`, `data.shadow_score`, `data.evidence_source`,
+  `data.runtime_policy`, `data.belief_state_enabled`,
+  `data.runtime_state_summary`, and `data.waiting_state`.
+- `TASK_STATUS_CHANGED` carries `data.runtime_state_summary` on relevant
+  runtime-state transitions.
+- `STEP_FAILED` carries failure details plus `data.action_name`,
+  `data.workflow_action_reason`, `data.evidence_source`,
+  `data.runtime_policy`, `data.belief_state_enabled`,
+  and `data.runtime_state_summary`.
+
+## Structured count check
+
+A structured scan of `output/**/*.json*` found derived experiment columns but
+not raw per-event audit fields:
+
+| Field | Count in `output/**/*.json*` |
+| --- | ---: |
+| `runtime_state_observable` | 280 |
+| `shadow_output_observable` | 280 |
+| `action_continue_count` | 280 |
+| `action_patch_local_count` | 280 |
+| `action_suffix_replan_count` | 280 |
+| `action_stop_count` | 280 |
+| `action_name` | 0 |
+| `action_score` | 0 |
+| `shadow_score` | 0 |
+| `runtime_state_summary` | 0 |
+| `evidence_source` | 0 |
+
+This is expected because raw audit fields live in event logs, while `output/`
+stores experiment-level rollups and links.
+
+A structured scan of the 120 event logs referenced by `output/**/run_level_results.json*`
+found the following selected event coverage:
+
+| Event | Count | Observed audit fields |
+| --- | ---: | --- |
+| `STEP_FINISHED` | 219 | `action_name`, `evidence_source`; `runtime_state_summary` in 24 rows |
+| `STEP_FAILED` | 3 | `action_name`, `evidence_source`; `runtime_state_summary` in 1 row |
+| `RECOVERY_ESCALATED` | 2 | `action_name`, `action_score`, `shadow_score`, `runtime_state_summary`, `evidence_source`, recovery nested score/runtime fields |
+| `TASK_STATUS_CHANGED` | 669 | `runtime_state_summary` in 55 rows |
+| `WAITING_ENTER` | 91 | `action_name`, `action_score`, `shadow_score`, `runtime_state_summary`, `evidence_source` |
+| `DECISION_APPLIED` | 176 | action/score/shadow/runtime/evidence fields in 88 rows |
+| `REPLACE_TOOL` | 2 | action/score/shadow/runtime/evidence fields plus recovery nested fields |
+| `STRUCTURE_PATCH` | 2 | action/score/shadow/runtime/evidence fields plus recovery nested fields |
+
+## Source-code traceability
+
+The experiment-side direct-consumption logic is implemented in
+`src/infra/w12_vertical_experiment.py`:
+
+- `_runtime_state_candidates()` reads `data.runtime_state_summary`,
+  `data.waiting_runtime_summary.runtime_state_summary`, and
+  `data.recovery.runtime_state_summary`.
+- `_has_shadow_output()` reads `data.shadow_score`,
+  `data.waiting_runtime_summary.shadow_score`, and
+  `data.recovery.shadow_score`.
+- `_summarize_run()` computes `runtime_state_observable`,
+  `shadow_output_observable`, and action counters from event rows.
+
+The timeline/log extraction path is implemented in `src/storage/log_store.py`:
+
+- `_extract_observability_fields()` normalizes `action_name`, `action_score`,
+  `shadow_score`, `runtime_state_summary`, `waiting_runtime_summary`,
+  `evidence_source`, and recovery metadata from event payloads.
+
+Integration coverage exists in `tests/integration/test_event_log_integration.py`
+for WAITING and decision events carrying:
+
+- `action_name`
+- `action_score`
+- `shadow_score`
+- `evidence_source`
+- `runtime_state_summary`
+
+## Evidence mapping to issue #233 requirements
+
+| Issue requirement | Evidence status |
+| --- | --- |
+| Action/runtime audit field names fixed | Present in contracts/logging code and raw event logs |
+| Fields land in step events | Present in `STEP_FINISHED` and `STEP_FAILED` rows |
+| Fields land in recovery escalation events | Present in `RECOVERY_ESCALATED` rows |
+| Fields land in `TASK_STATUS_CHANGED` events | Runtime summary present on relevant status changes |
+| Fields land in WAITING-related events | Present in `WAITING_ENTER`; decision path also covered by `DECISION_APPLIED` and `WAITING_EXIT` tests |
+| Experiment scripts can consume without manual stitching | Present through `run_level_results.json*` derived columns and event-log path linkage |
+| Compatible with existing log paths | Present through `data/logs/*.jsonl` referenced by output rows |
+
+## Caveat
+
+If the evidence requirement is interpreted as "all raw audit fields must be
+physically duplicated inside `output/` files", that is not currently true.
+The current design keeps raw event rows in `data/logs/` and stores derived
+experiment metrics plus traceability links in `output/`.


### PR DESCRIPTION
## 背景

本 PR 汇总 GitHub issue #233（`W14-Observability-3b: action/runtime 审计事件字段补齐`）在当前仓库中的证据，目标是把 issue 中要求的 action/runtime 审计字段落点、实验输出消费路径、原始事件日志追溯路径整理成一份可引用文档。

issue #233 的核心关注点包括：

- action 名称、action score、shadow score、runtime_state 摘要、升级证据来源等审计字段是否已经进入事件日志。
- 字段是否覆盖 `STEP_*`、`RECOVERY_ESCALATED`、`TASK_STATUS_CHANGED`、WAITING 相关事件。
- 实验脚本是否能直接消费这些信息，不需要人工二次拼接。
- 证据是否能映射到 `src/workflow/plan_runner.py`、`src/workflow/patch_runner.py`、`src/storage/log_store.py` 等路径，并供后续实验 issue 引用。

## 变更内容

### 新增 issue #233 证据文档

新增：

- `docs/evidence/issue-233-action-runtime-audit-output-evidence.md`

文档主要整理了三层证据：

1. **`output/` 实验消费层**

   说明 `output/**/run_level_results.json*` 和 `matrix_metrics_summary.json` 中已经存在实验脚本可直接消费的派生字段，例如：

   - `runtime_state_observable`
   - `shadow_output_observable`
   - `action_continue_count`
   - `action_patch_local_count`
   - `action_suffix_replan_count`
   - `action_stop_count`
   - `event_log_path`
   - `snapshot_path`
   - `run_config_path`

   文档也记录了代表性实验输出：

   - `output/experiment/w16-expr-1/issue270-rerun-20260419b/run_level_results.json`
   - `output/experiment/w16-expr-1/issue270-rerun-20260419b/matrix_metrics_summary.json`

2. **`data/logs/` 原始事件层**

   文档说明 raw audit fields 并不是直接复制在 `output/` 中，而是位于 `output` 通过 `event_log_path` 指向的 `data/logs/*.jsonl`。

   代表性日志：

   - `data/logs/issue270-rerun-20260419b_lite_belief_state_high_solubility_r02.jsonl`

   其中可观察到：

   - `STEP_FINISHED` 携带 `action_name`、`evidence_source`、`runtime_state_summary` 等字段。
   - `STEP_FAILED` 携带失败详情、action 名称、workflow action 原因、runtime_state 摘要等字段。
   - `RECOVERY_ESCALATED` 携带 `action_name`、`action_score`、`shadow_score`、`evidence_source`、`recovery` 和 `runtime_state_summary`。
   - `WAITING_ENTER` 携带 WAITING 状态、action 类型、action/shadow score、runtime_state 摘要和 evidence source。
   - `TASK_STATUS_CHANGED` 在相关状态变化中携带 runtime-level 摘要字段。

3. **源码与测试追溯层**

   文档记录了实验脚本和日志抽取逻辑中的直接消费入口：

   - `src/infra/w12_vertical_experiment.py`
     - `_runtime_state_candidates()`
     - `_has_shadow_output()`
     - `_summarize_run()`
   - `src/storage/log_store.py`
     - `_extract_observability_fields()`
   - `tests/integration/test_event_log_integration.py`
     - 覆盖 WAITING / decision 事件中的 `action_name`、`action_score`、`shadow_score`、`evidence_source`、`runtime_state_summary`。

### 窄范围放行证据文档

更新 `.gitignore`，仅放行本次新增的证据文档：

- `docs/evidence/issue-233-action-runtime-audit-output-evidence.md`

没有放开整个 `docs/` 目录，也没有放开 `output/` 目录，避免把实验输出或其他草稿文件批量纳入版本控制。

## 证据结论

本 PR 的文档结论是：

- issue #233 要求的 action/runtime 审计证据存在。
- `output/` 中存在实验脚本直接消费的派生字段和 traceability link。
- 原始 per-event audit fields 位于 `data/logs/*.jsonl`，并通过 `output/**/run_level_results.json*` 中的 `event_log_path` 可回溯。
- 当前没有发现单独命名为 `output/issue233*` 的 artifact；证据不是以单一 issue 专属输出文件存在，而是分布在实验输出与事件日志链路中。

## 重要边界

本文档明确区分两类证据：

- `output/`：面向实验聚合和论文指标消费的派生结果。
- `data/logs/`：原始事件日志，包含 action/runtime 审计字段本体。

因此，如果把 issue #233 的验收理解为“raw audit fields 必须物理复制到 `output/` 文件中”，当前仓库并不满足该解释；但如果验收重点是“实验脚本可直接消费，并能从 output 回溯到原始审计字段”，当前证据链是成立的。

## 验证

- 已检查 GitHub issue #233 的内容与本地仓库证据之间的对应关系。
- 已核对 `output/` 中的 run-level / matrix-level 派生字段。
- 已核对 `output` 结果中 `event_log_path` 指向的 `data/logs/*.jsonl` 原始事件。
- 已核对源码中的实验消费逻辑和日志抽取逻辑。
- 未运行测试；本 PR 仅新增文档并对 `.gitignore` 做窄范围放行，不改变运行时代码。

## 后续使用

该文档可作为 issue #233 的证据汇总，也可以被后续与 `#221`、`#222` 等实验分析相关的 issue/PR 引用，用于说明 action/runtime 审计字段从事件日志到实验输出的追溯关系。
