### PR TITLE
feat(api): add Task Intake compatibility layer

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.models.contracts import (
     ProteinDesignTask,
@@ -35,6 +35,20 @@ from src.workflow.decision_apply import (
 )
 from src.infra.runtime_init import RuntimeInitResult, initialize_runtime
 from src.models.contracts import PendingActionType, now_iso
+from src.models.db import ExternalStatus, InternalStatus
+from src.models.task_intake import (
+    ConfirmedTaskSpec,
+    IntentDraftClarificationRequest,
+    TaskIntakeConfirmRequest,
+    TaskIntakeCreateRequest,
+    TaskIntakePatchRequest,
+    TaskIntakeSession,
+    build_task_intake_schema,
+    confirm_task_intake_session,
+    create_task_intake_session,
+    patch_task_intake_session,
+    project_confirmed_task_spec,
+)
 from src.storage.log_store import read_timeline_events
 from src.workflow.context import WorkflowContext
 from src.infra.tool_readiness import (
@@ -51,6 +65,7 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 # 简单的内存存储，之后可以换成数据库或文件
 TASK_STORE: Dict[str, TaskRecord] = {}
+INTAKE_STORE: Dict[str, TaskIntakeSession] = {}
 RUNTIME_INIT: Optional[RuntimeInitResult] = None
 
 
@@ -82,9 +97,22 @@ async def _startup_init() -> None:
 
 
 class TaskCreateRequest(BaseModel):
-    goal: str = Field(..., description="蛋白质设计任务目标(自然语言)")
+    goal: Optional[str] = Field(None, description="蛋白质设计任务目标(自然语言)")
+    query: Optional[str] = Field(None, description="兼容自由文本入口；会收敛为 intake")
+    confirmed_task_spec: Optional[ConfirmedTaskSpec] = Field(
+        None,
+        description="已经确认的结构化任务输入",
+    )
     constraints: Dict[str, Any] = Field(default_factory=dict, description="结构化约束")
     metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_creation_mode(self) -> "TaskCreateRequest":
+        """确保 /tasks 请求明确选择一种兼容创建模式。"""
+
+        if self.goal is None and self.query is None and self.confirmed_task_spec is None:
+            raise ValueError("one of goal, query, or confirmed_task_spec is required")
+        return self
 
 
 class DecisionSubmitRequest(BaseModel):
@@ -503,6 +531,45 @@ def _find_record_by_pending_action_id(pending_action_id: str) -> Optional[TaskRe
     return None
 
 
+def _get_intake_or_404(intake_id: str) -> TaskIntakeSession:
+    session = INTAKE_STORE.get(intake_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="task intake not found")
+    return session
+
+
+def _create_task_record_from_confirmed_spec(spec: ConfirmedTaskSpec) -> TaskRecord:
+    goal, constraints, metadata = project_confirmed_task_spec(spec)
+    task_id = f"task_{uuid4().hex[:8]}"
+    record = TaskRecord(
+        id=task_id,
+        status=ExternalStatus.CREATED,
+        internal_status=InternalStatus.CREATED,
+        created_at=now_iso(),
+        updated_at=now_iso(),
+        goal=goal,
+        constraints=constraints,
+        metadata=metadata,
+        plan=None,
+        design_result=None,
+        safety_events=[],
+    )
+    TASK_STORE[task_id] = record
+    return record
+
+
+def _task_intake_summary(session: TaskIntakeSession) -> dict[str, Any]:
+    return {
+        "intake_id": session.intake_id,
+        "status": session.status.value,
+        "draft": session.draft.model_dump(mode="json"),
+        "missing_required_fields": list(session.missing_required_fields),
+        "ambiguous_fields": list(session.ambiguous_fields),
+        "unmapped_text": list(session.unmapped_text),
+        "warnings": list(session.warnings),
+    }
+
+
 @app.get("/", response_class=HTMLResponse)
 @app.get("/ui", response_class=HTMLResponse)
 async def get_hitl_dashboard() -> HTMLResponse:
@@ -544,9 +611,182 @@ async def get_capability_readiness() -> list[CapabilityReadinessEntry]:
     return [CapabilityReadinessEntry(**entry) for entry in entries]
 
 
-@app.post("/tasks", response_model=TaskRecord)
+@app.get("/task-intakes/schema")
+async def get_task_intake_schema() -> dict[str, Any]:
+    """返回 Web/CLI 共享的 Task Intake 字段注册表。"""
+
+    return build_task_intake_schema()
+
+
+@app.post("/task-intakes", response_model=TaskIntakeSession)
+async def create_task_intake(req: TaskIntakeCreateRequest) -> TaskIntakeSession:
+    """创建正式 Task 之前的 Task Intake 会话。"""
+
+    intake_id = f"intake_{uuid4().hex[:8]}"
+    session = create_task_intake_session(
+        intake_id=intake_id,
+        text=req.text,
+        structured_fields=req.structured_fields,
+        source=req.source,
+    )
+    INTAKE_STORE[intake_id] = session
+    return session
+
+
+@app.patch("/task-intakes/{intake_id}", response_model=TaskIntakeSession)
+async def update_task_intake(
+    intake_id: str,
+    req: TaskIntakePatchRequest,
+) -> TaskIntakeSession:
+    """更新 Task Intake 草稿字段。"""
+
+    session = _get_intake_or_404(intake_id)
+    try:
+        return patch_task_intake_session(
+            session,
+            fields=req.fields,
+            updated_by=req.updated_by,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@app.post("/task-intakes/{intake_id}/confirm")
+async def confirm_task_intake(
+    intake_id: str,
+    req: TaskIntakeConfirmRequest,
+) -> dict[str, Any]:
+    """确认 Task Intake 并从 ConfirmedTaskSpec 创建正式 Task。"""
+
+    session = _get_intake_or_404(intake_id)
+    try:
+        confirmed_spec = confirm_task_intake_session(
+            session,
+            confirmed_by=req.confirmed_by,
+            acknowledged_warnings=req.acknowledged_warnings,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    record = _create_task_record_from_confirmed_spec(confirmed_spec)
+    return {
+        "intake_id": intake_id,
+        "task_id": record.id,
+        "status": record.status.value,
+        "confirmed_task_spec": confirmed_spec.model_dump(mode="json"),
+    }
+
+
+@app.post("/intent-drafts")
+async def create_intent_draft(req: TaskIntakeCreateRequest) -> dict[str, Any]:
+    """兼容旧 IntentDraft 创建入口，内部投影到 Task Intake。"""
+
+    intake_id = f"intake_{uuid4().hex[:8]}"
+    session = create_task_intake_session(
+        intake_id=intake_id,
+        text=req.text,
+        structured_fields=req.structured_fields,
+        source=req.source,
+    )
+    session.raw_input["intent_draft_id"] = intake_id
+    INTAKE_STORE[intake_id] = session
+    payload = _task_intake_summary(session)
+    payload["intent_draft_id"] = intake_id
+    return payload
+
+
+@app.patch("/intent-drafts/{intent_draft_id}")
+async def patch_intent_draft(
+    intent_draft_id: str,
+    req: IntentDraftClarificationRequest,
+) -> dict[str, Any]:
+    """兼容旧 IntentDraft 字段更新入口。"""
+
+    return _apply_intent_draft_clarification(intent_draft_id, req)
+
+
+@app.post("/intent-drafts/{intent_draft_id}/clarification")
+@app.post("/intent-drafts/{intent_draft_id}/clarifications")
+async def clarify_intent_draft(
+    intent_draft_id: str,
+    req: IntentDraftClarificationRequest,
+) -> dict[str, Any]:
+    """兼容旧 clarification 入口，内部更新同一个 intake draft。"""
+
+    return _apply_intent_draft_clarification(intent_draft_id, req)
+
+
+@app.post("/intent-drafts/{intent_draft_id}/finalize")
+async def finalize_intent_draft(
+    intent_draft_id: str,
+    req: TaskIntakeConfirmRequest,
+) -> dict[str, Any]:
+    """兼容旧 finalize 入口，经 ConfirmedTaskSpec 创建正式 Task。"""
+
+    session = _get_intake_or_404(intent_draft_id)
+    try:
+        confirmed_spec = confirm_task_intake_session(
+            session,
+            confirmed_by=req.confirmed_by,
+            acknowledged_warnings=req.acknowledged_warnings,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    record = _create_task_record_from_confirmed_spec(confirmed_spec)
+    return {
+        "intent_draft_id": intent_draft_id,
+        "intake_id": intent_draft_id,
+        "task_id": record.id,
+        "status": record.status.value,
+        "confirmed_task_spec": confirmed_spec.model_dump(mode="json"),
+    }
+
+
+def _apply_intent_draft_clarification(
+    intent_draft_id: str,
+    req: IntentDraftClarificationRequest,
+) -> dict[str, Any]:
+    session = _get_intake_or_404(intent_draft_id)
+    fields = dict(req.structured_fields)
+    fields.update(req.fields)
+    if req.text:
+        session.raw_input["clarification_text"] = req.text
+    try:
+        session = patch_task_intake_session(
+            session,
+            fields=fields,
+            updated_by=req.updated_by,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    payload = _task_intake_summary(session)
+    payload["intent_draft_id"] = intent_draft_id
+    return payload
+
+
+@app.post("/tasks")
 async def create_task(req: TaskCreateRequest):
-    """创建一个任务并同步执行"""
+    """创建任务；兼容 goal、query 与 confirmed_task_spec 三种入口。"""
+
+    if req.query is not None and req.confirmed_task_spec is None and req.goal is None:
+        intake_id = f"intake_{uuid4().hex[:8]}"
+        session = create_task_intake_session(
+            intake_id=intake_id,
+            text=req.query,
+            structured_fields=req.constraints,
+            source="legacy",
+        )
+        INTAKE_STORE[intake_id] = session
+        payload = _task_intake_summary(session)
+        payload["needs_confirmation"] = True
+        payload["message"] = "free-text /tasks input was converted to task intake"
+        return payload
+
+    if req.confirmed_task_spec is not None:
+        return _create_task_record_from_confirmed_spec(req.confirmed_task_spec)
+
+    if req.goal is None:
+        raise HTTPException(status_code=422, detail="goal is required")
 
     task_id = f"task_{uuid4().hex[:8]}"
     task = ProteinDesignTask(

--- a/src/cli.py
+++ b/src/cli.py
@@ -34,6 +34,38 @@ def main(argv: list[str] | None = None) -> int:
             return _timeline_show(base_url, args.task_id, emit_json=args.json)
         if args.command == "report" and args.report_command == "show":
             return _report_show(base_url, args.task_id, emit_json=args.json)
+        if args.command == "intake" and args.intake_command == "schema":
+            return _intake_schema(base_url, emit_json=args.json)
+        if args.command == "intake" and args.intake_command == "create":
+            return _intake_create(
+                base_url,
+                text=args.text,
+                fields=_parse_field_args(args.field),
+                source=args.source,
+                emit_json=args.json,
+            )
+        if args.command == "intake" and args.intake_command == "patch":
+            return _intake_patch(
+                base_url,
+                intake_id=args.intake_id,
+                fields=_parse_field_args(args.field),
+                updated_by=args.updated_by,
+                emit_json=args.json,
+            )
+        if args.command == "intake" and args.intake_command == "confirm":
+            return _intake_confirm(
+                base_url,
+                intake_id=args.intake_id,
+                confirmed_by=args.confirmed_by,
+                acknowledged_warnings=args.acknowledge,
+                emit_json=args.json,
+            )
+        if args.command == "preflight":
+            print(
+                "preflight has moved to Task Intake; use `design intake ...`.",
+                file=sys.stderr,
+            )
+            return 2
     except httpx.HTTPError as exc:
         print(f"API request failed: {exc}", file=sys.stderr)
         return 2
@@ -78,6 +110,37 @@ def _build_parser() -> argparse.ArgumentParser:
     report_show = report_subparsers.add_parser("show")
     report_show.add_argument("task_id")
     report_show.add_argument("--json", action="store_true")
+
+    intake_parser = subparsers.add_parser("intake")
+    intake_subparsers = intake_parser.add_subparsers(dest="intake_command")
+    intake_schema = intake_subparsers.add_parser("schema")
+    intake_schema.add_argument("--json", action="store_true")
+    intake_create = intake_subparsers.add_parser("create")
+    intake_create.add_argument("--text", default=None)
+    intake_create.add_argument(
+        "--field",
+        action="append",
+        default=[],
+        help="Structured field as key=JSON_VALUE, for example length_range='[100,140]'",
+    )
+    intake_create.add_argument(
+        "--source",
+        default="cli",
+        choices=["web", "cli", "api", "script", "legacy"],
+    )
+    intake_create.add_argument("--json", action="store_true")
+    intake_patch = intake_subparsers.add_parser("patch")
+    intake_patch.add_argument("intake_id")
+    intake_patch.add_argument("--field", action="append", default=[])
+    intake_patch.add_argument("--updated-by", default="cli")
+    intake_patch.add_argument("--json", action="store_true")
+    intake_confirm = intake_subparsers.add_parser("confirm")
+    intake_confirm.add_argument("intake_id")
+    intake_confirm.add_argument("--confirmed-by", default="cli")
+    intake_confirm.add_argument("--acknowledge", action="append", default=[])
+    intake_confirm.add_argument("--json", action="store_true")
+
+    subparsers.add_parser("preflight")
     return parser
 
 
@@ -151,6 +214,88 @@ def _timeline_show(base_url: str, task_id: str, *, emit_json: bool) -> int:
     return 0
 
 
+def _intake_schema(base_url: str, *, emit_json: bool) -> int:
+    schema = _get_json(base_url, "/task-intakes/schema")
+    if emit_json:
+        _print_json({"schema": schema})
+    else:
+        fields = schema.get("fields", {}) if isinstance(schema, dict) else {}
+        print(f"registry_version: {schema.get('version') if isinstance(schema, dict) else '-'}")
+        for name, definition in fields.items():
+            if isinstance(definition, dict):
+                print(
+                    "field: "
+                    f"{name} group={definition.get('group')} "
+                    f"type={definition.get('type')} control={definition.get('ui_control')}"
+                )
+    return 0
+
+
+def _intake_create(
+    base_url: str,
+    *,
+    text: str | None,
+    fields: dict[str, Any],
+    source: str,
+    emit_json: bool,
+) -> int:
+    payload = _post_json(
+        base_url,
+        "/task-intakes",
+        {"text": text, "structured_fields": fields, "source": source},
+    )
+    if emit_json:
+        _print_json({"intake": payload})
+    else:
+        _print_intake(payload)
+    return 0
+
+
+def _intake_patch(
+    base_url: str,
+    *,
+    intake_id: str,
+    fields: dict[str, Any],
+    updated_by: str,
+    emit_json: bool,
+) -> int:
+    payload = _patch_json(
+        base_url,
+        f"/task-intakes/{intake_id}",
+        {"fields": fields, "updated_by": updated_by},
+    )
+    if emit_json:
+        _print_json({"intake": payload})
+    else:
+        _print_intake(payload)
+    return 0
+
+
+def _intake_confirm(
+    base_url: str,
+    *,
+    intake_id: str,
+    confirmed_by: str,
+    acknowledged_warnings: list[str],
+    emit_json: bool,
+) -> int:
+    payload = _post_json(
+        base_url,
+        f"/task-intakes/{intake_id}/confirm",
+        {
+            "confirmed_by": confirmed_by,
+            "acknowledged_warnings": acknowledged_warnings,
+        },
+    )
+    if emit_json:
+        _print_json({"confirmation": payload})
+    else:
+        print(f"intake_id: {payload.get('intake_id')}")
+        print(f"task_id: {payload.get('task_id')}")
+        print(f"status: {payload.get('status')}")
+    return 0
+
+
 def _get_json(base_url: str, path: str) -> dict[str, Any] | list[dict[str, Any]]:
     response = httpx.get(f"{base_url}{path}", timeout=10.0)
     response.raise_for_status()
@@ -158,6 +303,40 @@ def _get_json(base_url: str, path: str) -> dict[str, Any] | list[dict[str, Any]]
     if not isinstance(payload, (dict, list)):
         raise ValueError(f"API payload for {path} is not an object or list")
     return payload
+
+
+def _post_json(base_url: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    response = httpx.post(f"{base_url}{path}", json=payload, timeout=10.0)
+    response.raise_for_status()
+    body = response.json()
+    if not isinstance(body, dict):
+        raise ValueError(f"API payload for {path} is not an object")
+    return body
+
+
+def _patch_json(base_url: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    response = httpx.patch(f"{base_url}{path}", json=payload, timeout=10.0)
+    response.raise_for_status()
+    body = response.json()
+    if not isinstance(body, dict):
+        raise ValueError(f"API payload for {path} is not an object")
+    return body
+
+
+def _parse_field_args(items: list[str]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"field must use key=value syntax: {item}")
+        key, raw_value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("field key must not be empty")
+        try:
+            fields[key] = json.loads(raw_value)
+        except json.JSONDecodeError:
+            fields[key] = raw_value
+    return fields
 
 
 def _readiness_summary(readiness: dict[str, Any] | list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -188,6 +367,17 @@ def _print_task(payload: dict[str, Any]) -> None:
             if isinstance(candidate, dict):
                 _print_candidate_runtime_line(candidate)
     _print_readiness_summary(payload["readiness_summary"])
+
+
+def _print_intake(payload: dict[str, Any]) -> None:
+    print(f"intake_id: {payload.get('intake_id')}")
+    print(f"status: {payload.get('status')}")
+    missing = payload.get("missing_required_fields") or []
+    ambiguous = payload.get("ambiguous_fields") or []
+    unmapped = payload.get("unmapped_text") or []
+    print(f"missing_required_fields: {', '.join(missing) if missing else '-'}")
+    print(f"ambiguous_fields: {', '.join(ambiguous) if ambiguous else '-'}")
+    print(f"unmapped_text: {', '.join(unmapped) if unmapped else '-'}")
 
 
 def _print_pending(payload: dict[str, Any]) -> None:

--- a/src/models/task_intake.py
+++ b/src/models/task_intake.py
@@ -1,0 +1,737 @@
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from src.models.contracts import now_iso
+
+
+TASK_FIELD_REGISTRY_VERSION = "task-intake.v1"
+HIGH_CONFIDENCE_THRESHOLD = 0.80
+LOW_CONFIDENCE_THRESHOLD = 0.50
+
+
+class TaskIntakeStatus(str, Enum):
+    """Task Intake 前置录入状态。"""
+
+    COLLECTING = "collecting"
+    NEEDS_CONFIRMATION = "needs_confirmation"
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+
+
+class TaskDraftFieldSource(str, Enum):
+    """TaskSpecDraft 字段来源。"""
+
+    USER_EXPLICIT = "user_explicit"
+    LLM_EXTRACT = "llm_extract"
+    SYSTEM_DEFAULT = "system_default"
+    KG_DERIVED = "kg_derived"
+    USER_MODIFIED = "user_modified"
+
+
+class TaskDraftField(BaseModel):
+    """TaskSpecDraft 中单个字段的可审计包装。"""
+
+    value: Any
+    source: TaskDraftFieldSource
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    source_span: str | None = None
+    confirmed: bool = False
+    warnings: list[str] = Field(default_factory=list)
+    last_modified_by: str | None = None
+
+
+class TaskSpecDraft(BaseModel):
+    """可编辑、可解释的任务草稿。"""
+
+    fields: dict[str, TaskDraftField] = Field(default_factory=dict)
+    unmapped_text: list[str] = Field(default_factory=list)
+
+
+class ConfirmedTaskSpec(BaseModel):
+    """唯一允许进入正式 Task 创建的结构化输入。"""
+
+    goal: str
+    objective: dict[str, Any] = Field(default_factory=dict)
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    constraints: dict[str, Any] = Field(default_factory=dict)
+    initial_artifacts: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("goal")
+    @classmethod
+    def _validate_goal(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("goal must not be empty")
+        return normalized
+
+
+class TaskIntakeSession(BaseModel):
+    """一次正式 Task 创建前的录入会话。"""
+
+    intake_id: str
+    status: TaskIntakeStatus
+    raw_input: dict[str, Any] = Field(default_factory=dict)
+    draft: TaskSpecDraft = Field(default_factory=TaskSpecDraft)
+    missing_required_fields: list[str] = Field(default_factory=list)
+    ambiguous_fields: list[str] = Field(default_factory=list)
+    unmapped_text: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    created_at: str = Field(default_factory=now_iso)
+    updated_at: str = Field(default_factory=now_iso)
+    confirmed_task_spec: ConfirmedTaskSpec | None = None
+
+
+class TaskIntakeCreateRequest(BaseModel):
+    """创建 Task Intake 会话的请求。"""
+
+    text: str | None = None
+    structured_fields: dict[str, Any] = Field(default_factory=dict)
+    source: Literal["web", "cli", "api", "script", "legacy"] = "api"
+
+
+class TaskIntakePatchRequest(BaseModel):
+    """更新 Task Intake 草稿字段的请求。"""
+
+    fields: dict[str, Any] = Field(default_factory=dict)
+    updated_by: str = "user"
+
+
+class TaskIntakeConfirmRequest(BaseModel):
+    """确认 Task Intake 并生成 ConfirmedTaskSpec 的请求。"""
+
+    confirmed_by: str
+    acknowledged_warnings: list[str] = Field(default_factory=list)
+
+
+class IntentDraftClarificationRequest(BaseModel):
+    """旧 IntentDraft clarification 入口的兼容请求。"""
+
+    text: str | None = None
+    fields: dict[str, Any] = Field(default_factory=dict)
+    structured_fields: dict[str, Any] = Field(default_factory=dict)
+    updated_by: str = "user"
+
+
+def build_task_intake_schema() -> dict[str, Any]:
+    """生成 Web/CLI 共享的字段注册表视图。"""
+
+    return {
+        "version": TASK_FIELD_REGISTRY_VERSION,
+        "fields": _registry_fields(),
+        "task_profiles": _task_profiles(),
+        "conditional_required": [],
+    }
+
+
+def create_task_intake_session(
+    *,
+    intake_id: str,
+    text: str | None,
+    structured_fields: dict[str, Any] | None,
+    source: str,
+) -> TaskIntakeSession:
+    """从自然语言和结构化字段创建 Task Intake 会话。"""
+
+    raw_input: dict[str, Any] = {
+        "text": text or "",
+        "source": source,
+        "structured_fields": dict(structured_fields or {}),
+    }
+    draft = TaskSpecDraft()
+
+    if text:
+        _merge_extracted_text(draft, text)
+    _merge_structured_fields(
+        draft,
+        structured_fields or {},
+        source=TaskDraftFieldSource.USER_EXPLICIT,
+        confirmed=True,
+        actor=source,
+    )
+
+    session = TaskIntakeSession(
+        intake_id=intake_id,
+        status=TaskIntakeStatus.COLLECTING,
+        raw_input=raw_input,
+        draft=draft,
+    )
+    return refresh_task_intake_session(session)
+
+
+def patch_task_intake_session(
+    session: TaskIntakeSession,
+    *,
+    fields: dict[str, Any],
+    updated_by: str,
+) -> TaskIntakeSession:
+    """应用用户字段修改并重新计算确认状态。"""
+
+    _merge_structured_fields(
+        session.draft,
+        fields,
+        source=TaskDraftFieldSource.USER_MODIFIED,
+        confirmed=True,
+        actor=updated_by,
+    )
+    session.updated_at = now_iso()
+    return refresh_task_intake_session(session)
+
+
+def refresh_task_intake_session(session: TaskIntakeSession) -> TaskIntakeSession:
+    """根据 registry 校验结果刷新缺失、歧义和状态。"""
+
+    session.warnings = []
+    session.ambiguous_fields = []
+    session.unmapped_text = list(session.draft.unmapped_text)
+
+    for field_name, field in list(session.draft.fields.items()):
+        field.warnings = []
+        error = _validate_registry_value(field_name, field.value)
+        if error is not None:
+            field.warnings.append(error)
+            session.warnings.append(error)
+        if field.confidence < HIGH_CONFIDENCE_THRESHOLD:
+            session.ambiguous_fields.append(field_name)
+
+    required = _required_fields_for(session.draft.fields)
+    session.missing_required_fields = [
+        field_name
+        for field_name in required
+        if field_name not in session.draft.fields
+        or session.draft.fields[field_name].value in (None, "")
+    ]
+    if session.confirmed_task_spec is not None:
+        session.status = TaskIntakeStatus.CONFIRMED
+    elif session.missing_required_fields:
+        session.status = TaskIntakeStatus.COLLECTING
+    else:
+        session.status = TaskIntakeStatus.NEEDS_CONFIRMATION
+    session.updated_at = now_iso()
+    return session
+
+
+def confirm_task_intake_session(
+    session: TaskIntakeSession,
+    *,
+    confirmed_by: str,
+    acknowledged_warnings: list[str],
+) -> ConfirmedTaskSpec:
+    """确认草稿并生成 ConfirmedTaskSpec。"""
+
+    refresh_task_intake_session(session)
+    if session.missing_required_fields:
+        missing = ", ".join(session.missing_required_fields)
+        raise ValueError(f"missing required fields: {missing}")
+    if session.ambiguous_fields:
+        ambiguous = ", ".join(session.ambiguous_fields)
+        raise ValueError(f"ambiguous fields require confirmation: {ambiguous}")
+    if session.warnings:
+        warnings = ", ".join(session.warnings)
+        raise ValueError(f"field validation warnings must be resolved: {warnings}")
+
+    for field in session.draft.fields.values():
+        field.confirmed = True
+        field.last_modified_by = confirmed_by
+
+    confirmed_spec = _build_confirmed_spec(
+        session,
+        confirmed_by=confirmed_by,
+        acknowledged_warnings=acknowledged_warnings,
+    )
+    session.confirmed_task_spec = confirmed_spec
+    session.status = TaskIntakeStatus.CONFIRMED
+    session.updated_at = now_iso()
+    return confirmed_spec
+
+
+def project_confirmed_task_spec(
+    spec: ConfirmedTaskSpec,
+) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """将 ConfirmedTaskSpec 投影为现有 ProteinDesignTask 字段。"""
+
+    constraints = dict(spec.constraints)
+    if spec.objective:
+        constraints.setdefault("objective", dict(spec.objective))
+    if spec.inputs:
+        constraints.setdefault("inputs", dict(spec.inputs))
+    metadata = dict(spec.metadata)
+    metadata["confirmed_task_spec"] = spec.model_dump(mode="json")
+    return spec.goal, constraints, metadata
+
+
+def _registry_fields() -> dict[str, dict[str, Any]]:
+    return {
+        "task_kind": {
+            "group": "objective",
+            "type": "enum",
+            "ui_control": "select",
+            "nl_aliases": ["任务类型", "design mode", "task kind"],
+            "validators": {},
+            "options": [
+                "de_novo_design",
+                "sequence_evaluation",
+                "template_constrained_design",
+                "stability_optimization",
+                "motif_scaffold_design",
+                "binding_design",
+                "enzyme_like_design",
+            ],
+            "default": "de_novo_design",
+            "maps_to": "constraints.task_kind",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "objective_type": {
+            "group": "objective",
+            "type": "enum",
+            "ui_control": "select",
+            "nl_aliases": ["目标", "objective", "optimization target"],
+            "validators": {},
+            "options": ["stability", "structure", "binding", "activity"],
+            "default": None,
+            "maps_to": "objective.objective_type",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "length_range": {
+            "group": "design_constraints",
+            "type": "integer_range",
+            "ui_control": "range",
+            "nl_aliases": ["长度", "aa", "amino acids"],
+            "validators": {"min": 1, "max": 5000},
+            "options": [],
+            "default": None,
+            "maps_to": "constraints.length_range",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "sequence": {
+            "group": "inputs",
+            "type": "protein_sequence",
+            "ui_control": "textarea",
+            "nl_aliases": ["序列", "sequence"],
+            "validators": {"alphabet": "ACDEFGHIKLMNPQRSTVWY"},
+            "options": [],
+            "default": None,
+            "maps_to": "inputs.sequence",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "design_count": {
+            "group": "execution_preferences",
+            "type": "integer",
+            "ui_control": "number",
+            "nl_aliases": ["候选数", "design count"],
+            "validators": {"min": 1, "max": 100},
+            "options": [],
+            "default": 4,
+            "maps_to": "constraints.design_count",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "safety_level": {
+            "group": "safety_constraints",
+            "type": "enum",
+            "ui_control": "select",
+            "nl_aliases": ["安全等级", "safety"],
+            "validators": {},
+            "options": ["S0", "S1", "S2"],
+            "default": "S1",
+            "maps_to": "constraints.safety_level",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "run_profile": {
+            "group": "execution_preferences",
+            "type": "enum",
+            "ui_control": "segmented",
+            "nl_aliases": ["运行模式", "profile", "speed"],
+            "validators": {},
+            "options": ["fast_smoke", "balanced", "thorough"],
+            "default": "balanced",
+            "maps_to": "constraints.run_profile",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "require_plan_confirm": {
+            "group": "planner_policy",
+            "type": "boolean",
+            "ui_control": "checkbox",
+            "nl_aliases": ["确认计划", "plan confirmation"],
+            "validators": {},
+            "options": [],
+            "default": True,
+            "maps_to": "constraints.require_plan_confirm",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "tools_allowed": {
+            "group": "execution_preferences",
+            "type": "tool_id_list",
+            "ui_control": "multi_select",
+            "nl_aliases": ["允许工具", "allowed tools"],
+            "validators": {"source": "ToolKG"},
+            "options": [],
+            "default": [],
+            "maps_to": "constraints.tools_allowed",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "tools_excluded": {
+            "group": "execution_preferences",
+            "type": "tool_id_list",
+            "ui_control": "multi_select",
+            "nl_aliases": ["排除工具", "excluded tools"],
+            "validators": {"source": "ToolKG"},
+            "options": [],
+            "default": [],
+            "maps_to": "constraints.tools_excluded",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+    }
+
+
+def _task_profiles() -> dict[str, dict[str, Any]]:
+    return {
+        "de_novo_design": {
+            "support_level": "P0",
+            "required": ["task_kind", "objective_type", "length_range"],
+            "optional": [
+                "design_count",
+                "safety_level",
+                "run_profile",
+                "require_plan_confirm",
+                "tools_allowed",
+                "tools_excluded",
+            ],
+            "conditional_required": [],
+            "capability_hints": ["sequence_generation", "structure_prediction"],
+        },
+        "sequence_evaluation": {
+            "support_level": "P0",
+            "required": ["task_kind", "sequence", "objective_type"],
+            "optional": ["safety_level", "run_profile"],
+            "conditional_required": [],
+            "capability_hints": ["sequence_evaluation", "objective_scoring"],
+        },
+        "template_constrained_design": {
+            "support_level": "P0",
+            "required": ["task_kind", "objective_type", "length_range"],
+            "optional": ["design_count", "safety_level", "run_profile"],
+            "conditional_required": [],
+            "capability_hints": ["structure_prediction", "sequence_design"],
+        },
+        "stability_optimization": {
+            "support_level": "P1",
+            "required": ["task_kind", "sequence"],
+            "optional": ["objective_type", "run_profile"],
+            "conditional_required": [],
+            "capability_hints": ["objective_scoring"],
+        },
+        "motif_scaffold_design": {
+            "support_level": "P1",
+            "required": ["task_kind"],
+            "optional": ["objective_type", "length_range"],
+            "conditional_required": [],
+            "capability_hints": ["motif_scaffolding"],
+        },
+        "binding_design": {
+            "support_level": "P2",
+            "required": ["task_kind", "objective_type"],
+            "optional": ["length_range", "run_profile"],
+            "conditional_required": [],
+            "capability_hints": ["binding_design"],
+        },
+        "enzyme_like_design": {
+            "support_level": "P2",
+            "required": ["task_kind", "objective_type"],
+            "optional": ["length_range", "run_profile"],
+            "conditional_required": [],
+            "capability_hints": ["enzyme_design"],
+        },
+    }
+
+
+def _merge_extracted_text(draft: TaskSpecDraft, text: str) -> None:
+    extracted: dict[str, TaskDraftField] = {}
+    lowered = text.lower()
+    if "de novo" in lowered or "de-novo" in lowered or "从头" in text:
+        extracted["task_kind"] = TaskDraftField(
+            value="de_novo_design",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.86,
+            source_span="de novo",
+        )
+    elif "评估" in text or "evaluate" in lowered:
+        extracted["task_kind"] = TaskDraftField(
+            value="sequence_evaluation",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.84,
+        )
+    elif "template" in lowered or "模板" in text:
+        extracted["task_kind"] = TaskDraftField(
+            value="template_constrained_design",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.84,
+        )
+
+    if "稳定" in text or "stability" in lowered or "stable" in lowered:
+        extracted["objective_type"] = TaskDraftField(
+            value="stability",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.88,
+            source_span="稳定",
+        )
+    elif "binding" in lowered or "结合" in text:
+        extracted["objective_type"] = TaskDraftField(
+            value="binding",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.72,
+            source_span="binding",
+        )
+
+    range_match = re.search(r"(\d{2,4})\s*(?:-|~|到|至)\s*(\d{2,4})", text)
+    if range_match:
+        extracted["length_range"] = TaskDraftField(
+            value=[int(range_match.group(1)), int(range_match.group(2))],
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.92,
+            source_span=range_match.group(0),
+        )
+    else:
+        approx_match = re.search(
+            r"(?:约|大约|around|about)?\s*(\d{2,4})\s*(?:aa|氨基酸)",
+            text,
+            re.IGNORECASE,
+        )
+        if approx_match:
+            center = int(approx_match.group(1))
+            extracted["length_range"] = TaskDraftField(
+                value=[max(1, center - 20), center + 20],
+                source=TaskDraftFieldSource.LLM_EXTRACT,
+                confidence=0.91,
+                source_span=approx_match.group(0),
+            )
+
+    count_match = re.search(
+        r"(\d{1,2})\s*(?:个)?(?:候选|candidate)",
+        text,
+        re.IGNORECASE,
+    )
+    if count_match:
+        extracted["design_count"] = TaskDraftField(
+            value=int(count_match.group(1)),
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.84,
+            source_span=count_match.group(0),
+        )
+
+    if "快" in text or "fast" in lowered:
+        extracted["run_profile"] = TaskDraftField(
+            value="fast_smoke",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.82,
+        )
+    elif "balanced" in lowered or "均衡" in text:
+        extracted["run_profile"] = TaskDraftField(
+            value="balanced",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.86,
+        )
+    elif "thorough" in lowered or "全面" in text:
+        extracted["run_profile"] = TaskDraftField(
+            value="thorough",
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.86,
+        )
+
+    if "确认计划" in text or "confirm plan" in lowered:
+        extracted["require_plan_confirm"] = TaskDraftField(
+            value=True,
+            source=TaskDraftFieldSource.LLM_EXTRACT,
+            confidence=0.95,
+            source_span="确认计划",
+        )
+
+    for field_name, field in extracted.items():
+        if field.confidence < LOW_CONFIDENCE_THRESHOLD:
+            draft.unmapped_text.append(str(field.source_span or field.value))
+            continue
+        draft.fields[field_name] = field
+
+    if not extracted and text.strip():
+        draft.unmapped_text.append(text.strip())
+
+
+def _merge_structured_fields(
+    draft: TaskSpecDraft,
+    fields: dict[str, Any],
+    *,
+    source: TaskDraftFieldSource,
+    confirmed: bool,
+    actor: str,
+) -> None:
+    for field_name, raw_value in fields.items():
+        value, confidence, source_span = _unwrap_field_value(raw_value)
+        if confidence < LOW_CONFIDENCE_THRESHOLD:
+            draft.unmapped_text.append(f"{field_name}={value}")
+            draft.fields.pop(field_name, None)
+            continue
+        draft.fields[field_name] = TaskDraftField(
+            value=value,
+            source=source,
+            confidence=confidence,
+            source_span=source_span,
+            confirmed=confirmed and confidence >= HIGH_CONFIDENCE_THRESHOLD,
+            last_modified_by=actor,
+        )
+
+
+def _unwrap_field_value(raw_value: Any) -> tuple[Any, float, str | None]:
+    if isinstance(raw_value, dict) and "value" in raw_value:
+        confidence = raw_value.get("confidence", 1.0)
+        if not isinstance(confidence, (int, float)):
+            confidence = 1.0
+        source_span = raw_value.get("source_span")
+        normalized_span = source_span if isinstance(source_span, str) else None
+        return raw_value["value"], float(confidence), normalized_span
+    return raw_value, 1.0, None
+
+
+def _required_fields_for(fields: dict[str, TaskDraftField]) -> list[str]:
+    task_kind = fields.get("task_kind")
+    task_kind_value = task_kind.value if task_kind is not None else "de_novo_design"
+    profiles = _task_profiles()
+    profile = profiles.get(str(task_kind_value), profiles["de_novo_design"])
+    return list(profile["required"])
+
+
+def _validate_registry_value(field_name: str, value: Any) -> str | None:
+    registry = _registry_fields()
+    field = registry.get(field_name)
+    if field is None:
+        return f"unknown intake field: {field_name}"
+
+    field_type = field["type"]
+    if field_type == "enum" and value not in set(field["options"]):
+        return f"{field_name} must be one of {field['options']}"
+    if field_type == "boolean" and not isinstance(value, bool):
+        return f"{field_name} must be a boolean"
+    if field_type == "integer":
+        if not isinstance(value, int) or isinstance(value, bool):
+            return f"{field_name} must be an integer"
+        validators = field.get("validators", {})
+        if value < validators.get("min", value) or value > validators.get("max", value):
+            return f"{field_name} is outside allowed range"
+    if field_type == "integer_range":
+        if (
+            not isinstance(value, list)
+            or len(value) != 2
+            or not all(
+                isinstance(item, int) and not isinstance(item, bool)
+                for item in value
+            )
+            or value[0] > value[1]
+        ):
+            return f"{field_name} must be [min, max] integers"
+    if field_type == "protein_sequence":
+        if not isinstance(value, str) or not value.strip():
+            return f"{field_name} must be a non-empty sequence"
+        alphabet = set(field["validators"]["alphabet"])
+        invalid = set(value.upper()) - alphabet
+        if invalid:
+            return f"{field_name} contains invalid residues: {''.join(sorted(invalid))}"
+    if field_type == "tool_id_list":
+        if not isinstance(value, list) or not all(
+            isinstance(item, str) and item for item in value
+        ):
+            return f"{field_name} must be a list of tool ids"
+    return None
+
+
+def _build_confirmed_spec(
+    session: TaskIntakeSession,
+    *,
+    confirmed_by: str,
+    acknowledged_warnings: list[str],
+) -> ConfirmedTaskSpec:
+    fields = {name: field.value for name, field in session.draft.fields.items()}
+    objective: dict[str, Any] = {}
+    inputs: dict[str, Any] = {}
+    constraints: dict[str, Any] = {}
+    registry = _registry_fields()
+
+    for field_name, value in fields.items():
+        maps_to = registry[field_name]["maps_to"]
+        if maps_to.startswith("objective."):
+            objective[maps_to.split(".", 1)[1]] = value
+        elif maps_to.startswith("inputs."):
+            inputs[maps_to.split(".", 1)[1]] = value
+        elif maps_to.startswith("constraints."):
+            constraints[maps_to.split(".", 1)[1]] = value
+
+    goal = _build_goal(fields)
+    metadata = {
+        "intake_id": session.intake_id,
+        "field_registry_version": TASK_FIELD_REGISTRY_VERSION,
+        "support_level": _support_level_for(fields),
+        "confirmed_by": confirmed_by,
+        "input_mode": _input_mode(session),
+        "acknowledged_warnings": list(acknowledged_warnings),
+        "raw_query": session.raw_input.get("text") or "",
+        "unmapped_text": list(session.unmapped_text),
+        "intake_summary": {
+            "field_count": len(session.draft.fields),
+            "ambiguous_fields": list(session.ambiguous_fields),
+            "missing_required_fields": list(session.missing_required_fields),
+        },
+    }
+    if "intent_draft_id" in session.raw_input:
+        metadata["intent_draft_id"] = session.raw_input["intent_draft_id"]
+
+    return ConfirmedTaskSpec(
+        goal=goal,
+        objective=objective,
+        inputs=inputs,
+        constraints=constraints,
+        initial_artifacts=[],
+        metadata=metadata,
+    )
+
+
+def _build_goal(fields: dict[str, Any]) -> str:
+    task_kind = fields.get("task_kind", "de_novo_design")
+    objective = fields.get("objective_type", "protein design")
+    length_range = fields.get("length_range")
+    if isinstance(length_range, list) and len(length_range) == 2:
+        return (
+            f"{task_kind} for {objective} "
+            f"with length {length_range[0]}-{length_range[1]} aa"
+        )
+    return f"{task_kind} for {objective}"
+
+
+def _support_level_for(fields: dict[str, Any]) -> str:
+    task_kind = fields.get("task_kind", "de_novo_design")
+    profile = _task_profiles().get(
+        str(task_kind),
+        _task_profiles()["de_novo_design"],
+    )
+    return str(profile["support_level"])
+
+
+def _input_mode(session: TaskIntakeSession) -> str:
+    has_text = bool(session.raw_input.get("text"))
+    has_structured = bool(session.raw_input.get("structured_fields"))
+    if has_text and has_structured:
+        return "mixed_with_confirmation"
+    if has_text:
+        return "natural_language_with_confirmation"
+    return "structured_with_confirmation"

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -4,7 +4,7 @@ import json
 import pytest
 import httpx
 
-from src.api.main import app, TASK_STORE
+from src.api.main import app, INTAKE_STORE, TASK_STORE
 from src.models.contracts import (
     DecisionChoice,
     DesignResult,
@@ -54,11 +54,13 @@ class TestAPIEndpoints:
     @pytest.fixture(autouse=True)
     def clear_task_store(self):
         TASK_STORE.clear()
+        INTAKE_STORE.clear()
         if DEFAULT_LOG_DIR.exists():
             for path in DEFAULT_LOG_DIR.glob("test_api_events_*.jsonl"):
                 path.unlink()
         yield
         TASK_STORE.clear()
+        INTAKE_STORE.clear()
         if DEFAULT_LOG_DIR.exists():
             for path in DEFAULT_LOG_DIR.glob("test_api_events_*.jsonl"):
                 path.unlink()
@@ -243,6 +245,159 @@ class TestAPIEndpoints:
         data = response.json()
         assert data["constraints"]["length_range"] == [40, 60]
         assert data["metadata"]["priority"] == "high"
+
+    async def test_task_intake_schema_exposes_registry_fields(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """Task Builder 应从 /task-intakes/schema 获取字段注册表。"""
+
+        response = await client.get("/task-intakes/schema")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["version"] == "task-intake.v1"
+        assert data["fields"]["task_kind"]["maps_to"] == "constraints.task_kind"
+        assert "de_novo_design" in data["task_profiles"]
+        assert data["task_profiles"]["binding_design"]["support_level"] == "P2"
+
+    async def test_task_intake_create_tracks_ambiguous_and_unmapped_text(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """低置信度字段进入 ambiguous，未识别文本进入 unmapped_text。"""
+
+        response = await client.post(
+            "/task-intakes",
+            json={
+                "text": "unmapped legacy request",
+                "structured_fields": {
+                    "task_kind": "de_novo_design",
+                    "objective_type": {
+                        "value": "stability",
+                        "confidence": 0.65,
+                        "source_span": "maybe stable",
+                    },
+                    "length_range": [100, 140],
+                },
+                "source": "web",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "needs_confirmation"
+        assert data["ambiguous_fields"] == ["objective_type"]
+        assert data["unmapped_text"] == ["unmapped legacy request"]
+        assert data["draft"]["fields"]["objective_type"]["source"] == "user_explicit"
+
+    async def test_task_intake_patch_and_confirm_creates_created_task_with_backlink(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """confirm 通过 ConfirmedTaskSpec 创建正式 Task 并回链 intake_id。"""
+
+        create_response = await client.post(
+            "/task-intakes",
+            json={
+                "structured_fields": {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": [100, 140],
+                },
+                "source": "web",
+            },
+        )
+        assert create_response.status_code == 200
+        intake_id = create_response.json()["intake_id"]
+
+        patch_response = await client.patch(
+            f"/task-intakes/{intake_id}",
+            json={"fields": {"run_profile": "balanced"}, "updated_by": "tester"},
+        )
+        assert patch_response.status_code == 200
+        assert patch_response.json()["draft"]["fields"]["run_profile"]["confirmed"] is True
+
+        confirm_response = await client.post(
+            f"/task-intakes/{intake_id}/confirm",
+            json={"confirmed_by": "tester", "acknowledged_warnings": []},
+        )
+        assert confirm_response.status_code == 200
+        confirmation = confirm_response.json()
+        assert confirmation["status"] == ExternalStatus.CREATED.value
+
+        task_response = await client.get(f"/tasks/{confirmation['task_id']}")
+        assert task_response.status_code == 200
+        task = task_response.json()
+        assert task["status"] == ExternalStatus.CREATED.value
+        assert task["internal_status"] == InternalStatus.CREATED.value
+        assert task["metadata"]["intake_id"] == intake_id
+        assert (
+            task["metadata"]["confirmed_task_spec"]["metadata"]["intake_id"]
+            == intake_id
+        )
+
+    async def test_legacy_tasks_query_converges_to_intake(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """旧 /tasks query 自由文本入口只返回 intake，不直接进入 Planner。"""
+
+        response = await client.post(
+            "/tasks",
+            json={"query": "please design around 120 aa stable protein"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["needs_confirmation"] is True
+        assert data["status"] in {"collecting", "needs_confirmation"}
+        assert data["intake_id"] in INTAKE_STORE
+        assert TASK_STORE == {}
+
+    async def test_legacy_intent_draft_maps_to_task_intake_finalize(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """旧 IntentDraft create/clarification/finalize 投影到 Task Intake。"""
+
+        create_response = await client.post(
+            "/intent-drafts",
+            json={
+                "text": "design de novo stable protein around 120 aa",
+                "source": "legacy",
+            },
+        )
+        assert create_response.status_code == 200
+        intent_draft_id = create_response.json()["intent_draft_id"]
+
+        clarification_response = await client.post(
+            f"/intent-drafts/{intent_draft_id}/clarification",
+            json={
+                "fields": {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": [100, 140],
+                },
+                "updated_by": "tester",
+            },
+        )
+        assert clarification_response.status_code == 200
+        assert clarification_response.json()["intake_id"] == intent_draft_id
+
+        finalize_response = await client.post(
+            f"/intent-drafts/{intent_draft_id}/finalize",
+            json={"confirmed_by": "tester", "acknowledged_warnings": []},
+        )
+        assert finalize_response.status_code == 200
+        data = finalize_response.json()
+        assert data["intake_id"] == intent_draft_id
+        assert data["status"] == ExternalStatus.CREATED.value
+
+        task = TASK_STORE[data["task_id"]]
+        assert task.status == ExternalStatus.CREATED
+        assert task.metadata["intake_id"] == intent_draft_id
+        assert task.metadata["intent_draft_id"] == intent_draft_id
 
     async def test_get_task_endpoint_success(self, client: httpx.AsyncClient):
         """测试获取任务端点成功"""

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -201,3 +201,56 @@ def test_timeline_show_human_outputs_execution_mode(monkeypatch, capsys) -> None
     assert "adapter=openfold" in output
     assert "execution_mode=openfold3_rest" in output
     assert "endpoint=rest" in output
+
+
+def test_intake_create_json_posts_task_intake_payload(monkeypatch, capsys) -> None:
+    """design intake create 应调用 /task-intakes 并输出 intake_id。"""
+
+    seen: dict[str, Any] = {}
+
+    def fake_post(url: str, json: dict[str, Any], timeout: float) -> _FakeResponse:
+        assert timeout == 10.0
+        seen["url"] = url
+        seen["json"] = json
+        return _FakeResponse(
+            {
+                "intake_id": "intake_cli",
+                "status": "needs_confirmation",
+                "draft": {},
+                "missing_required_fields": [],
+                "ambiguous_fields": [],
+                "unmapped_text": [],
+                "warnings": [],
+            }
+        )
+
+    monkeypatch.setattr(cli.httpx, "post", fake_post)
+
+    code = cli.main(
+        [
+            "--api-base-url",
+            "http://api.test",
+            "intake",
+            "create",
+            "--text",
+            "design stable protein",
+            "--field",
+            "length_range=[100,140]",
+            "--json",
+        ]
+    )
+
+    assert code == 0
+    assert seen["url"] == "http://api.test/task-intakes"
+    assert seen["json"]["structured_fields"]["length_range"] == [100, 140]
+    output = capsys.readouterr().out
+    assert '"intake_id": "intake_cli"' in output
+
+
+def test_preflight_command_prompts_migration(capsys) -> None:
+    """旧 preflight CLI 入口提示迁移到 design intake。"""
+
+    code = cli.main(["preflight"])
+
+    assert code == 2
+    assert "design intake" in capsys.readouterr().err


### PR DESCRIPTION
## 背景

本 PR 实现 #260，将旧的 `IntentDraft -> Clarification -> finalize` / preflight 创建前流程收敛到新的 Task Intake 语义上，避免在正式 Workflow FSM 之外再形成第二套含义相近但状态不同的创建前状态机。

对应设计文档为 `structured-task-intake-design.md` 与 `interaction-entry-surfaces.md`。实现遵循 issue 中的边界：Task Intake 发生在正式 Task 创建前，不新增正式 `WAITING_*` 状态，不改变 `PendingAction / Decision / TaskSnapshot` 核心语义，也不新增 Agent 角色。

## 主要变更

1. 新增 Task Intake 契约与兼容映射层

- 新增 `src/models/task_intake.py`，定义 `TaskIntakeSession`、`TaskSpecDraft`、`TaskDraftField`、`ConfirmedTaskSpec`、字段来源枚举与 `TaskIntakeStatus`。
- 增加轻量字段 registry，覆盖 task profile、字段分组、控件建议、枚举选项、默认值、`maps_to`、support level 与 capability hints。
- 将旧 `IntentDraft` 入口映射到同一个 `TaskIntakeSession / TaskSpecDraft / ConfirmedTaskSpec` 流程，不引入独立语义。

2. 新增 Task Intake API

- `GET /task-intakes/schema`：返回 Web/CLI 共享的字段注册表，避免 Task Builder 硬编码字段选项。
- `POST /task-intakes`：创建 intake session，接收 `text`、`structured_fields`、`source`。
- `PATCH /task-intakes/{intake_id}`：更新草稿字段，并重新计算 missing/ambiguous/warnings。
- `POST /task-intakes/{intake_id}/confirm`：确认草稿，生成 `ConfirmedTaskSpec`，再创建正式 Task。

3. 旧 IntentDraft API 兼容

- `POST /intent-drafts` 投影到 Task Intake create。
- `PATCH /intent-drafts/{intent_draft_id}` 与 clarification 入口投影到 Task Intake patch。
- `POST /intent-drafts/{intent_draft_id}/finalize` 通过 `ConfirmedTaskSpec` 创建正式 Task，并回链 `intake_id` / `intent_draft_id`。

4. `/tasks` 兼容入口收敛

- 保留原有 `goal + constraints + metadata` 创建路径，避免破坏现有调用方。
- 新增 `confirmed_task_spec` 输入路径，用已确认的结构化任务输入创建正式 Task。
- 自由文本 `query` 不再直接进入 Planner，而是创建 intake session 并返回 `intake_id` 与 `needs_confirmation`。

5. CLI 入口迁移

- 新增 `design intake schema/create/patch/confirm`。
- 旧 `design preflight` 入口会提示迁移到 `design intake ...`。

## Issue #260 逐项对照

- [x] 定义 `IntentDraft` 与 `TaskIntakeSession` 的兼容映射，并复用 registry、draft、confirm 语义。
- [x] 旧 `POST /intent-drafts`、clarification、finalize 均投影到 `/task-intakes` 等价流程。
- [x] 低置信度字段进入 `ambiguous_fields`，未映射文本进入 `unmapped_text`，自由文本不会直接进入 Planner。
- [x] finalize/confirm 生成 `ConfirmedTaskSpec`，正式 Task 从 `CREATED` 开始。
- [x] Task Builder 需要通过 `/task-intakes/schema` 获取字段注册表，API 契约测试已覆盖该入口。
- [x] CLI 优先提供 `design intake ...`，旧 preflight 命令提示迁移。

## FSM 与边界说明

本 PR 没有修改 `ExternalStatus`、`InternalStatus` 或 workflow transition table。Task Intake 的状态仅存在于 `TaskIntakeStatus`，用于正式 Task 创建前的录入会话。确认成功后创建的正式 Task 记录状态为：

- `status = CREATED`
- `internal_status = CREATED`

因此 preflight/intake 阶段与运行态 FSM 保持解耦。

## 测试

已运行：

```bash
uv run pytest tests/api/test_api_endpoints.py tests/unit/test_cli.py tests/unit/test_contracts.py tests/unit/test_status_transition.py -q
```

结果：

```text
103 passed
```

同时运行：

```bash
git diff --check
python -m compileall src/models/task_intake.py src/api/main.py src/cli.py
```

均通过。

Closes #260