### PR TITLE
feat(runtime): 解耦 tool_id 与 execution_mode

### DIFF
--- a/src/adapters/base_tool_adapter.py
+++ b/src/adapters/base_tool_adapter.py
@@ -69,9 +69,15 @@ class BaseToolAdapter(ABC):
 
     def describe_capabilities(self) -> Dict[str, Any]:
         """返回适配器能力摘要。"""
+        execution_mode = getattr(self, "execution_mode", None)
+        if not isinstance(execution_mode, str) or not execution_mode.strip():
+            execution_mode = getattr(self, "default_execution_mode", None)
         return {
             "tool_id": getattr(self, "tool_id", ""),
             "adapter_id": getattr(self, "adapter_id", None),
+            "execution_mode": execution_mode,
+            "provider": getattr(self, "provider", None),
+            "endpoint_type": getattr(self, "endpoint_type", None),
         }
 
     def healthcheck(self) -> Dict[str, Any]:

--- a/src/adapters/nim_adapter.py
+++ b/src/adapters/nim_adapter.py
@@ -22,6 +22,9 @@ class NIMESMFoldAdapter(BaseToolAdapter):
 
     tool_id = "nim_esmfold"
     adapter_id = "nim_esmfold"
+    execution_mode = "nvidia_nim"
+    provider = "nvidia_nim"
+    endpoint_type = "nim"
     max_sequence_length = 400
 
     def __init__(
@@ -144,7 +147,11 @@ class NIMESMFoldAdapter(BaseToolAdapter):
         metrics = {
             "exec_type": "nvidia_nim",
             "duration_ms": duration_ms,
+            "tool_id": self.tool_id,
+            "adapter_id": self.adapter_id,
+            "execution_mode": self.execution_mode,
             "provider": "nvidia_nim",
+            "endpoint_type": self.endpoint_type,
             "model_id": self.model_id,
         }
         return outputs, metrics

--- a/src/adapters/openfold_adapter.py
+++ b/src/adapters/openfold_adapter.py
@@ -56,6 +56,28 @@ class OpenFold3Adapter(BaseToolAdapter):
         self.base_url = base_url
         self.output_dir = Path(output_dir or "output/pdb")
 
+    def describe_capabilities(self) -> Dict[str, Any]:
+        """返回 OpenFold3 适配器的执行通道摘要。"""
+        return {
+            "tool_id": self.tool_id,
+            "adapter_id": self.adapter_id,
+            "execution_mode": self.execution_mode,
+            "provider": (
+                self.rest_provider_name
+                if self.execution_mode in self.rest_provider_aliases
+                else "nvidia_nim"
+                if self.execution_mode == "nvidia_nim"
+                else None
+            ),
+            "endpoint_type": (
+                "rest"
+                if self.execution_mode in self.rest_provider_aliases
+                else "nim"
+                if self.execution_mode == "nvidia_nim"
+                else None
+            ),
+        }
+
     def resolve_inputs(
         self,
         step: PlanStep,
@@ -180,7 +202,11 @@ class OpenFold3Adapter(BaseToolAdapter):
         metrics = {
             "exec_type": "nvidia_nim",
             "duration_ms": int((perf_counter() - t0) * 1000),
+            "tool_id": self.tool_id,
+            "adapter_id": self.adapter_id,
+            "execution_mode": "nvidia_nim",
             "provider": "nvidia_nim",
+            "endpoint_type": "nim",
             "model_id": self.nim_model_id,
         }
         return outputs, metrics
@@ -198,11 +224,17 @@ class OpenFold3Adapter(BaseToolAdapter):
         job_id = service.submit_job(payload=payload, task_id=task_id, step_id=step_id)
         final_status = service.wait_for_completion(job_id)
         if final_status == JobStatus.FAILED:
-            raise StepRunError(
+            error = StepRunError(
                 failure_type=FailureType.TOOL_ERROR,
                 message=f"Remote job {job_id} failed",
                 code=FailureCode.REMOTE_JOB_FAILED.value,
             )
+            error.remote_job_id = job_id  # type: ignore[attr-defined]
+            error.remote_endpoint = getattr(service, "base_url", None)  # type: ignore[attr-defined]
+            error.execution_mode = self.rest_provider_name  # type: ignore[attr-defined]
+            error.provider = self.rest_provider_name  # type: ignore[attr-defined]
+            error.endpoint_type = "rest"  # type: ignore[attr-defined]
+            raise error
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
         outputs = service.download_results(job_id=job_id, output_dir=self.output_dir)
@@ -236,8 +268,13 @@ class OpenFold3Adapter(BaseToolAdapter):
         metrics = {
             "exec_type": "remote",
             "duration_ms": int((perf_counter() - t0) * 1000),
+            "tool_id": self.tool_id,
+            "adapter_id": self.adapter_id,
+            "execution_mode": self.rest_provider_name,
             "provider": self.rest_provider_name,
+            "endpoint_type": "rest",
             "job_id": job_id,
+            "remote_job_id": job_id,
         }
         return outputs, metrics
 

--- a/src/adapters/protgpt2_adapter.py
+++ b/src/adapters/protgpt2_adapter.py
@@ -33,6 +33,9 @@ class ProtGPT2Adapter(BaseToolAdapter):
 
     tool_id = "protgpt2"
     adapter_id = "protgpt2"
+    execution_mode = "plm_rest"
+    provider = "plm_rest"
+    endpoint_type = "rest"
 
     def __init__(
         self,
@@ -142,8 +145,13 @@ class ProtGPT2Adapter(BaseToolAdapter):
         metrics = {
             "exec_type": "remote",
             "duration_ms": duration_ms,
+            "tool_id": self.tool_id,
+            "adapter_id": self.adapter_id,
+            "execution_mode": self.execution_mode,
             "job_id": job_id,
+            "remote_job_id": job_id,
             "provider": "plm_rest",
+            "endpoint_type": self.endpoint_type,
         }
         return outputs, metrics
 

--- a/src/adapters/remote_esmfold_adapter.py
+++ b/src/adapters/remote_esmfold_adapter.py
@@ -39,6 +39,9 @@ class RemoteESMFoldAdapter(BaseToolAdapter):
 
     tool_id = "esmfold"
     adapter_id = "esmfold_remote"
+    execution_mode = "rest"
+    provider = "remote_model_service"
+    endpoint_type = "rest"
 
     def __init__(
         self,
@@ -270,7 +273,13 @@ class RemoteESMFoldAdapter(BaseToolAdapter):
         metrics = {
             "exec_type": "remote",
             "duration_ms": duration_ms,
+            "tool_id": self.tool_id,
+            "adapter_id": self.adapter_id,
+            "execution_mode": self.execution_mode,
+            "provider": self.provider,
+            "endpoint_type": self.endpoint_type,
             "job_id": job_id,
+            "remote_job_id": job_id,
             "resumed": resumed,
         }
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -121,13 +121,19 @@ class TaskTimelineEvent(BaseModel):
     step_id: Optional[str] = None
     tool: Optional[str] = None
     tool_id: Optional[str] = None
+    adapter_id: Optional[str] = None
+    execution_mode: Optional[str] = None
     capability_id: Optional[str] = None
     io_type: Optional[str] = None
     adapter_mode: Optional[str] = None
+    provider: Optional[str] = None
+    endpoint_type: Optional[str] = None
+    remote_job_id: Optional[str] = None
     from_tool: Optional[str] = None
     to_tool: Optional[str] = None
     failure_type: Optional[str] = None
     failure_code: Optional[str] = None
+    recovery_hint: Optional[str] = None
     candidate_id: Optional[str] = None
     decision_source: Optional[str] = None
     recovery_layer: Optional[str] = None
@@ -144,9 +150,16 @@ class TaskTimelineEvent(BaseModel):
 
 class PendingActionToolDisplay(BaseModel):
     tool_id: Optional[str] = None
+    adapter_id: Optional[str] = None
     capability_id: Optional[str] = None
     io_type: Optional[str] = None
     adapter_mode: Optional[str] = None
+    execution_mode: Optional[str] = None
+    provider: Optional[str] = None
+    endpoint_type: Optional[str] = None
+    remote_job_id: Optional[str] = None
+    failure_code: Optional[str] = None
+    recovery_hint: Optional[str] = None
     source: str = Field(..., description="工具来源(local/remote/mock/hybrid/unknown)")
     available: bool = Field(..., description="工具信息是否可用于决策展示")
     can_fallback: bool = Field(..., description="是否可回退到备选工具")
@@ -277,6 +290,19 @@ def _build_tool_display(
     adapter_mode = candidate.adapter_mode or _normalize_text(
         metadata.get("adapter_mode")
     )
+    adapter_id = candidate.adapter_id or _normalize_text(metadata.get("adapter_id"))
+    execution_mode = candidate.execution_mode or _normalize_text(
+        metadata.get("execution_mode")
+    )
+    provider = candidate.provider or _normalize_text(metadata.get("provider"))
+    endpoint_type = candidate.endpoint_type or _normalize_text(
+        metadata.get("endpoint_type")
+    )
+    remote_job_id = candidate.remote_job_id or _normalize_text(
+        metadata.get("remote_job_id")
+    )
+    failure_code = _normalize_text(metadata.get("failure_code"))
+    recovery_hint = _normalize_text(metadata.get("recovery_hint"))
 
     source = (
         adapter_mode
@@ -293,7 +319,6 @@ def _build_tool_display(
         missing.append("io_type")
     if adapter_mode is None:
         missing.append("adapter_mode")
-
     can_fallback = any(
         metadata.get(key)
         for key in (
@@ -312,6 +337,10 @@ def _build_tool_display(
     if missing:
         availability_hint = (
             f"Tool metadata missing ({', '.join(missing)}); use degraded display."
+        )
+    elif execution_mode == "openfold3_rest":
+        availability_hint = (
+            "OpenFold3 REST execution mode configured; availability depends on remote service health."
         )
     elif source == "remote":
         availability_hint = (
@@ -351,9 +380,16 @@ def _build_tool_display(
 
     return PendingActionToolDisplay(
         tool_id=tool_id,
+        adapter_id=adapter_id,
         capability_id=capability_id,
         io_type=io_type,
         adapter_mode=adapter_mode,
+        execution_mode=execution_mode,
+        provider=provider,
+        endpoint_type=endpoint_type,
+        remote_job_id=remote_job_id,
+        failure_code=failure_code,
+        recovery_hint=recovery_hint,
         source=source,
         available=available,
         can_fallback=can_fallback,
@@ -380,6 +416,10 @@ def _build_candidate_reason(
     reason_parts.append(f"risk={candidate.risk_level or 'unknown'}")
     reason_parts.append(f"cost={candidate.cost_estimate or 'unknown'}")
     reason_parts.append(f"tool_source={tool_display.source}")
+    if tool_display.execution_mode:
+        reason_parts.append(f"execution_mode={tool_display.execution_mode}")
+    if tool_display.provider:
+        reason_parts.append(f"provider={tool_display.provider}")
     if tool_display.readiness_status:
         reason_parts.append(f"readiness={tool_display.readiness_status}")
     if tool_display.can_fallback:
@@ -560,6 +600,7 @@ def _event_matches_filters(
     tool_id: Optional[str],
     capability_id: Optional[str],
     adapter_mode: Optional[str],
+    execution_mode: Optional[str],
 ) -> bool:
     if event_type and event.get("event_type") != event_type:
         return False
@@ -581,6 +622,9 @@ def _event_matches_filters(
     if adapter_mode and event.get("adapter_mode") != adapter_mode:
         return False
 
+    if execution_mode and event.get("execution_mode") != execution_mode:
+        return False
+
     return True
 
 
@@ -591,6 +635,7 @@ async def get_task_events(
     tool_id: Optional[str] = Query(default=None),
     capability_id: Optional[str] = Query(default=None),
     adapter_mode: Optional[str] = Query(default=None),
+    execution_mode: Optional[str] = Query(default=None),
 ) -> list[TaskTimelineEvent]:
     runtime = _ensure_runtime_initialized()
     timeline = read_timeline_events(task_id, log_dir=runtime.paths.log_dir)
@@ -625,6 +670,7 @@ async def get_task_events(
             tool_id=_normalize_text(tool_id),
             capability_id=_normalize_text(capability_id),
             adapter_mode=_normalize_text(adapter_mode),
+            execution_mode=_normalize_text(execution_mode),
         )
     ]
 

--- a/src/api/static/js/event-timeline.js
+++ b/src/api/static/js/event-timeline.js
@@ -83,7 +83,19 @@ function renderTimeline(events) {
       </div>
       <div class="event-meta">${event.summary}</div>
       <div class="event-meta">state: ${stateInfo}</div>
-      <div class="event-meta">step: ${event.step_id ?? "-"} | tool: ${event.tool ?? "-"}</div>
+      <div class="event-meta">
+        step: ${event.step_id ?? "-"} |
+        tool: ${event.tool_id ?? event.tool ?? "-"} |
+        adapter: ${event.adapter_id ?? "-"} |
+        execution: ${event.execution_mode ?? "-"}
+      </div>
+      <div class="event-meta">
+        provider: ${event.provider ?? "-"} |
+        endpoint: ${event.endpoint_type ?? "-"} |
+        remote job: ${event.remote_job_id ?? "-"} |
+        failure: ${event.failure_code ?? "-"} |
+        recovery: ${event.recovery_hint ?? "-"}
+      </div>
     `;
         list.appendChild(item);
     }

--- a/src/api/static/js/hitl-dashboard.js
+++ b/src/api/static/js/hitl-dashboard.js
@@ -1,3 +1,9 @@
+const MODEL_INVOCATION_CAPABILITIES = new Set([
+    "sequence_generation",
+    "sequence_design",
+    "structure_prediction",
+    "objective_scoring",
+]);
 const ALLOWED_CHOICES = {
     plan_confirm: ["accept", "replan", "cancel"],
     patch_confirm: ["accept", "replan", "cancel"],
@@ -75,12 +81,6 @@ function formatText(value) {
     const normalized = value?.trim();
     return normalized ? normalized : "-";
 }
-const MODEL_INVOCATION_CAPABILITIES = new Set([
-    "sequence_generation",
-    "sequence_design",
-    "structure_prediction",
-    "objective_scoring",
-]);
 async function parseError(response) {
     try {
         const payload = (await response.json());
@@ -364,6 +364,7 @@ function renderCandidateComparison(detail) {
         "Risk",
         "Cost",
         "Tool",
+        "Endpoint",
         "Readiness",
         "Recovery",
         "Reason",
@@ -403,9 +404,16 @@ function renderCandidateComparison(detail) {
         const toolCell = document.createElement("td");
         toolCell.textContent =
             `${formatText(candidate.tool.tool_id)} / ${formatText(candidate.tool.capability_id)} / ` +
-                `${formatText(candidate.tool.io_type)} / mode=${formatText(candidate.tool.adapter_mode)} / ` +
-                `source=${candidate.tool.source}`;
+                `${formatText(candidate.tool.io_type)} / adapter=${formatText(candidate.tool.adapter_id)} / ` +
+                `adapter_mode=${formatText(candidate.tool.adapter_mode)}`;
         row.appendChild(toolCell);
+        const endpointCell = document.createElement("td");
+        endpointCell.textContent =
+            `execution=${formatText(candidate.tool.execution_mode)} / ` +
+                `provider=${formatText(candidate.tool.provider)} / ` +
+                `endpoint=${formatText(candidate.tool.endpoint_type)} / ` +
+                `job=${formatText(candidate.tool.remote_job_id)}`;
+        row.appendChild(endpointCell);
         const readinessCell = document.createElement("td");
         const readiness = candidate.tool.readiness_status ?? (candidate.tool.available ? "ready" : "degraded");
         const readinessChip = document.createElement("span");
@@ -417,7 +425,7 @@ function renderCandidateComparison(detail) {
             : candidate.tool.availability_hint;
         row.appendChild(readinessCell);
         const recoveryCell = document.createElement("td");
-        recoveryCell.textContent = formatText(candidate.tool.suggested_recovery);
+        recoveryCell.textContent = formatText(candidate.tool.recovery_hint ?? candidate.tool.suggested_recovery);
         row.appendChild(recoveryCell);
         const reasonCell = document.createElement("td");
         reasonCell.textContent = candidate.recommendation_reason;
@@ -433,7 +441,8 @@ function renderCandidateComparison(detail) {
 function buildCandidateOptionLabel(candidate) {
     const source = candidate.tool.source;
     const mode = formatText(candidate.tool.adapter_mode);
-    return `${candidate.candidate_id} | #${candidate.rank} | risk=${formatText(candidate.risk_level)} | cost=${formatText(candidate.cost_estimate)} | source=${source} | mode=${mode}`;
+    const executionMode = formatText(candidate.tool.execution_mode);
+    return `${candidate.candidate_id} | #${candidate.rank} | risk=${formatText(candidate.risk_level)} | cost=${formatText(candidate.cost_estimate)} | source=${source} | mode=${mode} | execution=${executionMode}`;
 }
 function renderDecisionForm(detail) {
     const container = byId("decision-form-container");

--- a/src/api/static/ts/event-timeline.ts
+++ b/src/api/static/ts/event-timeline.ts
@@ -15,6 +15,14 @@ interface TaskTimelineEvent {
   decision_id?: string | null;
   step_id?: string | null;
   tool?: string | null;
+  tool_id?: string | null;
+  adapter_id?: string | null;
+  execution_mode?: string | null;
+  provider?: string | null;
+  endpoint_type?: string | null;
+  remote_job_id?: string | null;
+  failure_code?: string | null;
+  recovery_hint?: string | null;
   status?: string | null;
   from_status?: string | null;
   to_status?: string | null;
@@ -117,7 +125,19 @@ function renderTimeline(events: TaskTimelineEvent[]): void {
       </div>
       <div class="event-meta">${event.summary}</div>
       <div class="event-meta">state: ${stateInfo}</div>
-      <div class="event-meta">step: ${event.step_id ?? "-"} | tool: ${event.tool ?? "-"}</div>
+      <div class="event-meta">
+        step: ${event.step_id ?? "-"} |
+        tool: ${event.tool_id ?? event.tool ?? "-"} |
+        adapter: ${event.adapter_id ?? "-"} |
+        execution: ${event.execution_mode ?? "-"}
+      </div>
+      <div class="event-meta">
+        provider: ${event.provider ?? "-"} |
+        endpoint: ${event.endpoint_type ?? "-"} |
+        remote job: ${event.remote_job_id ?? "-"} |
+        failure: ${event.failure_code ?? "-"} |
+        recovery: ${event.recovery_hint ?? "-"}
+      </div>
     `;
     list.appendChild(item);
   }

--- a/src/api/static/ts/hitl-dashboard.ts
+++ b/src/api/static/ts/hitl-dashboard.ts
@@ -22,9 +22,16 @@ interface PendingActionLite {
 
 interface PendingActionToolDisplay {
   tool_id: string | null;
+  adapter_id?: string | null;
   capability_id: string | null;
   io_type: string | null;
   adapter_mode: string | null;
+  execution_mode?: string | null;
+  provider?: string | null;
+  endpoint_type?: string | null;
+  remote_job_id?: string | null;
+  failure_code?: string | null;
+  recovery_hint?: string | null;
   source: string;
   available: boolean;
   can_fallback: boolean;
@@ -558,6 +565,7 @@ function renderCandidateComparison(detail: PendingActionDetail): void {
     "Risk",
     "Cost",
     "Tool",
+    "Endpoint",
     "Readiness",
     "Recovery",
     "Reason",
@@ -604,9 +612,17 @@ function renderCandidateComparison(detail: PendingActionDetail): void {
     const toolCell = document.createElement("td");
     toolCell.textContent =
       `${formatText(candidate.tool.tool_id)} / ${formatText(candidate.tool.capability_id)} / ` +
-      `${formatText(candidate.tool.io_type)} / mode=${formatText(candidate.tool.adapter_mode)} / ` +
-      `source=${candidate.tool.source}`;
+      `${formatText(candidate.tool.io_type)} / adapter=${formatText(candidate.tool.adapter_id)} / ` +
+      `adapter_mode=${formatText(candidate.tool.adapter_mode)}`;
     row.appendChild(toolCell);
+
+    const endpointCell = document.createElement("td");
+    endpointCell.textContent =
+      `execution=${formatText(candidate.tool.execution_mode)} / ` +
+      `provider=${formatText(candidate.tool.provider)} / ` +
+      `endpoint=${formatText(candidate.tool.endpoint_type)} / ` +
+      `job=${formatText(candidate.tool.remote_job_id)}`;
+    row.appendChild(endpointCell);
 
     const readinessCell = document.createElement("td");
     const readiness = candidate.tool.readiness_status ?? (
@@ -622,7 +638,9 @@ function renderCandidateComparison(detail: PendingActionDetail): void {
     row.appendChild(readinessCell);
 
     const recoveryCell = document.createElement("td");
-    recoveryCell.textContent = formatText(candidate.tool.suggested_recovery);
+    recoveryCell.textContent = formatText(
+      candidate.tool.recovery_hint ?? candidate.tool.suggested_recovery,
+    );
     row.appendChild(recoveryCell);
 
     const reasonCell = document.createElement("td");
@@ -643,7 +661,8 @@ function renderCandidateComparison(detail: PendingActionDetail): void {
 function buildCandidateOptionLabel(candidate: PendingActionCandidateDisplay): string {
   const source = candidate.tool.source;
   const mode = formatText(candidate.tool.adapter_mode);
-  return `${candidate.candidate_id} | #${candidate.rank} | risk=${formatText(candidate.risk_level)} | cost=${formatText(candidate.cost_estimate)} | source=${source} | mode=${mode}`;
+  const executionMode = formatText(candidate.tool.execution_mode);
+  return `${candidate.candidate_id} | #${candidate.rank} | risk=${formatText(candidate.risk_level)} | cost=${formatText(candidate.cost_estimate)} | source=${source} | mode=${mode} | execution=${executionMode}`;
 }
 
 function renderDecisionForm(detail: PendingActionDetail): void {

--- a/src/cli.py
+++ b/src/cli.py
@@ -30,6 +30,8 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.command == "pending" and args.pending_command == "show":
             return _pending_show(base_url, args.pending_action_id, emit_json=args.json)
+        if args.command == "timeline" and args.timeline_command == "show":
+            return _timeline_show(base_url, args.task_id, emit_json=args.json)
         if args.command == "report" and args.report_command == "show":
             return _report_show(base_url, args.task_id, emit_json=args.json)
     except httpx.HTTPError as exc:
@@ -65,6 +67,12 @@ def _build_parser() -> argparse.ArgumentParser:
     pending_show.add_argument("pending_action_id")
     pending_show.add_argument("--json", action="store_true")
 
+    timeline_parser = subparsers.add_parser("timeline")
+    timeline_subparsers = timeline_parser.add_subparsers(dest="timeline_command")
+    timeline_show = timeline_subparsers.add_parser("show")
+    timeline_show.add_argument("task_id")
+    timeline_show.add_argument("--json", action="store_true")
+
     report_parser = subparsers.add_parser("report")
     report_subparsers = report_parser.add_subparsers(dest="report_command")
     report_show = report_subparsers.add_parser("show")
@@ -97,6 +105,15 @@ def _task_watch(
     while True:
         code = _task_show(base_url, task_id, emit_json=emit_json)
         task = _get_json(base_url, f"/tasks/{task_id}")
+        if isinstance(task, dict) and str(task.get("status", "")).startswith("WAITING_"):
+            pending = task.get("pending_action")
+            if isinstance(pending, dict) and not emit_json:
+                print("watch: waiting for human decision")
+                print(
+                    f"pending_action: {pending.get('pending_action_id')} "
+                    f"({pending.get('action_type')})"
+                )
+            return code
         if str(task.get("status")) in {"DONE", "FAILED", "CANCELLED"}:
             return code
         time.sleep(max(1.0, interval_s))
@@ -122,6 +139,15 @@ def _report_show(base_url: str, task_id: str, *, emit_json: bool) -> int:
         _print_json({"report": report})
     else:
         _print_report(report)
+    return 0
+
+
+def _timeline_show(base_url: str, task_id: str, *, emit_json: bool) -> int:
+    timeline = _get_json(base_url, f"/tasks/{task_id}/events")
+    if emit_json:
+        _print_json({"events": timeline})
+    else:
+        _print_timeline(timeline)
     return 0
 
 
@@ -158,6 +184,9 @@ def _print_task(payload: dict[str, Any]) -> None:
     pending = task.get("pending_action")
     if isinstance(pending, dict):
         print(f"pending_action: {pending.get('pending_action_id')} ({pending.get('action_type')})")
+        for candidate in pending.get("candidates") or []:
+            if isinstance(candidate, dict):
+                _print_candidate_runtime_line(candidate)
     _print_readiness_summary(payload["readiness_summary"])
 
 
@@ -175,9 +204,50 @@ def _print_pending(payload: dict[str, Any]) -> None:
             "candidate: "
             f"{candidate.get('candidate_id')} "
             f"readiness={tool.get('readiness_status') or '-'} "
-            f"recovery={tool.get('suggested_recovery') or '-'}"
+            f"tool={tool.get('tool_id') or '-'} "
+            f"adapter={tool.get('adapter_id') or '-'} "
+            f"execution_mode={tool.get('execution_mode') or '-'} "
+            f"endpoint={tool.get('endpoint_type') or '-'} "
+            f"remote_job_id={tool.get('remote_job_id') or '-'} "
+            f"failure_code={tool.get('failure_code') or '-'} "
+            f"recovery={tool.get('recovery_hint') or tool.get('suggested_recovery') or '-'}"
         )
     _print_readiness_summary(payload["readiness_summary"])
+
+
+def _print_candidate_runtime_line(candidate: dict[str, Any]) -> None:
+    print(
+        "candidate_runtime: "
+        f"{candidate.get('candidate_id') or '-'} "
+        f"tool={candidate.get('tool_id') or candidate.get('tool') or '-'} "
+        f"adapter={candidate.get('adapter_id') or '-'} "
+        f"execution_mode={candidate.get('execution_mode') or '-'} "
+        f"endpoint={candidate.get('endpoint_type') or '-'} "
+        f"remote_job_id={candidate.get('remote_job_id') or '-'}"
+    )
+
+
+def _print_timeline(timeline: dict[str, Any] | list[dict[str, Any]]) -> None:
+    if not isinstance(timeline, list):
+        print("timeline: unavailable")
+        return
+    for event in timeline:
+        if not isinstance(event, dict):
+            continue
+        print(
+            "event: "
+            f"{event.get('event_type') or '-'} "
+            f"ts={event.get('ts') or '-'} "
+            f"step={event.get('step_id') or '-'} "
+            f"tool={event.get('tool_id') or event.get('tool') or '-'} "
+            f"adapter={event.get('adapter_id') or '-'} "
+            f"execution_mode={event.get('execution_mode') or '-'} "
+            f"endpoint={event.get('endpoint_type') or '-'} "
+            f"remote_job_id={event.get('remote_job_id') or '-'} "
+            f"failure_code={event.get('failure_code') or '-'} "
+            f"recovery={event.get('recovery_hint') or event.get('recovery_reason') or '-'} "
+            f"summary={event.get('summary') or '-'}"
+        )
 
 
 def _print_report(report: dict[str, Any] | list[dict[str, Any]]) -> None:

--- a/src/kg/protein_tool_kg.json
+++ b/src/kg/protein_tool_kg.json
@@ -650,9 +650,26 @@
       "execution": {
         "backend": "remote_model_service",
         "provider": "nvidia_nim",
+        "execution_mode": "nvidia_nim",
         "model_id": "openfold/openfold3/predict",
         "sync_mode": true,
-        "alternate_provider": "openfold3_rest"
+        "alternate_provider": "openfold3_rest",
+        "execution_modes": [
+          {
+            "execution_mode": "nvidia_nim",
+            "adapter_id": "openfold",
+            "provider": "nvidia_nim",
+            "endpoint_type": "nim",
+            "model_id": "openfold/openfold3/predict"
+          },
+          {
+            "execution_mode": "openfold3_rest",
+            "adapter_id": "openfold",
+            "provider": "openfold3_rest",
+            "endpoint_type": "rest",
+            "base_url_env": "OPENFOLD3_REST_BASE_URL"
+          }
+        ]
       },
       "cost_score": 0.75,
       "safety_level": 1,

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -29,6 +29,11 @@ WAITING_RUNTIME_SUMMARY_METADATA_KEY = "waiting_runtime_summary"
 DECISION_SUMMARY_ARTIFACT_KEY = "decision_summary"
 CAPABILITY_READINESS_METADATA_KEY = "capability_readiness"
 TOOL_READINESS_METADATA_KEY = "tool_readiness"
+ADAPTER_ID_METADATA_KEY = "adapter_id"
+EXECUTION_MODE_METADATA_KEY = "execution_mode"
+PROVIDER_METADATA_KEY = "provider"
+ENDPOINT_TYPE_METADATA_KEY = "endpoint_type"
+REMOTE_JOB_ID_METADATA_KEY = "remote_job_id"
 
 
 def _validate_runtime_state_schema_version(value: int) -> int:
@@ -132,6 +137,13 @@ class StepResult(BaseModel):
     task_id: str
     step_id: str
     tool: str
+    # additive observability fields: tool/tool_id remains the scientific identity.
+    tool_id: Optional[str] = None
+    adapter_id: Optional[str] = None
+    execution_mode: Optional[str] = None
+    provider: Optional[str] = None
+    endpoint_type: Optional[str] = None
+    remote_job_id: Optional[str] = None
     status: Literal["success", "failed", "skipped"]
     # 失败分类：对齐 FailureType 枚举的字符串值；成功时可为 None
     failure_type: Optional[str] = None
@@ -146,6 +158,64 @@ class StepResult(BaseModel):
     risk_flags: List[RiskFlag] = Field(default_factory=list)
     logs_path: Optional[str] = None
     timestamp: str
+
+    @field_validator(
+        "tool_id",
+        "adapter_id",
+        "execution_mode",
+        "provider",
+        "endpoint_type",
+        "remote_job_id",
+    )
+    @classmethod
+    def _validate_optional_invocation_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return _validate_non_empty_text(value, field_name="invocation metadata")
+
+    @model_validator(mode="after")
+    def _sync_invocation_metadata(self) -> "StepResult":
+        """同步执行元数据，保持旧 metrics/error_details 消费者兼容。"""
+        metrics = dict(self.metrics or {})
+        self.metrics = metrics
+
+        self.tool_id = _sync_step_metadata_field(
+            metrics,
+            field_name="tool_id",
+            field_value=self.tool_id or self.tool,
+        )
+        self.adapter_id = _sync_step_metadata_field(
+            metrics,
+            field_name=ADAPTER_ID_METADATA_KEY,
+            field_value=self.adapter_id,
+        )
+        self.execution_mode = _sync_step_metadata_field(
+            metrics,
+            field_name=EXECUTION_MODE_METADATA_KEY,
+            field_value=self.execution_mode,
+        )
+        self.provider = _sync_step_metadata_field(
+            metrics,
+            field_name=PROVIDER_METADATA_KEY,
+            field_value=self.provider,
+        )
+        self.endpoint_type = _sync_step_metadata_field(
+            metrics,
+            field_name=ENDPOINT_TYPE_METADATA_KEY,
+            field_value=self.endpoint_type,
+        )
+        self.remote_job_id = _sync_step_metadata_field(
+            metrics,
+            field_name=REMOTE_JOB_ID_METADATA_KEY,
+            field_value=self.remote_job_id or _coerce_non_empty_text(metrics.get("job_id")),
+        )
+        if self.failure_type is not None:
+            metrics.setdefault("failure_type", self.failure_type)
+        if isinstance(self.error_details, dict):
+            failure_code = _coerce_non_empty_text(self.error_details.get("failure_code"))
+            if failure_code is not None:
+                metrics.setdefault("failure_code", failure_code)
+        return self
 
 
 class ToolReadiness(BaseModel):
@@ -731,6 +801,11 @@ class PendingActionCandidate(BaseModel):
         capability_id: 工具能力标识（与 metadata.capability_id 同步）。
         io_type: I/O 类型标识（与 metadata.io_type 同步）。
         adapter_mode: 适配器模式（local/remote/mock/hybrid/unknown）。
+        adapter_id: 代码适配器标识。
+        execution_mode: 运行通道标识（local/remote/rest/nim/openfold3_rest 等）。
+        provider: 模型或远程服务提供方。
+        endpoint_type: endpoint 类型（local/rest/nim 等）。
+        remote_job_id: 远程作业 ID（如候选已有关联作业）。
         summary: 候选摘要信息。
         metadata: 额外元数据。
             - `runtime_state_summary` 可承载候选展示所需的轻量状态摘要。
@@ -751,6 +826,11 @@ class PendingActionCandidate(BaseModel):
     capability_id: str | None = None
     io_type: str | None = None
     adapter_mode: Literal["local", "remote", "mock", "hybrid", "unknown"] | None = None
+    adapter_id: str | None = None
+    execution_mode: str | None = None
+    provider: str | None = None
+    endpoint_type: str | None = None
+    remote_job_id: str | None = None
     summary: Optional[str] = None
     metadata: Dict = Field(default_factory=dict)
 
@@ -774,7 +854,16 @@ class PendingActionCandidate(BaseModel):
             normalized[key] = float(score)
         return normalized
 
-    @field_validator("tool_id", "capability_id", "io_type")
+    @field_validator(
+        "tool_id",
+        "capability_id",
+        "io_type",
+        "adapter_id",
+        "execution_mode",
+        "provider",
+        "endpoint_type",
+        "remote_job_id",
+    )
     @classmethod
     def _validate_tool_fields(cls, value: str | None) -> str | None:
         if value is None:
@@ -829,9 +918,43 @@ class PendingActionCandidate(BaseModel):
             metadata,
             field_value=self.adapter_mode,
         )
+        self.adapter_id = _sync_metadata_field(
+            metadata,
+            field_name=ADAPTER_ID_METADATA_KEY,
+            field_value=self.adapter_id,
+        )
+        self.execution_mode = _sync_metadata_field(
+            metadata,
+            field_name=EXECUTION_MODE_METADATA_KEY,
+            field_value=self.execution_mode,
+        )
+        self.provider = _sync_metadata_field(
+            metadata,
+            field_name=PROVIDER_METADATA_KEY,
+            field_value=self.provider,
+        )
+        self.endpoint_type = _sync_metadata_field(
+            metadata,
+            field_name=ENDPOINT_TYPE_METADATA_KEY,
+            field_value=self.endpoint_type,
+        )
+        self.remote_job_id = _sync_metadata_field(
+            metadata,
+            field_name=REMOTE_JOB_ID_METADATA_KEY,
+            field_value=self.remote_job_id,
+        )
 
         has_any_tooling = any(
-            value is not None for value in (self.tool_id, self.capability_id, self.io_type)
+            value is not None
+            for value in (
+                self.tool_id,
+                self.capability_id,
+                self.io_type,
+                self.adapter_id,
+                self.execution_mode,
+                self.provider,
+                self.endpoint_type,
+            )
         )
         if has_any_tooling and self.adapter_mode is None:
             self.adapter_mode = "unknown"
@@ -879,6 +1002,32 @@ def _sync_metadata_field(
     if field_value != normalized:
         raise ValueError(f"metadata.{field_name} must match {field_name}")
     metadata[field_name] = field_value
+    return field_value
+
+
+def _coerce_non_empty_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _sync_step_metadata_field(
+    metrics: Dict[str, Any],
+    *,
+    field_name: str,
+    field_value: str | None,
+) -> str | None:
+    metric_value = _coerce_non_empty_text(metrics.get(field_name))
+    if metric_value is None:
+        if field_value is not None:
+            metrics[field_name] = field_value
+        return field_value
+    if field_value is None:
+        return metric_value
+    if field_value != metric_value:
+        raise ValueError(f"metrics.{field_name} must match {field_name}")
+    metrics[field_name] = field_value
     return field_value
 
 

--- a/src/storage/log_store.py
+++ b/src/storage/log_store.py
@@ -193,13 +193,19 @@ def _normalize_timeline_event(
         "step_id": _string_field(payload, "step_id"),
         "tool": _string_field(payload, "tool"),
         "tool_id": observability["tool_id"],
+        "adapter_id": observability["adapter_id"],
+        "execution_mode": observability["execution_mode"],
         "capability_id": observability["capability_id"],
         "io_type": observability["io_type"],
         "adapter_mode": observability["adapter_mode"],
+        "provider": observability["provider"],
+        "endpoint_type": observability["endpoint_type"],
+        "remote_job_id": observability["remote_job_id"],
         "from_tool": observability["from_tool"],
         "to_tool": observability["to_tool"],
         "failure_type": observability["failure_type"],
         "failure_code": observability["failure_code"],
+        "recovery_hint": observability["recovery_hint"],
         "candidate_id": observability["candidate_id"],
         "decision_source": observability["decision_source"],
         "action_name": observability["action_name"],
@@ -325,6 +331,7 @@ def _extract_observability_fields(
 ) -> dict[str, Any]:
     recovery = data.get("recovery") if isinstance(data.get("recovery"), dict) else {}
     patch = data.get("patch") if isinstance(data.get("patch"), dict) else {}
+    fallback = data.get("fallback") if isinstance(data.get("fallback"), dict) else {}
     waiting_runtime_summary = (
         data.get("waiting_runtime_summary")
         if isinstance(data.get("waiting_runtime_summary"), dict)
@@ -360,8 +367,10 @@ def _extract_observability_fields(
         or _string_field(data, "tool")
         or _string_field(patch, "to_tool")
         or _string_field(recovery, "to_tool")
+        or _string_field(fallback, "to_tool_id")
         or _string_field(patch, "from_tool")
         or _string_field(recovery, "from_tool")
+        or _string_field(fallback, "from_tool_id")
     )
     capability_id = (
         _string_field(payload, "capability_id")
@@ -382,18 +391,53 @@ def _extract_observability_fields(
         or _string_field(patch, "adapter_mode")
         or _string_field(recovery, "adapter_mode")
     )
+    adapter_id = (
+        _string_field(payload, "adapter_id")
+        or _string_field(data, "adapter_id")
+        or _string_field(patch, "adapter_id")
+        or _string_field(recovery, "adapter_id")
+        or _string_field(fallback, "to_adapter_id")
+    )
+    execution_mode = (
+        _string_field(payload, "execution_mode")
+        or _string_field(data, "execution_mode")
+        or _string_field(patch, "execution_mode")
+        or _string_field(recovery, "execution_mode")
+        or _string_field(fallback, "to_execution_mode")
+    )
+    provider = (
+        _string_field(payload, "provider")
+        or _string_field(data, "provider")
+        or _string_field(patch, "provider")
+        or _string_field(recovery, "provider")
+    )
+    endpoint_type = (
+        _string_field(payload, "endpoint_type")
+        or _string_field(data, "endpoint_type")
+        or _string_field(patch, "endpoint_type")
+        or _string_field(recovery, "endpoint_type")
+    )
+    remote_job_id = (
+        _string_field(payload, "remote_job_id")
+        or _string_field(data, "remote_job_id")
+        or _string_field(data, "job_id")
+        or _string_field(patch, "remote_job_id")
+        or _string_field(recovery, "remote_job_id")
+    )
 
     from_tool = (
         _string_field(payload, "from_tool")
         or _string_field(data, "from_tool")
         or _string_field(recovery, "from_tool")
         or _string_field(patch, "from_tool")
+        or _string_field(fallback, "from_tool_id")
     )
     to_tool = (
         _string_field(payload, "to_tool")
         or _string_field(data, "to_tool")
         or _string_field(recovery, "to_tool")
         or _string_field(patch, "to_tool")
+        or _string_field(fallback, "to_tool_id")
     )
     failure_type = (
         _string_field(payload, "failure_type")
@@ -409,6 +453,8 @@ def _extract_observability_fields(
         error_details = payload.get("error_details")
         if isinstance(error_details, dict):
             failure_code = _string_field(error_details, "failure_code")
+            if remote_job_id is None:
+                remote_job_id = _string_field(error_details, "remote_job_id")
     if failure_code is None:
         s6 = data.get("s6")
         if isinstance(s6, dict):
@@ -436,19 +482,33 @@ def _extract_observability_fields(
     recovery_reason = (
         _string_field(recovery, "reason")
         or _string_field(recovery, "upgrade_reason")
+        or _string_field(fallback, "reason")
         or _string_field(data, "reason")
+    )
+    recovery_hint = (
+        _string_field(payload, "recovery_hint")
+        or _string_field(data, "recovery_hint")
+        or _string_field(data, "suggested_recovery")
+        or _string_field(recovery, "recovery_hint")
+        or _string_field(recovery, "suggested_recovery")
     )
     action_name = _extract_action_name(payload=payload, data=data, recovery=recovery)
 
     return {
         "tool_id": tool_id,
+        "adapter_id": adapter_id,
+        "execution_mode": execution_mode,
         "capability_id": capability_id,
         "io_type": io_type,
         "adapter_mode": adapter_mode,
+        "provider": provider,
+        "endpoint_type": endpoint_type,
+        "remote_job_id": remote_job_id,
         "from_tool": from_tool,
         "to_tool": to_tool,
         "failure_type": failure_type,
         "failure_code": failure_code,
+        "recovery_hint": recovery_hint,
         "candidate_id": candidate_id,
         "decision_source": decision_source,
         "action_name": action_name,

--- a/src/workflow/decision_apply.py
+++ b/src/workflow/decision_apply.py
@@ -631,10 +631,39 @@ def _emit_decision_applied_event(
                 if selected_candidate
                 else candidate_meta.get("adapter_mode")
             ),
+            "adapter_id": (
+                selected_candidate.adapter_id
+                if selected_candidate
+                else candidate_meta.get("adapter_id")
+            ),
+            "execution_mode": (
+                selected_candidate.execution_mode
+                if selected_candidate
+                else candidate_meta.get("execution_mode")
+            ),
+            "provider": (
+                selected_candidate.provider
+                if selected_candidate
+                else candidate_meta.get("provider")
+            ),
+            "endpoint_type": (
+                selected_candidate.endpoint_type
+                if selected_candidate
+                else candidate_meta.get("endpoint_type")
+            ),
+            "remote_job_id": (
+                selected_candidate.remote_job_id
+                if selected_candidate
+                else candidate_meta.get("remote_job_id")
+            ),
             "waiting_runtime_summary": extract_pending_action_waiting_summary(context),
             "action_score": candidate_meta.get("action_score"),
             "shadow_score": candidate_meta.get("shadow_score"),
             "evidence_source": candidate_meta.get("default_recommendation_reason"),
+            "execution_mode": candidate_meta.get("execution_mode"),
+            "provider": candidate_meta.get("provider"),
+            "endpoint_type": candidate_meta.get("endpoint_type"),
+            "remote_job_id": candidate_meta.get("remote_job_id"),
             "terminal_policy": candidate_meta.get("terminal_policy"),
             "terminal_reason": candidate_meta.get("terminal_reason"),
             "runtime_policy": runtime_trace["runtime_policy"],

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -624,6 +624,11 @@ def _extract_recovery_metadata(
         "candidate_id": selected_candidate.candidate_id if selected_candidate else None,
         "io_type": selected_candidate.io_type if selected_candidate else None,
         "adapter_mode": selected_candidate.adapter_mode if selected_candidate else None,
+        "adapter_id": selected_candidate.adapter_id if selected_candidate else None,
+        "execution_mode": selected_candidate.execution_mode if selected_candidate else None,
+        "provider": selected_candidate.provider if selected_candidate else None,
+        "endpoint_type": selected_candidate.endpoint_type if selected_candidate else None,
+        "remote_job_id": selected_candidate.remote_job_id if selected_candidate else None,
     }
     for key in (
         "runtime_state_summary",

--- a/src/workflow/pending_action.py
+++ b/src/workflow/pending_action.py
@@ -213,6 +213,31 @@ def enter_waiting_state(
                 if selected_candidate
                 else selected_meta.get("adapter_mode")
             ),
+            "adapter_id": (
+                selected_candidate.adapter_id
+                if selected_candidate
+                else selected_meta.get("adapter_id")
+            ),
+            "execution_mode": (
+                selected_candidate.execution_mode
+                if selected_candidate
+                else selected_meta.get("execution_mode")
+            ),
+            "provider": (
+                selected_candidate.provider
+                if selected_candidate
+                else selected_meta.get("provider")
+            ),
+            "endpoint_type": (
+                selected_candidate.endpoint_type
+                if selected_candidate
+                else selected_meta.get("endpoint_type")
+            ),
+            "remote_job_id": (
+                selected_candidate.remote_job_id
+                if selected_candidate
+                else selected_meta.get("remote_job_id")
+            ),
             "waiting_runtime_summary": (
                 pending_action.metadata.get(WAITING_RUNTIME_SUMMARY_METADATA_KEY)
                 if isinstance(pending_action.metadata, dict)
@@ -357,6 +382,13 @@ def _build_waiting_runtime_summary(
         "terminal_reason",
         "replan_mode",
         "preserve_prefix_until_step_index",
+        "adapter_id",
+        "execution_mode",
+        "provider",
+        "endpoint_type",
+        "remote_job_id",
+        "failure_code",
+        "recovery_hint",
     ):
         value = candidate_metadata.get(key)
         if value is not None:

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -970,10 +970,24 @@ def _should_require_replan_confirm(error: PlanRunError) -> bool:
 
 def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
     data: dict[str, Any] = {}
+    for field_name in (
+        "tool_id",
+        "adapter_id",
+        "execution_mode",
+        "provider",
+        "endpoint_type",
+        "remote_job_id",
+    ):
+        value = getattr(step_result, field_name, None)
+        if isinstance(value, str) and value:
+            data[field_name] = value
     if isinstance(step_result.error_details, dict):
         failure_code = step_result.error_details.get("failure_code")
         if isinstance(failure_code, str) and failure_code:
             data["failure_code"] = failure_code
+        remote_job_id = step_result.error_details.get("remote_job_id")
+        if isinstance(remote_job_id, str) and remote_job_id and "remote_job_id" not in data:
+            data["remote_job_id"] = remote_job_id
 
     outputs = step_result.outputs if isinstance(step_result.outputs, dict) else {}
     stage_id = outputs.get("stage_id")
@@ -1006,6 +1020,20 @@ def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:
             "candidate_id": recovery_meta.get("candidate_id"),
             "reason": recovery_meta.get("reason"),
             "upgrade_reason": recovery_meta.get("upgrade_reason"),
+        }
+
+    fallback_meta = step_result.metrics.get("fallback")
+    if isinstance(fallback_meta, dict) and fallback_meta:
+        data["fallback"] = {
+            "fallback_kind": fallback_meta.get("fallback_kind"),
+            "reason": fallback_meta.get("reason"),
+            "from_tool_id": fallback_meta.get("from_tool_id"),
+            "to_tool_id": fallback_meta.get("to_tool_id"),
+            "from_execution_mode": fallback_meta.get("from_execution_mode"),
+            "to_execution_mode": fallback_meta.get("to_execution_mode"),
+            "from_adapter_id": fallback_meta.get("from_adapter_id"),
+            "to_adapter_id": fallback_meta.get("to_adapter_id"),
+            "capability_preserved": fallback_meta.get("capability_preserved"),
         }
 
     workflow_action = step_result.metrics.get("workflow_action")

--- a/src/workflow/step_runner.py
+++ b/src/workflow/step_runner.py
@@ -182,6 +182,11 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=step.tool,
+                tool_id=step.tool,
+                adapter_id="safety_precheck",
+                execution_mode="local",
+                provider="safety_agent",
+                endpoint_type="local",
                 status="failed",
                 failure_type=FailureType.SAFETY_BLOCK,
                 error_message=f"SafetyAgent blocked step {step.id} before execution",
@@ -212,6 +217,10 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=step.tool,
+                tool_id=step.tool,
+                adapter_id="adapter_lookup",
+                execution_mode="unknown",
+                endpoint_type="unknown",
                 status="failed",
                 failure_type=FailureType.NON_RETRYABLE,
                 error_message=str(exc),
@@ -244,6 +253,14 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=resolved_tool_id,
+                tool_id=resolved_tool_id,
+                adapter_id=_string_or_none(adapter_meta.get("adapter_id")),
+                execution_mode=_string_or_none(getattr(exc, "execution_mode", None))
+                or _string_or_none(adapter_meta.get("execution_mode")),
+                provider=_string_or_none(getattr(exc, "provider", None))
+                or _string_or_none(adapter_meta.get("provider")),
+                endpoint_type=_string_or_none(getattr(exc, "endpoint_type", None))
+                or _string_or_none(adapter_meta.get("endpoint_type")),
                 status="failed",
                 failure_type=FailureType.NON_RETRYABLE,
                 error_message=str(exc),
@@ -290,6 +307,12 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=resolved_tool_id,
+                tool_id=resolved_tool_id,
+                adapter_id=_string_or_none(adapter_meta.get("adapter_id")),
+                execution_mode=_string_or_none(adapter_meta.get("execution_mode")),
+                provider=_string_or_none(adapter_meta.get("provider")),
+                endpoint_type=_string_or_none(adapter_meta.get("endpoint_type")),
+                remote_job_id=_string_or_none(getattr(exc, "remote_job_id", None)),
                 status="failed",
                 failure_type=exc.failure_type,
                 error_message=str(exc),
@@ -299,6 +322,8 @@ class StepRunner:
                     timestamp=now_iso,
                     exception_type=type(exc).__name__,
                     exception_message=str(exc),
+                    remote_job_id=_string_or_none(getattr(exc, "remote_job_id", None)),
+                    remote_endpoint=_string_or_none(getattr(exc, "remote_endpoint", None)),
                 ),
                 inputs=resolved_inputs,
                 outputs={},
@@ -319,6 +344,11 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=resolved_tool_id,
+                tool_id=resolved_tool_id,
+                adapter_id=_string_or_none(adapter_meta.get("adapter_id")),
+                execution_mode=_string_or_none(adapter_meta.get("execution_mode")),
+                provider=_string_or_none(adapter_meta.get("provider")),
+                endpoint_type=_string_or_none(adapter_meta.get("endpoint_type")),
                 status="failed",
                 failure_type=FailureType.TOOL_ERROR,
                 error_message=f"Unexpected tool exception: {exc}",
@@ -476,19 +506,48 @@ class StepRunner:
         """解析适配器，必要时回退到本地工具"""
         try:
             adapter = get_adapter(step.tool)
-            return adapter, step.tool, {}
+            return adapter, step.tool, _adapter_invocation_metadata(
+                adapter,
+                requested_tool=step.tool,
+                resolved_tool=step.tool,
+            )
         except KeyError:
             fallback_tool = self._select_fallback_tool(step)
             if not fallback_tool:
                 raise
             adapter = get_adapter(fallback_tool)
+            fallback_meta = _adapter_invocation_metadata(
+                adapter,
+                requested_tool=step.tool,
+                resolved_tool=fallback_tool,
+            )
+            fallback_meta.setdefault(
+                "execution_mode",
+                _execution_mode_from_tool_entry(self._lookup_tool_entry(fallback_tool)),
+            )
+            fallback_payload = _build_fallback_payload(
+                requested_tool=step.tool,
+                fallback_tool=fallback_tool,
+                requested_meta={
+                    "tool_id": step.tool,
+                    "execution_mode": _execution_mode_from_tool_entry(
+                        self._lookup_tool_entry(step.tool)
+                    ),
+                },
+                fallback_meta=fallback_meta,
+                requested_capabilities=self._tool_capabilities(step.tool),
+                fallback_capabilities=self._tool_capabilities(fallback_tool),
+                reason="adapter_missing",
+            )
             return (
                 adapter,
                 fallback_tool,
                 {
+                    **fallback_meta,
                     "requested_tool": step.tool,
                     "fallback_from": step.tool,
                     "fallback_reason": "adapter_missing",
+                    "fallback": fallback_payload,
                 },
             )
 
@@ -513,6 +572,30 @@ class StepRunner:
             adapter = get_adapter(fallback_tool)
         except KeyError:
             return None
+        fallback_meta = _adapter_invocation_metadata(
+            adapter,
+            requested_tool=step.tool,
+            resolved_tool=fallback_tool,
+        )
+        fallback_meta.setdefault(
+            "execution_mode",
+            _execution_mode_from_tool_entry(self._lookup_tool_entry(fallback_tool)),
+        )
+        requested_meta = {
+            "tool_id": requested_tool,
+            "execution_mode": _execution_mode_from_tool_entry(
+                self._lookup_tool_entry(requested_tool)
+            ),
+        }
+        fallback_payload = _build_fallback_payload(
+            requested_tool=requested_tool,
+            fallback_tool=fallback_tool,
+            requested_meta=requested_meta,
+            fallback_meta=fallback_meta,
+            requested_capabilities=self._tool_capabilities(requested_tool),
+            fallback_capabilities=self._tool_capabilities(fallback_tool),
+            reason="nim_unavailable",
+        )
 
         try:
             outputs_payload, adapter_metrics = adapter.run_local(resolved_inputs)
@@ -525,6 +608,11 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=fallback_tool,
+                tool_id=fallback_tool,
+                adapter_id=_string_or_none(fallback_meta.get("adapter_id")),
+                execution_mode=_string_or_none(fallback_meta.get("execution_mode")),
+                provider=_string_or_none(fallback_meta.get("provider")),
+                endpoint_type=_string_or_none(fallback_meta.get("endpoint_type")),
                 status="failed",
                 failure_type=exc.failure_type,
                 error_message=str(exc),
@@ -544,6 +632,8 @@ class StepRunner:
                     "fallback_from": requested_tool,
                     "fallback_reason": "nim_unavailable",
                     "requested_tool": step.tool,
+                    "fallback": fallback_payload,
+                    **fallback_meta,
                 },
                 risk_flags=[],
                 logs_path=None,
@@ -556,6 +646,11 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=fallback_tool,
+                tool_id=fallback_tool,
+                adapter_id=_string_or_none(fallback_meta.get("adapter_id")),
+                execution_mode=_string_or_none(fallback_meta.get("execution_mode")),
+                provider=_string_or_none(fallback_meta.get("provider")),
+                endpoint_type=_string_or_none(fallback_meta.get("endpoint_type")),
                 status="failed",
                 failure_type=FailureType.TOOL_ERROR,
                 error_message=f"Unexpected tool exception: {exc}",
@@ -575,6 +670,8 @@ class StepRunner:
                     "fallback_from": requested_tool,
                     "fallback_reason": "nim_unavailable",
                     "requested_tool": step.tool,
+                    "fallback": fallback_payload,
+                    **fallback_meta,
                 },
                 risk_flags=[],
                 logs_path=None,
@@ -593,6 +690,8 @@ class StepRunner:
                 "fallback_from": requested_tool,
                 "fallback_reason": "nim_unavailable",
                 "requested_tool": step.tool,
+                "fallback": fallback_payload,
+                **fallback_meta,
             },
         )
 
@@ -651,6 +750,15 @@ class StepRunner:
                 return tool
         return None
 
+    def _tool_capabilities(self, tool_id: str) -> set[str]:
+        tool_entry = self._lookup_tool_entry(tool_id)
+        if not isinstance(tool_entry, dict):
+            return set()
+        capabilities = tool_entry.get("capabilities")
+        if not isinstance(capabilities, list):
+            return set()
+        return {item for item in capabilities if isinstance(item, str) and item}
+
     def _iter_tools(self) -> list[dict]:
         try:
             kg = load_tool_kg()
@@ -694,7 +802,14 @@ class StepRunner:
         metrics_payload.setdefault("exec_type", "adapter_local")
         metrics_payload.setdefault("duration_ms", duration_ms)
         if metrics_extra:
-            metrics_payload.update(metrics_extra)
+            for key, value in metrics_extra.items():
+                metrics_payload.setdefault(key, value)
+        normalized_execution_mode = _normalize_execution_mode_for_trace(
+            _string_or_none(metrics_payload.get("execution_mode")),
+            raw_exec_type=_string_or_none(metrics_payload.get("exec_type")),
+        )
+        if normalized_execution_mode is not None:
+            metrics_payload["execution_mode"] = normalized_execution_mode
 
         artifacts_payload = self._extract_artifacts(outputs_payload)
 
@@ -702,6 +817,13 @@ class StepRunner:
             task_id=context.task.task_id,
             step_id=step.id,
             tool=tool_id,
+            tool_id=tool_id,
+            adapter_id=_string_or_none(metrics_payload.get("adapter_id")),
+            execution_mode=_string_or_none(metrics_payload.get("execution_mode")),
+            provider=_string_or_none(metrics_payload.get("provider")),
+            endpoint_type=_string_or_none(metrics_payload.get("endpoint_type")),
+            remote_job_id=_string_or_none(metrics_payload.get("remote_job_id"))
+            or _string_or_none(metrics_payload.get("job_id")),
             status="success",
             failure_type=None,
             error_message=None,
@@ -726,6 +848,13 @@ class StepRunner:
                 task_id=context.task.task_id,
                 step_id=step.id,
                 tool=tool_id,
+                tool_id=tool_id,
+                adapter_id=_string_or_none(metrics_payload.get("adapter_id")),
+                execution_mode=_string_or_none(metrics_payload.get("execution_mode")),
+                provider=_string_or_none(metrics_payload.get("provider")),
+                endpoint_type=_string_or_none(metrics_payload.get("endpoint_type")),
+                remote_job_id=_string_or_none(metrics_payload.get("remote_job_id"))
+                or _string_or_none(metrics_payload.get("job_id")),
                 status="failed",
                 failure_type=FailureType.SAFETY_BLOCK,
                 error_message=f"SafetyAgent blocked step {step.id} after execution",
@@ -752,6 +881,13 @@ class StepRunner:
             task_id=context.task.task_id,
             step_id=step.id,
             tool=tool_id,
+            tool_id=tool_id,
+            adapter_id=_string_or_none(metrics_payload.get("adapter_id")),
+            execution_mode=_string_or_none(metrics_payload.get("execution_mode")),
+            provider=_string_or_none(metrics_payload.get("provider")),
+            endpoint_type=_string_or_none(metrics_payload.get("endpoint_type")),
+            remote_job_id=_string_or_none(metrics_payload.get("remote_job_id"))
+            or _string_or_none(metrics_payload.get("job_id")),
             status="success",
             failure_type=None,
             error_message=None,
@@ -770,3 +906,113 @@ def _is_remote_execution(execution: Any) -> bool:
     if isinstance(execution, dict):
         return execution.get("backend") == "remote_model_service"
     return False
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _adapter_invocation_metadata(
+    adapter: BaseToolAdapter,
+    *,
+    requested_tool: str,
+    resolved_tool: str,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """构造 StepResult/EventLog 共享的执行通道元数据。"""
+    raw = adapter.describe_capabilities()
+    metadata: dict[str, Any] = {}
+    tool_id = _string_or_none(raw.get("tool_id")) or resolved_tool
+    adapter_id = _string_or_none(raw.get("adapter_id")) or tool_id
+    execution_mode = _normalize_execution_mode_for_trace(
+        _string_or_none(raw.get("execution_mode")),
+        raw_exec_type=None,
+    )
+    provider = _string_or_none(raw.get("provider"))
+    endpoint_type = _string_or_none(raw.get("endpoint_type"))
+
+    metadata["tool_id"] = tool_id
+    metadata["adapter_id"] = adapter_id
+    if execution_mode is not None:
+        metadata["execution_mode"] = execution_mode
+    if provider is not None:
+        metadata["provider"] = provider
+    if endpoint_type is not None:
+        metadata["endpoint_type"] = endpoint_type
+    if requested_tool != resolved_tool:
+        metadata["requested_tool"] = requested_tool
+        metadata["resolved_tool_id"] = resolved_tool
+    if extra:
+        metadata.update(extra)
+    return metadata
+
+
+def _normalize_execution_mode_for_trace(
+    value: str | None,
+    *,
+    raw_exec_type: str | None,
+) -> str | None:
+    raw = value or raw_exec_type
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    if not normalized:
+        return None
+    if normalized == "adapter_local":
+        return "local"
+    if normalized == "remote":
+        return "remote"
+    if normalized in {"nvidia_nim", "nim"}:
+        return "nvidia_nim"
+    return normalized
+
+
+def _execution_mode_from_tool_entry(tool_entry: dict[str, Any] | None) -> str | None:
+    if not isinstance(tool_entry, dict):
+        return None
+    execution = tool_entry.get("execution")
+    if isinstance(execution, dict):
+        provider = _string_or_none(execution.get("provider"))
+        if provider:
+            return provider
+        backend = _string_or_none(execution.get("backend"))
+        if backend:
+            return backend
+    if isinstance(execution, str):
+        return execution
+    return None
+
+
+def _build_fallback_payload(
+    *,
+    requested_tool: str,
+    fallback_tool: str,
+    requested_meta: dict[str, Any],
+    fallback_meta: dict[str, Any],
+    requested_capabilities: set[str],
+    fallback_capabilities: set[str],
+    reason: str,
+) -> dict[str, Any]:
+    requested_mode = _string_or_none(requested_meta.get("execution_mode"))
+    fallback_mode = _string_or_none(fallback_meta.get("execution_mode"))
+    shared_capability = bool(requested_capabilities.intersection(fallback_capabilities))
+    if requested_tool == fallback_tool and requested_mode != fallback_mode:
+        fallback_kind = "execution_channel"
+    elif shared_capability and requested_tool != fallback_tool:
+        fallback_kind = "scientific_tool"
+    else:
+        fallback_kind = "tool"
+    return {
+        "fallback_kind": fallback_kind,
+        "reason": reason,
+        "from_tool_id": requested_tool,
+        "to_tool_id": fallback_tool,
+        "from_execution_mode": requested_mode,
+        "to_execution_mode": fallback_mode,
+        "from_adapter_id": _string_or_none(requested_meta.get("adapter_id")),
+        "to_adapter_id": _string_or_none(fallback_meta.get("adapter_id")),
+        "capability_preserved": shared_capability,
+    }

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -106,6 +106,71 @@ class TestAPIEndpoints:
         assert "degraded_reasons" in objective_entry
         assert "suggested_recovery" in objective_entry
 
+    async def test_pending_action_detail_exposes_execution_mode(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """PendingAction detail 应展示 tool/adapter/execution mode 边界。"""
+
+        task_id = "test_api_execution_mode"
+        pending_action = PendingAction(
+            pending_action_id="pa_execution_mode",
+            task_id=task_id,
+            action_type=PendingActionType.PLAN_CONFIRM,
+            status=PendingActionStatus.PENDING,
+            candidates=[
+                PendingActionCandidate(
+                    candidate_id="cand_openfold_rest",
+                    payload=Plan(
+                        task_id=task_id,
+                        steps=[
+                            PlanStep(
+                                id="S2",
+                                tool="openfold",
+                                inputs={"sequence": "S1.sequence"},
+                            )
+                        ],
+                    ),
+                    tool_id="openfold",
+                    adapter_id="openfold",
+                    capability_id="structure_prediction",
+                    io_type="sequence_to_structure",
+                    adapter_mode="remote",
+                    execution_mode="openfold3_rest",
+                    provider="openfold3_rest",
+                    endpoint_type="rest",
+                    remote_job_id="of3_job_1",
+                    metadata={
+                        "failure_code": "REMOTE_JOB_FAILED",
+                        "recovery_hint": "Inspect OpenFold3 REST logs.",
+                    },
+                )
+            ],
+            explanation="review execution mode",
+            default_recommendation="cand_openfold_rest",
+        )
+        TASK_STORE[task_id] = TaskRecord(
+            id=task_id,
+            status=ExternalStatus.WAITING_PLAN_CONFIRM,
+            internal_status=InternalStatus.WAITING_PLAN_CONFIRM,
+            goal="review",
+            pending_action=pending_action,
+        )
+
+        response = await client.get("/pending-actions/pa_execution_mode")
+
+        assert response.status_code == 200
+        data = response.json()
+        tool = data["candidates"][0]["tool"]
+        assert tool["tool_id"] == "openfold"
+        assert tool["adapter_id"] == "openfold"
+        assert tool["execution_mode"] == "openfold3_rest"
+        assert tool["provider"] == "openfold3_rest"
+        assert tool["endpoint_type"] == "rest"
+        assert tool["remote_job_id"] == "of3_job_1"
+        assert tool["failure_code"] == "REMOTE_JOB_FAILED"
+        assert tool["recovery_hint"] == "Inspect OpenFold3 REST logs."
+
     async def test_task_report_endpoint_exposes_objective_scoring(
         self,
         client: httpx.AsyncClient,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -103,3 +103,101 @@ def test_report_show_json_exposes_objective_scoring(monkeypatch, capsys) -> None
     output = capsys.readouterr().out
     assert '"objective_score": 0.77' in output
     assert '"rank_reason": "cand_a ranks by objective_score=0.770"' in output
+
+
+def test_pending_show_human_outputs_execution_mode(monkeypatch, capsys) -> None:
+    """pending show 应输出执行通道与远程失败恢复提示。"""
+
+    def fake_get(url: str, timeout: float) -> _FakeResponse:
+        assert timeout == 10.0
+        if url.endswith("/pending-actions/pa_cli"):
+            return _FakeResponse(
+                {
+                    "pending_action_id": "pa_cli",
+                    "task_id": "task_cli",
+                    "action_type": "patch_confirm",
+                    "default_suggestion": "cand_openfold_rest",
+                    "candidates": [
+                        {
+                            "candidate_id": "cand_openfold_rest",
+                            "tool": {
+                                "tool_id": "openfold",
+                                "adapter_id": "openfold",
+                                "execution_mode": "openfold3_rest",
+                                "endpoint_type": "rest",
+                                "remote_job_id": "of3_job_1",
+                                "failure_code": "REMOTE_JOB_FAILED",
+                                "recovery_hint": "Inspect OpenFold3 REST logs.",
+                                "readiness_status": "degraded",
+                            },
+                        }
+                    ],
+                }
+            )
+        if url.endswith("/capabilities/readiness"):
+            return _FakeResponse([])
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(cli.httpx, "get", fake_get)
+
+    code = cli.main(
+        [
+            "--api-base-url",
+            "http://api.test",
+            "pending",
+            "show",
+            "pa_cli",
+        ]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "execution_mode=openfold3_rest" in output
+    assert "remote_job_id=of3_job_1" in output
+    assert "failure_code=REMOTE_JOB_FAILED" in output
+    assert "recovery=Inspect OpenFold3 REST logs." in output
+
+
+def test_timeline_show_human_outputs_execution_mode(monkeypatch, capsys) -> None:
+    """timeline show 应输出 execution mode 与 endpoint 上下文。"""
+
+    def fake_get(url: str, timeout: float) -> _FakeResponse:
+        assert timeout == 10.0
+        if url.endswith("/tasks/task_cli/events"):
+            return _FakeResponse(
+                [
+                    {
+                        "event_type": "STEP_FAILED",
+                        "ts": "2026-04-27T00:00:00+00:00",
+                        "step_id": "S2",
+                        "tool_id": "openfold",
+                        "adapter_id": "openfold",
+                        "execution_mode": "openfold3_rest",
+                        "endpoint_type": "rest",
+                        "remote_job_id": "of3_job_1",
+                        "failure_code": "REMOTE_JOB_FAILED",
+                        "recovery_hint": "Inspect OpenFold3 REST logs.",
+                        "summary": "Step failed (S2)",
+                    }
+                ]
+            )
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(cli.httpx, "get", fake_get)
+
+    code = cli.main(
+        [
+            "--api-base-url",
+            "http://api.test",
+            "timeline",
+            "show",
+            "task_cli",
+        ]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "tool=openfold" in output
+    assert "adapter=openfold" in output
+    assert "execution_mode=openfold3_rest" in output
+    assert "endpoint=rest" in output

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -347,16 +347,49 @@ class TestCandidateSetContracts:
             payload=sample_plan,
             metadata={
                 "tool_id": "nim_esmfold",
+                "adapter_id": "nim_esmfold",
                 "capability_id": "structure_prediction",
                 "io_type": "sequence_to_structure",
                 "adapter_mode": "remote",
+                "execution_mode": "nvidia_nim",
+                "provider": "nvidia_nim",
+                "endpoint_type": "nim",
             },
         )
 
         assert candidate.tool_id == "nim_esmfold"
+        assert candidate.adapter_id == "nim_esmfold"
         assert candidate.capability_id == "structure_prediction"
         assert candidate.io_type == "sequence_to_structure"
         assert candidate.adapter_mode == "remote"
+        assert candidate.execution_mode == "nvidia_nim"
+        assert candidate.provider == "nvidia_nim"
+        assert candidate.endpoint_type == "nim"
+
+    def test_step_result_invocation_metadata_syncs_to_metrics(self):
+        result = StepResult(
+            task_id="task_contract_step",
+            step_id="S2",
+            tool="openfold",
+            status="success",
+            inputs={},
+            outputs={"pdb_path": "x.pdb"},
+            metrics={
+                "adapter_id": "openfold",
+                "execution_mode": "openfold3_rest",
+                "provider": "openfold3_rest",
+                "endpoint_type": "rest",
+                "job_id": "of3_job_1",
+            },
+            timestamp="2026-04-27T00:00:00+00:00",
+        )
+
+        assert result.tool_id == "openfold"
+        assert result.adapter_id == "openfold"
+        assert result.execution_mode == "openfold3_rest"
+        assert result.remote_job_id == "of3_job_1"
+        assert result.metrics["tool_id"] == "openfold"
+        assert result.metrics["remote_job_id"] == "of3_job_1"
 
     def test_candidate_tool_metadata_conflict_rejected(self, sample_plan: Plan):
         with pytest.raises(ValueError, match="metadata\\.tool_id must match tool_id"):

--- a/tests/unit/test_log_store_timeline.py
+++ b/tests/unit/test_log_store_timeline.py
@@ -80,6 +80,54 @@ def test_read_timeline_events_extracts_recovery_observability_fields(tmp_path: P
 
 
 @pytest.mark.unit
+def test_read_timeline_events_extracts_execution_mode_metadata(tmp_path: Path) -> None:
+    task_id = "timeline_execution_mode_001"
+    log_file = tmp_path / f"{task_id}.jsonl"
+    event = {
+        "event": "STEP_FAILED",
+        "task_id": task_id,
+        "step_id": "S2",
+        "tool": "openfold",
+        "failure_type": "tool_error",
+        "timestamp": "2026-04-27T01:00:00+00:00",
+        "data": {
+            "tool_id": "openfold",
+            "adapter_id": "openfold",
+            "execution_mode": "openfold3_rest",
+            "provider": "openfold3_rest",
+            "endpoint_type": "rest",
+            "remote_job_id": "job_of3_1",
+            "failure_code": "REMOTE_JOB_FAILED",
+            "recovery_hint": "Check OpenFold3 REST service logs and retry.",
+            "fallback": {
+                "fallback_kind": "scientific_tool",
+                "from_tool_id": "nim_esmfold",
+                "to_tool_id": "esmfold",
+                "from_execution_mode": "nvidia_nim",
+                "to_execution_mode": "nextflow",
+                "reason": "nim_unavailable",
+            },
+        },
+    }
+
+    with log_file.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=True) + "\n")
+
+    timeline = read_timeline_events(task_id, log_dir=tmp_path)
+
+    assert len(timeline) == 1
+    row = timeline[0]
+    assert row["tool_id"] == "openfold"
+    assert row["adapter_id"] == "openfold"
+    assert row["execution_mode"] == "openfold3_rest"
+    assert row["provider"] == "openfold3_rest"
+    assert row["endpoint_type"] == "rest"
+    assert row["remote_job_id"] == "job_of3_1"
+    assert row["failure_code"] == "REMOTE_JOB_FAILED"
+    assert row["recovery_hint"] == "Check OpenFold3 REST service logs and retry."
+
+
+@pytest.mark.unit
 def test_read_timeline_events_extracts_action_runtime_audit_fields(tmp_path: Path) -> None:
     task_id = "timeline_action_runtime_001"
     log_file = tmp_path / f"{task_id}.jsonl"

--- a/tests/unit/test_step_runner.py
+++ b/tests/unit/test_step_runner.py
@@ -332,6 +332,12 @@ def test_run_step_fallbacks_to_local_tool_when_nim_missing(empty_context, monkey
     assert result.status == "success"
     assert result.tool == "esmfold"
     assert result.metrics.get("fallback_from") == "nim_esmfold"
+    assert result.metrics["fallback"]["fallback_kind"] == "scientific_tool"
+    assert result.metrics["fallback"]["from_tool_id"] == "nim_esmfold"
+    assert result.metrics["fallback"]["to_tool_id"] == "esmfold"
+    assert result.metrics["fallback"]["from_execution_mode"] == "remote_model_service"
+    assert result.metrics["fallback"]["to_execution_mode"] == "nextflow"
+    assert result.execution_mode == "nextflow"
 
 
 def test_run_step_missing_adapter_returns_failed_result(empty_context):


### PR DESCRIPTION
## 背景

实现 issue #259：显式解耦 scientific `tool_id` 与 runtime `execution_mode`，并让 `openfold3_rest` 在候选、执行结果、事件日志、Web 与 CLI 中都能稳定追踪。

本 PR 遵守现有设计边界：不新增 Workflow FSM 状态、不改变 `PendingAction / Decision / TaskSnapshot` 核心语义、不新增 Agent 角色；所有字段扩展均为 additive，旧消费者仍可继续读取 `tool_id`。

## 改动范围

### 1. 契约与元数据字段

- 在 `PendingActionCandidate` 中新增：
  - `adapter_id`
  - `execution_mode`
  - `provider`
  - `endpoint_type`
  - `remote_job_id`
- 在 `StepResult` 中新增同类执行元数据字段，并同步写入 `metrics`，保持旧 metrics 消费路径兼容。
- 保留 `tool_id` 作为科学工具/能力身份，不把 `openfold3_rest` 混入 `tool_id`。

### 2. Adapter 与 StepRunner

- 为 adapter 能力摘要补充 `adapter_id / execution_mode / provider / endpoint_type`。
- 在 NIM、OpenFold3 REST、ProtGPT2 REST、Remote ESMFold adapter 返回 metrics 时写入执行通道元数据。
- 将 `openfold3_rest` 作为 `openfold` 的明确 execution mode：
  - `tool_id = openfold`
  - `adapter_id = openfold`
  - `execution_mode = openfold3_rest`
  - `provider = openfold3_rest`
  - `endpoint_type = rest`
- StepRunner 在成功、失败、adapter lookup、fallback 路径中统一附加执行元数据。
- fallback metadata 增加 `fallback_kind`，用于区分：
  - `scientific_tool`：科学工具替代，例如 `nim_esmfold -> esmfold`
  - `execution_channel`：同科学工具不同执行通道替代

### 3. EventLog / Timeline / PendingAction

- Timeline 归一化新增输出：
  - `adapter_id`
  - `execution_mode`
  - `provider`
  - `endpoint_type`
  - `remote_job_id`
  - `failure_code`
  - `recovery_hint`
- `WAITING_ENTER`、`DECISION_APPLIED`、`WAITING_EXIT` 事件透传候选中的执行通道元数据。
- Step 事件会把 StepResult 的执行通道、fallback、失败码和远程 job 信息写入 `data`。

### 4. Web/API 展示

- PendingAction detail API 展示 tool、adapter、execution mode、provider、endpoint、remote job、failure code 与 recovery hint。
- Event timeline API 支持按 `execution_mode` 过滤。
- Web Pending Review 候选对比表新增 endpoint 相关展示。
- Web Timeline 展示 execution mode、provider、endpoint、remote job、failure code、recovery hint。

### 5. CLI 展示

- `design pending show` 输出：
  - tool
  - adapter
  - execution mode
  - endpoint
  - remote job id
  - failure code
  - recovery hint
- 新增 `design timeline show <task_id>`，用于查看事件链中的 execution mode 和远程失败上下文。
- `design task watch` 在进入 `WAITING_*` 时停止并输出 PendingAction 提示，避免继续轮询掩盖人工确认点。

### 6. ToolKG

- 在 `openfold` 的 ToolKG execution metadata 中加入 `execution_modes`：
  - `nvidia_nim`
  - `openfold3_rest`
- 该改动不新增新的科学工具 ID，只明确同一科学工具下的运行通道映射。

## 影响

- Web/CLI 能清楚区分“调用了哪个科学工具”和“通过哪个执行通道运行”。
- `openfold3_rest` 在候选、日志、timeline、CLI/Web 中可稳定识别。
- 远程失败可以携带 job id、endpoint、失败码与恢复提示，便于无头环境排查。
- fallback 记录可以区分科学替代和执行通道替代，避免把 REST/NIM 通道选择误解为工具能力变化。

## 验证

- `uv run pytest tests/unit/test_contracts.py tests/unit/test_log_store_timeline.py tests/unit/test_step_runner.py tests/unit/test_cli.py tests/api/test_api_endpoints.py -q`
- `npm run check:ui`
- `uv run pytest tests/unit/test_protein_tool_kg.py tests/unit/test_kg_client_backend.py tests/unit/test_active_tool_metadata.py -q`

## 关联

- Closes #259
