### PR TITLE
test(task-intake): 固化 intake 对象契约

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -110,8 +110,15 @@ class TaskCreateRequest(BaseModel):
     def _validate_creation_mode(self) -> "TaskCreateRequest":
         """确保 /tasks 请求明确选择一种兼容创建模式。"""
 
-        if self.goal is None and self.query is None and self.confirmed_task_spec is None:
+        modes = [
+            self.goal is not None,
+            self.query is not None,
+            self.confirmed_task_spec is not None,
+        ]
+        if not any(modes):
             raise ValueError("one of goal, query, or confirmed_task_spec is required")
+        if sum(modes) > 1:
+            raise ValueError("choose exactly one of goal, query, or confirmed_task_spec")
         return self
 
 

--- a/src/models/task_intake.py
+++ b/src/models/task_intake.py
@@ -485,7 +485,7 @@ class TaskIntakeSession(BaseModel):
     """一次正式 Task 创建前的录入会话。"""
 
     intake_id: str
-    status: TaskIntakeStatus
+    status: TaskIntakeStatus = TaskIntakeStatus.COLLECTING
     raw_input: dict[str, Any] = Field(default_factory=dict)
     draft: TaskSpecDraft = Field(default_factory=TaskSpecDraft)
     missing_required_fields: list[str] = Field(default_factory=list)

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -372,6 +372,33 @@ class TestAPIEndpoints:
         assert data["intake_id"] in INTAKE_STORE
         assert TASK_STORE == {}
 
+    async def test_tasks_create_rejects_mixed_creation_modes(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """正式 Task 创建入口应明确选择一种输入模式。"""
+
+        response = await client.post(
+            "/tasks",
+            json={
+                "goal": "direct legacy goal",
+                "confirmed_task_spec": {
+                    "goal": "confirmed goal",
+                    "metadata": {
+                        "intake_id": "intake_mixed",
+                        "field_registry_version": "task-intake.v1",
+                        "support_level": "P0",
+                        "confirmed_by": "tester",
+                        "input_mode": "structured_with_confirmation",
+                        "acknowledged_warnings": [],
+                    },
+                },
+            },
+        )
+
+        assert response.status_code == 422
+        assert "choose exactly one" in response.text
+
     async def test_legacy_intent_draft_maps_to_task_intake_finalize(
         self,
         client: httpx.AsyncClient,

--- a/tests/unit/test_task_intake_contracts.py
+++ b/tests/unit/test_task_intake_contracts.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from src.models.task_intake import (
+    ConfirmedTaskSpec,
+    TaskDraftField,
+    TaskDraftFieldSource,
+    TaskIntakeSession,
+    TaskIntakeStatus,
+    TaskSpecDraft,
+    confirm_task_intake_session,
+    create_task_intake_session,
+    project_confirmed_task_spec,
+)
+
+
+def test_task_intake_session_defaults_and_status_values() -> None:
+    """TaskIntakeSession 应表达前置录入状态和审计集合默认值。"""
+
+    session = TaskIntakeSession(intake_id="intake_defaults")
+
+    assert session.status == TaskIntakeStatus.COLLECTING
+    assert set(TaskIntakeStatus) == {
+        TaskIntakeStatus.COLLECTING,
+        TaskIntakeStatus.NEEDS_CONFIRMATION,
+        TaskIntakeStatus.CONFIRMED,
+        TaskIntakeStatus.CANCELLED,
+    }
+    assert session.raw_input == {}
+    assert session.draft == TaskSpecDraft()
+    assert session.missing_required_fields == []
+    assert session.ambiguous_fields == []
+    assert session.unmapped_text == []
+    assert session.warnings == []
+
+
+def test_task_draft_field_source_and_confirmation_contract() -> None:
+    """TaskSpecDraft 字段包装应保留来源、置信度、确认和修改审计。"""
+
+    field = TaskDraftField(
+        value="stability",
+        source=TaskDraftFieldSource.USER_EXPLICIT,
+        confidence=0.9,
+        source_span="stable",
+        confirmed=True,
+        warnings=["checked"],
+        last_modified_by="tester",
+    )
+
+    assert {source.value for source in TaskDraftFieldSource} == {
+        "user_explicit",
+        "llm_extract",
+        "system_default",
+        "kg_derived",
+        "user_modified",
+    }
+    assert field.model_dump(mode="json") == {
+        "value": "stability",
+        "source": "user_explicit",
+        "confidence": 0.9,
+        "source_span": "stable",
+        "confirmed": True,
+        "warnings": ["checked"],
+        "last_modified_by": "tester",
+    }
+
+
+def test_task_intake_session_serialization_round_trip() -> None:
+    """TaskIntakeSession 应支持稳定序列化/反序列化。"""
+
+    session = create_task_intake_session(
+        intake_id="intake_roundtrip",
+        text="design de novo stable protein around 120 aa",
+        structured_fields={},
+        source="api",
+    )
+
+    restored = TaskIntakeSession.model_validate(session.model_dump(mode="json"))
+
+    assert restored == session
+    assert restored.draft.fields["task_kind"].source == TaskDraftFieldSource.LLM_EXTRACT
+    assert restored.draft.fields["length_range"].value == [100, 140]
+
+
+def test_confirmed_task_spec_projection_to_protein_design_task_shape() -> None:
+    """ConfirmedTaskSpec 应可投影到现有 ProteinDesignTask 字段。"""
+
+    spec = ConfirmedTaskSpec(
+        goal="de_novo_design for stability",
+        objective={"objective_type": "stability"},
+        inputs={"sequence": "ACDE"},
+        constraints={"length_range": [4, 8]},
+        initial_artifacts=[{"kind": "sequence", "path": "input.fa"}],
+        metadata={
+            "intake_id": "intake_projection",
+            "field_registry_version": "task-intake.v1",
+            "support_level": "P0",
+            "confirmed_by": "tester",
+            "input_mode": "structured_with_confirmation",
+            "acknowledged_warnings": [],
+        },
+    )
+
+    goal, constraints, metadata = project_confirmed_task_spec(spec)
+
+    assert goal == "de_novo_design for stability"
+    assert constraints["length_range"] == [4, 8]
+    assert constraints["objective"] == {"objective_type": "stability"}
+    assert constraints["inputs"] == {"sequence": "ACDE"}
+    assert metadata["intake_id"] == "intake_projection"
+    assert metadata["confirmed_task_spec"]["initial_artifacts"] == [
+        {"kind": "sequence", "path": "input.fa"}
+    ]
+
+
+def test_confirmed_task_spec_metadata_contains_required_audit_keys() -> None:
+    """确认流程应保留 issue 要求的 metadata 审计键。"""
+
+    session = create_task_intake_session(
+        intake_id="intake_confirmed",
+        text="design stable binding protein around 130 aa",
+        structured_fields={
+            "task_kind": "de_novo_design",
+            "objective_type": "stability",
+            "length_range": [120, 150],
+        },
+        source="web",
+    )
+    spec = confirm_task_intake_session(
+        session,
+        confirmed_by="tester",
+        acknowledged_warnings=["reviewed"],
+    )
+
+    assert {
+        "intake_id",
+        "field_registry_version",
+        "support_level",
+        "confirmed_by",
+        "input_mode",
+        "acknowledged_warnings",
+    } <= set(spec.metadata)
+    assert spec.metadata["acknowledged_warnings"] == ["reviewed"]
+    assert session.status == TaskIntakeStatus.CONFIRMED
+    assert all(field.confirmed for field in session.draft.fields.values())
+
+
+def test_structured_fields_override_raw_text_extraction() -> None:
+    """原始自然语言只能进入 audit，不能覆盖已确认结构化字段。"""
+
+    session = create_task_intake_session(
+        intake_id="intake_raw_text",
+        text="please evaluate binding protein around 300 aa",
+        structured_fields={
+            "task_kind": "de_novo_design",
+            "objective_type": "stability",
+            "length_range": [80, 120],
+        },
+        source="web",
+    )
+    spec = confirm_task_intake_session(
+        session,
+        confirmed_by="tester",
+        acknowledged_warnings=[],
+    )
+
+    assert spec.constraints["task_kind"] == "de_novo_design"
+    assert spec.objective["objective_type"] == "stability"
+    assert spec.constraints["length_range"] == [80, 120]
+    assert spec.metadata["raw_query"] == "please evaluate binding protein around 300 aa"


### PR DESCRIPTION
## 变更内容

- 为 `TaskIntakeSession` 增加 `collecting` 默认状态，保持前置录入对象可直接表达默认草稿态。
- 收紧 `/tasks` 创建请求的兼容入口校验，要求 `goal`、`query`、`confirmed_task_spec` 三种模式明确三选一，避免结构化确认输入与 legacy 输入混用。
- 新增 Task Intake contract tests，覆盖状态默认值、字段来源枚举、字段包装审计信息、序列化/反序列化、ConfirmedTaskSpec 到 ProteinDesignTask 的投影、metadata 审计键，以及原始自然语言不能覆盖结构化确认字段。

## 对齐 issue

Closes #277

本 PR 只固化 Task Intake 前置契约与持久化形状，不新增正式 Workflow FSM 状态，不改变 PendingAction / Decision / TaskSnapshot 核心语义，不新增 Agent 角色，也不实现 Planner 逻辑。

## 验证

- `uv run pytest tests/unit/test_task_intake_contracts.py tests/unit/test_task_field_registry.py tests/api/test_api_endpoints.py tests/unit/test_cli.py`
- 结果：57 passed
