### PR TITLE
docs(evidence): add issue 224 evidence templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ docs/algorithm-and-llm/*
 !docs/evidence/
 docs/evidence/*
 !docs/evidence/issue-233-action-runtime-audit-output-evidence.md
+!docs/evidence/issue-224/
+!docs/evidence/issue-224/**
 plan/
 shared/
 drafts/

--- a/docs/evidence/issue-224/evidence-index.json
+++ b/docs/evidence/issue-224/evidence-index.json
@@ -1,0 +1,293 @@
+{
+  "schema_version": "w16.issue224.evidence-index.v1",
+  "issue_id": 224,
+  "title": "W16-Docs-4 evidence index, figure/table templates, and report templates",
+  "generated_at": "2026-04-26T00:00:00+08:00",
+  "execution_window": {
+    "start": "2026-04-17",
+    "end": "2026-04-20"
+  },
+  "naming_convention": {
+    "source": "../thesis-project.design/docs/experiment/algorithm-group-paper-mapping.md",
+    "paper_groups": [
+      "static_top1",
+      "fixed_threshold_gate",
+      "dynamic_no_belief_state",
+      "lite_belief_state"
+    ],
+    "external_groups": [
+      "E0",
+      "E1",
+      "E2"
+    ],
+    "historical_alias_policy": "A0-A6 only appear as appendix or traceability aliases, not as main paper rows.",
+    "display_names": {
+      "static_top1": "Static Top-1",
+      "fixed_threshold_gate": "Fixed Threshold Gate",
+      "dynamic_no_belief_state": "Dynamic Recovery (No Belief-State)",
+      "lite_belief_state": "Lite Belief-State",
+      "E0": "ReAct Baseline",
+      "E1": "ToT Baseline",
+      "E2": "Reflexion Baseline"
+    }
+  },
+  "source_roots": {
+    "w16_01_run_output": "output/experiment/w16-expr-1/issue221-real-full-20260418b",
+    "w16_02_analysis_output": "output/experiment/w16-expr-1/<analysis_run_id>",
+    "w16_03_case_output": "reports/w16-issue223/<case_pack_id>",
+    "event_logs": "data/logs",
+    "snapshots": "data/snapshots",
+    "task_reports": "output/reports",
+    "templates": "docs/evidence/issue-224"
+  },
+  "traceability_chains": {
+    "table": {
+      "required_refs": [
+        "config_path",
+        "resolved_config_snapshot_path",
+        "run_manifest_path",
+        "run_log_index_path",
+        "aggregate_source_path",
+        "metric_definition_path",
+        "template_path"
+      ],
+      "chain_rule": "config -> resolved_config_snapshot -> runs_manifest/run_log_index -> aggregate table -> metric definitions -> paper table template"
+    },
+    "figure": {
+      "required_refs": [
+        "aggregate_source_path",
+        "chart_summary_rows_path",
+        "statistical_deltas_path",
+        "template_path",
+        "rendered_artifact_path"
+      ],
+      "chain_rule": "aggregate table -> long-form chart rows/statistical deltas -> figure template -> rendered chart"
+    },
+    "case": {
+      "required_refs": [
+        "run_config_path",
+        "event_log_path",
+        "snapshot_path",
+        "run_traceability_index_path",
+        "case_template_path"
+      ],
+      "chain_rule": "run_traceability_index -> run_config -> event_log/snapshot -> case template -> report section"
+    }
+  },
+  "upstream_deliverables": [
+    {
+      "issue_id": 221,
+      "name": "Four-group experiment matrix",
+      "status": "available_locally",
+      "primary_paths": [
+        "output/experiment/w16-expr-1/issue221-real-full-20260418b/runs_manifest.json",
+        "output/experiment/w16-expr-1/issue221-real-full-20260418b/run_level_results.json",
+        "output/experiment/w16-expr-1/issue221-real-full-20260418b/matrix_metrics_summary.csv",
+        "output/experiment/w16-expr-1/issue221-real-full-20260418b/run_traceability_index.csv",
+        "output/experiment/w16-expr-1/issue221-real-full-20260418b/evidence_index.json"
+      ]
+    },
+    {
+      "issue_id": 222,
+      "name": "Aggregation and stratified analysis",
+      "status": "contract_available",
+      "producer": "src/infra/w16_issue222_integration_analysis.py",
+      "expected_paths": [
+        "overall_metrics.csv",
+        "difficulty_stratified_metrics.csv",
+        "recovery_complexity_high_cost.csv",
+        "chart_summary_rows.csv",
+        "statistical_deltas.csv",
+        "metric_definitions.csv",
+        "statistical_summary.json",
+        "issue222_analysis_report.md"
+      ]
+    },
+    {
+      "issue_id": 223,
+      "name": "Case study and failure analysis",
+      "status": "template_consumable",
+      "expected_case_types": [
+        "loss_control_success",
+        "static_vs_dynamic_contrast",
+        "failure_analysis"
+      ]
+    }
+  ],
+  "artifacts": [
+    {
+      "artifact_id": "table-main-internal-overall",
+      "artifact_type": "table",
+      "title": "Internal main result table",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/figure-table-templates.md#table-main-internal-overall",
+      "source_refs": {
+        "aggregate_source_path": "output/experiment/w16-expr-1/<analysis_run_id>/overall_metrics.csv",
+        "fallback_source_path": "output/experiment/w16-expr-1/issue221-real-full-20260418b/matrix_metrics_summary.csv",
+        "metric_definition_path": "output/experiment/w16-expr-1/<analysis_run_id>/metric_definitions.csv"
+      },
+      "required_columns": [
+        "group_id",
+        "runs",
+        "success_rate",
+        "first_pass_success_rate",
+        "duration_ms_mean",
+        "high_cost_call_mean",
+        "patch_events_mean",
+        "replan_events_mean",
+        "suffix_replan_events_mean"
+      ],
+      "group_scope": [
+        "static_top1",
+        "fixed_threshold_gate",
+        "dynamic_no_belief_state",
+        "lite_belief_state"
+      ],
+      "generated_by": {
+        "source_script": "src/infra/w16_issue222_integration_analysis.py",
+        "function_template": "load_and_analyze_issue222_results(run_manifest_path=<runs_manifest.json>, output_dir=<analysis_run_dir>)"
+      },
+      "traceability_status": "all rows must join back through run_log_index.csv and metric_definitions.csv"
+    },
+    {
+      "artifact_id": "table-difficulty-stratified",
+      "artifact_type": "table",
+      "title": "Difficulty-stratified result table",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/figure-table-templates.md#table-difficulty-stratified",
+      "source_refs": {
+        "aggregate_source_path": "output/experiment/w16-expr-1/<analysis_run_id>/difficulty_stratified_metrics.csv",
+        "run_level_source_path": "output/experiment/w16-expr-1/<analysis_run_id>/run_level_results.jsonl"
+      },
+      "required_columns": [
+        "slice_type",
+        "slice_value",
+        "group_id",
+        "runs",
+        "success_rate",
+        "duration_ms_mean",
+        "high_cost_call_mean",
+        "recovery_event_mean"
+      ],
+      "traceability_status": "slice_value must derive from run-level difficulty in runs_manifest.json"
+    },
+    {
+      "artifact_id": "table-recovery-high-cost",
+      "artifact_type": "table",
+      "title": "Recovery complexity and high-cost call table",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/figure-table-templates.md#table-recovery-high-cost",
+      "source_refs": {
+        "aggregate_source_path": "output/experiment/w16-expr-1/<analysis_run_id>/recovery_complexity_high_cost.csv",
+        "action_source_path": "output/experiment/w16-expr-1/issue221-real-full-20260418b/action_distribution.csv",
+        "patch_replan_source_path": "output/experiment/w16-expr-1/issue221-real-full-20260418b/patch_replan_breakdown.csv"
+      },
+      "required_columns": [
+        "group_id",
+        "patch_events_mean",
+        "replan_events_mean",
+        "suffix_replan_events_mean",
+        "patch_minimality_hit_rate",
+        "suffix_replan_prefix_preservation_rate",
+        "high_cost_call_mean",
+        "high_cost_failure_mean"
+      ],
+      "traceability_status": "recovery metrics must link to event log rows through run_log_index.csv"
+    },
+    {
+      "artifact_id": "figure-success-cost-recovery",
+      "artifact_type": "figure",
+      "title": "Success, cost, and recovery overview",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/figure-table-templates.md#figure-success-cost-recovery",
+      "source_refs": {
+        "chart_summary_rows_path": "output/experiment/w16-expr-1/<analysis_run_id>/chart_summary_rows.csv",
+        "overall_metrics_path": "output/experiment/w16-expr-1/<analysis_run_id>/overall_metrics.csv"
+      },
+      "rendered_artifact_path": "reports/w16-issue224/figures/figure-success-cost-recovery.<ext>",
+      "traceability_status": "chart panel values must reference chart_summary_rows metric and row id"
+    },
+    {
+      "artifact_id": "figure-difficulty-stratified",
+      "artifact_type": "figure",
+      "title": "Difficulty-stratified group comparison",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/figure-table-templates.md#figure-difficulty-stratified",
+      "source_refs": {
+        "chart_summary_rows_path": "output/experiment/w16-expr-1/<analysis_run_id>/chart_summary_rows.csv",
+        "difficulty_table_path": "output/experiment/w16-expr-1/<analysis_run_id>/difficulty_stratified_metrics.csv"
+      },
+      "rendered_artifact_path": "reports/w16-issue224/figures/figure-difficulty-stratified.<ext>",
+      "traceability_status": "each facet must preserve slice_type, slice_value, group_id, and metric"
+    },
+    {
+      "artifact_id": "case-loss-control-success",
+      "artifact_type": "case",
+      "title": "Loss-control success case",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/report-template.md#case-study-template",
+      "source_refs": {
+        "run_id": "issue270-rerun-waiting-replan-20260420_lite_belief_state_high_solubility_r02",
+        "run_config_path": "output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/run_configs/issue270-rerun-waiting-replan-20260420_lite_belief_state_high_solubility_r02.json",
+        "event_log_path": "data/logs/issue270-rerun-waiting-replan-20260420_lite_belief_state_high_solubility_r02.jsonl",
+        "snapshot_path": "data/snapshots/issue270-rerun-waiting-replan-20260420_lite_belief_state_high_solubility_r02.jsonl",
+        "run_traceability_index_path": "output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/run_traceability_index.csv"
+      },
+      "required_sections": [
+        "selection_reason",
+        "action_path",
+        "evidence_chain",
+        "result_contrast",
+        "claim_boundary"
+      ]
+    },
+    {
+      "artifact_id": "case-static-vs-dynamic-contrast",
+      "artifact_type": "case",
+      "title": "Static versus dynamic contrast case",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/report-template.md#case-study-template",
+      "source_refs": {
+        "task_key": "secondary_balance",
+        "static_run_id": "issue270-rerun-waiting-replan-20260420_fixed_threshold_gate_secondary_balance_r01",
+        "dynamic_run_id": "issue270-rerun-waiting-replan-20260420_dynamic_no_belief_state_secondary_balance_r01",
+        "run_traceability_index_path": "output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/run_traceability_index.csv"
+      },
+      "required_sections": [
+        "matched_task",
+        "group_difference",
+        "action_or_waiting_difference",
+        "metric_row_refs",
+        "claim_boundary"
+      ]
+    },
+    {
+      "artifact_id": "case-failure-analysis",
+      "artifact_type": "case",
+      "title": "Failure analysis case",
+      "status": "template_ready",
+      "template_path": "docs/evidence/issue-224/report-template.md#case-study-template",
+      "source_refs": {
+        "run_id": "issue221-real-full-20260418b_fixed_threshold_gate_enzyme_like_fold_r01",
+        "run_config_path": "output/experiment/w16-expr-1/issue221-real-full-20260418b/run_configs/issue221-real-full-20260418b_fixed_threshold_gate_enzyme_like_fold_r01.json",
+        "event_log_path": "data/logs/issue221-real-full-20260418b_fixed_threshold_gate_enzyme_like_fold_r01.jsonl",
+        "snapshot_path": "data/snapshots/issue221-real-full-20260418b_fixed_threshold_gate_enzyme_like_fold_r01.jsonl",
+        "known_failure": "RuntimeError: auto decision loop exhausted before task reached terminal state"
+      },
+      "required_sections": [
+        "failure_signal",
+        "wrong_or_missing_decision",
+        "evidence_gap",
+        "risk_to_claim",
+        "follow_up"
+      ]
+    }
+  ],
+  "validation_rules": [
+    "Every figure/table/case artifact must include source_refs and generated_by or template_path.",
+    "Every paper-facing group id must use canonical names from naming_convention.paper_groups.",
+    "Every metric used in a table or figure must be definable from metric_definitions.csv or the W16-01 matrix summary fallback.",
+    "Every case must include at least one run_config_path, event_log_path or run_traceability_index_path, and snapshot_path when available.",
+    "Rendered reports must state whether they use W16-02 analysis outputs or the W16-01 fallback summary."
+  ]
+}

--- a/docs/evidence/issue-224/figure-table-templates.md
+++ b/docs/evidence/issue-224/figure-table-templates.md
@@ -1,0 +1,106 @@
+# Issue #224 Figure and Table Templates
+
+These templates are traceability-first. A rendered table or figure is paper-ready only when every value links back to `source_refs` in `evidence-index.json`.
+
+## Table Main Internal Overall
+
+Source priority:
+
+1. `output/experiment/w16-expr-1/<analysis_run_id>/overall_metrics.csv`
+2. fallback: `output/experiment/w16-expr-1/issue221-real-full-20260418b/matrix_metrics_summary.csv`
+
+Required row order:
+
+| group_id | display_name | runs | success_rate | first_pass_success_rate | duration_ms_mean | high_cost_call_mean | patch_events_mean | replan_events_mean | suffix_replan_events_mean | trace_ref |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `static_top1` | Static Top-1 |  |  |  |  |  |  |  |  | `table-main-internal-overall:<row_id>` |
+| `fixed_threshold_gate` | Fixed Threshold Gate |  |  |  |  |  |  |  |  | `table-main-internal-overall:<row_id>` |
+| `dynamic_no_belief_state` | Dynamic Recovery (No Belief-State) |  |  |  |  |  |  |  |  | `table-main-internal-overall:<row_id>` |
+| `lite_belief_state` | Lite Belief-State |  |  |  |  |  |  |  |  | `table-main-internal-overall:<row_id>` |
+
+Traceability notes:
+
+- `group_id` must be canonical; historical `A0-A6` names are allowed only in appendix notes.
+- `trace_ref` resolves to `evidence-index.json -> artifacts[artifact_id=table-main-internal-overall]`.
+- Metric definitions should cite `metric_definitions.csv`; if using the fallback summary, cite `src/infra/w12_vertical_experiment.py` and `src/infra/w16_issue221_experiment_matrix.py`.
+
+## Table Difficulty Stratified
+
+Source: `output/experiment/w16-expr-1/<analysis_run_id>/difficulty_stratified_metrics.csv`.
+
+| difficulty | group_id | display_name | runs | success_rate | duration_ms_mean | high_cost_call_mean | recovery_event_mean | trace_ref |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `easy` | `static_top1` | Static Top-1 |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `easy` | `fixed_threshold_gate` | Fixed Threshold Gate |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `easy` | `dynamic_no_belief_state` | Dynamic Recovery (No Belief-State) |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `easy` | `lite_belief_state` | Lite Belief-State |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `medium` | `static_top1` | Static Top-1 |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `medium` | `fixed_threshold_gate` | Fixed Threshold Gate |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `medium` | `dynamic_no_belief_state` | Dynamic Recovery (No Belief-State) |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `medium` | `lite_belief_state` | Lite Belief-State |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `hard` | `static_top1` | Static Top-1 |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `hard` | `fixed_threshold_gate` | Fixed Threshold Gate |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `hard` | `dynamic_no_belief_state` | Dynamic Recovery (No Belief-State) |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+| `hard` | `lite_belief_state` | Lite Belief-State |  |  |  |  |  | `table-difficulty-stratified:<row_id>` |
+
+Traceability notes:
+
+- `difficulty` comes from `runs_manifest.json` task metadata.
+- Missing difficulty rows must remain absent, not imputed.
+
+## Table Recovery High Cost
+
+Source: `output/experiment/w16-expr-1/<analysis_run_id>/recovery_complexity_high_cost.csv`.
+
+| slice | group_id | patch_events_mean | replan_events_mean | suffix_replan_events_mean | patch_minimality_hit_rate | suffix_replan_prefix_preservation_rate | high_cost_call_mean | high_cost_failure_mean | trace_ref |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| `overall:all` | `static_top1` |  |  |  |  |  |  |  | `table-recovery-high-cost:<row_id>` |
+| `overall:all` | `fixed_threshold_gate` |  |  |  |  |  |  |  | `table-recovery-high-cost:<row_id>` |
+| `overall:all` | `dynamic_no_belief_state` |  |  |  |  |  |  |  | `table-recovery-high-cost:<row_id>` |
+| `overall:all` | `lite_belief_state` |  |  |  |  |  |  |  | `table-recovery-high-cost:<row_id>` |
+
+Traceability notes:
+
+- Recovery columns must be linked to event-level rows through `run_log_index.csv`.
+- `suffix_replan_prefix_preservation_rate` may be null when no suffix replan sample exists; report it as `N/A`, not zero.
+
+## Figure Success Cost Recovery
+
+Source: `output/experiment/w16-expr-1/<analysis_run_id>/chart_summary_rows.csv`.
+
+Recommended layout:
+
+- Panel A: `success_rate` by canonical internal group.
+- Panel B: `duration_ms_mean` and `high_cost_call_mean` by canonical internal group.
+- Panel C: `patch_events_mean`, `replan_events_mean`, and `suffix_replan_events_mean` by canonical internal group.
+
+Data contract:
+
+| field | source column | required |
+| --- | --- | --- |
+| panel | derived from `metric_dimension` | yes |
+| group_id | `group_id` | yes |
+| metric | `metric` | yes |
+| value | `value` | yes |
+| trace_ref | `figure-success-cost-recovery:<metric>:<group_id>` | yes |
+
+## Figure Difficulty Stratified
+
+Source: `output/experiment/w16-expr-1/<analysis_run_id>/difficulty_stratified_metrics.csv`.
+
+Recommended layout:
+
+- Facet by `slice_value` (`easy`, `medium`, `hard`).
+- Within each facet, compare the four canonical internal groups.
+- Use consistent metric ordering: `success_rate`, `duration_ms_mean`, `recovery_event_mean`.
+
+Data contract:
+
+| field | source column | required |
+| --- | --- | --- |
+| facet | `slice_value` | yes |
+| group_id | `group_id` | yes |
+| metric | selected metric column | yes |
+| value | selected metric value | yes |
+| source_row | stable row id or CSV line number | yes |
+

--- a/docs/evidence/issue-224/report-template.md
+++ b/docs/evidence/issue-224/report-template.md
@@ -1,0 +1,102 @@
+# Issue #224 Report Template
+
+Use this template for the W16 result package, issue closeout notes, or thesis result-section drafting. Do not remove trace fields when converting to prose.
+
+## Result Section Template
+
+### Evidence Scope
+
+- Evidence index: `docs/evidence/issue-224/evidence-index.json`
+- W16-01 run output: `output/experiment/w16-expr-1/issue221-real-full-20260418b`
+- W16-02 analysis output: `output/experiment/w16-expr-1/<analysis_run_id>`
+- W16-03 case output: `reports/w16-issue223/<case_pack_id>`
+- Group naming source: `../thesis-project.design/docs/experiment/algorithm-group-paper-mapping.md`
+
+### Main Claim
+
+Claim:
+
+`<one sentence using Static Top-1 / Fixed Threshold Gate / Dynamic Recovery (No Belief-State) / Lite Belief-State>`
+
+Required evidence:
+
+| claim fragment | table_or_figure_ref | source_ref | caveat |
+| --- | --- | --- | --- |
+| success comparison | `table-main-internal-overall` | `overall_metrics.csv` or fallback summary |  |
+| cost comparison | `figure-success-cost-recovery` | `chart_summary_rows.csv` |  |
+| recovery behavior | `table-recovery-high-cost` | `recovery_complexity_high_cost.csv` |  |
+| difficulty stability | `table-difficulty-stratified` | `difficulty_stratified_metrics.csv` |  |
+
+### Paragraph Skeleton
+
+In the canonical internal comparison, `<group display name>` is evaluated against `<group display names>` under the same task set and freeze. The primary table uses `<source table>` and keeps row-level links to `runs_manifest.json`, `run_log_index.csv`, event logs, and snapshots. The result supports `<claim>` because `<metric 1>` changes from `<value>` to `<value>`, while `<metric 2>` remains `<value or caveat>`.
+
+For recovery behavior, cite `table-recovery-high-cost` rather than only the success table. The discussion should distinguish patch, replan, suffix replan, and high-cost failures. If any recovery metric is null because no event occurred, state that it is not observed instead of treating it as zero.
+
+For difficulty stratification, cite `table-difficulty-stratified` and state whether the claim holds across `easy`, `medium`, and `hard` slices. Do not generalize beyond slices present in the source table.
+
+## Case Study Template
+
+### Case Header
+
+- case_id: `<case-loss-control-success | case-static-vs-dynamic-contrast | case-failure-analysis>`
+- case_type: `<loss_control_success | static_vs_dynamic_contrast | failure_analysis>`
+- task_key: `<task key>`
+- group_id: `<canonical group id>`
+- run_id: `<run id>`
+- source refs:
+  - run_config: `<path>`
+  - event_log: `<path>`
+  - snapshot: `<path>`
+  - run_traceability_index: `<path>`
+
+### Selection Reason
+
+Explain why this case was selected. Tie the reason to a row in `run_traceability_index.csv`, an aggregate metric row, or a known failure field.
+
+### Action Path
+
+| order | event_or_step | observed action | runtime state or shadow signal | source ref |
+| ---: | --- | --- | --- | --- |
+| 1 |  |  |  |  |
+| 2 |  |  |  |  |
+| 3 |  |  |  |  |
+
+### Evidence Chain
+
+| evidence item | path | key fields | completeness |
+| --- | --- | --- | --- |
+| run config |  | `group_id`, `task_key`, `runtime_policy`, `constraints_hash` |  |
+| event log |  | `event`, `from_status`, `to_status`, `data.recovery`, `data.runtime_state_summary` |  |
+| snapshot |  | `status`, `artifacts.runtime_state`, `artifacts.decision_summary` |  |
+| report or aggregate row |  | `summary_row_id`, metric columns |  |
+
+### Result Contrast
+
+For contrast cases, compare canonical groups only. Use historical `A0-A6` aliases only in an appendix trace note.
+
+| dimension | reference group | comparison group | observed difference | source ref |
+| --- | --- | --- | --- | --- |
+| success |  |  |  |  |
+| cost |  |  |  |  |
+| recovery |  |  |  |  |
+| evidence completeness |  |  |  |  |
+
+### Failure Analysis Addendum
+
+Use this block for `case-failure-analysis`.
+
+- failure signal:
+- wrong or missing decision:
+- evidence gap:
+- why the gap matters for the paper claim:
+- follow-up issue or mitigation:
+
+## Closeout Checklist
+
+- [ ] Every table value has a source row or source file path.
+- [ ] Every figure panel names the input CSV/JSON file and metric column.
+- [ ] Every case has run config, event log, snapshot, and traceability index references where available.
+- [ ] Canonical group naming matches `algorithm-group-paper-mapping.md`.
+- [ ] Null and absent recovery metrics are reported as unobserved, not as zero.
+- [ ] The report states whether it used W16-02 analysis outputs or W16-01 fallback summaries.


### PR DESCRIPTION
## 对照 Issue

Closes #224

## 变更内容

本 PR 为 W16-Docs-4 补齐可版本化的证据索引、图表/表格模板和报告模板，目标是把 W16-01/W16-02/W16-03 的实验结果整理成可直接服务论文写作、后续 release 和 issue 沉淀的证据包。

## 文件路径与主要内容

- `docs/evidence/issue-224/evidence-index.json`
  - 定义 issue #224 的证据索引 schema、执行窗口、命名约定和追溯链。
  - 对齐 `static_top1 / fixed_threshold_gate / dynamic_no_belief_state / lite_belief_state` 四个论文主结果组，以及 `E0/E1/E2` 外部对照组。
  - 收录表格、图表、案例三类 artifact，并为每个 artifact 指明输入来源、模板路径、生成来源或验证规则。

- `docs/evidence/issue-224/figure-table-templates.md`
  - 提供主结果表、难度分层表、恢复复杂度与高代价调用表的模板。
  - 提供 success/cost/recovery 总览图和难度分层图的数据契约。
  - 强调每个表格值和图表面板都必须能回链到 `evidence-index.json` 和上游 CSV/JSON 结果。

- `docs/evidence/issue-224/report-template.md`
  - 提供论文结果章节模板、主命题证据映射、段落骨架和案例研究模板。
  - 覆盖止损成功、静态 vs 动态对照、失败分析三类案例写法。
  - 明确 null/缺失恢复指标应报告为未观测，避免误写成 0。

- `.gitignore`
  - 只放行 `docs/evidence/issue-224/**`，保持既有 `docs/` 和 `output/` 忽略策略不变。

## 设计边界

- 仅新增文档与证据模板，不修改运行时、FSM、agent 边界或执行语义。
- 不把大体量 `output/` 产物纳入版本控制，只在证据索引中引用其路径。
- W16-02 独立分析目录在本地未作为固定 tracked 路径出现，因此索引中保留 `<analysis_run_id>` 占位，并提供 W16-01 summary fallback。

## 验证

- `python -m json.tool docs/evidence/issue-224/evidence-index.json`
- 未运行 pytest：本 PR 为 docs/evidence-only 变更，没有 Python 行为变更。