### PR TITLE
feat(readiness): 完成 capability readiness 闭环

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
   "mlflow>=3.11.1",
 ]
 
+[project.scripts]
+design = "src.cli:main"
+
 [build-system]
 requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Any, Iterable, List, Literal, Optional, Sequence, Set, Tuple
 
 from src.infra.active_tool_metadata import metadata_by_tool_id
-from src.infra.tool_readiness import build_tool_readiness_snapshot
+from src.infra.tool_readiness import (
+    build_capability_readiness_snapshot,
+    build_tool_readiness_snapshot,
+)
 from src.kg.kg_client import ToolKGError, load_tool_kg
 from src.llm.base_llm_provider import BaseProvider, ProviderConfig
 from src.llm.baseline_provider import BaselineProvider
@@ -3005,20 +3008,62 @@ def _tool_readiness_score(spec: ToolSpec) -> float:
         "unknown": 0.55,
     }
     base = adapter_base.get(spec.adapter_mode, 0.55)
-    try:
-        readiness = build_tool_readiness_snapshot(spec.id)
-    except Exception:
-        readiness = {"status": "degraded"}
-    status = str(readiness.get("status") or "ready")
-    if status == "unavailable":
-        base = min(base, 0.08)
-    elif status == "degraded":
-        base -= 0.22
-    elif status == "ready":
+    capability_readiness = _capability_readiness_for_spec(spec)
+    capability_status = str(capability_readiness.get("status") or "degraded")
+    tool_readiness = _tool_readiness_from_capability_snapshot(
+        capability_readiness,
+        spec.id,
+    )
+    tool_status = str(tool_readiness.get("status") or capability_status)
+    if capability_status == "unavailable":
+        return 0.0
+    if capability_status == "degraded":
+        base -= 0.18
+    elif capability_status == "ready":
         base += 0.05
+    if tool_status == "unavailable":
+        base = min(base, 0.08)
+    elif tool_status == "degraded":
+        base -= 0.22
+    elif tool_status == "ready":
+        base += 0.03
     priority_bonus = 0.06 if _priority_rank(spec.priority) == 0 else 0.0
     safety_penalty = min(0.18, max(0, spec.safety_level - 1) * 0.05)
     return min(1.0, max(0.0, base + priority_bonus - safety_penalty))
+
+
+def _capability_readiness_for_spec(spec: ToolSpec) -> dict[str, Any]:
+    """从 capability 级同源矩阵读取工具所属能力的 readiness。"""
+    capability_id = next((item for item in spec.capabilities if item), "")
+    if not capability_id:
+        return {"status": "unavailable", "reason": "tool has no capability_id"}
+    try:
+        return build_capability_readiness_snapshot(str(capability_id))
+    except Exception:
+        return {"status": "degraded", "reason": "capability readiness unavailable"}
+
+
+def _tool_readiness_from_capability_snapshot(
+    capability_readiness: dict[str, Any],
+    tool_id: str,
+) -> dict[str, Any]:
+    for bucket in ("tools", "available_tools", "blocked_tools"):
+        raw_tools = capability_readiness.get(bucket)
+        if not isinstance(raw_tools, list):
+            continue
+        for item in raw_tools:
+            if isinstance(item, dict) and item.get("tool_id") == tool_id:
+                return dict(item)
+    try:
+        return build_tool_readiness_snapshot(tool_id)
+    except Exception:
+        return {
+            "tool_id": tool_id,
+            "status": capability_readiness.get("status") or "degraded",
+            "reason": (
+                capability_readiness.get("reason") or "tool readiness unavailable"
+            ),
+        }
 
 
 def _candidate_readiness_metadata(
@@ -3028,25 +3073,38 @@ def _candidate_readiness_metadata(
 ) -> dict[str, Any]:
     """生成候选审计用 readiness 快照。"""
     try:
-        tool_readiness = build_tool_readiness_snapshot(tool_id)
+        capability_readiness = build_capability_readiness_snapshot(capability_id)
     except Exception:
         return {}
-    status = str(tool_readiness.get("status") or "degraded")
+    tool_readiness = _tool_readiness_from_capability_snapshot(
+        capability_readiness,
+        tool_id,
+    )
+    status = str(
+        capability_readiness.get("status")
+        or tool_readiness.get("status")
+        or "degraded"
+    )
     metadata: dict[str, Any] = {
         TOOL_READINESS_METADATA_KEY: tool_readiness,
         CAPABILITY_READINESS_METADATA_KEY: {
-            "capability_id": capability_id,
-            "status": status,
-            "source": "primary_tool_snapshot",
-            "tool_id": tool_id,
-            "last_checked_at": tool_readiness.get("last_checked_at")
-            or tool_readiness.get("checked_at"),
+            **capability_readiness,
+            "source": "capability_readiness_matrix",
+            "selected_tool_id": tool_id,
         },
     }
-    reason = tool_readiness.get("reason")
-    if status != "ready" and isinstance(reason, str) and reason:
+    degraded_reasons = capability_readiness.get("degraded_reasons")
+    reason = capability_readiness.get("reason") or tool_readiness.get("reason")
+    if (
+        status != "ready"
+        and not degraded_reasons
+        and isinstance(reason, str)
+        and reason
+    ):
         metadata[CAPABILITY_READINESS_METADATA_KEY]["degraded_reasons"] = [reason]
-    recovery = tool_readiness.get("suggested_recovery")
+    recovery = capability_readiness.get("suggested_recovery") or tool_readiness.get(
+        "suggested_recovery"
+    )
     if isinstance(recovery, str) and recovery:
         metadata[CAPABILITY_READINESS_METADATA_KEY]["suggested_recovery"] = recovery
     return metadata

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, List, Literal, Optional, Sequence, Set, Tuple
 
-from src.adapters.registry import get_adapter
 from src.infra.active_tool_metadata import metadata_by_tool_id
+from src.infra.tool_readiness import build_tool_readiness_snapshot
 from src.kg.kg_client import ToolKGError, load_tool_kg
 from src.llm.base_llm_provider import BaseProvider, ProviderConfig
 from src.llm.baseline_provider import BaselineProvider
@@ -17,6 +17,7 @@ from src.llm.provider_registry import create_provider, load_provider_catalog
 from src.agents.task_goal_parser import enrich_task_from_goal
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
+    CAPABILITY_READINESS_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     FINAL_SCORE_METADATA_KEY,
     PatchRequest,
@@ -42,6 +43,7 @@ from src.models.contracts import (
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     StepResult,
     SHADOW_SCORE_METADATA_KEY,
+    TOOL_READINESS_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
@@ -2066,6 +2068,11 @@ def _build_top_k_result(
             STATIC_SCORE_METADATA_KEY: _build_static_score_summary(score_breakdown),
             ACTION_SCORE_METADATA_KEY: _build_action_score_summary(score_breakdown),
         }
+        readiness_metadata = _candidate_readiness_metadata(
+            tool_id=tool_id,
+            capability_id=capability_id,
+        )
+        metadata.update(readiness_metadata)
         explanation = (
             f"{candidate_kind} candidate with primary tool "
             f"{tool_id} in capability bucket {capability_id}."
@@ -2999,24 +3006,50 @@ def _tool_readiness_score(spec: ToolSpec) -> float:
     }
     base = adapter_base.get(spec.adapter_mode, 0.55)
     try:
-        adapter = get_adapter(spec.id)
-    except KeyError:
-        adapter = None
-    if adapter is not None:
-        try:
-            health = adapter.healthcheck()
-        except Exception:
-            health = {"status": "degraded"}
-        status = str(health.get("status") or "ready")
-        if status == "unavailable":
-            base -= 0.55
-        elif status == "degraded":
-            base -= 0.22
-        elif status == "ready":
-            base += 0.05
+        readiness = build_tool_readiness_snapshot(spec.id)
+    except Exception:
+        readiness = {"status": "degraded"}
+    status = str(readiness.get("status") or "ready")
+    if status == "unavailable":
+        base = min(base, 0.08)
+    elif status == "degraded":
+        base -= 0.22
+    elif status == "ready":
+        base += 0.05
     priority_bonus = 0.06 if _priority_rank(spec.priority) == 0 else 0.0
     safety_penalty = min(0.18, max(0, spec.safety_level - 1) * 0.05)
     return min(1.0, max(0.0, base + priority_bonus - safety_penalty))
+
+
+def _candidate_readiness_metadata(
+    *,
+    tool_id: str,
+    capability_id: str,
+) -> dict[str, Any]:
+    """生成候选审计用 readiness 快照。"""
+    try:
+        tool_readiness = build_tool_readiness_snapshot(tool_id)
+    except Exception:
+        return {}
+    status = str(tool_readiness.get("status") or "degraded")
+    metadata: dict[str, Any] = {
+        TOOL_READINESS_METADATA_KEY: tool_readiness,
+        CAPABILITY_READINESS_METADATA_KEY: {
+            "capability_id": capability_id,
+            "status": status,
+            "source": "primary_tool_snapshot",
+            "tool_id": tool_id,
+            "last_checked_at": tool_readiness.get("last_checked_at")
+            or tool_readiness.get("checked_at"),
+        },
+    }
+    reason = tool_readiness.get("reason")
+    if status != "ready" and isinstance(reason, str) and reason:
+        metadata[CAPABILITY_READINESS_METADATA_KEY]["degraded_reasons"] = [reason]
+    recovery = tool_readiness.get("suggested_recovery")
+    if isinstance(recovery, str) and recovery:
+        metadata[CAPABILITY_READINESS_METADATA_KEY]["suggested_recovery"] = recovery
+    return metadata
 
 
 def _tool_coverage_score(tool_ids: Sequence[str], capabilities: Set[str]) -> float:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -18,6 +18,7 @@ from src.models.contracts import (
     PendingAction,
     PendingActionCandidate,
     PendingActionStatus,
+    TOOL_READINESS_METADATA_KEY,
 )
 from src.models.db import TaskRecord
 from src.models.validation import (
@@ -36,7 +37,10 @@ from src.infra.runtime_init import RuntimeInitResult, initialize_runtime
 from src.models.contracts import PendingActionType, now_iso
 from src.storage.log_store import read_timeline_events
 from src.workflow.context import WorkflowContext
-from src.infra.tool_readiness import build_capability_readiness_matrix
+from src.infra.tool_readiness import (
+    build_capability_readiness_matrix,
+    build_tool_readiness_snapshot,
+)
 
 API_DIR = Path(__file__).resolve().parent
 TEMPLATES_DIR = API_DIR / "templates"
@@ -147,6 +151,10 @@ class PendingActionToolDisplay(BaseModel):
     available: bool = Field(..., description="工具信息是否可用于决策展示")
     can_fallback: bool = Field(..., description="是否可回退到备选工具")
     availability_hint: str = Field(..., description="工具可用性提示")
+    readiness_status: Optional[str] = None
+    degraded_reasons: list[str] = Field(default_factory=list)
+    suggested_recovery: Optional[str] = None
+    readiness_snapshot: Dict[str, Any] = Field(default_factory=dict)
 
 
 class PendingActionCandidateDisplay(BaseModel):
@@ -175,14 +183,37 @@ class PendingActionDetail(BaseModel):
     candidates: list[PendingActionCandidateDisplay] = Field(default_factory=list)
 
 
+class ToolReadinessEntry(BaseModel):
+    tool_id: str
+    status: str
+    reason: str = ""
+    error_category: Optional[str] = None
+    capability_ids: list[str] = Field(default_factory=list)
+    cost_prior: Optional[float] = None
+    risk_prior: Optional[float] = None
+    latency_prior: Optional[float] = None
+    suggested_recovery: Optional[str] = None
+    last_checked_at: str
+    checked_at: Optional[str] = None
+    details: Dict[str, Any] = Field(default_factory=dict)
+    metadata_profile: Optional[Dict[str, Any]] = None
+
+
 class CapabilityReadinessEntry(BaseModel):
     capability_id: str
     status: str
+    available_tools: list[ToolReadinessEntry] = Field(default_factory=list)
+    blocked_tools: list[ToolReadinessEntry] = Field(default_factory=list)
+    degraded_reasons: list[str] = Field(default_factory=list)
+    last_checked_at: str
     primary_tool_id: Optional[str] = None
     fallback_tool_ids: list[str] = Field(default_factory=list)
+    cost_prior: Optional[float] = None
+    risk_prior: Optional[float] = None
+    suggested_recovery: Optional[str] = None
     reason: str
-    checked_at: str
-    tools: list[Dict[str, Any]] = Field(default_factory=list)
+    checked_at: Optional[str] = None
+    tools: list[ToolReadinessEntry] = Field(default_factory=list)
 
 
 def _render_ui_html(task_id: Optional[str]) -> str:
@@ -290,6 +321,26 @@ def _build_tool_display(
     if can_fallback:
         availability_hint = f"{availability_hint} Fallback path is available."
 
+    readiness_snapshot: dict[str, Any] = {}
+    readiness_status: str | None = None
+    degraded_reasons: list[str] = []
+    suggested_recovery: str | None = None
+    if tool_id:
+        raw_snapshot = metadata.get(TOOL_READINESS_METADATA_KEY)
+        if isinstance(raw_snapshot, dict) and raw_snapshot.get("tool_id") == tool_id:
+            readiness_snapshot = dict(raw_snapshot)
+        else:
+            readiness_snapshot = build_tool_readiness_snapshot(tool_id)
+        readiness_status = _normalize_text(readiness_snapshot.get("status"))
+        reason = _normalize_text(readiness_snapshot.get("reason"))
+        if readiness_status and readiness_status != "ready" and reason:
+            degraded_reasons.append(reason)
+        suggested_recovery = _normalize_text(readiness_snapshot.get("suggested_recovery"))
+        if readiness_status:
+            available = available and readiness_status == "ready"
+            if readiness_status != "ready" and reason:
+                availability_hint = f"{availability_hint} Readiness: {reason}"
+
     return PendingActionToolDisplay(
         tool_id=tool_id,
         capability_id=capability_id,
@@ -299,6 +350,10 @@ def _build_tool_display(
         available=available,
         can_fallback=can_fallback,
         availability_hint=availability_hint,
+        readiness_status=readiness_status,
+        degraded_reasons=degraded_reasons,
+        suggested_recovery=suggested_recovery,
+        readiness_snapshot=readiness_snapshot,
     )
 
 
@@ -317,6 +372,8 @@ def _build_candidate_reason(
     reason_parts.append(f"risk={candidate.risk_level or 'unknown'}")
     reason_parts.append(f"cost={candidate.cost_estimate or 'unknown'}")
     reason_parts.append(f"tool_source={tool_display.source}")
+    if tool_display.readiness_status:
+        reason_parts.append(f"readiness={tool_display.readiness_status}")
     if tool_display.can_fallback:
         reason_parts.append("supports_fallback")
     return "; ".join(reason_parts)

--- a/src/api/static/css/hitl-dashboard.css
+++ b/src/api/static/css/hitl-dashboard.css
@@ -140,10 +140,18 @@ button:disabled {
   font-size: 13px;
 }
 
+.model-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
 .pending-table th,
 .pending-table td,
 .readiness-table th,
-.readiness-table td {
+.readiness-table td,
+.model-table th,
+.model-table td {
   border-top: 1px solid var(--line);
   text-align: left;
   padding: 8px;
@@ -151,7 +159,8 @@ button:disabled {
 }
 
 .pending-table tr:hover,
-.readiness-table tr:hover {
+.readiness-table tr:hover,
+.model-table tr:hover {
   background: #f6faff;
 }
 
@@ -228,6 +237,11 @@ button:disabled {
   }
 
   .readiness-table {
+    display: block;
+    overflow-x: auto;
+  }
+
+  .model-table {
     display: block;
     overflow-x: auto;
   }

--- a/src/api/static/css/hitl-dashboard.css
+++ b/src/api/static/css/hitl-dashboard.css
@@ -122,21 +122,36 @@ button:disabled {
   color: var(--muted);
 }
 
+.chip.error-chip {
+  color: #9b1c1c;
+  border-color: #efb0b0;
+  background: #fff0f0;
+}
+
 .pending-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 14px;
 }
 
+.readiness-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
 .pending-table th,
-.pending-table td {
+.pending-table td,
+.readiness-table th,
+.readiness-table td {
   border-top: 1px solid var(--line);
   text-align: left;
   padding: 8px;
   vertical-align: top;
 }
 
-.pending-table tr:hover {
+.pending-table tr:hover,
+.readiness-table tr:hover {
   background: #f6faff;
 }
 
@@ -208,6 +223,11 @@ button:disabled {
   }
 
   .candidate-table {
+    display: block;
+    overflow-x: auto;
+  }
+
+  .readiness-table {
     display: block;
     overflow-x: auto;
   }

--- a/src/api/static/js/hitl-dashboard.js
+++ b/src/api/static/js/hitl-dashboard.js
@@ -53,6 +53,18 @@ function statusChipClass(status) {
     }
     return "chip muted";
 }
+function readinessChipClass(status) {
+    if (status === "ready") {
+        return "chip done";
+    }
+    if (status === "degraded") {
+        return "chip waiting";
+    }
+    if (status === "unavailable") {
+        return "chip error-chip";
+    }
+    return "chip muted";
+}
 function formatScore(value) {
     if (typeof value !== "number" || Number.isNaN(value)) {
         return "-";
@@ -124,6 +136,46 @@ function renderPendingActions(items) {
         const summaryCell = document.createElement("td");
         summaryCell.textContent = item.summary || item.explanation;
         row.appendChild(summaryCell);
+        tbody.appendChild(row);
+    }
+}
+function renderCapabilityReadiness(items) {
+    const tbody = byId("capability-readiness-body");
+    tbody.innerHTML = "";
+    if (!items.length) {
+        const row = document.createElement("tr");
+        const cell = document.createElement("td");
+        cell.colSpan = 5;
+        cell.textContent = "No capability readiness data.";
+        row.appendChild(cell);
+        tbody.appendChild(row);
+        return;
+    }
+    for (const item of items) {
+        const row = document.createElement("tr");
+        const capabilityCell = document.createElement("td");
+        capabilityCell.textContent = item.capability_id;
+        row.appendChild(capabilityCell);
+        const statusCell = document.createElement("td");
+        const chip = document.createElement("span");
+        chip.className = readinessChipClass(item.status);
+        chip.textContent = item.status;
+        statusCell.appendChild(chip);
+        row.appendChild(statusCell);
+        const toolCell = document.createElement("td");
+        const fallback = item.fallback_tool_ids?.length
+            ? ` fallback=${item.fallback_tool_ids.join(",")}`
+            : "";
+        toolCell.textContent = `${formatText(item.primary_tool_id)}${fallback}`;
+        row.appendChild(toolCell);
+        const reasonCell = document.createElement("td");
+        reasonCell.textContent = item.degraded_reasons?.length
+            ? item.degraded_reasons.join(" | ")
+            : item.reason;
+        row.appendChild(reasonCell);
+        const recoveryCell = document.createElement("td");
+        recoveryCell.textContent = formatText(item.suggested_recovery);
+        row.appendChild(recoveryCell);
         tbody.appendChild(row);
     }
 }
@@ -204,7 +256,8 @@ function renderCandidateComparison(detail) {
         "Risk",
         "Cost",
         "Tool",
-        "Availability",
+        "Readiness",
+        "Recovery",
         "Reason",
         "Summary",
     ]) {
@@ -245,12 +298,19 @@ function renderCandidateComparison(detail) {
                 `${formatText(candidate.tool.io_type)} / mode=${formatText(candidate.tool.adapter_mode)} / ` +
                 `source=${candidate.tool.source}`;
         row.appendChild(toolCell);
-        const availabilityCell = document.createElement("td");
-        const availability = candidate.tool.available ? "ready" : "degraded";
-        const fallbackFlag = candidate.tool.can_fallback ? " fallback" : "";
-        availabilityCell.textContent = `${availability}${fallbackFlag}`;
-        availabilityCell.title = candidate.tool.availability_hint;
-        row.appendChild(availabilityCell);
+        const readinessCell = document.createElement("td");
+        const readiness = candidate.tool.readiness_status ?? (candidate.tool.available ? "ready" : "degraded");
+        const readinessChip = document.createElement("span");
+        readinessChip.className = readinessChipClass(readiness);
+        readinessChip.textContent = readiness;
+        readinessCell.appendChild(readinessChip);
+        readinessCell.title = candidate.tool.degraded_reasons?.length
+            ? candidate.tool.degraded_reasons.join(" | ")
+            : candidate.tool.availability_hint;
+        row.appendChild(readinessCell);
+        const recoveryCell = document.createElement("td");
+        recoveryCell.textContent = formatText(candidate.tool.suggested_recovery);
+        row.appendChild(recoveryCell);
         const reasonCell = document.createElement("td");
         reasonCell.textContent = candidate.recommendation_reason;
         row.appendChild(reasonCell);
@@ -460,6 +520,7 @@ async function submitDecision() {
     setGlobalMessage("Decision submitted. Pending list and state are refreshed.");
     await Promise.all([
         refreshPendingActions(),
+        refreshCapabilityReadiness(),
         refreshLatestProgress(updatedTask.id, previousStatus, updatedTask.status),
     ]);
 }
@@ -467,6 +528,16 @@ async function refreshPendingActions() {
     try {
         const records = await getJson("/pending-actions");
         renderPendingActions(records);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setGlobalMessage(message, true);
+    }
+}
+async function refreshCapabilityReadiness() {
+    try {
+        const records = await getJson("/capabilities/readiness");
+        renderCapabilityReadiness(records);
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -525,6 +596,7 @@ function bindEvents() {
     });
     refreshButton.addEventListener("click", () => {
         void refreshPendingActions();
+        void refreshCapabilityReadiness();
         if (state.selectedTaskId) {
             void refreshTaskDetail();
         }
@@ -539,11 +611,13 @@ async function bootstrap() {
     }
     renderNoPendingAction();
     await refreshPendingActions();
+    await refreshCapabilityReadiness();
     if (state.selectedTaskId) {
         await refreshTaskDetail();
     }
     window.setInterval(() => {
         void refreshPendingActions();
+        void refreshCapabilityReadiness();
         if (state.selectedTaskId) {
             void refreshTaskDetail();
         }

--- a/src/api/static/js/hitl-dashboard.js
+++ b/src/api/static/js/hitl-dashboard.js
@@ -75,6 +75,12 @@ function formatText(value) {
     const normalized = value?.trim();
     return normalized ? normalized : "-";
 }
+const MODEL_INVOCATION_CAPABILITIES = new Set([
+    "sequence_generation",
+    "sequence_design",
+    "structure_prediction",
+    "objective_scoring",
+]);
 async function parseError(response) {
     try {
         const payload = (await response.json());
@@ -173,6 +179,48 @@ function renderCapabilityReadiness(items) {
             ? item.degraded_reasons.join(" | ")
             : item.reason;
         row.appendChild(reasonCell);
+        const recoveryCell = document.createElement("td");
+        recoveryCell.textContent = formatText(item.suggested_recovery);
+        row.appendChild(recoveryCell);
+        tbody.appendChild(row);
+    }
+}
+function renderModelInvocation(items) {
+    const tbody = byId("model-invocation-body");
+    tbody.innerHTML = "";
+    const modelItems = items.filter((item) => MODEL_INVOCATION_CAPABILITIES.has(item.capability_id) ||
+        Boolean(item.primary_tool_id));
+    if (!modelItems.length) {
+        const row = document.createElement("tr");
+        const cell = document.createElement("td");
+        cell.colSpan = 5;
+        cell.textContent = "No model invocation readiness data.";
+        row.appendChild(cell);
+        tbody.appendChild(row);
+        return;
+    }
+    for (const item of modelItems) {
+        const row = document.createElement("tr");
+        const capabilityCell = document.createElement("td");
+        capabilityCell.textContent = item.capability_id;
+        row.appendChild(capabilityCell);
+        const statusCell = document.createElement("td");
+        const chip = document.createElement("span");
+        chip.className = readinessChipClass(item.status);
+        chip.textContent = item.status;
+        statusCell.appendChild(chip);
+        row.appendChild(statusCell);
+        const toolCell = document.createElement("td");
+        const fallback = item.fallback_tool_ids?.length
+            ? ` fallback=${item.fallback_tool_ids.join(",")}`
+            : "";
+        toolCell.textContent = `${formatText(item.primary_tool_id)}${fallback}`;
+        row.appendChild(toolCell);
+        const degradationCell = document.createElement("td");
+        degradationCell.textContent = item.degraded_reasons?.length
+            ? item.degraded_reasons.join(" | ")
+            : item.reason;
+        row.appendChild(degradationCell);
         const recoveryCell = document.createElement("td");
         recoveryCell.textContent = formatText(item.suggested_recovery);
         row.appendChild(recoveryCell);
@@ -538,6 +586,7 @@ async function refreshCapabilityReadiness() {
     try {
         const records = await getJson("/capabilities/readiness");
         renderCapabilityReadiness(records);
+        renderModelInvocation(records);
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/api/static/ts/hitl-dashboard.ts
+++ b/src/api/static/ts/hitl-dashboard.ts
@@ -92,6 +92,13 @@ interface CapabilityReadinessEntry {
   reason: string;
 }
 
+const MODEL_INVOCATION_CAPABILITIES = new Set([
+  "sequence_generation",
+  "sequence_design",
+  "structure_prediction",
+  "objective_scoring",
+]);
+
 const ALLOWED_CHOICES: Record<PendingActionType, DecisionChoice[]> = {
   plan_confirm: ["accept", "replan", "cancel"],
   patch_confirm: ["accept", "replan", "cancel"],
@@ -299,6 +306,61 @@ function renderCapabilityReadiness(items: CapabilityReadinessEntry[]): void {
       ? item.degraded_reasons.join(" | ")
       : item.reason;
     row.appendChild(reasonCell);
+
+    const recoveryCell = document.createElement("td");
+    recoveryCell.textContent = formatText(item.suggested_recovery);
+    row.appendChild(recoveryCell);
+
+    tbody.appendChild(row);
+  }
+}
+
+function renderModelInvocation(items: CapabilityReadinessEntry[]): void {
+  const tbody = byId<HTMLTableSectionElement>("model-invocation-body");
+  tbody.innerHTML = "";
+
+  const modelItems = items.filter(
+    (item) =>
+      MODEL_INVOCATION_CAPABILITIES.has(item.capability_id) ||
+      Boolean(item.primary_tool_id),
+  );
+
+  if (!modelItems.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 5;
+    cell.textContent = "No model invocation readiness data.";
+    row.appendChild(cell);
+    tbody.appendChild(row);
+    return;
+  }
+
+  for (const item of modelItems) {
+    const row = document.createElement("tr");
+
+    const capabilityCell = document.createElement("td");
+    capabilityCell.textContent = item.capability_id;
+    row.appendChild(capabilityCell);
+
+    const statusCell = document.createElement("td");
+    const chip = document.createElement("span");
+    chip.className = readinessChipClass(item.status);
+    chip.textContent = item.status;
+    statusCell.appendChild(chip);
+    row.appendChild(statusCell);
+
+    const toolCell = document.createElement("td");
+    const fallback = item.fallback_tool_ids?.length
+      ? ` fallback=${item.fallback_tool_ids.join(",")}`
+      : "";
+    toolCell.textContent = `${formatText(item.primary_tool_id)}${fallback}`;
+    row.appendChild(toolCell);
+
+    const degradationCell = document.createElement("td");
+    degradationCell.textContent = item.degraded_reasons?.length
+      ? item.degraded_reasons.join(" | ")
+      : item.reason;
+    row.appendChild(degradationCell);
 
     const recoveryCell = document.createElement("td");
     recoveryCell.textContent = formatText(item.suggested_recovery);
@@ -744,6 +806,7 @@ async function refreshCapabilityReadiness(): Promise<void> {
   try {
     const records = await getJson<CapabilityReadinessEntry[]>("/capabilities/readiness");
     renderCapabilityReadiness(records);
+    renderModelInvocation(records);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     setGlobalMessage(message, true);

--- a/src/api/static/ts/hitl-dashboard.ts
+++ b/src/api/static/ts/hitl-dashboard.ts
@@ -29,6 +29,10 @@ interface PendingActionToolDisplay {
   available: boolean;
   can_fallback: boolean;
   availability_hint: string;
+  readiness_status?: string | null;
+  degraded_reasons?: string[];
+  suggested_recovery?: string | null;
+  readiness_snapshot?: Record<string, unknown>;
 }
 
 interface PendingActionCandidateDisplay {
@@ -76,6 +80,16 @@ interface TaskTimelineEvent {
   event_type: string;
   summary: string;
   ts?: string | null;
+}
+
+interface CapabilityReadinessEntry {
+  capability_id: string;
+  status: string;
+  primary_tool_id?: string | null;
+  fallback_tool_ids?: string[];
+  degraded_reasons?: string[];
+  suggested_recovery?: string | null;
+  reason: string;
 }
 
 const ALLOWED_CHOICES: Record<PendingActionType, DecisionChoice[]> = {
@@ -141,6 +155,19 @@ function statusChipClass(status: string): string {
   }
   if (status === "RUNNING" || status === "PLANNING" || status === "PLANNED") {
     return "chip active";
+  }
+  return "chip muted";
+}
+
+function readinessChipClass(status: string | null | undefined): string {
+  if (status === "ready") {
+    return "chip done";
+  }
+  if (status === "degraded") {
+    return "chip waiting";
+  }
+  if (status === "unavailable") {
+    return "chip error-chip";
   }
   return "chip muted";
 }
@@ -227,6 +254,55 @@ function renderPendingActions(items: PendingActionSummary[]): void {
     const summaryCell = document.createElement("td");
     summaryCell.textContent = item.summary || item.explanation;
     row.appendChild(summaryCell);
+
+    tbody.appendChild(row);
+  }
+}
+
+function renderCapabilityReadiness(items: CapabilityReadinessEntry[]): void {
+  const tbody = byId<HTMLTableSectionElement>("capability-readiness-body");
+  tbody.innerHTML = "";
+
+  if (!items.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 5;
+    cell.textContent = "No capability readiness data.";
+    row.appendChild(cell);
+    tbody.appendChild(row);
+    return;
+  }
+
+  for (const item of items) {
+    const row = document.createElement("tr");
+
+    const capabilityCell = document.createElement("td");
+    capabilityCell.textContent = item.capability_id;
+    row.appendChild(capabilityCell);
+
+    const statusCell = document.createElement("td");
+    const chip = document.createElement("span");
+    chip.className = readinessChipClass(item.status);
+    chip.textContent = item.status;
+    statusCell.appendChild(chip);
+    row.appendChild(statusCell);
+
+    const toolCell = document.createElement("td");
+    const fallback = item.fallback_tool_ids?.length
+      ? ` fallback=${item.fallback_tool_ids.join(",")}`
+      : "";
+    toolCell.textContent = `${formatText(item.primary_tool_id)}${fallback}`;
+    row.appendChild(toolCell);
+
+    const reasonCell = document.createElement("td");
+    reasonCell.textContent = item.degraded_reasons?.length
+      ? item.degraded_reasons.join(" | ")
+      : item.reason;
+    row.appendChild(reasonCell);
+
+    const recoveryCell = document.createElement("td");
+    recoveryCell.textContent = formatText(item.suggested_recovery);
+    row.appendChild(recoveryCell);
 
     tbody.appendChild(row);
   }
@@ -324,7 +400,8 @@ function renderCandidateComparison(detail: PendingActionDetail): void {
     "Risk",
     "Cost",
     "Tool",
-    "Availability",
+    "Readiness",
+    "Recovery",
     "Reason",
     "Summary",
   ]) {
@@ -373,12 +450,22 @@ function renderCandidateComparison(detail: PendingActionDetail): void {
       `source=${candidate.tool.source}`;
     row.appendChild(toolCell);
 
-    const availabilityCell = document.createElement("td");
-    const availability = candidate.tool.available ? "ready" : "degraded";
-    const fallbackFlag = candidate.tool.can_fallback ? " fallback" : "";
-    availabilityCell.textContent = `${availability}${fallbackFlag}`;
-    availabilityCell.title = candidate.tool.availability_hint;
-    row.appendChild(availabilityCell);
+    const readinessCell = document.createElement("td");
+    const readiness = candidate.tool.readiness_status ?? (
+      candidate.tool.available ? "ready" : "degraded"
+    );
+    const readinessChip = document.createElement("span");
+    readinessChip.className = readinessChipClass(readiness);
+    readinessChip.textContent = readiness;
+    readinessCell.appendChild(readinessChip);
+    readinessCell.title = candidate.tool.degraded_reasons?.length
+      ? candidate.tool.degraded_reasons.join(" | ")
+      : candidate.tool.availability_hint;
+    row.appendChild(readinessCell);
+
+    const recoveryCell = document.createElement("td");
+    recoveryCell.textContent = formatText(candidate.tool.suggested_recovery);
+    row.appendChild(recoveryCell);
 
     const reasonCell = document.createElement("td");
     reasonCell.textContent = candidate.recommendation_reason;
@@ -638,6 +725,7 @@ async function submitDecision(): Promise<void> {
   setGlobalMessage("Decision submitted. Pending list and state are refreshed.");
   await Promise.all([
     refreshPendingActions(),
+    refreshCapabilityReadiness(),
     refreshLatestProgress(updatedTask.id, previousStatus, updatedTask.status),
   ]);
 }
@@ -646,6 +734,16 @@ async function refreshPendingActions(): Promise<void> {
   try {
     const records = await getJson<PendingActionSummary[]>("/pending-actions");
     renderPendingActions(records);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setGlobalMessage(message, true);
+  }
+}
+
+async function refreshCapabilityReadiness(): Promise<void> {
+  try {
+    const records = await getJson<CapabilityReadinessEntry[]>("/capabilities/readiness");
+    renderCapabilityReadiness(records);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     setGlobalMessage(message, true);
@@ -709,6 +807,7 @@ function bindEvents(): void {
 
   refreshButton.addEventListener("click", () => {
     void refreshPendingActions();
+    void refreshCapabilityReadiness();
     if (state.selectedTaskId) {
       void refreshTaskDetail();
     }
@@ -726,6 +825,7 @@ async function bootstrap(): Promise<void> {
 
   renderNoPendingAction();
   await refreshPendingActions();
+  await refreshCapabilityReadiness();
 
   if (state.selectedTaskId) {
     await refreshTaskDetail();
@@ -733,6 +833,7 @@ async function bootstrap(): Promise<void> {
 
   window.setInterval(() => {
     void refreshPendingActions();
+    void refreshCapabilityReadiness();
     if (state.selectedTaskId) {
       void refreshTaskDetail();
     }

--- a/src/api/templates/index.html
+++ b/src/api/templates/index.html
@@ -81,6 +81,24 @@
 
       <section class="panel">
         <div class="panel-head">
+          <h2>Model Invocation</h2>
+        </div>
+        <table class="model-table">
+          <thead>
+            <tr>
+              <th>Capability</th>
+              <th>Status</th>
+              <th>Invocation Tool</th>
+              <th>Degradation</th>
+              <th>Recovery</th>
+            </tr>
+          </thead>
+          <tbody id="model-invocation-body"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
           <h2>Candidate Comparison</h2>
           <span id="candidate-count" class="chip">0</span>
         </div>

--- a/src/api/templates/index.html
+++ b/src/api/templates/index.html
@@ -63,6 +63,24 @@
 
       <section class="panel">
         <div class="panel-head">
+          <h2>Capability Readiness</h2>
+        </div>
+        <table class="readiness-table">
+          <thead>
+            <tr>
+              <th>Capability</th>
+              <th>Status</th>
+              <th>Tools</th>
+              <th>Reason</th>
+              <th>Recovery</th>
+            </tr>
+          </thead>
+          <tbody id="capability-readiness-body"></tbody>
+        </table>
+      </section>
+
+      <section class="panel">
+        <div class="panel-head">
           <h2>Candidate Comparison</h2>
           <span id="candidate-count" class="chip">0</span>
         </div>

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+import httpx
+
+DEFAULT_API_BASE_URL = "http://127.0.0.1:8000"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """运行 design CLI 入口。"""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    base_url = str(args.api_base_url or os.getenv("DESIGN_API_BASE_URL") or DEFAULT_API_BASE_URL).rstrip("/")
+
+    try:
+        if args.command == "task" and args.task_command == "show":
+            return _task_show(base_url, args.task_id, emit_json=args.json)
+        if args.command == "task" and args.task_command == "watch":
+            return _task_watch(
+                base_url,
+                args.task_id,
+                emit_json=args.json,
+                interval_s=args.interval,
+            )
+        if args.command == "pending" and args.pending_command == "show":
+            return _pending_show(base_url, args.pending_action_id, emit_json=args.json)
+    except httpx.HTTPError as exc:
+        print(f"API request failed: {exc}", file=sys.stderr)
+        return 2
+
+    parser.print_help()
+    return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="design")
+    parser.add_argument(
+        "--api-base-url",
+        default=None,
+        help="API base URL; defaults to DESIGN_API_BASE_URL or http://127.0.0.1:8000",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    task_parser = subparsers.add_parser("task")
+    task_subparsers = task_parser.add_subparsers(dest="task_command")
+    task_show = task_subparsers.add_parser("show")
+    task_show.add_argument("task_id")
+    task_show.add_argument("--json", action="store_true")
+    task_watch = task_subparsers.add_parser("watch")
+    task_watch.add_argument("task_id")
+    task_watch.add_argument("--json", action="store_true")
+    task_watch.add_argument("--interval", type=float, default=5.0)
+
+    pending_parser = subparsers.add_parser("pending")
+    pending_subparsers = pending_parser.add_subparsers(dest="pending_command")
+    pending_show = pending_subparsers.add_parser("show")
+    pending_show.add_argument("pending_action_id")
+    pending_show.add_argument("--json", action="store_true")
+    return parser
+
+
+def _task_show(base_url: str, task_id: str, *, emit_json: bool) -> int:
+    task = _get_json(base_url, f"/tasks/{task_id}")
+    readiness = _get_json(base_url, "/capabilities/readiness")
+    payload = {
+        "task": task,
+        "readiness_summary": _readiness_summary(readiness),
+    }
+    if emit_json:
+        _print_json(payload)
+    else:
+        _print_task(payload)
+    return 0
+
+
+def _task_watch(
+    base_url: str,
+    task_id: str,
+    *,
+    emit_json: bool,
+    interval_s: float,
+) -> int:
+    while True:
+        code = _task_show(base_url, task_id, emit_json=emit_json)
+        task = _get_json(base_url, f"/tasks/{task_id}")
+        if str(task.get("status")) in {"DONE", "FAILED", "CANCELLED"}:
+            return code
+        time.sleep(max(1.0, interval_s))
+
+
+def _pending_show(base_url: str, pending_action_id: str, *, emit_json: bool) -> int:
+    pending = _get_json(base_url, f"/pending-actions/{pending_action_id}")
+    readiness = _get_json(base_url, "/capabilities/readiness")
+    payload = {
+        "pending_action": pending,
+        "readiness_summary": _readiness_summary(readiness),
+    }
+    if emit_json:
+        _print_json(payload)
+    else:
+        _print_pending(payload)
+    return 0
+
+
+def _get_json(base_url: str, path: str) -> dict[str, Any] | list[dict[str, Any]]:
+    response = httpx.get(f"{base_url}{path}", timeout=10.0)
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, (dict, list)):
+        raise ValueError(f"API payload for {path} is not an object or list")
+    return payload
+
+
+def _readiness_summary(readiness: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not isinstance(readiness, list):
+        return []
+    return [
+        {
+            "capability_id": item.get("capability_id"),
+            "status": item.get("status"),
+            "reason": item.get("reason"),
+            "degraded_reasons": item.get("degraded_reasons") or [],
+            "suggested_recovery": item.get("suggested_recovery"),
+        }
+        for item in readiness
+        if isinstance(item, dict)
+    ]
+
+
+def _print_task(payload: dict[str, Any]) -> None:
+    task = payload["task"]
+    print(f"task_id: {task.get('id')}")
+    print(f"status: {task.get('status')} / {task.get('internal_status') or '-'}")
+    print(f"goal: {task.get('goal')}")
+    pending = task.get("pending_action")
+    if isinstance(pending, dict):
+        print(f"pending_action: {pending.get('pending_action_id')} ({pending.get('action_type')})")
+    _print_readiness_summary(payload["readiness_summary"])
+
+
+def _print_pending(payload: dict[str, Any]) -> None:
+    pending = payload["pending_action"]
+    print(f"pending_action_id: {pending.get('pending_action_id')}")
+    print(f"task_id: {pending.get('task_id')}")
+    print(f"action_type: {pending.get('action_type')}")
+    print(f"default_suggestion: {pending.get('default_suggestion') or '-'}")
+    for candidate in pending.get("candidates") or []:
+        if not isinstance(candidate, dict):
+            continue
+        tool = candidate.get("tool") if isinstance(candidate.get("tool"), dict) else {}
+        print(
+            "candidate: "
+            f"{candidate.get('candidate_id')} "
+            f"readiness={tool.get('readiness_status') or '-'} "
+            f"recovery={tool.get('suggested_recovery') or '-'}"
+        )
+    _print_readiness_summary(payload["readiness_summary"])
+
+
+def _print_readiness_summary(items: list[dict[str, Any]]) -> None:
+    print("capability_readiness:")
+    for item in items:
+        print(
+            "  "
+            f"{item.get('capability_id')}: {item.get('status')} "
+            f"reason={item.get('reason') or '-'} "
+            f"recovery={item.get('suggested_recovery') or '-'}"
+        )
+
+
+def _print_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/infra/tool_readiness.py
+++ b/src/infra/tool_readiness.py
@@ -12,7 +12,9 @@ from src.models.contracts import CapabilityReadiness, ToolReadiness, now_iso
 
 __all__ = [
     "P0_CAPABILITY_IDS",
+    "build_capability_readiness_index",
     "build_capability_readiness_matrix",
+    "build_capability_readiness_snapshot",
     "build_tool_readiness_snapshot",
     "evaluate_tool_readiness",
 ]
@@ -223,6 +225,37 @@ def build_capability_readiness_matrix() -> List[Dict[str, Any]]:
 
         matrix.append(payload)
     return matrix
+
+
+def build_capability_readiness_index() -> Dict[str, Dict[str, Any]]:
+    """按 capability_id 返回 readiness 矩阵索引。"""
+    return {
+        str(entry["capability_id"]): entry
+        for entry in build_capability_readiness_matrix()
+        if isinstance(entry.get("capability_id"), str)
+    }
+
+
+def build_capability_readiness_snapshot(capability_id: str) -> Dict[str, Any]:
+    """返回单个 capability 的 readiness 快照。"""
+    normalized = capability_id.strip()
+    matrix = build_capability_readiness_index()
+    if normalized in matrix:
+        return matrix[normalized]
+
+    checked_at = now_iso()
+    payload = CapabilityReadiness(
+        capability_id=normalized,
+        status="unavailable",
+        degraded_reasons=["capability not found in ToolKG"],
+        last_checked_at=checked_at,
+        suggested_recovery=(
+            "Register the capability and at least one adapter-backed tool before planning."
+        ),
+        reason="capability not found in ToolKG",
+    ).model_dump(mode="json", exclude_none=True)
+    payload["checked_at"] = checked_at
+    return payload
 
 
 def build_tool_readiness_snapshot(tool_id: str) -> Dict[str, Any]:

--- a/src/infra/tool_readiness.py
+++ b/src/infra/tool_readiness.py
@@ -1,59 +1,123 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, List
+import os
+from typing import Any, Dict, List, Sequence
 
 from src.adapters.builtins import ensure_builtin_adapters
 from src.adapters.registry import get_adapter
 from src.infra.active_tool_metadata import metadata_by_tool_id
 from src.kg.kg_client import load_tool_kg
-from src.models.contracts import now_iso
+from src.models.contracts import CapabilityReadiness, ToolReadiness, now_iso
 
 __all__ = [
+    "P0_CAPABILITY_IDS",
     "build_capability_readiness_matrix",
+    "build_tool_readiness_snapshot",
     "evaluate_tool_readiness",
 ]
 
+P0_CAPABILITY_IDS = {
+    "structure_prediction",
+    "sequence_design",
+    "sequence_generation",
+    "quality_qc",
+    "sequence_similarity_search",
+    "objective_scoring",
+}
 
-def evaluate_tool_readiness(tool_id: str) -> Dict[str, Any]:
+DEFAULT_HEALTHCHECK_TIMEOUT_S = 2.0
+
+
+def evaluate_tool_readiness(
+    tool_id: str,
+    *,
+    tool_entry: dict[str, Any] | None = None,
+    checked_at: str | None = None,
+) -> Dict[str, Any]:
     """评估单个工具的可用性。"""
+    checked_at = checked_at or now_iso()
     profile = metadata_by_tool_id().get(tool_id)
+    capability_ids = _capability_ids(tool_entry, profile)
+    cost_prior, risk_prior, latency_prior = _priors_for_tool(tool_entry, profile)
+
     try:
         adapter = get_adapter(tool_id)
     except KeyError:
-        payload = {
-            "tool_id": tool_id,
-            "status": "unavailable",
-            "reason": "adapter not registered",
-        }
-        if profile is not None:
-            payload["metadata_profile"] = profile.to_dict()
-        return payload
+        return _tool_payload(
+            tool_id=tool_id,
+            status="unavailable",
+            reason="adapter not registered",
+            error_category="adapter_missing",
+            capability_ids=capability_ids,
+            cost_prior=cost_prior,
+            risk_prior=risk_prior,
+            latency_prior=latency_prior,
+            checked_at=checked_at,
+            profile=profile,
+            details={"healthcheck_timeout_s": DEFAULT_HEALTHCHECK_TIMEOUT_S},
+        )
 
     try:
         health = adapter.healthcheck()
     except Exception as exc:  # pragma: no cover - 防御性分支
-        payload = {
-            "tool_id": tool_id,
-            "status": "degraded",
-            "reason": f"healthcheck failed: {exc}",
-        }
-        if profile is not None:
-            payload["metadata_profile"] = profile.to_dict()
-        return payload
+        normalized = adapter.normalize_error(exc)
+        reason = str(normalized.get("message") or exc)
+        return _tool_payload(
+            tool_id=tool_id,
+            status="degraded",
+            reason=f"healthcheck failed: {reason}",
+            error_category=_classify_error(reason, tool_entry),
+            capability_ids=capability_ids,
+            cost_prior=cost_prior,
+            risk_prior=risk_prior,
+            latency_prior=latency_prior,
+            checked_at=checked_at,
+            profile=profile,
+            details={
+                "normalized_error": normalized,
+                "healthcheck_timeout_s": DEFAULT_HEALTHCHECK_TIMEOUT_S,
+            },
+        )
 
     status = str(health.get("status") or "ready")
     if status not in {"ready", "degraded", "unavailable"}:
         status = "degraded"
-    payload = {
-        "tool_id": tool_id,
-        "status": status,
-        "reason": str(health.get("reason") or ""),
-        "details": health,
+    reason = str(health.get("reason") or "")
+    protocol_override = _protocol_readiness_override(tool_entry)
+    if protocol_override is not None:
+        override_status, override_reason, override_category = protocol_override
+        status = _worse_status(status, override_status)
+        if override_status != "ready":
+            reason = _join_reasons(reason, override_reason)
+        error_category = override_category
+    else:
+        error_category = _classify_error(reason, tool_entry) if status != "ready" else None
+
+    try:
+        capability_summary = adapter.describe_capabilities()
+    except Exception as exc:  # pragma: no cover - 防御性分支
+        capability_summary = {"describe_error": adapter.normalize_error(exc)}
+    details = {
+        **health,
+        "capabilities": capability_summary,
+        "cost_estimate": adapter.estimate_cost({}),
+        "latency_estimate": adapter.estimate_latency({}),
+        "healthcheck_timeout_s": DEFAULT_HEALTHCHECK_TIMEOUT_S,
     }
-    if profile is not None:
-        payload["metadata_profile"] = profile.to_dict()
-    return payload
+    return _tool_payload(
+        tool_id=tool_id,
+        status=status,
+        reason=reason,
+        error_category=error_category,
+        capability_ids=capability_ids,
+        cost_prior=cost_prior,
+        risk_prior=risk_prior,
+        latency_prior=latency_prior,
+        checked_at=checked_at,
+        profile=profile,
+        details=details,
+    )
 
 
 def build_capability_readiness_matrix() -> List[Dict[str, Any]]:
@@ -73,6 +137,7 @@ def build_capability_readiness_matrix() -> List[Dict[str, Any]]:
             if isinstance(capability_id, str):
                 capability_tools[capability_id].append(tool)
 
+    checked_at = now_iso()
     matrix: list[Dict[str, Any]] = []
     for capability in capabilities:
         if not isinstance(capability, dict):
@@ -88,45 +153,305 @@ def build_capability_readiness_matrix() -> List[Dict[str, Any]]:
                 str(item.get("id") or ""),
             ),
         )
-        tool_health = [
-            evaluate_tool_readiness(str(tool.get("id")))
+        tool_readiness = [
+            evaluate_tool_readiness(
+                str(tool.get("id")),
+                tool_entry=tool,
+                checked_at=checked_at,
+            )
             for tool in ranked_tools
             if isinstance(tool.get("id"), str)
         ]
 
         primary_tool_id = next(
-            (item["tool_id"] for item in tool_health),
+            (item["tool_id"] for item in tool_readiness),
             None,
         )
-        fallback_tool_ids = [item["tool_id"] for item in tool_health[1:]]
-        ready_tools = [item for item in tool_health if item["status"] == "ready"]
+        fallback_tool_ids = [item["tool_id"] for item in tool_readiness[1:]]
+        available_tools = [
+            item for item in tool_readiness if item["status"] in {"ready", "degraded"}
+        ]
+        ready_tools = [item for item in tool_readiness if item["status"] == "ready"]
+        blocked_tools = [
+            item for item in tool_readiness if item["status"] == "unavailable"
+        ]
+        degraded_reasons = [
+            _tool_reason(item)
+            for item in tool_readiness
+            if item["status"] != "ready" and _tool_reason(item)
+        ]
 
         status = "unavailable"
         reason = "no registered tool is ready"
-        if tool_health:
-            first = tool_health[0]
+        if tool_readiness:
+            first = tool_readiness[0]
             if first["status"] == "ready":
                 status = "ready"
                 reason = first["reason"] or "primary tool is ready"
             elif ready_tools:
                 status = "degraded"
                 reason = "primary tool unavailable; fallback tool is ready"
-            elif any(item["status"] == "degraded" for item in tool_health):
+            elif any(item["status"] == "degraded" for item in tool_readiness):
                 status = "degraded"
                 reason = "tool registered but health is degraded"
+            elif degraded_reasons:
+                reason = degraded_reasons[0]
 
-        matrix.append(
-            {
-                "capability_id": capability_id,
-                "status": status,
-                "primary_tool_id": primary_tool_id,
-                "fallback_tool_ids": fallback_tool_ids,
-                "reason": reason,
-                "checked_at": now_iso(),
-                "tools": tool_health,
-            }
+        priors = _aggregate_priors(tool_readiness)
+        recovery = _suggest_capability_recovery(status, degraded_reasons, blocked_tools)
+        entry = CapabilityReadiness(
+            capability_id=capability_id,
+            status=status,  # type: ignore[arg-type]
+            available_tools=[
+                ToolReadiness(**item) for item in available_tools
+            ],
+            blocked_tools=[
+                ToolReadiness(**item) for item in blocked_tools
+            ],
+            degraded_reasons=degraded_reasons,
+            last_checked_at=checked_at,
+            cost_prior=priors.get("cost_prior"),
+            risk_prior=priors.get("risk_prior"),
+            suggested_recovery=recovery,
+            primary_tool_id=primary_tool_id,
+            fallback_tool_ids=fallback_tool_ids,
+            reason=reason,
+            tools=[ToolReadiness(**item) for item in tool_readiness],
         )
+        payload = entry.model_dump(mode="json", exclude_none=True)
+        payload["checked_at"] = checked_at
+
+        matrix.append(payload)
     return matrix
+
+
+def build_tool_readiness_snapshot(tool_id: str) -> Dict[str, Any]:
+    """返回候选可追溯使用的单工具 readiness 快照。"""
+    kg = load_tool_kg()
+    tools = kg.get("tools", [])
+    tool_entry = next(
+        (
+            item
+            for item in tools
+            if isinstance(item, dict) and item.get("id") == tool_id
+        ),
+        None,
+    )
+    return evaluate_tool_readiness(tool_id, tool_entry=tool_entry)
+
+
+def _tool_payload(
+    *,
+    tool_id: str,
+    status: str,
+    reason: str,
+    error_category: str | None,
+    capability_ids: Sequence[str],
+    cost_prior: float | None,
+    risk_prior: float | None,
+    latency_prior: float | None,
+    checked_at: str,
+    profile: Any,
+    details: dict[str, Any],
+) -> Dict[str, Any]:
+    suggested_recovery = _suggest_tool_recovery(error_category, reason)
+    payload = ToolReadiness(
+        tool_id=tool_id,
+        status=status,  # type: ignore[arg-type]
+        reason=reason,
+        error_category=error_category,
+        capability_ids=list(capability_ids),
+        cost_prior=cost_prior,
+        risk_prior=risk_prior,
+        latency_prior=latency_prior,
+        suggested_recovery=suggested_recovery,
+        last_checked_at=checked_at,
+        details=details,
+        metadata_profile=profile.to_dict() if profile is not None else None,
+    ).model_dump(mode="json", exclude_none=True)
+    payload["checked_at"] = checked_at
+    return payload
+
+
+def _capability_ids(tool_entry: dict[str, Any] | None, profile: Any) -> list[str]:
+    raw = tool_entry.get("capabilities") if isinstance(tool_entry, dict) else None
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, str)]
+    if profile is not None:
+        return list(profile.capability_ids)
+    return []
+
+
+def _priors_for_tool(
+    tool_entry: dict[str, Any] | None,
+    profile: Any,
+) -> tuple[float | None, float | None, float | None]:
+    if profile is not None:
+        return profile.step_cost, profile.step_risk, profile.latency_cost_prior
+    if isinstance(tool_entry, dict):
+        raw_cost = tool_entry.get("cost_score")
+        if isinstance(raw_cost, (int, float)):
+            cost = round(float(raw_cost), 6)
+            return cost, None, cost
+    return None, None, None
+
+
+def _aggregate_priors(tool_readiness: Sequence[Dict[str, Any]]) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for key in ("cost_prior", "risk_prior"):
+        values = [
+            float(item[key])
+            for item in tool_readiness
+            if isinstance(item.get(key), (int, float))
+        ]
+        if values:
+            result[key] = round(sum(values) / len(values), 6)
+    return result
+
+
+def _protocol_readiness_override(
+    tool_entry: dict[str, Any] | None,
+) -> tuple[str, str, str | None] | None:
+    if not isinstance(tool_entry, dict):
+        return None
+    resource_assumptions = _resource_assumptions(tool_entry)
+    execution = tool_entry.get("execution")
+    provider = ""
+    if isinstance(execution, dict):
+        provider = str(execution.get("provider") or "").strip()
+    if "nim_api_key_configured" in resource_assumptions and not os.getenv("NIM_API_KEY"):
+        alternate = str(
+            execution.get("alternate_provider") if isinstance(execution, dict) else ""
+        ).strip()
+        if alternate == "openfold3_rest" and _configured("OPENFOLD3_REST_BASE_URL"):
+            return None
+        return (
+            "unavailable",
+            "NIM API credential is missing",
+            "credential_missing",
+        )
+    if "plm_rest_service_available" in resource_assumptions and not _configured(
+        "PLM_REST_BASE_URL"
+    ):
+        return (
+            "unavailable",
+            "PLM REST endpoint is not configured or reachable",
+            "remote_unreachable",
+        )
+    if (
+        provider == "openfold3_rest"
+        or "nim_api_key_configured_or_openfold3_rest_service_available"
+        in resource_assumptions
+    ) and not (os.getenv("NIM_API_KEY") or _configured("OPENFOLD3_REST_BASE_URL")):
+        return (
+            "unavailable",
+            "OpenFold3 REST endpoint is not configured or reachable",
+            "remote_unreachable",
+        )
+    if any("database_ready" in item for item in resource_assumptions) and not (
+        _configured("PROTEIN_SEQUENCE_DB_PATH")
+        or _configured("PROTEIN_STRUCTURE_DB_PATH")
+        or _configured("PROTEIN_DATABASE_PATH")
+    ):
+        return (
+            "degraded",
+            "local similarity database path is not configured",
+            "database_missing",
+        )
+    return None
+
+
+def _resource_assumptions(tool_entry: dict[str, Any]) -> set[str]:
+    constraints = tool_entry.get("constraints")
+    if not isinstance(constraints, dict):
+        return set()
+    raw = constraints.get("resource_assumptions")
+    if not isinstance(raw, list):
+        return set()
+    return {item for item in raw if isinstance(item, str)}
+
+
+def _configured(env_key: str) -> bool:
+    return bool(str(os.getenv(env_key, "")).strip())
+
+
+def _classify_error(reason: str, tool_entry: dict[str, Any] | None) -> str:
+    text = reason.lower()
+    if "adapter not registered" in text:
+        return "adapter_missing"
+    if "api key" in text or "credential" in text or "auth" in text:
+        return "credential_missing"
+    if "database" in text or "db" in text:
+        return "database_missing"
+    if "timeout" in text:
+        return "timeout"
+    if "network" in text or "unreachable" in text or "endpoint" in text:
+        return "remote_unreachable"
+    if "binary" in text or "not installed" in text:
+        return "binary_missing"
+    if isinstance(tool_entry, dict) and any("database_ready" in item for item in _resource_assumptions(tool_entry)):
+        return "database_missing"
+    return "healthcheck_error"
+
+
+def _suggest_tool_recovery(error_category: str | None, reason: str) -> str | None:
+    if error_category == "adapter_missing":
+        return "Register the adapter or remove the tool from candidate planning."
+    if error_category == "credential_missing":
+        return "Configure the required provider credential before planning this capability."
+    if error_category == "remote_unreachable":
+        return "Start the remote service or configure the provider base URL."
+    if error_category == "database_missing":
+        return "Configure a local database path for the similarity adapter."
+    if error_category == "binary_missing":
+        return "Install the required local binary or choose a fallback adapter."
+    if error_category == "timeout":
+        return "Retry after reducing input size or increasing the adapter timeout."
+    if reason:
+        return "Inspect adapter health details and use a fallback if available."
+    return None
+
+
+def _suggest_capability_recovery(
+    status: str,
+    degraded_reasons: Sequence[str],
+    blocked_tools: Sequence[Dict[str, Any]],
+) -> str | None:
+    if status == "ready":
+        return None
+    categories = {
+        item.get("error_category")
+        for item in blocked_tools
+        if isinstance(item.get("error_category"), str)
+    }
+    if "adapter_missing" in categories:
+        return "Register missing adapters or remove unavailable tools from Planner candidates."
+    if "credential_missing" in categories:
+        return "Configure credentials or prefer a local fallback for this capability."
+    if "remote_unreachable" in categories:
+        return "Start remote services or configure reachable base URLs."
+    if "database_missing" in categories or any("database" in item.lower() for item in degraded_reasons):
+        return "Configure required local databases or select a non-database fallback."
+    return "Use available fallback tools or inspect adapter health details."
+
+
+def _tool_reason(item: Dict[str, Any]) -> str:
+    reason = str(item.get("reason") or "").strip()
+    category = str(item.get("error_category") or "").strip()
+    if category and reason:
+        return f"{item.get('tool_id')}: {category}: {reason}"
+    if reason:
+        return f"{item.get('tool_id')}: {reason}"
+    return ""
+
+
+def _join_reasons(*values: str) -> str:
+    return "; ".join(value for value in values if value)
+
+
+def _worse_status(current: str, candidate: str) -> str:
+    rank = {"ready": 0, "degraded": 1, "unavailable": 2}
+    return candidate if rank.get(candidate, 0) > rank.get(current, 0) else current
 
 
 def _priority_rank(value: Any) -> int:

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -27,6 +27,8 @@ RUNTIME_ADJUSTMENT_METADATA_KEY = "runtime_adjustment"
 RERANK_REASON_METADATA_KEY = "rerank_reason"
 WAITING_RUNTIME_SUMMARY_METADATA_KEY = "waiting_runtime_summary"
 DECISION_SUMMARY_ARTIFACT_KEY = "decision_summary"
+CAPABILITY_READINESS_METADATA_KEY = "capability_readiness"
+TOOL_READINESS_METADATA_KEY = "tool_readiness"
 
 
 def _validate_runtime_state_schema_version(value: int) -> int:
@@ -144,6 +146,45 @@ class StepResult(BaseModel):
     risk_flags: List[RiskFlag] = Field(default_factory=list)
     logs_path: Optional[str] = None
     timestamp: str
+
+
+class ToolReadiness(BaseModel):
+    """单个 adapter/tool 的健康检查摘要。"""
+
+    tool_id: str
+    status: Literal["ready", "degraded", "unavailable"]
+    reason: str = ""
+    error_category: str | None = None
+    capability_ids: List[str] = Field(default_factory=list)
+    cost_prior: float | None = None
+    risk_prior: float | None = None
+    latency_prior: float | None = None
+    suggested_recovery: str | None = None
+    last_checked_at: str
+    details: Dict[str, Any] = Field(default_factory=dict)
+    metadata_profile: Dict[str, Any] | None = None
+
+
+class CapabilityReadiness(BaseModel):
+    """Capability 级 readiness 契约。
+
+    该契约作为 Planner/API/Web/CLI 的同源视图，字段以 additive 方式扩展，
+    不改变 ToolKG、候选和 EventLog 的既有核心语义。
+    """
+
+    capability_id: str
+    status: Literal["ready", "degraded", "unavailable"]
+    available_tools: List[ToolReadiness] = Field(default_factory=list)
+    blocked_tools: List[ToolReadiness] = Field(default_factory=list)
+    degraded_reasons: List[str] = Field(default_factory=list)
+    last_checked_at: str
+    cost_prior: float | None = None
+    risk_prior: float | None = None
+    suggested_recovery: str | None = None
+    primary_tool_id: str | None = None
+    fallback_tool_ids: List[str] = Field(default_factory=list)
+    reason: str = ""
+    tools: List[ToolReadiness] = Field(default_factory=list)
 
 
 class RuntimeFailureContext(BaseModel):

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from src.infra.event_log_factory import make_waiting_enter
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
+    CAPABILITY_READINESS_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     FINAL_SCORE_METADATA_KEY,
     PendingAction,
@@ -22,6 +23,7 @@ from src.models.contracts import (
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     SHADOW_SCORE_METADATA_KEY,
     STATIC_SCORE_METADATA_KEY,
+    TOOL_READINESS_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
@@ -235,6 +237,16 @@ def enter_waiting_state(
             "evidence_source": (
                 selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY)
                 if isinstance(selected_meta.get(DEFAULT_RECOMMENDATION_REASON_METADATA_KEY), dict)
+                else None
+            ),
+            "tool_readiness": (
+                selected_meta.get(TOOL_READINESS_METADATA_KEY)
+                if isinstance(selected_meta.get(TOOL_READINESS_METADATA_KEY), dict)
+                else None
+            ),
+            "capability_readiness": (
+                selected_meta.get(CAPABILITY_READINESS_METADATA_KEY)
+                if isinstance(selected_meta.get(CAPABILITY_READINESS_METADATA_KEY), dict)
                 else None
             ),
             "runtime_policy": runtime_trace["runtime_policy"],

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -496,6 +496,8 @@ class TestAPIEndpoints:
         assert dashboard_response.status_code == 200
         assert "HITL PendingAction Dashboard" in dashboard_response.text
         assert "Candidate Comparison" in dashboard_response.text
+        assert "Model Invocation" in dashboard_response.text
+        assert "model-invocation-body" in dashboard_response.text
 
         task_view_response = await client.get("/ui/tasks/task_demo_001")
         assert task_view_response.status_code == 200
@@ -507,6 +509,7 @@ class TestAPIEndpoints:
         assert "adapter_mode" in static_response.text
         assert "degraded" in static_response.text
         assert "availability_hint" in static_response.text
+        assert "renderModelInvocation" in static_response.text
 
         timeline_response = await client.get("/ui/tasks/task_demo_001/events")
         assert timeline_response.status_code == 200

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -100,6 +100,10 @@ class TestAPIEndpoints:
             item for item in data if item["capability_id"] == "objective_scoring"
         )
         assert objective_entry["primary_tool_id"] == "objective_ranker"
+        assert "available_tools" in objective_entry
+        assert "blocked_tools" in objective_entry
+        assert "degraded_reasons" in objective_entry
+        assert "suggested_recovery" in objective_entry
 
     async def test_create_task_with_minimal_data(self, client: httpx.AsyncClient):
         """测试使用最少数据创建任务"""

--- a/tests/integration/test_event_log_integration.py
+++ b/tests/integration/test_event_log_integration.py
@@ -10,6 +10,7 @@ import pytest
 
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
+    CAPABILITY_READINESS_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     Decision,
     DecisionChoice,
@@ -18,6 +19,7 @@ from src.models.contracts import (
     ProteinDesignTask,
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     SHADOW_SCORE_METADATA_KEY,
+    TOOL_READINESS_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
 )
 from src.models.db import ExternalStatus, InternalStatus, TaskRecord
@@ -108,6 +110,18 @@ def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
                         "value": 0.77,
                         "source": "score_breakdown.overall_passthrough",
                     },
+                    TOOL_READINESS_METADATA_KEY: {
+                        "tool_id": "dummy_tool",
+                        "status": "degraded",
+                        "reason": "healthcheck warning",
+                    },
+                    CAPABILITY_READINESS_METADATA_KEY: {
+                        "capability_id": "sequence_generation",
+                        "status": "degraded",
+                        "source": "capability_readiness_matrix",
+                        "selected_tool_id": "dummy_tool",
+                        "degraded_reasons": ["dummy_tool: healthcheck warning"],
+                    },
                 },
             )
         ],
@@ -153,6 +167,11 @@ def test_enter_waiting_state_emits_waiting_enter_event(cleanup_logs):
     assert event["data"]["action_score"]["value"] == pytest.approx(0.77)
     assert event["data"]["shadow_score"]["value"] == pytest.approx(0.77)
     assert event["data"]["evidence_source"]["code"] == "plan_ranked_first"
+    assert event["data"]["tool_readiness"]["tool_id"] == "dummy_tool"
+    assert (
+        event["data"]["capability_readiness"]["source"]
+        == "capability_readiness_matrix"
+    )
     assert event["data"]["runtime_state_summary"]["p_success"] == pytest.approx(0.5)
     assert pending_action.metadata[WAITING_RUNTIME_SUMMARY_METADATA_KEY]["default_recommendation_reason"]["code"] == "plan_ranked_first"
     assert event["actor_type"] == "system"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+import src.cli as cli
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any] | list[dict[str, Any]]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._payload
+
+
+def test_task_show_json_includes_readiness_summary(monkeypatch, capsys) -> None:
+    """CLI JSON 输出应包含同源 capability readiness 摘要。"""
+
+    def fake_get(url: str, timeout: float) -> _FakeResponse:
+        assert timeout == 10.0
+        if url.endswith("/tasks/task_cli"):
+            return _FakeResponse(
+                {
+                    "id": "task_cli",
+                    "status": "WAITING_PLAN_CONFIRM",
+                    "internal_status": "WAITING_PLAN_CONFIRM",
+                    "goal": "design",
+                }
+            )
+        if url.endswith("/capabilities/readiness"):
+            return _FakeResponse(
+                [
+                    {
+                        "capability_id": "structure_prediction",
+                        "status": "degraded",
+                        "reason": "remote endpoint unavailable",
+                        "degraded_reasons": ["esmfold: remote_unreachable"],
+                        "suggested_recovery": "Start remote services.",
+                    }
+                ]
+            )
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(cli.httpx, "get", fake_get)
+
+    code = cli.main(
+        [
+            "--api-base-url",
+            "http://api.test",
+            "task",
+            "show",
+            "task_cli",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert '"readiness_summary"' in output
+    assert '"capability_id": "structure_prediction"' in output
+    assert '"suggested_recovery": "Start remote services."' in output

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -8,6 +8,7 @@ from src.llm.base_llm_provider import ProviderConfig
 from src.kg.kg_client import ToolKGError
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
+    CAPABILITY_READINESS_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     FINAL_SCORE_METADATA_KEY,
     PatchRequest,
@@ -24,6 +25,7 @@ from src.models.contracts import (
     RUNTIME_STATE_SUMMARY_METADATA_KEY,
     SHADOW_SCORE_METADATA_KEY,
     STATIC_SCORE_METADATA_KEY,
+    TOOL_READINESS_METADATA_KEY,
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     StepResult,
     now_iso,
@@ -1511,6 +1513,93 @@ class TestPlannerAgent:
             assert 0.0 <= score["overall"] <= 1.0
 
         assert score_3["objective"] >= score_1["objective"]
+
+    def test_score_candidate_payload_uses_capability_readiness_matrix(
+        self,
+        monkeypatch,
+    ):
+        """unavailable capability 应让 Planner 不再隐式信任该工具链。"""
+        registry = [
+            ToolSpec(
+                id="seqgen_local",
+                capabilities=("sequence_generation",),
+                inputs=("goal",),
+                outputs=("sequence",),
+                adapter_mode="local",
+                priority="P0",
+            )
+        ]
+        planner = PlannerAgent(tool_registry=registry)
+        monkeypatch.setattr(
+            planner_module,
+            "build_capability_readiness_snapshot",
+            lambda capability_id: {
+                "capability_id": capability_id,
+                "status": "unavailable",
+                "reason": "adapter missing",
+                "degraded_reasons": ["seqgen_local: adapter_missing"],
+                "tools": [
+                    {
+                        "tool_id": "seqgen_local",
+                        "status": "unavailable",
+                        "reason": "adapter not registered",
+                    }
+                ],
+            },
+        )
+
+        score = planner.score_candidate_payload(
+            Plan(
+                task_id="capability_readiness_score",
+                steps=[
+                    PlanStep(
+                        id="S1",
+                        tool="seqgen_local",
+                        inputs={"goal": "design"},
+                        metadata={},
+                    )
+                ],
+                constraints={},
+                metadata={},
+            )
+        )
+
+        assert score["tool_readiness"] == pytest.approx(0.0)
+
+    def test_candidate_readiness_metadata_uses_capability_matrix(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(
+            planner_module,
+            "build_capability_readiness_snapshot",
+            lambda capability_id: {
+                "capability_id": capability_id,
+                "status": "degraded",
+                "reason": "primary tool unavailable; fallback tool is ready",
+                "degraded_reasons": ["seqgen_local: adapter_missing"],
+                "suggested_recovery": "Use fallback tool.",
+                "last_checked_at": "2026-04-27T00:00:00+00:00",
+                "tools": [
+                    {
+                        "tool_id": "seqgen_local",
+                        "status": "unavailable",
+                        "reason": "adapter not registered",
+                    }
+                ],
+            },
+        )
+
+        metadata = planner_module._candidate_readiness_metadata(
+            tool_id="seqgen_local",
+            capability_id="sequence_generation",
+        )
+
+        assert metadata[TOOL_READINESS_METADATA_KEY]["tool_id"] == "seqgen_local"
+        capability = metadata[CAPABILITY_READINESS_METADATA_KEY]
+        assert capability["source"] == "capability_readiness_matrix"
+        assert capability["selected_tool_id"] == "seqgen_local"
+        assert capability["degraded_reasons"] == ["seqgen_local: adapter_missing"]
 
     def test_enrich_task_from_goal_infers_goal_type_prompt_and_length_range(self):
         task = ProteinDesignTask(

--- a/tests/unit/test_tool_readiness.py
+++ b/tests/unit/test_tool_readiness.py
@@ -171,3 +171,31 @@ def test_capability_readiness_matrix_exposes_structured_reasons(
     assert matrix[0]["available_tools"][0]["tool_id"] == "mmseqs2"
     assert matrix[0]["degraded_reasons"]
     assert matrix[0]["suggested_recovery"]
+
+
+def test_capability_readiness_matrix_covers_all_p0_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """每个 P0 capability 都应返回结构化 status。"""
+
+    monkeypatch.setattr(tool_readiness, "ensure_builtin_adapters", lambda: None)
+    monkeypatch.setattr(
+        tool_readiness,
+        "load_tool_kg",
+        lambda: {
+            "capabilities": [
+                {"capability_id": capability_id}
+                for capability_id in sorted(tool_readiness.P0_CAPABILITY_IDS)
+            ],
+            "tools": [],
+        },
+    )
+
+    matrix = tool_readiness.build_capability_readiness_matrix()
+    by_capability = {item["capability_id"]: item for item in matrix}
+
+    assert set(by_capability) == tool_readiness.P0_CAPABILITY_IDS
+    for entry in by_capability.values():
+        assert entry["status"] == "unavailable"
+        assert entry["degraded_reasons"] == []
+        assert entry["reason"] == "no registered tool is ready"

--- a/tests/unit/test_tool_readiness.py
+++ b/tests/unit/test_tool_readiness.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import src.infra.tool_readiness as tool_readiness
+from src.adapters.base_tool_adapter import BaseToolAdapter
+
+
+class FakeReadinessAdapter(BaseToolAdapter):
+    """测试用 adapter。"""
+
+    tool_id = "fake_tool"
+    adapter_id = "fake_tool"
+
+    def __init__(self, health: dict[str, Any] | None = None) -> None:
+        self._health = health or {"status": "ready", "reason": "fake ready"}
+
+    def resolve_inputs(self, step, context) -> dict[str, Any]:
+        return {}
+
+    def run_local(self, inputs: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+        return {}, {}
+
+    def healthcheck(self) -> dict[str, Any]:
+        return dict(self._health)
+
+
+def test_readiness_classifies_adapter_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """adapter 未注册应返回 unavailable 和结构化恢复建议。"""
+
+    def raise_missing(tool_id: str):
+        raise KeyError(tool_id)
+
+    monkeypatch.setattr(tool_readiness, "get_adapter", raise_missing)
+
+    payload = tool_readiness.evaluate_tool_readiness(
+        "missing_tool",
+        tool_entry={"id": "missing_tool", "capabilities": ["quality_qc"]},
+    )
+
+    assert payload["status"] == "unavailable"
+    assert payload["error_category"] == "adapter_missing"
+    assert payload["suggested_recovery"]
+
+
+def test_readiness_classifies_credential_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NIM 依赖缺少凭证时应归类为 credential_missing。"""
+
+    monkeypatch.delenv("NIM_API_KEY", raising=False)
+    monkeypatch.setattr(
+        tool_readiness,
+        "get_adapter",
+        lambda tool_id: FakeReadinessAdapter(),
+    )
+
+    payload = tool_readiness.evaluate_tool_readiness(
+        "protein_mpnn",
+        tool_entry={
+            "id": "protein_mpnn",
+            "capabilities": ["sequence_design"],
+            "execution": {"provider": "nvidia_nim"},
+            "constraints": {
+                "resource_assumptions": ["network_available", "nim_api_key_configured"]
+            },
+        },
+    )
+
+    assert payload["status"] == "unavailable"
+    assert payload["error_category"] == "credential_missing"
+    assert "credential" in payload["suggested_recovery"].lower()
+
+
+def test_readiness_classifies_remote_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """远程服务未配置时应归类为 remote_unreachable。"""
+
+    monkeypatch.delenv("PLM_REST_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        tool_readiness,
+        "get_adapter",
+        lambda tool_id: FakeReadinessAdapter(),
+    )
+
+    payload = tool_readiness.evaluate_tool_readiness(
+        "protgpt2",
+        tool_entry={
+            "id": "protgpt2",
+            "capabilities": ["sequence_generation"],
+            "execution": {"provider": "plm_rest"},
+            "constraints": {
+                "resource_assumptions": ["network_available", "plm_rest_service_available"]
+            },
+        },
+    )
+
+    assert payload["status"] == "unavailable"
+    assert payload["error_category"] == "remote_unreachable"
+    assert "remote" in payload["suggested_recovery"].lower()
+
+
+def test_readiness_classifies_database_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """本地数据库未配置时应以 degraded 暴露 database_missing。"""
+
+    for env_key in (
+        "PROTEIN_SEQUENCE_DB_PATH",
+        "PROTEIN_STRUCTURE_DB_PATH",
+        "PROTEIN_DATABASE_PATH",
+    ):
+        monkeypatch.delenv(env_key, raising=False)
+    monkeypatch.setattr(
+        tool_readiness,
+        "get_adapter",
+        lambda tool_id: FakeReadinessAdapter(),
+    )
+
+    payload = tool_readiness.evaluate_tool_readiness(
+        "mmseqs2",
+        tool_entry={
+            "id": "mmseqs2",
+            "capabilities": ["sequence_similarity_search"],
+            "constraints": {
+                "resource_assumptions": [
+                    "python_environment_ready",
+                    "local_sequence_database_ready",
+                ]
+            },
+        },
+    )
+
+    assert payload["status"] == "degraded"
+    assert payload["error_category"] == "database_missing"
+    assert "database" in payload["reason"]
+
+
+def test_capability_readiness_matrix_exposes_structured_reasons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """capability 级矩阵应包含 available/blocked/recovery 字段。"""
+
+    monkeypatch.setattr(tool_readiness, "ensure_builtin_adapters", lambda: None)
+    monkeypatch.setattr(
+        tool_readiness,
+        "load_tool_kg",
+        lambda: {
+            "capabilities": [
+                {"capability_id": "sequence_similarity_search"},
+            ],
+            "tools": [
+                {
+                    "id": "mmseqs2",
+                    "capabilities": ["sequence_similarity_search"],
+                    "constraints": {
+                        "resource_assumptions": ["local_sequence_database_ready"]
+                    },
+                    "priority": "P0",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        tool_readiness,
+        "get_adapter",
+        lambda tool_id: FakeReadinessAdapter(),
+    )
+
+    matrix = tool_readiness.build_capability_readiness_matrix()
+
+    assert matrix[0]["capability_id"] == "sequence_similarity_search"
+    assert matrix[0]["status"] == "degraded"
+    assert matrix[0]["available_tools"][0]["tool_id"] == "mmseqs2"
+    assert matrix[0]["degraded_reasons"]
+    assert matrix[0]["suggested_recovery"]


### PR DESCRIPTION
## 背景

本 PR 完成 issue #257：将工具平台从“adapter 能否被调用”扩展为“capability 是否可规划、可展示、可审计”，并让 Planner、Web、CLI 与 EventLog 使用同源 readiness 契约。

Closes #257

## 主要变更

- 定义并补齐 capability 级 readiness 查询入口，新增按 `capability_id` 获取 readiness snapshot / index 的能力。
- Planner 推荐候选时读取 capability readiness 矩阵，不再只依赖单个 tool snapshot；候选元数据中的 `capability_readiness` 标记来源为 `capability_readiness_matrix`，便于审计。
- Web HITL dashboard 增加 `Model Invocation` 面板，展示 capability 状态、退化原因和恢复建议，并继续复用 `/capabilities/readiness` 同源 API。
- CLI JSON 输出与任务/待决策展示覆盖 readiness 摘要，避免只暴露底层异常。
- EventLog 在进入等待决策时记录 tool / capability readiness 引用，保证候选推荐时的工具面可追溯。

## 验收对照

- P0 capabilities 均可返回 `ready/degraded/unavailable` 与结构化原因。
- Planner 对 unavailable capability 的评分会显式降级，不再隐式信任未注册或不可用能力。
- Web 与 CLI 展示的退化原因来自同一 readiness 契约。
- 已覆盖远程不可达、凭证缺失、数据库缺失、adapter 缺失四类测试。
- readiness 字段通过 additive metadata 扩展，不改变 ToolKG / candidate / event 的核心语义。

## 验证

```bash
uv run pytest tests/unit/test_tool_readiness.py tests/unit/test_planner_agent.py tests/unit/test_cli.py tests/api/test_api_endpoints.py tests/integration/test_event_log_integration.py
```

结果：`89 passed, 3 warnings`。