### PR TITLE
feat(api): 完成 Task Intake API 收敛

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException, Query
-from fastapi.responses import HTMLResponse
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, model_validator
 
@@ -67,6 +67,36 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 TASK_STORE: Dict[str, TaskRecord] = {}
 INTAKE_STORE: Dict[str, TaskIntakeSession] = {}
 RUNTIME_INIT: Optional[RuntimeInitResult] = None
+
+
+class TaskIntakeAPIError(Exception):
+    """Task Intake API 的稳定错误响应。"""
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        detail: str,
+        missing_fields: list[str] | None = None,
+        validation_errors: list[dict[str, Any]] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.payload = {
+            "status": status_code,
+            "detail": detail,
+            "missing_fields": missing_fields or [],
+            "validation_errors": validation_errors or [],
+            "context": context or {},
+        }
+
+
+@app.exception_handler(TaskIntakeAPIError)
+async def _handle_task_intake_api_error(
+    _request: Request,
+    exc: TaskIntakeAPIError,
+) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content=exc.payload)
 
 
 def _path_from_env(env_key: str) -> Optional[Path]:
@@ -569,12 +599,70 @@ def _task_intake_summary(session: TaskIntakeSession) -> dict[str, Any]:
     return {
         "intake_id": session.intake_id,
         "status": session.status.value,
+        "human_summary": session.human_summary,
         "draft": session.draft.model_dump(mode="json"),
         "missing_required_fields": list(session.missing_required_fields),
         "ambiguous_fields": list(session.ambiguous_fields),
         "unmapped_text": list(session.unmapped_text),
         "warnings": list(session.warnings),
     }
+
+
+def _task_intake_validation_errors(
+    session: TaskIntakeSession,
+) -> list[dict[str, Any]]:
+    errors: list[dict[str, Any]] = []
+    for field_name, field in session.draft.fields.items():
+        for warning in field.warnings:
+            errors.append(
+                {
+                    "field": field_name,
+                    "message": warning,
+                    "value": field.value,
+                }
+            )
+    for warning in session.warnings:
+        if not any(error["message"] == warning for error in errors):
+            errors.append({"field": None, "message": warning, "value": None})
+    return errors
+
+
+def _raise_task_intake_error(
+    session: TaskIntakeSession,
+    *,
+    detail: str,
+    status_code: int = 422,
+) -> None:
+    raise TaskIntakeAPIError(
+        status_code=status_code,
+        detail=detail,
+        missing_fields=list(session.missing_required_fields),
+        validation_errors=_task_intake_validation_errors(session),
+        context={
+            "intake_id": session.intake_id,
+            "status": session.status.value,
+            "ambiguous_fields": list(session.ambiguous_fields),
+        },
+    )
+
+
+def _raise_task_intake_value_error(
+    *,
+    detail: str,
+    field_context: dict[str, Any] | None = None,
+) -> None:
+    raise TaskIntakeAPIError(
+        status_code=422,
+        detail=detail,
+        validation_errors=[
+            {
+                "field": field_context.get("field") if field_context else None,
+                "message": detail,
+                "value": field_context.get("value") if field_context else None,
+            }
+        ],
+        context=field_context or {},
+    )
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -630,12 +718,17 @@ async def create_task_intake(req: TaskIntakeCreateRequest) -> TaskIntakeSession:
     """创建正式 Task 之前的 Task Intake 会话。"""
 
     intake_id = f"intake_{uuid4().hex[:8]}"
-    session = create_task_intake_session(
-        intake_id=intake_id,
-        text=req.text,
-        structured_fields=req.structured_fields,
-        source=req.source,
-    )
+    try:
+        session = create_task_intake_session(
+            intake_id=intake_id,
+            text=req.text,
+            structured_fields=req.structured_fields,
+            source=req.source,
+        )
+    except ValueError as exc:
+        _raise_task_intake_value_error(detail=str(exc))
+    if session.warnings:
+        _raise_task_intake_error(session, detail="task intake validation failed")
     INTAKE_STORE[intake_id] = session
     return session
 
@@ -648,14 +741,22 @@ async def update_task_intake(
     """更新 Task Intake 草稿字段。"""
 
     session = _get_intake_or_404(intake_id)
+    candidate = session.model_copy(deep=True)
     try:
-        return patch_task_intake_session(
-            session,
+        updated = patch_task_intake_session(
+            candidate,
             fields=req.fields,
             updated_by=req.updated_by,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        _raise_task_intake_value_error(
+            detail=str(exc),
+            field_context={"intake_id": intake_id},
+        )
+    if updated.warnings:
+        _raise_task_intake_error(updated, detail="task intake validation failed")
+    INTAKE_STORE[intake_id] = updated
+    return updated
 
 
 @app.post("/task-intakes/{intake_id}/confirm")
@@ -673,13 +774,14 @@ async def confirm_task_intake(
             acknowledged_warnings=req.acknowledged_warnings,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        _raise_task_intake_error(session, detail=str(exc))
 
     record = _create_task_record_from_confirmed_spec(confirmed_spec)
     return {
         "intake_id": intake_id,
         "task_id": record.id,
         "status": record.status.value,
+        "human_summary": session.human_summary,
         "confirmed_task_spec": confirmed_spec.model_dump(mode="json"),
     }
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -49,7 +49,7 @@ from src.models.task_intake import (
     patch_task_intake_session,
     project_confirmed_task_spec,
 )
-from src.storage.log_store import read_timeline_events
+from src.storage.log_store import append_event, read_timeline_events
 from src.workflow.context import WorkflowContext
 from src.infra.tool_readiness import (
     build_capability_readiness_matrix,
@@ -578,12 +578,13 @@ def _get_intake_or_404(intake_id: str) -> TaskIntakeSession:
 def _create_task_record_from_confirmed_spec(spec: ConfirmedTaskSpec) -> TaskRecord:
     goal, constraints, metadata = project_confirmed_task_spec(spec)
     task_id = f"task_{uuid4().hex[:8]}"
+    timestamp = now_iso()
     record = TaskRecord(
         id=task_id,
         status=ExternalStatus.CREATED,
         internal_status=InternalStatus.CREATED,
-        created_at=now_iso(),
-        updated_at=now_iso(),
+        created_at=timestamp,
+        updated_at=timestamp,
         goal=goal,
         constraints=constraints,
         metadata=metadata,
@@ -592,6 +593,21 @@ def _create_task_record_from_confirmed_spec(spec: ConfirmedTaskSpec) -> TaskReco
         safety_events=[],
     )
     TASK_STORE[task_id] = record
+    append_event(
+        task_id,
+        {
+            "event": "TASK_CREATED_FROM_CONFIRMED_INTAKE",
+            "task_id": task_id,
+            "status": ExternalStatus.CREATED.value,
+            "actor_type": "api",
+            "timestamp": timestamp,
+            "data": {
+                "intake_id": metadata.get("intake_id"),
+                "support_level": metadata.get("support_level"),
+                "input_mode": metadata.get("input_mode"),
+            },
+        },
+    )
     return record
 
 

--- a/src/models/task_intake.py
+++ b/src/models/task_intake.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from src.kg.kg_client import ToolKGError, get_tool_nodes
 from src.models.contracts import now_iso
 
 
@@ -93,6 +94,18 @@ TASK_FIELD_REGISTRY: dict[str, Any] = {
             "options": [],
             "default": None,
             "maps_to": "inputs.template_pdb",
+            "support_level": "P0",
+            "audit_visibility": "public",
+        },
+        "initial_artifacts": {
+            "group": "inputs",
+            "type": "artifact_ref_list",
+            "ui_control": "artifact_picker",
+            "nl_aliases": ["初始产物", "artifacts", "artifact refs"],
+            "validators": {"ref_schemes": ["artifact", "task", "relative_path"]},
+            "options": [],
+            "default": [],
+            "maps_to": "initial_artifacts",
             "support_level": "P0",
             "audit_visibility": "public",
         },
@@ -323,6 +336,7 @@ TASK_FIELD_REGISTRY: dict[str, Any] = {
                 "quality_metric",
                 "min_quality_score",
                 "target_fold",
+                "initial_artifacts",
                 "forbidden_motifs",
                 "safety_level",
                 "run_profile",
@@ -341,6 +355,7 @@ TASK_FIELD_REGISTRY: dict[str, Any] = {
             "optional": [
                 "quality_metric",
                 "min_quality_score",
+                "initial_artifacts",
                 "safety_level",
                 "run_profile",
                 "tools_allowed",
@@ -361,6 +376,7 @@ TASK_FIELD_REGISTRY: dict[str, Any] = {
                 "quality_metric",
                 "min_quality_score",
                 "target_fold",
+                "initial_artifacts",
                 "safety_level",
                 "run_profile",
                 "tools_allowed",
@@ -480,6 +496,17 @@ class ConfirmedTaskSpec(BaseModel):
             raise ValueError("goal must not be empty")
         return normalized
 
+    @field_validator("initial_artifacts")
+    @classmethod
+    def _validate_initial_artifacts(
+        cls,
+        value: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        error = _validate_artifact_ref_list("initial_artifacts", value)
+        if error is not None:
+            raise ValueError(error)
+        return value
+
 
 class TaskIntakeSession(BaseModel):
     """一次正式 Task 创建前的录入会话。"""
@@ -492,6 +519,7 @@ class TaskIntakeSession(BaseModel):
     ambiguous_fields: list[str] = Field(default_factory=list)
     unmapped_text: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
+    human_summary: str = ""
     created_at: str = Field(default_factory=now_iso)
     updated_at: str = Field(default_factory=now_iso)
     confirmed_task_spec: ConfirmedTaskSpec | None = None
@@ -532,6 +560,9 @@ def build_task_intake_schema() -> dict[str, Any]:
     """生成 Web/CLI 共享的字段注册表视图。"""
 
     registry = get_task_field_registry()
+    tool_options = build_tool_kg_options()
+    _attach_tool_options(registry["fields"], tool_options)
+    registry["tool_options"] = tool_options
     registry["web_schema"] = build_task_intake_web_schema()
     registry["cli_arguments"] = build_task_intake_cli_arguments()
     registry["cli_questions"] = build_task_intake_cli_questions()
@@ -551,7 +582,7 @@ def get_task_field_registry() -> dict[str, Any]:
 def build_task_intake_web_schema() -> dict[str, Any]:
     """从 registry 派生 Web 表单分组 schema。"""
 
-    fields = _registry_fields()
+    fields = _schema_fields()
     return {
         "groups": [
             {
@@ -581,7 +612,7 @@ def build_task_intake_cli_arguments() -> list[dict[str, Any]]:
             "required_by_profiles": required_by.get(name, []),
             "nl_aliases": list(definition["nl_aliases"]),
         }
-        for name, definition in _registry_fields().items()
+        for name, definition in _schema_fields().items()
     ]
 
 
@@ -599,7 +630,7 @@ def build_task_intake_cli_questions() -> list[dict[str, Any]]:
             "default": definition["default"],
             "required_by_profiles": required_by.get(name, []),
         }
-        for name, definition in _registry_fields().items()
+        for name, definition in _schema_fields().items()
     ]
 
 
@@ -607,12 +638,19 @@ def build_task_intake_llm_extraction_schema() -> dict[str, Any]:
     """从 registry 派生自然语言字段抽取 schema。"""
 
     properties: dict[str, Any] = {}
-    for name, definition in _registry_fields().items():
+    for name, definition in _schema_fields().items():
         property_schema = {
             "type": _json_schema_type_for_field(definition),
             "description": ", ".join(definition["nl_aliases"]),
         }
-        if definition["options"]:
+        if definition["type"] == "tool_id_list":
+            property_schema["items"] = {
+                "type": "string",
+                "enum": list(definition["options"]),
+            }
+        elif definition["type"] == "artifact_ref_list":
+            property_schema["items"] = {"type": "object"}
+        elif definition["options"]:
             property_schema["enum"] = list(definition["options"])
         properties[name] = property_schema
     return {
@@ -638,6 +676,31 @@ def build_planner_capability_hints() -> dict[str, list[str]]:
         name: list(profile["capability_hints"])
         for name, profile in _task_profiles().items()
     }
+
+
+def build_tool_kg_options() -> list[dict[str, Any]]:
+    """从 ProteinToolKG 派生 Web/CLI 可用的工具选项。"""
+
+    try:
+        tools = get_tool_nodes()
+    except ToolKGError:
+        return []
+
+    options: list[dict[str, Any]] = []
+    for tool in tools:
+        tool_id = tool.get("id") or tool.get("tool_id")
+        if not isinstance(tool_id, str) or not tool_id:
+            continue
+        options.append(
+            {
+                "tool_id": tool_id,
+                "label": tool.get("name") or tool_id,
+                "capabilities": list(tool.get("capabilities") or []),
+                "support_level": tool.get("priority"),
+                "execution": tool.get("execution"),
+            }
+        )
+    return options
 
 
 def create_task_intake_session(
@@ -709,6 +772,7 @@ def refresh_task_intake_session(session: TaskIntakeSession) -> TaskIntakeSession
             session.warnings.append(error)
         if field.confidence < HIGH_CONFIDENCE_THRESHOLD:
             session.ambiguous_fields.append(field_name)
+    session.warnings.extend(_run_safety_input_precheck(session))
 
     required = _required_fields_for(session.draft.fields)
     session.missing_required_fields = [
@@ -723,6 +787,7 @@ def refresh_task_intake_session(session: TaskIntakeSession) -> TaskIntakeSession
         session.status = TaskIntakeStatus.COLLECTING
     else:
         session.status = TaskIntakeStatus.NEEDS_CONFIRMATION
+    session.human_summary = _build_human_summary(session)
     session.updated_at = now_iso()
     return session
 
@@ -780,6 +845,23 @@ def _registry_fields() -> dict[str, dict[str, Any]]:
     return deepcopy(TASK_FIELD_REGISTRY["fields"])
 
 
+def _schema_fields() -> dict[str, dict[str, Any]]:
+    fields = _registry_fields()
+    _attach_tool_options(fields, build_tool_kg_options())
+    return fields
+
+
+def _attach_tool_options(
+    fields: dict[str, dict[str, Any]],
+    tool_options: list[dict[str, Any]],
+) -> None:
+    tool_ids = [option["tool_id"] for option in tool_options]
+    for field_name in ("tools_allowed", "tools_excluded"):
+        if field_name in fields:
+            fields[field_name]["options"] = list(tool_ids)
+            fields[field_name]["tool_options"] = deepcopy(tool_options)
+
+
 def _task_profiles() -> dict[str, dict[str, Any]]:
     return deepcopy(TASK_FIELD_REGISTRY["task_profiles"])
 
@@ -811,7 +893,12 @@ def _json_schema_type_for_field(definition: dict[str, Any]) -> str | list[str]:
         return "number"
     if field_type == "boolean":
         return "boolean"
-    if field_type in {"string_list", "residue_list", "tool_id_list"}:
+    if field_type in {
+        "string_list",
+        "residue_list",
+        "tool_id_list",
+        "artifact_ref_list",
+    }:
         return "array"
     return "string"
 
@@ -942,6 +1029,7 @@ def _merge_structured_fields(
 ) -> None:
     for field_name, raw_value in fields.items():
         value, confidence, source_span = _unwrap_field_value(raw_value)
+        value = _normalize_registry_value(field_name, value)
         if confidence < LOW_CONFIDENCE_THRESHOLD:
             draft.unmapped_text.append(f"{field_name}={value}")
             draft.fields.pop(field_name, None)
@@ -957,7 +1045,7 @@ def _merge_structured_fields(
 
 
 def _unwrap_field_value(raw_value: Any) -> tuple[Any, float, str | None]:
-    if isinstance(raw_value, dict) and "value" in raw_value:
+    if isinstance(raw_value, dict) and "value" in raw_value and "unit" not in raw_value:
         confidence = raw_value.get("confidence", 1.0)
         if not isinstance(confidence, (int, float)):
             confidence = 1.0
@@ -965,6 +1053,56 @@ def _unwrap_field_value(raw_value: Any) -> tuple[Any, float, str | None]:
         normalized_span = source_span if isinstance(source_span, str) else None
         return raw_value["value"], float(confidence), normalized_span
     return raw_value, 1.0, None
+
+
+def _normalize_registry_value(field_name: str, value: Any) -> Any:
+    registry = _registry_fields()
+    field = registry.get(field_name)
+    if field is None:
+        return value
+
+    field_type = field["type"]
+    if field_type == "integer_range" and isinstance(value, dict):
+        unit = str(value.get("unit", "aa")).strip().lower()
+        if unit not in {"aa", "amino_acid", "amino_acids", "residue", "residues"}:
+            raise ValueError(f"{field_name} unit must be amino-acid based")
+        lower = value.get("min", value.get("start"))
+        upper = value.get("max", value.get("end"))
+        if (
+            not isinstance(lower, int)
+            or isinstance(lower, bool)
+            or not isinstance(upper, int)
+            or isinstance(upper, bool)
+        ):
+            raise ValueError(f"{field_name} min/max must be integers")
+        return [lower, upper]
+
+    if field_name == "max_runtime_min" and isinstance(value, dict):
+        raw_amount = value.get("value")
+        unit = str(value.get("unit", "min")).strip().lower()
+        multipliers = {
+            "m": 1,
+            "min": 1,
+            "minute": 1,
+            "minutes": 1,
+            "h": 60,
+            "hr": 60,
+            "hour": 60,
+            "hours": 60,
+            "d": 1440,
+            "day": 1440,
+            "days": 1440,
+        }
+        if unit not in multipliers:
+            raise ValueError("max_runtime_min unit must be minutes, hours, or days")
+        if not isinstance(raw_amount, (int, float)) or isinstance(raw_amount, bool):
+            raise ValueError("max_runtime_min value must be numeric")
+        minutes = raw_amount * multipliers[unit]
+        if not float(minutes).is_integer():
+            raise ValueError("max_runtime_min must normalize to whole minutes")
+        return int(minutes)
+
+    return value
 
 
 def _required_fields_for(fields: dict[str, TaskDraftField]) -> list[str]:
@@ -1041,13 +1179,111 @@ def _validate_registry_value(field_name: str, value: Any) -> str | None:
             isinstance(item, str) and item for item in value
         ):
             return f"{field_name} must be a list of strings"
+        if field_type == "tool_id_list":
+            invalid_tool_ids = sorted(set(value) - _allowed_tool_ids())
+            if invalid_tool_ids:
+                return (
+                    f"{field_name} contains unknown tool_id(s): "
+                    f"{', '.join(invalid_tool_ids)}"
+                )
     if field_type == "residue_list":
         if not isinstance(value, list) or not all(
             isinstance(item, str) and re.match(r"^[A-Z][0-9]+$", item)
             for item in value
         ):
             return f"{field_name} must be residue ids like A42"
+    if field_type == "artifact_ref_list":
+        return _validate_artifact_ref_list(field_name, value)
     return None
+
+
+def _allowed_tool_ids() -> set[str]:
+    return {option["tool_id"] for option in build_tool_kg_options()}
+
+
+def _validate_artifact_ref_list(field_name: str, value: Any) -> str | None:
+    if not isinstance(value, list):
+        return f"{field_name} must be a list of artifact refs"
+
+    for index, artifact in enumerate(value):
+        if not isinstance(artifact, dict):
+            return f"{field_name}[{index}] must be an object"
+        kind = artifact.get("kind")
+        if not isinstance(kind, str) or not kind.strip():
+            return f"{field_name}[{index}].kind must be a non-empty string"
+
+        ref_values = [
+            artifact.get("artifact_id"),
+            artifact.get("uri"),
+            artifact.get("path"),
+            artifact.get("ref"),
+        ]
+        if not any(isinstance(item, str) and item.strip() for item in ref_values):
+            return (
+                f"{field_name}[{index}] must include artifact_id, uri, path, or ref"
+            )
+
+        artifact_id = artifact.get("artifact_id")
+        if isinstance(artifact_id, str) and not re.match(
+            r"^[A-Za-z0-9_.:-]+$",
+            artifact_id,
+        ):
+            return f"{field_name}[{index}].artifact_id is invalid"
+
+        uri = artifact.get("uri")
+        if isinstance(uri, str) and not (
+            uri.startswith("artifact://") or uri.startswith("task://")
+        ):
+            return f"{field_name}[{index}].uri must use artifact:// or task://"
+
+        path = artifact.get("path")
+        if isinstance(path, str) and (
+            path.startswith("/")
+            or path.startswith("~")
+            or ".." in path.split("/")
+            or not path.strip()
+        ):
+            return f"{field_name}[{index}].path must be a safe relative path"
+
+        ref = artifact.get("ref")
+        if isinstance(ref, str) and not re.match(
+            r"^task_[A-Za-z0-9_:-]+\.[A-Za-z][A-Za-z0-9_.-]*$",
+            ref,
+        ):
+            return f"{field_name}[{index}].ref must look like task_id.artifact_key"
+
+    return None
+
+
+def _run_safety_input_precheck(session: TaskIntakeSession) -> list[str]:
+    fields = {name: field.value for name, field in session.draft.fields.items()}
+    sequence = fields.get("sequence")
+    forbidden_motifs = fields.get("forbidden_motifs")
+    if not isinstance(sequence, str) or not isinstance(forbidden_motifs, list):
+        return []
+
+    normalized_sequence = sequence.upper()
+    warnings: list[str] = []
+    for motif in forbidden_motifs:
+        if isinstance(motif, str) and motif.upper() in normalized_sequence:
+            warnings.append(
+                f"forbidden_motifs contains motif present in sequence: {motif}"
+            )
+    return warnings
+
+
+def _build_human_summary(session: TaskIntakeSession) -> str:
+    fields = {name: field.value for name, field in session.draft.fields.items()}
+    task_kind = fields.get("task_kind", "unknown task")
+    objective = fields.get("objective_type", "unspecified objective")
+    pieces = [f"{task_kind} / {objective}", f"status={session.status.value}"]
+    if session.missing_required_fields:
+        pieces.append(f"missing={', '.join(session.missing_required_fields)}")
+    if session.ambiguous_fields:
+        pieces.append(f"ambiguous={', '.join(session.ambiguous_fields)}")
+    if session.warnings:
+        pieces.append(f"warnings={len(session.warnings)}")
+    return "; ".join(pieces)
 
 
 def _build_confirmed_spec(
@@ -1060,6 +1296,7 @@ def _build_confirmed_spec(
     objective: dict[str, Any] = {}
     inputs: dict[str, Any] = {}
     constraints: dict[str, Any] = {}
+    initial_artifacts: list[dict[str, Any]] = []
     registry = _registry_fields()
 
     for field_name, value in fields.items():
@@ -1070,6 +1307,8 @@ def _build_confirmed_spec(
             inputs[maps_to.split(".", 1)[1]] = value
         elif maps_to.startswith("constraints."):
             constraints[maps_to.split(".", 1)[1]] = value
+        elif maps_to == "initial_artifacts":
+            initial_artifacts = list(value)
 
     goal = _build_goal(fields)
     metadata = {
@@ -1096,7 +1335,7 @@ def _build_confirmed_spec(
         objective=objective,
         inputs=inputs,
         constraints=constraints,
-        initial_artifacts=[],
+        initial_artifacts=initial_artifacts,
         metadata=metadata,
     )
 

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -269,6 +269,11 @@ class TestAPIEndpoints:
             "planner_policy",
         ]
         assert data["fields"]["task_kind"]["maps_to"] == "constraints.task_kind"
+        assert "esmfold" in data["fields"]["tools_allowed"]["options"]
+        assert any(
+            option["tool_id"] == "esmfold" and option["support_level"] == "P0"
+            for option in data["tool_options"]
+        )
         assert "de_novo_design" in data["task_profiles"]
         assert data["task_profiles"]["binding_design"]["support_level"] == "P2"
         assert data["cli_arguments"][0]["flag"].startswith("--")
@@ -353,6 +358,127 @@ class TestAPIEndpoints:
         assert task["metadata"]["confirmed_task_spec"]["metadata"][
             "planner_capability_hints"
         ] == ["sequence_generation", "structure_prediction"]
+
+    async def test_task_intake_confirm_missing_fields_returns_stable_error(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """缺少必填/条件必填字段时 confirm 返回稳定错误结构。"""
+
+        create_response = await client.post(
+            "/task-intakes",
+            json={
+                "structured_fields": {"task_kind": "binding_design"},
+                "source": "web",
+            },
+        )
+        assert create_response.status_code == 200
+        intake_id = create_response.json()["intake_id"]
+
+        confirm_response = await client.post(
+            f"/task-intakes/{intake_id}/confirm",
+            json={"confirmed_by": "tester", "acknowledged_warnings": []},
+        )
+
+        assert confirm_response.status_code == 422
+        data = confirm_response.json()
+        assert data["status"] == 422
+        assert "missing required fields" in data["detail"]
+        assert "objective_type" in data["missing_fields"]
+        assert data["context"]["intake_id"] == intake_id
+
+    @pytest.mark.parametrize(
+        ("fields", "expected_message"),
+        [
+            (
+                {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "invalid",
+                    "length_range": [90, 120],
+                },
+                "objective_type must be one of",
+            ),
+            (
+                {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": [120, 90],
+                },
+                "length_range must be [min, max] integers",
+            ),
+            (
+                {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": {"min": 90, "max": 120, "unit": "nt"},
+                },
+                "length_range unit must be amino-acid based",
+            ),
+            (
+                {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": [90, 120],
+                    "tools_allowed": ["not_a_tool"],
+                },
+                "tools_allowed contains unknown tool_id",
+            ),
+            (
+                {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": [90, 120],
+                    "initial_artifacts": [{"kind": "template", "path": "../x.pdb"}],
+                },
+                "initial_artifacts[0].path must be a safe relative path",
+            ),
+        ],
+    )
+    async def test_task_intake_rejects_invalid_contract_inputs(
+        self,
+        client: httpx.AsyncClient,
+        fields: dict[str, object],
+        expected_message: str,
+    ):
+        """非法 enum/tool_id/artifact ref/unit/range 均返回 4xx 稳定错误。"""
+
+        response = await client.post(
+            "/task-intakes",
+            json={"structured_fields": fields, "source": "web"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["status"] == 422
+        assert expected_message in json.dumps(data, ensure_ascii=False)
+        assert "validation_errors" in data
+
+    async def test_task_intake_patch_validates_without_mutating_on_error(
+        self,
+        client: httpx.AsyncClient,
+    ):
+        """PATCH 校验失败时返回稳定错误且不污染已保存 draft。"""
+
+        create_response = await client.post(
+            "/task-intakes",
+            json={
+                "structured_fields": {
+                    "task_kind": "de_novo_design",
+                    "objective_type": "stability",
+                    "length_range": [90, 120],
+                },
+                "source": "web",
+            },
+        )
+        intake_id = create_response.json()["intake_id"]
+
+        patch_response = await client.patch(
+            f"/task-intakes/{intake_id}",
+            json={"fields": {"tools_allowed": ["missing_tool"]}},
+        )
+
+        assert patch_response.status_code == 422
+        assert "tools_allowed" not in INTAKE_STORE[intake_id].draft.fields
 
     async def test_legacy_tasks_query_converges_to_intake(
         self,

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -359,6 +359,12 @@ class TestAPIEndpoints:
             "planner_capability_hints"
         ] == ["sequence_generation", "structure_prediction"]
 
+        events_response = await client.get(f"/tasks/{confirmation['task_id']}/events")
+        assert events_response.status_code == 200
+        events = events_response.json()
+        assert events[0]["event_type"] == "TASK_CREATED_FROM_CONFIRMED_INTAKE"
+        assert events[0]["data"]["intake_id"] == intake_id
+
     async def test_task_intake_confirm_missing_fields_returns_stable_error(
         self,
         client: httpx.AsyncClient,

--- a/tests/unit/test_task_field_registry.py
+++ b/tests/unit/test_task_field_registry.py
@@ -52,14 +52,16 @@ def test_task_profiles_mark_support_levels_and_capability_hints() -> None:
 
 
 def test_tool_selection_fields_defer_candidates_to_toolkg() -> None:
-    """工具选择字段只声明控件和 ToolKG 校验来源。"""
+    """工具选择字段应从 ToolKG 派生候选，避免前端硬编码。"""
 
     schema = build_task_intake_schema()
 
+    assert any(option["tool_id"] == "esmfold" for option in schema["tool_options"])
     for name in ("tools_allowed", "tools_excluded"):
         field = schema["fields"][name]
         assert field["ui_control"] == "multi_select"
-        assert field["options"] == []
+        assert "esmfold" in field["options"]
+        assert field["tool_options"][0]["tool_id"]
         assert field["validators"] == {"source": "ToolKG"}
 
 

--- a/tests/unit/test_task_intake_contracts.py
+++ b/tests/unit/test_task_intake_contracts.py
@@ -167,3 +167,32 @@ def test_structured_fields_override_raw_text_extraction() -> None:
     assert spec.objective["objective_type"] == "stability"
     assert spec.constraints["length_range"] == [80, 120]
     assert spec.metadata["raw_query"] == "please evaluate binding protein around 300 aa"
+
+
+def test_intake_normalizes_units_and_carries_initial_artifacts() -> None:
+    """Task Intake 应归一化单位并把合法 artifact ref 投影到确认规格。"""
+
+    session = create_task_intake_session(
+        intake_id="intake_units_artifacts",
+        text=None,
+        structured_fields={
+            "task_kind": "de_novo_design",
+            "objective_type": "stability",
+            "length_range": {"min": 90, "max": 120, "unit": "aa"},
+            "max_runtime_min": {"value": 2, "unit": "hour"},
+            "initial_artifacts": [
+                {"kind": "template", "path": "input/template.pdb"}
+            ],
+        },
+        source="api",
+    )
+
+    spec = confirm_task_intake_session(
+        session,
+        confirmed_by="tester",
+        acknowledged_warnings=[],
+    )
+
+    assert spec.constraints["length_range"] == [90, 120]
+    assert spec.constraints["max_runtime_min"] == 120
+    assert spec.initial_artifacts == [{"kind": "template", "path": "input/template.pdb"}]


### PR DESCRIPTION
## 背景

Closes #278。

本 PR 完成 Task Intake 服务端 API 与旧 `/tasks` 创建入口的兼容收敛，使 Web、CLI 和脚本入口都通过同一套字段注册表、草稿校验、确认和正式 Task 创建链路工作。

## 主要变更

- 新增/补齐 `/task-intakes/schema`、`POST /task-intakes`、`PATCH /task-intakes/{intake_id}`、`POST /task-intakes/{intake_id}/confirm` 的服务端链路。
- 通过 TaskFieldRegistry 暴露字段定义、控件建议、枚举选项、条件必填、默认值、ToolKG 派生工具选项与 `support_level`，避免 Web/CLI 硬编码字段选项。
- 引入 `TaskIntakeSession`、`TaskSpecDraft`、`ConfirmedTaskSpec` 相关校验与投影逻辑，覆盖必填字段、条件必填、单位归一化、ToolKG `tool_id`、artifact ref、范围和 Safety 输入预检查。
- 收敛旧 `/tasks`：`confirmed_task_spec` 可直接创建正式 Task，自由 `query` 会创建 intake 并返回 `intake_id` 与 `needs_confirmation`，不直接进入 Planner。
- confirm 成功后正式 Task 保持从 `CREATED` 开始，并通过 metadata 回链 `intake_id` 与完整 `confirmed_task_spec`。
- 补齐确认创建正式 Task 后的 `TASK_CREATED_FROM_CONFIRMED_INTAKE` 时间线事件，便于审计和 UI 时间线展示。
- 保留旧 IntentDraft create/clarification/finalize 兼容入口，内部投影到 Task Intake。

## API 与前端影响

- React Task Builder 可以仅依赖正式 API 完成 schema/create/patch/confirm/create 链路。
- API 响应同时包含 `human_summary` 和稳定 JSON 字段。
- Task Intake 业务错误返回稳定结构，包含 `status`、`detail`、`missing_fields`、`validation_errors` 和上下文，减少前端自行推断失败原因。

## 验证

- `uv run pytest tests/unit/test_task_field_registry.py tests/unit/test_task_intake_contracts.py tests/api/test_api_endpoints.py -q`

