### PR TITLE
feat(objective): 接入 objective_ranker v1 执行闭环

### DIFF
--- a/src/adapters/objective_ranker_adapter.py
+++ b/src/adapters/objective_ranker_adapter.py
@@ -44,7 +44,15 @@ class ObjectiveRankerAdapter(BaseToolAdapter):
 
         t0 = perf_counter()
         weights = _resolve_weights(inputs.get("objective_weights"))
-        scored_candidates = [_score_candidate(candidate, index=index, weights=weights) for index, candidate in enumerate(candidates, start=1)]
+        shared_context = _extract_shared_context(inputs)
+        scored_candidates = [
+            _score_candidate(
+                _merge_candidate_context(candidate, shared_context),
+                index=index,
+                weights=weights,
+            )
+            for index, candidate in enumerate(candidates, start=1)
+        ]
         scored_candidates.sort(
             key=lambda item: (
                 float(item.get("objective_score", 0.0)),
@@ -69,7 +77,8 @@ class ObjectiveRankerAdapter(BaseToolAdapter):
         outputs = build_objective_outputs(
             self.tool_id,
             {**inputs, "input_candidate_count": len(candidates)},
-            selected,
+            scored_candidates,
+            top_k_candidates=selected,
             default_recommendation=default_recommendation,
             explanation=explanation,
         )
@@ -79,6 +88,11 @@ class ObjectiveRankerAdapter(BaseToolAdapter):
         )
         metrics["duration_ms"] = int((perf_counter() - t0) * 1000)
         metrics["weights"] = weights
+        metrics["objective_progress"] = outputs.get("objective_score")
+        metrics["objective_gap"] = _objective_gap(scored_candidates)
+        metrics["warning_count"] = len(outputs.get("warnings") or [])
+        if default_recommendation:
+            metrics["top_candidate_id"] = default_recommendation
         return outputs, metrics
 
 
@@ -112,6 +126,30 @@ def _resolve_top_k(raw: Any, *, default: int) -> int:
     return max(1, value)
 
 
+def _extract_shared_context(inputs: Dict[str, Any]) -> Dict[str, Any]:
+    keys = (
+        "sequence",
+        "structure_pdb",
+        "pdb_path",
+        "qc_metrics",
+        "similarity_hits",
+        "structure_similarity_hits",
+        "secondary_structure_summary",
+        "task_constraints",
+    )
+    return {key: inputs[key] for key in keys if key in inputs}
+
+
+def _merge_candidate_context(
+    candidate: Any,
+    shared_context: Dict[str, Any],
+) -> Dict[str, Any]:
+    row = dict(candidate) if isinstance(candidate, dict) else {}
+    for key, value in shared_context.items():
+        row.setdefault(key, value)
+    return row
+
+
 def _score_candidate(
     candidate: Any,
     *,
@@ -141,17 +179,29 @@ def _score_candidate(
         sum(score_breakdown[key] * weights[key] for key in score_breakdown),
         6,
     )
+    warnings = _candidate_warnings(row)
+    evidence_refs = _candidate_evidence_refs(row, candidate_id)
+    rank_reason = _rank_reason(
+        candidate_id=candidate_id,
+        objective_score=objective_score,
+        score_breakdown=score_breakdown,
+        warnings=warnings,
+    )
 
     return {
         **row,
         "candidate_id": candidate_id,
         "objective_score": objective_score,
         "score_breakdown": score_breakdown,
+        "component_scores": score_breakdown,
         "top_k_rank": index,
         "objective_explanation": (
             f"quality={quality:.3f}, novelty={novelty:.3f}, stability={stability:.3f}, "
             f"function={function:.3f}, docking={docking:.3f}"
         ),
+        "rank_reason": rank_reason,
+        "warnings": warnings,
+        "evidence_refs": evidence_refs,
     }
 
 
@@ -160,6 +210,8 @@ def _quality_score(candidate: Dict[str, Any]) -> float:
     if plddt is None:
         plddt = _as_float(_deep_get(candidate, "metrics", "plddt_mean"))
     qc_metrics = candidate.get("qc_metrics")
+    if plddt is None and isinstance(qc_metrics, dict):
+        plddt = _as_float(qc_metrics.get("plddt_mean"))
     pass_fail = candidate.get("pass_fail")
     if pass_fail is None and isinstance(qc_metrics, dict):
         pass_fail = qc_metrics.get("pass_fail")
@@ -181,6 +233,16 @@ def _novelty_score(candidate: Dict[str, Any]) -> float:
 def _stability_score(candidate: Dict[str, Any]) -> float:
     stability_metrics = candidate.get("stability_metrics")
     if not isinstance(stability_metrics, dict):
+        secondary = candidate.get("secondary_structure_summary")
+        if isinstance(secondary, dict):
+            coil_fraction = _as_float(secondary.get("coil_fraction"))
+            if coil_fraction is None:
+                coil_fraction = _as_float(secondary.get("coil"))
+            if coil_fraction is not None:
+                return round(
+                    min(max(0.75 - min(coil_fraction, 1.0) * 0.25, 0.0), 1.0),
+                    6,
+                )
         return 0.5
     rg = _as_float(stability_metrics.get("radius_of_gyration"))
     span = _as_float(stability_metrics.get("coordinate_span"))
@@ -230,6 +292,91 @@ def _extract_similarity_value(candidate: Dict[str, Any], key: str) -> float | No
     if isinstance(structure_hits, list) and structure_hits and isinstance(structure_hits[0], dict):
         return _as_float(structure_hits[0].get(key))
     return None
+
+
+def _candidate_warnings(candidate: Dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    qc_metrics = candidate.get("qc_metrics")
+    qc_plddt = (
+        _as_float(qc_metrics.get("plddt_mean")) if isinstance(qc_metrics, dict) else None
+    )
+    if _as_float(candidate.get("plddt")) is None and _as_float(
+        _deep_get(candidate, "metrics", "plddt_mean")
+    ) is None and qc_plddt is None:
+        warnings.append("quality uses neutral proxy because pLDDT is missing")
+    if _extract_similarity_value(candidate, "identity") is None:
+        warnings.append("novelty uses neutral proxy because similarity hits are missing")
+    if not isinstance(candidate.get("stability_metrics"), dict) and not isinstance(
+        candidate.get("secondary_structure_summary"),
+        dict,
+    ):
+        warnings.append("stability uses neutral proxy because stability metrics are missing")
+    if not isinstance(candidate.get("annotation_summary"), dict) and not isinstance(
+        candidate.get("function_terms"),
+        list,
+    ):
+        warnings.append("function uses neutral proxy because annotation evidence is missing")
+    if _as_float(candidate.get("binding_score")) is None and not isinstance(
+        candidate.get("best_pose"),
+        dict,
+    ):
+        warnings.append("docking uses neutral proxy because binding evidence is missing")
+    return warnings
+
+
+def _candidate_evidence_refs(
+    candidate: Dict[str, Any],
+    candidate_id: str,
+) -> list[Dict[str, Any]]:
+    refs: list[Dict[str, Any]] = []
+    field_groups = {
+        "quality": ("plddt", "metrics", "qc_metrics", "pass_fail"),
+        "novelty": ("similarity_hits", "structure_similarity_hits", "top_hit"),
+        "stability": ("stability_metrics", "secondary_structure_summary"),
+        "function": ("annotation_summary", "function_terms"),
+        "docking": ("binding_score", "best_pose"),
+    }
+    for component, fields in field_groups.items():
+        present_fields = [field for field in fields if candidate.get(field) is not None]
+        if present_fields:
+            refs.append(
+                {
+                    "candidate_id": candidate_id,
+                    "component": component,
+                    "fields": present_fields,
+                }
+            )
+    return refs
+
+
+def _rank_reason(
+    *,
+    candidate_id: str,
+    objective_score: float,
+    score_breakdown: Dict[str, float],
+    warnings: list[str],
+) -> str:
+    strongest = sorted(
+        score_breakdown.items(),
+        key=lambda item: item[1],
+        reverse=True,
+    )[:2]
+    strengths = ", ".join(f"{key}={value:.3f}" for key, value in strongest)
+    warning_suffix = "" if not warnings else f"; warnings={len(warnings)}"
+    return (
+        f"{candidate_id} ranks by objective_score={objective_score:.3f} "
+        f"with strongest components {strengths}{warning_suffix}"
+    )
+
+
+def _objective_gap(scored_candidates: list[Dict[str, Any]]) -> float | None:
+    if not scored_candidates:
+        return None
+    if len(scored_candidates) == 1:
+        return 0.0
+    top = _as_float(scored_candidates[0].get("objective_score")) or 0.0
+    runner_up = _as_float(scored_candidates[1].get("objective_score")) or 0.0
+    return round(top - runner_up, 6)
 
 
 def _deep_get(candidate: Dict[str, Any], *path: str) -> Any:

--- a/src/adapters/tool_schema_utils.py
+++ b/src/adapters/tool_schema_utils.py
@@ -310,20 +310,44 @@ def build_objective_outputs(
     inputs: Dict[str, Any],
     scored_candidates: list[Dict[str, Any]],
     *,
+    top_k_candidates: list[Dict[str, Any]] | None = None,
     default_recommendation: str | None,
     explanation: str,
 ) -> Dict[str, Any]:
+    top_k_rows = top_k_candidates if top_k_candidates is not None else scored_candidates
     top_score = (
-        _to_float(scored_candidates[0].get("objective_score"))
-        if scored_candidates
+        _to_float(top_k_rows[0].get("objective_score"))
+        if top_k_rows
         else None
+    )
+    component_scores = {
+        str(row.get("candidate_id") or f"candidate_{index}"): dict(
+            row.get("component_scores") or row.get("score_breakdown") or {}
+        )
+        for index, row in enumerate(scored_candidates, start=1)
+    }
+    warnings = _unique_strings(
+        warning
+        for row in scored_candidates
+        for warning in row.get("warnings", [])
+        if isinstance(row.get("warnings"), list)
+    )
+    evidence_refs = [
+        ref
+        for row in scored_candidates
+        for ref in row.get("evidence_refs", [])
+        if isinstance(row.get("evidence_refs"), list) and isinstance(ref, dict)
+    ]
+    rank_reason = (
+        _to_str(scored_candidates[0].get("rank_reason")) if scored_candidates else None
     )
     return {
         "tool_id": tool_id,
         "capability_id": "objective_scoring",
         "io_type": "candidates_to_objective_scores_topk",
         "score_table": scored_candidates,
-        "top_k": scored_candidates,
+        "top_k": top_k_rows,
+        "component_scores": component_scores,
         "default_recommendation": default_recommendation,
         "objective_score": top_score,
         "score_breakdown": (
@@ -331,9 +355,13 @@ def build_objective_outputs(
             if scored_candidates
             else {}
         ),
+        "warnings": warnings,
+        "evidence_refs": evidence_refs,
+        "rank_reason": rank_reason,
         "objective_explanation": explanation,
         "explanation": explanation,
         "candidate_count": len(scored_candidates),
+        "top_k_count": len(top_k_rows),
         "input_candidate_count": _to_int(inputs.get("input_candidate_count")) or len(scored_candidates),
     }
 
@@ -351,6 +379,18 @@ def build_objective_metrics(
             "io_type": "candidates_to_objective_scores_topk",
         },
     }
+
+
+def _unique_strings(values: Iterable[Any]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = _to_str(value)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
 
 
 def build_stability_outputs(

--- a/src/agents/summarizer.py
+++ b/src/agents/summarizer.py
@@ -41,6 +41,12 @@ class SuccessReport(BaseModel):
     structure_pdb_path: Optional[str] = None
     plddt_mean: Optional[float] = None
     confidence: Optional[str] = None
+    objective_score: Optional[float] = None
+    objective_top_k: List[Dict[str, Any]] = Field(default_factory=list)
+    component_scores: Dict[str, Any] = Field(default_factory=dict)
+    objective_warnings: List[str] = Field(default_factory=list)
+    evidence_refs: List[Dict[str, Any]] = Field(default_factory=list)
+    rank_reason: Optional[str] = None
 
 
 class FailureReport(BaseModel):
@@ -154,6 +160,16 @@ class SummarizerAgent:
             scores["sequence_length"] = seq_len
         # 合并结构预测的分数
         scores.update(structure_scores)
+        objective_scoring = _extract_objective_scoring_summary(context)
+        objective_score = objective_scoring.get("objective_score")
+        if isinstance(objective_score, (int, float)):
+            scores["objective_score"] = objective_score
+        objective_gap = objective_scoring.get("objective_gap")
+        if isinstance(objective_gap, (int, float)):
+            scores["objective_gap"] = objective_gap
+        objective_progress = objective_scoring.get("objective_progress")
+        if isinstance(objective_progress, (int, float)):
+            scores["objective_progress"] = objective_progress
 
         report_dir = Path("output/reports")
         report_dir.mkdir(parents=True, exist_ok=True)
@@ -201,6 +217,7 @@ class SummarizerAgent:
                 "plan_metadata": plan_metadata,
                 "plan_version": plan_version,
                 "execution_steps": execution_steps,
+                "objective_scoring": objective_scoring,
                 **de_novo_report_paths,
             },
         )
@@ -256,6 +273,39 @@ def _select_report_path(
         return fallback_path, "visualization_fallback"
 
     return report_dir / f"{task_id}.json", "summary_json"
+
+
+def _extract_objective_scoring_summary(context: WorkflowContext) -> dict[str, Any]:
+    """从 objective_ranker StepResult 提取可复用的报告摘要。"""
+
+    selected: StepResult | None = None
+    for step_result in context.step_results.values():
+        outputs = step_result.outputs or {}
+        if (
+            step_result.tool == "objective_ranker"
+            or outputs.get("capability_id") == "objective_scoring"
+        ):
+            selected = step_result
+
+    if selected is None:
+        return {}
+
+    outputs = selected.outputs or {}
+    metrics = selected.metrics or {}
+    return {
+        "step_id": selected.step_id,
+        "tool": selected.tool,
+        "objective_score": outputs.get("objective_score"),
+        "objective_progress": metrics.get("objective_progress"),
+        "objective_gap": metrics.get("objective_gap"),
+        "score_table": outputs.get("score_table") or [],
+        "top_k": outputs.get("top_k") or [],
+        "component_scores": outputs.get("component_scores") or {},
+        "warnings": outputs.get("warnings") or [],
+        "evidence_refs": outputs.get("evidence_refs") or [],
+        "rank_reason": outputs.get("rank_reason"),
+        "default_recommendation": outputs.get("default_recommendation"),
+    }
 
 
 def _write_fallback_report(
@@ -395,6 +445,15 @@ def _build_step_summary(step_result: StepResult) -> StepSummary:
             }
         elif key == "pdb_path":
             outputs_summary[key] = value
+        elif key in {
+            "score_table",
+            "top_k",
+            "component_scores",
+            "warnings",
+            "evidence_refs",
+            "rank_reason",
+        }:
+            outputs_summary[key] = value
         elif isinstance(value, (str, int, float, bool)):
             outputs_summary[key] = value
 
@@ -453,6 +512,7 @@ def _build_success_report(context: WorkflowContext) -> SuccessReport:
     structure_pdb_path = None
     plddt_mean = None
     confidence = None
+    objective_scoring = _extract_objective_scoring_summary(context)
 
     for step_result in context.step_results.values():
         outputs = step_result.outputs or {}
@@ -478,6 +538,12 @@ def _build_success_report(context: WorkflowContext) -> SuccessReport:
         structure_pdb_path=structure_pdb_path,
         plddt_mean=plddt_mean,
         confidence=confidence,
+        objective_score=objective_scoring.get("objective_score"),
+        objective_top_k=objective_scoring.get("top_k") or [],
+        component_scores=objective_scoring.get("component_scores") or {},
+        objective_warnings=objective_scoring.get("warnings") or [],
+        evidence_refs=objective_scoring.get("evidence_refs") or [],
+        rank_reason=objective_scoring.get("rank_reason"),
     )
 
 
@@ -677,6 +743,30 @@ def _render_de_novo_markdown(report: DeNovoReport) -> str:
         if sr.confidence:
             lines.append(f"- **置信度等级**: {sr.confidence}")
         lines.append("")
+
+        if sr.objective_score is not None or sr.objective_top_k:
+            lines.append("### 目标评分")
+            lines.append("")
+            if sr.objective_score is not None:
+                lines.append(f"- **综合目标分**: {sr.objective_score:.3f}")
+            if sr.rank_reason:
+                lines.append(f"- **排序理由**: {sr.rank_reason}")
+            if sr.objective_warnings:
+                lines.append(
+                    f"- **评分警告**: {'; '.join(sr.objective_warnings)}"
+                )
+            if sr.objective_top_k:
+                lines.append("")
+                lines.append("| Rank | Candidate | Score | Reason |")
+                lines.append("| --- | --- | ---: | --- |")
+                for row in sr.objective_top_k:
+                    rank = row.get("top_k_rank") or row.get("rank") or "-"
+                    candidate_id = row.get("candidate_id") or row.get("id") or "-"
+                    score = row.get("objective_score")
+                    score_text = f"{score:.3f}" if isinstance(score, (int, float)) else "-"
+                    reason = row.get("rank_reason") or row.get("objective_explanation") or "-"
+                    lines.append(f"| {rank} | `{candidate_id}` | {score_text} | {reason} |")
+            lines.append("")
 
     if report.failure_report:
         lines.append("## 失败分析")

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -216,6 +216,14 @@ class CapabilityReadinessEntry(BaseModel):
     tools: list[ToolReadinessEntry] = Field(default_factory=list)
 
 
+class TaskReportDetail(BaseModel):
+    task_id: str
+    report_path: Optional[str] = None
+    scores: Dict[str, Any] = Field(default_factory=dict)
+    objective_scoring: Dict[str, Any] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
 def _render_ui_html(task_id: Optional[str]) -> str:
     template_path = TEMPLATES_DIR / "index.html"
     if not template_path.exists():
@@ -520,6 +528,29 @@ async def get_task(task_id: str):
     if record is None:
         raise HTTPException(status_code=404, detail="task not found")
     return record
+
+
+@app.get("/tasks/{task_id}/report", response_model=TaskReportDetail)
+async def get_task_report(task_id: str) -> TaskReportDetail:
+    """查看任务最终报告摘要，包含 objective scoring 闭环字段。"""
+
+    record = TASK_STORE.get(task_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="task not found")
+    design_result = record.design_result
+    if design_result is None:
+        raise HTTPException(status_code=404, detail="task report not found")
+    metadata = design_result.metadata if isinstance(design_result.metadata, dict) else {}
+    objective_scoring = metadata.get("objective_scoring")
+    if not isinstance(objective_scoring, dict):
+        objective_scoring = {}
+    return TaskReportDetail(
+        task_id=task_id,
+        report_path=design_result.report_path,
+        scores=dict(design_result.scores or {}),
+        objective_scoring=objective_scoring,
+        metadata=metadata,
+    )
 
 
 def _event_matches_filters(

--- a/src/api/static/css/hitl-dashboard.css
+++ b/src/api/static/css/hitl-dashboard.css
@@ -225,6 +225,29 @@ button:disabled {
   padding: 10px;
 }
 
+.objective-report {
+  margin-top: 12px;
+}
+
+.objective-report table {
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  width: 100%;
+}
+
+.objective-report th,
+.objective-report td {
+  border-bottom: 1px solid var(--line);
+  padding: 6px 4px;
+  text-align: left;
+}
+
+.objective-report .warning-list {
+  color: #8a4b00;
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
 @media (max-width: 760px) {
   .pending-table {
     display: block;

--- a/src/api/static/js/hitl-dashboard.js
+++ b/src/api/static/js/hitl-dashboard.js
@@ -237,8 +237,68 @@ function renderReservedSections(task) {
     byId("reserved-report").textContent = reportPath
         ? `Report path: ${reportPath}`
         : "No report yet. Area reserved for report preview.";
+    renderObjectiveReport(byId("objective-report-explorer"), task.design_result?.metadata?.objective_scoring);
     byId("reserved-steps").textContent =
         "Step timeline area reserved for future execution details.";
+}
+function renderObjectiveReport(container, objective) {
+    container.replaceChildren();
+    if (!objective || !objective.top_k?.length) {
+        return;
+    }
+    const heading = document.createElement("h4");
+    heading.textContent = "Objective Score Table";
+    container.appendChild(heading);
+    const scoreLine = document.createElement("p");
+    const score = objective.objective_score;
+    scoreLine.textContent =
+        typeof score === "number" ? `Top objective score: ${score.toFixed(3)}` : "Top objective score: -";
+    container.appendChild(scoreLine);
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    ["Rank", "Candidate", "Score", "Reason"].forEach((label) => {
+        const th = document.createElement("th");
+        th.textContent = label;
+        headRow.appendChild(th);
+    });
+    head.appendChild(headRow);
+    table.appendChild(head);
+    const body = document.createElement("tbody");
+    objective.top_k.forEach((row) => {
+        const tr = document.createElement("tr");
+        const rankCell = document.createElement("td");
+        rankCell.textContent = String(row.top_k_rank ?? row.rank ?? "-");
+        tr.appendChild(rankCell);
+        const candidateCell = document.createElement("td");
+        candidateCell.textContent = row.candidate_id ?? row.id ?? "-";
+        tr.appendChild(candidateCell);
+        const scoreCell = document.createElement("td");
+        scoreCell.textContent =
+            typeof row.objective_score === "number" ? row.objective_score.toFixed(3) : "-";
+        tr.appendChild(scoreCell);
+        const reasonCell = document.createElement("td");
+        reasonCell.textContent = row.rank_reason ?? row.objective_explanation ?? "-";
+        tr.appendChild(reasonCell);
+        body.appendChild(tr);
+    });
+    table.appendChild(body);
+    container.appendChild(table);
+    if (objective.rank_reason) {
+        const reason = document.createElement("p");
+        reason.textContent = `Rank reason: ${objective.rank_reason}`;
+        container.appendChild(reason);
+    }
+    if (objective.warnings?.length) {
+        const warningList = document.createElement("ul");
+        warningList.className = "warning-list";
+        objective.warnings.forEach((warning) => {
+            const item = document.createElement("li");
+            item.textContent = warning;
+            warningList.appendChild(item);
+        });
+        container.appendChild(warningList);
+    }
 }
 function renderTaskOverview(task) {
     const badge = byId("task-state-badge");

--- a/src/api/static/ts/hitl-dashboard.ts
+++ b/src/api/static/ts/hitl-dashboard.ts
@@ -64,6 +64,26 @@ interface PendingActionDetail {
 interface DesignResult {
   report_path?: string | null;
   scores?: Record<string, number>;
+  metadata?: {
+    objective_scoring?: ObjectiveScoringSummary;
+  };
+}
+
+interface ObjectiveScoringSummary {
+  objective_score?: number | null;
+  top_k?: ObjectiveScoreRow[];
+  warnings?: string[];
+  rank_reason?: string | null;
+}
+
+interface ObjectiveScoreRow {
+  candidate_id?: string;
+  id?: string;
+  top_k_rank?: number;
+  rank?: number;
+  objective_score?: number;
+  rank_reason?: string;
+  objective_explanation?: string;
 }
 
 interface TaskRecord {
@@ -381,9 +401,85 @@ function renderReservedSections(task: TaskRecord): void {
   byId<HTMLParagraphElement>("reserved-report").textContent = reportPath
     ? `Report path: ${reportPath}`
     : "No report yet. Area reserved for report preview.";
+  renderObjectiveReport(
+    byId<HTMLDivElement>("objective-report-explorer"),
+    task.design_result?.metadata?.objective_scoring,
+  );
 
   byId<HTMLParagraphElement>("reserved-steps").textContent =
     "Step timeline area reserved for future execution details.";
+}
+
+function renderObjectiveReport(
+  container: HTMLDivElement,
+  objective: ObjectiveScoringSummary | undefined,
+): void {
+  container.replaceChildren();
+  if (!objective || !objective.top_k?.length) {
+    return;
+  }
+
+  const heading = document.createElement("h4");
+  heading.textContent = "Objective Score Table";
+  container.appendChild(heading);
+
+  const scoreLine = document.createElement("p");
+  const score = objective.objective_score;
+  scoreLine.textContent =
+    typeof score === "number" ? `Top objective score: ${score.toFixed(3)}` : "Top objective score: -";
+  container.appendChild(scoreLine);
+
+  const table = document.createElement("table");
+  const head = document.createElement("thead");
+  const headRow = document.createElement("tr");
+  ["Rank", "Candidate", "Score", "Reason"].forEach((label) => {
+    const th = document.createElement("th");
+    th.textContent = label;
+    headRow.appendChild(th);
+  });
+  head.appendChild(headRow);
+  table.appendChild(head);
+
+  const body = document.createElement("tbody");
+  objective.top_k.forEach((row) => {
+    const tr = document.createElement("tr");
+    const rankCell = document.createElement("td");
+    rankCell.textContent = String(row.top_k_rank ?? row.rank ?? "-");
+    tr.appendChild(rankCell);
+
+    const candidateCell = document.createElement("td");
+    candidateCell.textContent = row.candidate_id ?? row.id ?? "-";
+    tr.appendChild(candidateCell);
+
+    const scoreCell = document.createElement("td");
+    scoreCell.textContent =
+      typeof row.objective_score === "number" ? row.objective_score.toFixed(3) : "-";
+    tr.appendChild(scoreCell);
+
+    const reasonCell = document.createElement("td");
+    reasonCell.textContent = row.rank_reason ?? row.objective_explanation ?? "-";
+    tr.appendChild(reasonCell);
+    body.appendChild(tr);
+  });
+  table.appendChild(body);
+  container.appendChild(table);
+
+  if (objective.rank_reason) {
+    const reason = document.createElement("p");
+    reason.textContent = `Rank reason: ${objective.rank_reason}`;
+    container.appendChild(reason);
+  }
+
+  if (objective.warnings?.length) {
+    const warningList = document.createElement("ul");
+    warningList.className = "warning-list";
+    objective.warnings.forEach((warning) => {
+      const item = document.createElement("li");
+      item.textContent = warning;
+      warningList.appendChild(item);
+    });
+    container.appendChild(warningList);
+  }
 }
 
 function renderTaskOverview(task: TaskRecord): void {

--- a/src/api/templates/index.html
+++ b/src/api/templates/index.html
@@ -138,6 +138,7 @@
           <article>
             <h3>Report Preview</h3>
             <p id="reserved-report">Reserved for report path and final scores.</p>
+            <div id="objective-report-explorer" class="objective-report"></div>
           </article>
         </div>
       </section>

--- a/src/cli.py
+++ b/src/cli.py
@@ -30,6 +30,8 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.command == "pending" and args.pending_command == "show":
             return _pending_show(base_url, args.pending_action_id, emit_json=args.json)
+        if args.command == "report" and args.report_command == "show":
+            return _report_show(base_url, args.task_id, emit_json=args.json)
     except httpx.HTTPError as exc:
         print(f"API request failed: {exc}", file=sys.stderr)
         return 2
@@ -62,6 +64,12 @@ def _build_parser() -> argparse.ArgumentParser:
     pending_show = pending_subparsers.add_parser("show")
     pending_show.add_argument("pending_action_id")
     pending_show.add_argument("--json", action="store_true")
+
+    report_parser = subparsers.add_parser("report")
+    report_subparsers = report_parser.add_subparsers(dest="report_command")
+    report_show = report_subparsers.add_parser("show")
+    report_show.add_argument("task_id")
+    report_show.add_argument("--json", action="store_true")
     return parser
 
 
@@ -105,6 +113,15 @@ def _pending_show(base_url: str, pending_action_id: str, *, emit_json: bool) -> 
         _print_json(payload)
     else:
         _print_pending(payload)
+    return 0
+
+
+def _report_show(base_url: str, task_id: str, *, emit_json: bool) -> int:
+    report = _get_json(base_url, f"/tasks/{task_id}/report")
+    if emit_json:
+        _print_json({"report": report})
+    else:
+        _print_report(report)
     return 0
 
 
@@ -161,6 +178,33 @@ def _print_pending(payload: dict[str, Any]) -> None:
             f"recovery={tool.get('suggested_recovery') or '-'}"
         )
     _print_readiness_summary(payload["readiness_summary"])
+
+
+def _print_report(report: dict[str, Any] | list[dict[str, Any]]) -> None:
+    if not isinstance(report, dict):
+        print("report: unavailable")
+        return
+    print(f"task_id: {report.get('task_id')}")
+    print(f"report_path: {report.get('report_path') or '-'}")
+    scores = report.get("scores") if isinstance(report.get("scores"), dict) else {}
+    print(f"objective_score: {scores.get('objective_score', '-')}")
+    objective = (
+        report.get("objective_scoring")
+        if isinstance(report.get("objective_scoring"), dict)
+        else {}
+    )
+    print(f"rank_reason: {objective.get('rank_reason') or '-'}")
+    warnings = objective.get("warnings") if isinstance(objective.get("warnings"), list) else []
+    print(f"warnings: {len(warnings)}")
+    for row in objective.get("top_k") or []:
+        if not isinstance(row, dict):
+            continue
+        print(
+            "candidate: "
+            f"{row.get('candidate_id') or row.get('id')} "
+            f"rank={row.get('top_k_rank') or '-'} "
+            f"score={row.get('objective_score', '-')}"
+        )
 
 
 def _print_readiness_summary(items: list[dict[str, Any]]) -> None:

--- a/src/kg/protein_tool_kg.json
+++ b/src/kg/protein_tool_kg.json
@@ -1086,20 +1086,44 @@
       "io": {
         "io_type_id": "candidates_to_objective_scores_topk",
         "inputs": {
-          "candidates": "list"
+          "candidates": "list",
+          "sequence": "str",
+          "structure_pdb": "str",
+          "qc_metrics": "dict",
+          "similarity_hits": "list",
+          "secondary_structure_summary": "dict",
+          "objective_weights": "dict",
+          "task_constraints": "dict"
         },
         "outputs": {
           "score_table": "list",
           "top_k": "list",
+          "component_scores": "dict",
+          "objective_score": "float",
+          "warnings": "list",
+          "evidence_refs": "list",
+          "rank_reason": "str",
           "default_recommendation": "str",
           "explanation": "str"
         },
         "input_types": [
-          "candidates"
+          "candidates",
+          "sequence",
+          "structure_pdb",
+          "qc_metrics",
+          "similarity_hits",
+          "secondary_structure_summary",
+          "objective_weights",
+          "task_constraints"
         ],
         "output_types": [
           "score_table",
-          "top_k"
+          "top_k",
+          "component_scores",
+          "objective_score",
+          "warnings",
+          "evidence_refs",
+          "rank_reason"
         ],
         "combinable": true
       },

--- a/src/workflow/belief_state.py
+++ b/src/workflow/belief_state.py
@@ -106,6 +106,16 @@ def update_runtime_state(
             if _is_structural_step(stage_id=stage_id, tool_id=step_result.tool):
                 p_success += 0.04
                 p_structural_failure -= 0.05
+            objective_signal = _extract_objective_signal(step_result)
+            if objective_signal:
+                observation_summary.update(objective_signal)
+                progress = _as_float(objective_signal.get("objective_progress"))
+                gap = _as_float(objective_signal.get("objective_gap"))
+                if progress is not None:
+                    p_success += 0.04 * _clamp_unit_interval(progress)
+                    evidence_sufficiency += 0.03 * _clamp_unit_interval(progress)
+                if gap is not None:
+                    recovery_margin += 0.02 * _clamp_unit_interval(gap)
         elif step_result.status == "failed":
             p_success -= 0.18
             p_structural_failure += 0.14
@@ -490,6 +500,35 @@ def _is_structural_step(*, stage_id: str | None, tool_id: str) -> bool:
     )
 
 
+def _extract_objective_signal(step_result: StepResult) -> dict[str, Any]:
+    metrics = step_result.metrics if isinstance(step_result.metrics, dict) else {}
+    outputs = step_result.outputs if isinstance(step_result.outputs, dict) else {}
+    capability_id = _as_non_empty_text(outputs.get("capability_id"))
+    tool_key = step_result.tool.strip().lower()
+    if capability_id != "objective_scoring" and tool_key != "objective_ranker":
+        return {}
+
+    progress = _as_float(metrics.get("objective_progress"))
+    if progress is None:
+        progress = _as_float(outputs.get("objective_score"))
+    gap = _as_float(metrics.get("objective_gap"))
+    top_candidate_id = _as_non_empty_text(metrics.get("top_candidate_id"))
+    if top_candidate_id is None:
+        top_candidate_id = _as_non_empty_text(outputs.get("default_recommendation"))
+
+    payload: dict[str, Any] = {
+        "objective_progress": (
+            _round_metric(_clamp_unit_interval(progress))
+            if progress is not None
+            else None
+        ),
+        "objective_gap": _round_metric(max(gap, 0.0)) if gap is not None else None,
+        "objective_top_candidate_id": top_candidate_id,
+        "objective_warning_count": metrics.get("warning_count"),
+    }
+    return _drop_none_values(payload)
+
+
 def _clamp_unit_interval(value: float) -> float:
     if value < 0.0:
         return 0.0
@@ -511,6 +550,19 @@ def _as_non_empty_text(value: Any) -> str | None:
 
 def _as_bool(value: Any) -> bool:
     return bool(value)
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _drop_none_values(payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -1053,6 +1053,15 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
             "reject_code_counts": reject_counts if isinstance(reject_counts, dict) else {},
             "failed_samples": failed_samples,
         }
+    if outputs.get("capability_id") == "objective_scoring":
+        data["objective_scoring"] = {
+            "objective_score": outputs.get("objective_score"),
+            "objective_gap": step_result.metrics.get("objective_gap"),
+            "objective_progress": step_result.metrics.get("objective_progress"),
+            "default_recommendation": outputs.get("default_recommendation"),
+            "rank_reason": outputs.get("rank_reason"),
+            "warning_count": step_result.metrics.get("warning_count"),
+        }
     return data
 
 

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -7,6 +7,7 @@ import httpx
 from src.api.main import app, TASK_STORE
 from src.models.contracts import (
     DecisionChoice,
+    DesignResult,
     PendingAction,
     PendingActionCandidate,
     PendingActionStatus,
@@ -104,6 +105,48 @@ class TestAPIEndpoints:
         assert "blocked_tools" in objective_entry
         assert "degraded_reasons" in objective_entry
         assert "suggested_recovery" in objective_entry
+
+    async def test_task_report_endpoint_exposes_objective_scoring(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """报告接口应暴露 objective score table 与排序理由。"""
+
+        task_id = "test_api_report_objective"
+        TASK_STORE[task_id] = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.DONE,
+            internal_status=InternalStatus.DONE,
+            goal="设计候选并排序",
+            constraints={},
+            metadata={},
+            design_result=DesignResult(
+                task_id=task_id,
+                sequence="ACDE",
+                structure_pdb_path=None,
+                scores={"objective_score": 0.81},
+                risk_flags=[],
+                report_path="output/reports/test_api_report_objective.json",
+                metadata={
+                    "objective_scoring": {
+                        "top_k": [
+                            {"candidate_id": "cand_a", "objective_score": 0.81}
+                        ],
+                        "component_scores": {"cand_a": {"quality": 0.9}},
+                        "warnings": ["proxy warning"],
+                        "rank_reason": "cand_a ranks by objective_score=0.810",
+                    }
+                },
+            ),
+        )
+
+        response = await client.get(f"/tasks/{task_id}/report")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["scores"]["objective_score"] == 0.81
+        assert data["objective_scoring"]["top_k"][0]["candidate_id"] == "cand_a"
+        assert data["objective_scoring"]["rank_reason"].startswith("cand_a ranks")
 
     async def test_create_task_with_minimal_data(self, client: httpx.AsyncClient):
         """测试使用最少数据创建任务"""
@@ -498,6 +541,7 @@ class TestAPIEndpoints:
         assert "Candidate Comparison" in dashboard_response.text
         assert "Model Invocation" in dashboard_response.text
         assert "model-invocation-body" in dashboard_response.text
+        assert "objective-report-explorer" in dashboard_response.text
 
         task_view_response = await client.get("/ui/tasks/task_demo_001")
         assert task_view_response.status_code == 200
@@ -510,6 +554,7 @@ class TestAPIEndpoints:
         assert "degraded" in static_response.text
         assert "availability_hint" in static_response.text
         assert "renderModelInvocation" in static_response.text
+        assert "renderObjectiveReport" in static_response.text
 
         timeline_response = await client.get("/ui/tasks/task_demo_001/events")
         assert timeline_response.status_code == 200

--- a/tests/unit/test_belief_state.py
+++ b/tests/unit/test_belief_state.py
@@ -108,6 +108,68 @@ def test_update_runtime_state_accepts_structured_update_input() -> None:
     assert state.evidence_sufficiency == 0.5015
 
 
+def test_runtime_state_consumes_objective_signal_without_overriding_safety_block() -> None:
+    """objective gap/progress 可进入观测摘要，但安全阻断仍会降低成功概率。"""
+
+    step_result = StepResult(
+        task_id="task_belief",
+        step_id="S3",
+        tool="objective_ranker",
+        status="success",
+        failure_type=None,
+        error_message=None,
+        inputs={},
+        outputs={
+            "capability_id": "objective_scoring",
+            "objective_score": 0.9,
+            "default_recommendation": "cand_a",
+        },
+        artifacts={},
+        metrics={
+            "objective_progress": 0.9,
+            "objective_gap": 0.2,
+            "top_candidate_id": "cand_a",
+            "warning_count": 1,
+        },
+        risk_flags=[],
+        logs_path=None,
+        timestamp=now_iso(),
+    )
+    safety_block = SafetyResult(
+        task_id="task_belief",
+        phase="step",
+        scope="step:S3",
+        risk_flags=[
+            RiskFlag(
+                level="block",
+                code="SCHEMA_VIOLATION",
+                message="schema violation",
+                scope="step",
+                step_id="S3",
+                details={},
+            )
+        ],
+        action="block",
+        timestamp=now_iso(),
+    )
+
+    objective_only = update_runtime_state(
+        previous_state=None,
+        step_result=step_result,
+    )
+    blocked = update_runtime_state(
+        previous_state=None,
+        step_result=step_result,
+        safety_result=safety_block,
+    )
+
+    assert blocked.observation_summary["objective_progress"] == 0.9
+    assert blocked.observation_summary["objective_gap"] == 0.2
+    assert blocked.observation_summary["objective_top_candidate_id"] == "cand_a"
+    assert blocked.p_success < objective_only.p_success
+    assert blocked.observation_summary["last_safety_action"] == "block"
+
+
 def test_workflow_context_apply_runtime_state_update_is_runner_entrypoint() -> None:
     task = ProteinDesignTask(task_id="task_belief", goal="demo")
     plan = Plan(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -62,3 +62,44 @@ def test_task_show_json_includes_readiness_summary(monkeypatch, capsys) -> None:
     assert '"readiness_summary"' in output
     assert '"capability_id": "structure_prediction"' in output
     assert '"suggested_recovery": "Start remote services."' in output
+
+
+def test_report_show_json_exposes_objective_scoring(monkeypatch, capsys) -> None:
+    """design report show --json 应输出 objective scoring 报告结构。"""
+
+    def fake_get(url: str, timeout: float) -> _FakeResponse:
+        assert timeout == 10.0
+        if url.endswith("/tasks/task_report/report"):
+            return _FakeResponse(
+                {
+                    "task_id": "task_report",
+                    "report_path": "output/reports/task_report.json",
+                    "scores": {"objective_score": 0.77},
+                    "objective_scoring": {
+                        "top_k": [
+                            {"candidate_id": "cand_a", "objective_score": 0.77}
+                        ],
+                        "rank_reason": "cand_a ranks by objective_score=0.770",
+                    },
+                    "metadata": {},
+                }
+            )
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(cli.httpx, "get", fake_get)
+
+    code = cli.main(
+        [
+            "--api-base-url",
+            "http://api.test",
+            "report",
+            "show",
+            "task_report",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert '"objective_score": 0.77' in output
+    assert '"rank_reason": "cand_a ranks by objective_score=0.770"' in output

--- a/tests/unit/test_extended_tool_adapters.py
+++ b/tests/unit/test_extended_tool_adapters.py
@@ -75,6 +75,12 @@ def test_objective_ranker_scores_candidates_with_proxy_signals() -> None:
 
     assert outputs["default_recommendation"] == "cand_a"
     assert outputs["top_k"][0]["objective_score"] >= outputs["top_k"][1]["objective_score"]
+    assert outputs["component_scores"]["cand_a"]["quality"] > 0
+    assert outputs["rank_reason"].startswith("cand_a ranks by objective_score")
+    assert outputs["evidence_refs"][0]["candidate_id"] == "cand_a"
+    assert isinstance(outputs["warnings"], list)
+    assert metrics["objective_progress"] == outputs["objective_score"]
+    assert metrics["objective_gap"] > 0
     assert metrics["requirement2"]["capability_id"] == "objective_scoring"
 
 

--- a/tests/unit/test_step_runner.py
+++ b/tests/unit/test_step_runner.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 import pytest
 
 from src.adapters.base_tool_adapter import BaseToolAdapter
+from src.adapters.objective_ranker_adapter import ObjectiveRankerAdapter
 from src.adapters.registry import ADAPTER_REGISTRY, register_adapter
 from src.agents import safety
 from src.workflow import context
@@ -688,6 +689,46 @@ def test_run_step_safety_events_added_to_context(empty_context):
     # 最后两个应该是 step 阶段的检查
     assert empty_context.safety_events[-2].phase == "step"
     assert empty_context.safety_events[-1].phase == "step"
+
+
+def test_run_step_executes_objective_ranker_contract(empty_context):
+    """objective_ranker 应进入 StepRunner 执行链并返回可报告字段。"""
+
+    register_adapter(ObjectiveRankerAdapter())
+    step = PlanStep(
+        id="S3",
+        tool="objective_ranker",
+        inputs={
+            "candidates": [
+                {
+                    "candidate_id": "cand_a",
+                    "plddt": 90.0,
+                    "similarity_hits": [{"identity": 0.2}],
+                },
+                {"candidate_id": "cand_b", "plddt": 60.0},
+            ],
+            "top_k": 1,
+        },
+        metadata={
+            "required_outputs": [
+                "score_table",
+                "top_k",
+                "component_scores",
+                "objective_score",
+                "warnings",
+                "evidence_refs",
+                "rank_reason",
+            ],
+        },
+    )
+
+    result = StepRunner().run_step(step, empty_context)
+
+    assert result.status == "success"
+    assert result.outputs["capability_id"] == "objective_scoring"
+    assert result.outputs["top_k"][0]["candidate_id"] == "cand_a"
+    assert result.outputs["component_scores"]["cand_a"]["quality"] > 0
+    assert result.metrics["objective_progress"] == result.outputs["objective_score"]
 
 
 def test_run_step_pre_safety_block_raises(empty_context):

--- a/tests/unit/test_summarizer_agent.py
+++ b/tests/unit/test_summarizer_agent.py
@@ -111,6 +111,55 @@ class TestSummarizerAgent:
         assert result.scores == {}
         assert result.metadata["step_ids"] == []
 
+    def test_summarizer_includes_objective_scoring_report_fields(
+        self,
+        sample_workflow_context: WorkflowContext,
+    ):
+        """objective_ranker 输出应进入 DesignResult 分数与报告元数据。"""
+
+        summarizer = SummarizerAgent()
+        context = sample_workflow_context
+        context.step_results["S3"] = StepResult(
+            task_id=context.task.task_id,
+            step_id="S3",
+            tool="objective_ranker",
+            status="success",
+            failure_type=None,
+            error_message=None,
+            inputs={},
+            outputs={
+                "capability_id": "objective_scoring",
+                "objective_score": 0.82,
+                "score_table": [{"candidate_id": "cand_a", "objective_score": 0.82}],
+                "top_k": [{"candidate_id": "cand_a", "objective_score": 0.82}],
+                "component_scores": {"cand_a": {"quality": 0.9}},
+                "warnings": ["docking uses neutral proxy because binding evidence is missing"],
+                "evidence_refs": [
+                    {
+                        "candidate_id": "cand_a",
+                        "component": "quality",
+                        "fields": ["plddt"],
+                    }
+                ],
+                "rank_reason": "cand_a ranks by objective_score=0.820",
+                "default_recommendation": "cand_a",
+            },
+            artifacts={},
+            metrics={"objective_progress": 0.82, "objective_gap": 0.12},
+            risk_flags=[],
+            logs_path=None,
+            timestamp=now_iso(),
+        )
+
+        result = summarizer.summarize(context)
+
+        assert result.scores["objective_score"] == 0.82
+        assert result.scores["objective_gap"] == 0.12
+        objective = result.metadata["objective_scoring"]
+        assert objective["top_k"][0]["candidate_id"] == "cand_a"
+        assert objective["component_scores"]["cand_a"]["quality"] == 0.9
+        assert objective["warnings"]
+
     def test_summarizer_preserves_sequence_from_task(
         self, sample_workflow_context: WorkflowContext, sample_step_result: StepResult, tmp_path: Path
     ):


### PR DESCRIPTION
## 背景

Closes #258

本 PR 实现 `objective_ranker` v1 与 `objective_scoring` 的执行闭环。此前 `objective_scoring` 已出现在 ToolKG、fallback matrix 与 Top-K explanation 中，但真实 adapter、StepResult 输出、Report 展示、runtime evaluator 消费以及 Web/CLI 可解释输出仍不完整。

本次变更目标是让 objective scoring 从 KG 占位能力变为可执行、可追踪、可报告、可复用的 v1 规则评分链路。

## 主要变更

### objective_ranker v1 adapter

- 扩展 `objective_ranker` 输入支持：`candidates`、`sequence`、`structure_pdb`、`qc_metrics`、`similarity_hits`、`secondary_structure_summary`、`objective_weights`、`task_constraints`。
- 补齐输出结构：`score_table`、`top_k`、`component_scores`、`objective_score`、`warnings`、`evidence_refs`、`rank_reason`。
- 使用可解释规则与权重计算候选分数，不引入新的大模型依赖。
- 对缺失证据显式产生 warning，避免静默使用中性 proxy。
- 增加 `objective_progress`、`objective_gap`、`top_candidate_id` 等 metrics，供 runtime evaluator 和事件链复用。

### ToolKG 与执行链路

- 更新 `protein_tool_kg.json` 中 `objective_ranker` 的输入/输出 metadata。
- `StepRunner` 可将 `objective_ranker` 作为正式 adapter 执行，并通过 required outputs 校验。
- `PlanRunner` 的 step event metadata 现在会记录 objective scoring 摘要，包括总分、gap、progress、默认推荐、排序理由与 warning 数量。

### Report / Summarizer

- `SummarizerAgent` 会从 `objective_ranker` StepResult 提取 objective scoring 摘要。
- `DesignResult.scores` 现在包含 `objective_score`、`objective_gap`、`objective_progress`。
- `DesignResult.metadata.objective_scoring` 现在保留 `score_table`、`top_k`、`component_scores`、`warnings`、`evidence_refs`、`rank_reason`。
- De Novo Markdown 报告新增目标评分区块，展示综合分、排序理由、warning 与 Top-K 表。

### API / CLI / Web

- 新增 `GET /tasks/{task_id}/report`，返回最终报告摘要与 objective scoring 结构。
- 新增 CLI：`design report show <task_id> --json`，输出同一份报告结构。
- Web Task Detail / Report Preview 增加 Objective Score Table，展示候选排序、分数、理由和 warning。
- API 与前端仍只通过任务契约读取数据，不直接修改 workflow 内部状态。

### Runtime evaluator

- `belief_state` 现在能消费 `objective_progress` 与 `objective_gap`。
- objective 分数仅作为弱信号更新成功概率、证据充分性与 recovery margin。
- safety block / schema violation 仍按既有逻辑生效，不会被 objective 分数绕过或覆盖。

## 影响范围

- 让 `objective_ranker` 从 KG/metadata 占位变为真实可执行 adapter。
- objective scoring 结果进入执行链、事件链、报告链、Web、CLI 和 runtime evaluator。
- 最终报告和 API 可以复用 objective scoring 的 Top-K、分项分数、证据来源、排序理由和 warning。
- 不新增 Workflow FSM 状态。
- 不改变 `PendingAction / Decision / TaskSnapshot` 核心语义。
- 不新增 Agent 角色。

## 验证

已运行：

`uv run pytest tests/unit/test_extended_tool_adapters.py tests/unit/test_step_runner.py tests/unit/test_summarizer_agent.py tests/unit/test_belief_state.py tests/unit/test_cli.py tests/api/test_api_endpoints.py`

结果：

`92 passed, 3 warnings`

覆盖路径：

- adapter 输出契约与 proxy scoring
- StepRunner execution path
- Summarizer / Report path
- runtime evaluator objective signal 消费
- CLI `design report show --json`
- API `/tasks/{task_id}/report`
- Web Task Detail 静态资源与 objective report renderer
