### PR TITLE
docs(evidence): add issue 174 evidence handoff

### DIFF
--- a/reports/w12-issue-152/artifact_evidence_index.csv
+++ b/reports/w12-issue-152/artifact_evidence_index.csv
@@ -1,15 +1,21 @@
 issue,artifact_type,path,exists,role
-148,training_summary,output/training/w12-issue-148/v0.3.0-rc1/issue148-p0-p1/training_summary.json,yes,训练摘要与版本冻结
+148,training_summary,output/training/w12-issue-148/v0.3.0-rc1/issue148-p0-p1/training_summary.json,no,历史训练摘要路径；当前工作区未保留该 JSON
 148,model_card,output/training/w12-issue-148/v0.3.0-rc1/issue148-p0-p1/model_card.md,yes,模型适用范围与已知限制
-149,release_benchmark_json,output/experiment/w12-expr-2/issue149-offline-benchmark/release_benchmark.json,yes,离线门禁与基线对比
+149,release_benchmark_report,output/experiment/w12-expr-2/issue149-offline-benchmark/release-benchmark.md,yes,离线门禁与基线对比报告
 150,runtime_fallback_config,configs/runtime/w12_issue150_dual_route_fallback.json,yes,回退默认配置与熔断开关
 150,runtime_runbook,scripts/w12-issue-150-dual-route-fallback.md,yes,双路回退使用说明
-151,demo_summary,output/demo/w12-issue-151/demo-summary.json,yes,端到端演示摘要
+151,demo_summary,output/demo/w12-issue-151/demo-summary.json,no,历史 demo 摘要路径；当前工作区未保留该 JSON
 151,release_validation,output/demo/w12-issue-151/release-validation.md,yes,RC Gate-D 演示验证
-171,vertical_report,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_report.md,yes,A0-A6 纵向实验摘要
-171,vertical_summary_csv,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_metrics_summary.csv,yes,统一指标总表
-173,governance_summary,output/experiment/w12-expr-2/issue173-governance-review/governance_metrics_summary.json,yes,治理指标 JSON
+171,vertical_report,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_report.md,no,历史 A0-A6 纵向实验摘要路径；当前工作区未保留该批次文件
+171,vertical_summary_csv,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_metrics_summary.csv,no,历史统一指标总表路径；当前工作区未保留该批次文件
+173,governance_summary,output/experiment/w12-expr-2/issue173-governance-review/governance_metrics_summary.json,no,历史治理指标 JSON 路径；当前工作区未保留该 JSON
 173,governance_report,output/experiment/w12-expr-2/issue173-governance-review/governance-report.md,yes,治理复核报告
 174,midterm_chapter,reports/w12-issue-174/midterm_experiment_chapter.md,yes,中期实验章节草稿（当前可交子集）
 174,figure_index,reports/w12-issue-174/figure_table_index.csv,yes,图表证据索引
-172,horizontal_comparison,deferred,no,外部平台依赖，当前窗口延期
+174,evidence_pack_handoff,reports/w12-issue-174/evidence-pack-handoff.md,yes,W16 evidence pack 交接说明、路径索引、限制项与 #152/#225 后续入口
+172,horizontal_comparison,output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/horizontal_metrics_summary.csv,yes,E0/E1/E2 横向对照结果表；#174 可引用为外部范式对照证据
+172,horizontal_evidence_index,output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/evidence_index.json,yes,横向对照 run config/event log/snapshot/report 追溯索引
+221,w16_internal_matrix,output/experiment/w16-expr-1/issue221-real-full-20260418b/matrix_metrics_summary.csv,yes,W16 内部四组主结果 summary fallback
+221,w16_internal_traceability,output/experiment/w16-expr-1/issue221-real-full-20260418b/run_traceability_index.csv,yes,W16 内部矩阵 run 级追溯索引
+223,w16_case_rerun_pack,output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/evidence_index.json,yes,W16 案例/失败分析补充批次证据索引
+224,w16_evidence_template,docs/evidence/issue-224/evidence-index.json,yes,W16 evidence pack artifact 与 traceability 模板

--- a/reports/w12-issue-174/evidence-pack-handoff.md
+++ b/reports/w12-issue-174/evidence-pack-handoff.md
@@ -1,0 +1,79 @@
+# Issue #174 W16 Evidence Pack Handoff
+
+- issue: `#174`
+- status: addon evidence index
+- generated_at: `2026-04-26`
+- scope: report evidence pack only
+
+## Scope
+
+中期报告正文已经另行完成。本文件只整理 #174 还需要交接给论文、`#152` 和 `#225` 的证据入口，不重写章节正文。
+
+#174 当前应按 W16 末报告证据打包项理解，而不是旧版 W12 中期报告草稿。旧文件 `reports/w12-issue-174/midterm_experiment_chapter.md` 保留作历史中期草稿，不能再单独作为 #174 完成依据。
+
+## Primary Evidence Roots
+
+| scope | issue | path | role |
+| --- | ---: | --- | --- |
+| W16 internal matrix | #221 | `output/experiment/w16-expr-1/issue221-real-full-20260418b/matrix_metrics_summary.csv` | 内部四组主结果 summary fallback |
+| W16 internal traceability | #221 | `output/experiment/w16-expr-1/issue221-real-full-20260418b/run_traceability_index.csv` | run config / event log / snapshot / report 回链 |
+| W16 internal evidence index | #221 | `output/experiment/w16-expr-1/issue221-real-full-20260418b/evidence_index.json` | 内部矩阵证据索引 |
+| W16 rerun/case pack | #223 | `output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/evidence_index.json` | 案例、失败分析、WAITING/replan 补充证据 |
+| W12/W16 horizontal comparison | #172 | `output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/horizontal_metrics_summary.csv` | E0/E1/E2 外部对照结果表 |
+| Horizontal traceability | #172 | `output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/run_traceability_index.csv` | 横向 run 级追溯 |
+| Horizontal evidence index | #172 | `output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/evidence_index.json` | 横向证据索引 |
+| Figure/table index | #174 | `reports/w12-issue-174/figure_table_index.csv` | 可引用图表、表格、模板入口 |
+| W16 evidence templates | #224 | `docs/evidence/issue-224/evidence-index.json` | artifact/source_refs/traceability 模板 |
+
+## Naming Rules
+
+论文主表使用 canonical internal groups:
+
+- `static_top1`
+- `fixed_threshold_gate`
+- `dynamic_no_belief_state`
+- `lite_belief_state`
+
+外部对照只作为单独表或单独段落引用:
+
+- `E0`
+- `E1`
+- `E2`
+
+历史 `A0-A6` 只保留在 W12 附录追溯、实施路线和 issue 对账中，不应混入 W16 主结果表。
+
+## Result Package Status
+
+| requirement | current status | evidence |
+| --- | --- | --- |
+| 汇总内部矩阵结果 | available | `issue221-real-full-20260418b/matrix_metrics_summary.csv` |
+| 汇总横向对比结果 | available | `issue172-live-qwen-flash-tunnel-r1-attempt4-merged/horizontal_metrics_summary.csv` |
+| 案例/失败分析入口 | available as evidence pack reference | `issue270-rerun-waiting-replan-20260420/evidence_index.json` |
+| 图表清单 | refreshed | `reports/w12-issue-174/figure_table_index.csv` |
+| 证据引用说明 | this handoff | `reports/w12-issue-174/evidence-pack-handoff.md` |
+| 中期报告正文 | completed outside this addon | user-authored report, not regenerated here |
+
+## Recommended Citation Flow
+
+1. 章节正文引用 `reports/w12-issue-174/figure_table_index.csv` 中的 `artifact_id`。
+2. 图表和表格回链到对应 `source_path`。
+3. 每个统计值优先回链到 `run_traceability_index.csv` 中的 `summary_row_id` 或 run-level row。
+4. 每个案例回链到 `run_config_path`、`event_log_path` 和 `snapshot_path`。
+5. 如果使用 #224 模板渲染新图表，保留模板中的 `trace_ref`，不要只复制数值。
+
+## Limits And Follow-ups
+
+- W16-02 的独立 `overall_metrics.csv` / `difficulty_stratified_metrics.csv` 目录在当前 tracked 报告材料中没有固定版本路径；#174 可以使用 W16-01 `matrix_metrics_summary.csv` 作为 summary fallback，但正式论文图表应在生成固定 analysis run 后改指向该目录。
+- #223 已关闭，但当前 repo 中主要表现为 rerun/case 证据入口；如需完整案例正文，应另补 `reports/w16-issue223/` 或在论文草稿中直接消费 #224 case template。
+- 旧 `midterm_experiment_chapter.md` 中的 `#172 deferred` 是历史状态，不应再复制到新报告。
+- Null 或缺失 recovery 指标必须写作未观测，不得当作 0。
+
+## Handoff To #152 / #225
+
+`#152` 可更新 release evidence index 与 release draft，移除“#172 deferred”的旧阻塞说法，改为引用横向结果路径和剩余限制项。
+
+`#225` 可基于本文件继续拆分后续 issue:
+
+- 固定 W16-02 analysis run 的版本路径。
+- 补齐 case study 正文包。
+- 将 #224 模板渲染为最终论文图表与表格。

--- a/reports/w12-issue-174/figure_table_index.csv
+++ b/reports/w12-issue-174/figure_table_index.csv
@@ -1,7 +1,19 @@
 artifact_id,artifact_type,title,source_path,status,note
-table-1,table,A0-A6 纵向对比总表,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_metrics_summary.csv,ready,成功率、可执行率、patch/replan 与时延统一汇总。
-table-2,table,E0-E2 横向对比总表,issue #172 (deferred),deferred,E0/E1/E2 横向对比对应 issue #172。由于其依赖外部平台，当前中期窗口先显式延期，不把缺失结果伪装成已完成。
-figure-1,figure,成功率-时延平衡图,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_metrics_summary.csv,ready,使用 A0-A6 组的 success_rate 与 duration_ms_mean 绘制。
-figure-2,figure,恢复路径分布图,output/experiment/w12-expr-2/issue171-remote-batch3-r3/mechanism_increment_deltas.csv,ready,结合 patch/replan/suffix_replan 指标构图。
-figure-3,figure,治理雷达图,output/experiment/w12-expr-2/issue173-governance-review/governance_metrics_by_group.csv,ready,使用 waiting/replay/traceable/snapshot 四项治理指标。
-evidence-1,evidence,治理汇总 JSON,output/experiment/w12-expr-2/issue173-governance-review/governance_metrics_summary.json,ready,记录全局治理统计与输入来源。
+table-w12-vertical,table,A0-A6 纵向对比总表,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_metrics_summary.csv,legacy-reference,W12 中期草稿使用的历史纵向表；当前工作区未保留该批次文件，保留作附录追溯，不再作为 W16 主结果表。
+table-w12-horizontal,table,E0-E2 横向对比总表,output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/horizontal_metrics_summary.csv,ready,#172 已关闭；该表用于外部 E0/E1/E2 对照与 lite_belief_state 对照，需与 canonical naming 文档一起引用。
+table-w16-internal-main,table,W16 内部四组主结果表,output/experiment/w16-expr-1/issue221-real-full-20260418b/matrix_metrics_summary.csv,ready,内部主比较使用 static_top1/fixed_threshold_gate/dynamic_no_belief_state/lite_belief_state 四组。
+table-w16-run-traceability,table,W16 run 级追溯表,output/experiment/w16-expr-1/issue221-real-full-20260418b/run_traceability_index.csv,ready,每个 run 回链到 run config、event log、snapshot、report 与 summary row。
+table-w16-action-distribution,table,W16 action 分布表,output/experiment/w16-expr-1/issue221-real-full-20260418b/action_distribution.csv,ready,支持 action/recovery 相关表述；缺失或空值不得写成 0。
+table-w16-rerun-case,table,W16 rerun/case 补充表,output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/matrix_metrics_summary.csv,ready,用于 #223/#224 案例视角和 WAITING/replan 相关补充证据。
+figure-w12-success-latency,figure,W12 成功率-时延平衡图,output/experiment/w12-expr-2/issue171-remote-batch3-r3/vertical_metrics_summary.csv,legacy-reference,历史中期报告图位；当前工作区未保留该批次文件，仅作为 W12 附录追溯。
+figure-w12-recovery-distribution,figure,W12 恢复路径分布图,output/experiment/w12-expr-2/issue171-remote-batch3-r3/mechanism_increment_deltas.csv,legacy-reference,历史 A0-A6 机制增量证据；当前工作区未保留该批次文件，不混入 W16 主表。
+figure-w12-governance-radar,figure,W12 治理雷达图,output/experiment/w12-expr-2/issue173-governance-review/governance_metrics_by_group.csv,legacy-reference,历史治理图位；当前工作区仅保留 governance-report.md 与 replay sample。
+figure-w16-success-cost-recovery,figure,W16 success/cost/recovery 总览图,docs/evidence/issue-224/figure-table-templates.md#figure-success-cost-recovery,template-ready,按 #224 模板从 chart_summary_rows 或 W16 matrix fallback 派生。
+figure-w16-difficulty-stratified,figure,W16 难度分层图,docs/evidence/issue-224/figure-table-templates.md#figure-difficulty-stratified,template-ready,按 #224 模板消费 difficulty_stratified_metrics 或 run-level difficulty 字段。
+evidence-w12-governance,evidence,W12 治理报告,output/experiment/w12-expr-2/issue173-governance-review/governance-report.md,ready,当前工作区保留的 W12 治理复核报告。
+evidence-w12-horizontal-index,evidence,W12 横向证据索引,output/experiment/w12-expr-3/issue172-horizontal/issue172-live-qwen-flash-tunnel-r1-attempt4-merged/evidence_index.json,ready,#172 外部对照 run config/event log/snapshot/report 的索引。
+evidence-w16-internal-index,evidence,W16 内部矩阵证据索引,output/experiment/w16-expr-1/issue221-real-full-20260418b/evidence_index.json,ready,#221 内部四组 run config/event log/snapshot/report 的索引。
+evidence-w16-rerun-index,evidence,W16 rerun/case 证据索引,output/experiment/w16-expr-1/issue270-rerun-waiting-replan-20260420/evidence_index.json,ready,#223 案例与失败分析可优先引用该补充批次。
+template-issue224-evidence,template,#224 证据索引模板,docs/evidence/issue-224/evidence-index.json,ready,定义 W16 evidence pack 的 artifact、source_refs、traceability_chains 与 validation_rules。
+template-issue224-table-figure,template,#224 图表/表格模板,docs/evidence/issue-224/figure-table-templates.md,ready,定义 W16 主结果表、分层表、恢复高代价表与图表数据契约。
+template-issue224-report,template,#224 报告章节模板,docs/evidence/issue-224/report-template.md,ready,用于论文结果段落、案例研究与限制项写作；中期报告正文已另行完成。


### PR DESCRIPTION
## 对照 Issue

Refs #174

## 变更内容

本 PR 补充 #174 的 W16 evidence pack 交接材料。中期报告正文已由人工另行完成，因此本次不重写章节正文，只整理 #174 还需要交给论文、#152 和 #225 使用的证据入口、图表索引与限制说明。

## 文件路径与主要内容

- `reports/w12-issue-174/evidence-pack-handoff.md`
  - 新增 #174 W16 evidence pack handoff 文档。
  - 明确旧版 `midterm_experiment_chapter.md` 仅作为历史中期草稿保留，不再单独作为 #174 完成依据。
  - 汇总 #221 内部四组矩阵、#172 横向 E0/E1/E2、#223 rerun/case、#224 evidence templates 的主要路径。
  - 补充 canonical group 命名规则、推荐引用流程、限制项，以及交给 #152/#225 的后续事项。

- `reports/w12-issue-174/figure_table_index.csv`
  - 刷新 #174 图表/表格/证据索引。
  - 移除旧的 `#172 deferred` 判断，改为引用已存在的横向对照结果路径。
  - 补入 W16 内部四组主结果表、run 级追溯表、action 分布表、rerun/case 补充表，以及 #224 图表/报告模板。
  - 将当前工作区未保留的 W12 历史图位降级为 `legacy-reference`，避免误标为可直接消费的 ready 证据。

- `reports/w12-issue-152/artifact_evidence_index.csv`
  - 同步 #152 收口证据索引。
  - 将当前工作区不存在的旧 JSON/批次路径标记为 `no`，避免 release 证据索引误报。
  - 新增 #174 handoff、#172 横向结果、#221 W16 内部矩阵、#223 rerun/case 证据索引、#224 evidence template 的入口。

## 边界

- 仅修改报告索引和文档，不修改代码、FSM、agent 边界或执行语义。
- 不重新撰写中期报告正文。
- 不把 `output/` 大体量产物纳入版本控制，只通过索引引用既有路径。

## 验证

- 使用 Python `csv.DictReader` 校验两个 CSV 可解析。
- 对所有标记为 `ready/template-ready/yes` 的本地路径做存在性检查，当前无缺失。
- 未运行 pytest：本 PR 为 docs/evidence-only 变更，没有 Python 行为变更。