### PR TITLE
fix(workflow): 保持分层 patch 恢复顺序

### DIFF
--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -1713,6 +1713,8 @@ def _build_parameter_level_patch(
     if failed_result is None and not _reason_supports_parameter_patch(request.reason):
         return None
     param_updates = _derive_param_updates(failed_result, target_step)
+    if not param_updates and _reason_supports_parameter_patch(request.reason):
+        param_updates["retry_profile"] = "conservative"
     if not param_updates:
         return None
 
@@ -1751,8 +1753,10 @@ def _derive_param_updates(
     target_step: PlanStep,
 ) -> dict:
     updates: dict[str, object] = {}
-    failure_type = failed_result.failure_type if failed_result is not None else None
-    if failure_type in {"RETRYABLE", "TOOL_ERROR"}:
+    failure_type = _normalize_failure_type_value(
+        failed_result.failure_type if failed_result is not None else None
+    )
+    if failure_type in {"retryable", "tool_error"}:
         updates["retry_profile"] = "conservative"
     error_message = (failed_result.error_message or "").lower() if failed_result else ""
     if "timeout" in error_message:
@@ -1768,6 +1772,18 @@ def _derive_param_updates(
         except (TypeError, ValueError):
             pass
     return updates
+
+
+def _normalize_failure_type_value(value: object) -> str | None:
+    if value is None:
+        return None
+    raw = getattr(value, "value", value)
+    if not isinstance(raw, str):
+        return None
+    normalized = raw.strip().lower()
+    if not normalized:
+        return None
+    return normalized
 
 
 def _reason_supports_parameter_patch(reason: object) -> bool:

--- a/src/workflow/patch_runner.py
+++ b/src/workflow/patch_runner.py
@@ -186,19 +186,29 @@ class PatchRunner:
                 task_constraints=context.task.constraints,
             )
         except Exception as exc:
+            recovery_meta = _extract_recovery_metadata(
+                plan_patch=None,
+                selected_candidate=selected_candidate,
+                source_step=step,
+            )
+            _attach_recovery_upgrade_meta(
+                result,
+                recovery_meta,
+                upgrade_reason="patch_failed",
+            )
             _emit_recovery_escalation_event(
                 context,
                 step_id=step.id,
                 reason="patch_failed",
                 detail=f"patch candidate generation failed: {exc}",
-                recovery=_extract_recovery_metadata(
-                    plan_patch=None,
-                    selected_candidate=selected_candidate,
-                    source_step=step,
-                ),
+                recovery=recovery_meta,
             )
             _enter_replan_waiting(context, record, reason="patch_failed")
-            raise
+            return PatchRunOutcome(
+                plan=plan,
+                step_results=[result],
+                next_step_index=step_index + 1,
+            )
 
         if gate.requires_hitl:
             recovery_meta = _extract_recovery_metadata(

--- a/src/workflow/plan_runner.py
+++ b/src/workflow/plan_runner.py
@@ -287,11 +287,12 @@ class PlanRunner:
                         else None,
                     )
                     if step_result.status == "failed":
-                        blocked_by_safety = self._add_failed_step_safety_event(
-                            step_result,
-                            plan,
-                            context,
-                        )
+                        if not _has_recovery_upgrade(step_result):
+                            blocked_by_safety = self._add_failed_step_safety_event(
+                                step_result,
+                                plan,
+                                context,
+                            )
                         failed_result = step_result
 
                 if failed_result is not None:
@@ -966,6 +967,14 @@ def _should_require_replan_confirm(error: PlanRunError) -> bool:
             "ADAPTIVE_STOP_REQUESTED",
         }
     )
+
+
+def _has_recovery_upgrade(step_result: StepResult) -> bool:
+    recovery = step_result.metrics.get("recovery")
+    if not isinstance(recovery, dict):
+        return False
+    upgrade_reason = recovery.get("upgrade_reason")
+    return isinstance(upgrade_reason, str) and bool(upgrade_reason)
 
 
 def _build_step_trace_data(step_result: StepResult) -> dict[str, Any]:

--- a/tests/unit/test_patch_runner.py
+++ b/tests/unit/test_patch_runner.py
@@ -318,8 +318,7 @@ def test_patch_runner_enters_waiting_replan_on_patch_error(sample_task):
     planner = FailingPlanner()
     patch_runner = PatchRunner(step_runner=step_runner, planner_agent=planner)
 
-    with pytest.raises(RuntimeError):
-        patch_runner.run_step_with_patch(plan, 0, context, record=record)
+    outcome = patch_runner.run_step_with_patch(plan, 0, context, record=record)
 
     assert context.status == InternalStatus.WAITING_REPLAN
     assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
@@ -327,3 +326,6 @@ def test_patch_runner_enters_waiting_replan_on_patch_error(sample_task):
     assert record.pending_action.action_type == PendingActionType.REPLAN_CONFIRM
     assert record.pending_action.status == PendingActionStatus.PENDING
     assert record.pending_action.explanation
+    assert outcome.step_results
+    recovery = outcome.step_results[0].metrics.get("recovery")
+    assert recovery["upgrade_reason"] == "patch_failed"

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -1063,7 +1063,7 @@ class TestPlannerAgent:
 
         assert topk.candidates
         first = topk.candidates[0]
-        assert first.metadata.get("recovery_layer") == "tool_level"
+        assert first.metadata.get("recovery_layer") == "parameter_level"
         assert first.metadata.get("capability_id") == "structure_prediction"
 
         tool_level = [

--- a/tests/unit/test_planner_patch_agent.py
+++ b/tests/unit/test_planner_patch_agent.py
@@ -156,7 +156,7 @@ def test_patch_prefers_parameter_level_retry_before_tool_swap(monkeypatch):
     assert patch.metadata["reason"] == "parameter_tweak"
 
 
-def test_patch_raises_when_no_compatible_tool(monkeypatch):
+def test_patch_keeps_parameter_level_when_no_compatible_tool(monkeypatch):
     # registry 中的候选需要额外输入，无法满足
     registry = [
         ToolSpec(
@@ -184,5 +184,10 @@ def test_patch_raises_when_no_compatible_tool(monkeypatch):
     agent = PlannerAgent(tool_registry=registry)
     request = _build_request()
 
-    with pytest.raises(ValueError):
-        agent.patch(request)
+    patch = agent.patch(request)
+
+    assert isinstance(patch, PlanPatch)
+    op = patch.operations[0]
+    assert op.step.tool == "t_fail"
+    assert patch.metadata["recovery_layer"] == "parameter_level"
+    assert patch.metadata["reason"] == "parameter_tweak"

--- a/tests/unit/test_visualization_adapter.py
+++ b/tests/unit/test_visualization_adapter.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from src.adapters.registry import ADAPTER_REGISTRY, register_adapter
 from src.agents.planner import PlannerAgent, ToolSpec
 from src.models.contracts import Plan, PlanStep, now_iso
@@ -88,11 +86,11 @@ def test_invalid_pdb_ref_enters_waiting_replan(sample_task, tmp_path: Path) -> N
     step_runner = RecordingStepRunner()
     patch_runner = PatchRunner(step_runner=step_runner, planner_agent=FailingPlanner())
 
-    with pytest.raises(RuntimeError):
-        patch_runner.run_step_with_patch(plan, 0, context, record=record)
+    outcome = patch_runner.run_step_with_patch(plan, 0, context, record=record)
 
     assert context.status == InternalStatus.WAITING_REPLAN
     assert record.status == ExternalStatus.WAITING_REPLAN_CONFIRM
+    assert outcome.step_results
     assert step_runner.last_result is not None
     assert step_runner.last_result.status == "failed"
     assert step_runner.last_result.error_message


### PR DESCRIPTION
## 背景

当前恢复链路中，`retry_exhausted` 且局部可修时应优先走最小参数级 patch，再逐步升级到工具级替换或 replan。排查发现参数级 patch 对 `FailureType` enum / 小写字符串兼容不足，导致候选缺失时直接跳到工具级替换；另外 patch 候选生成失败后，状态已进入 `WAITING_REPLAN` 但异常仍继续冒泡，和受控恢复流不一致。

## 变更内容

- 让参数级 patch 兼容 `FailureType` enum、小写字符串和 `.value`，并在可修复 reason 下生成保守 `retry_profile`。
- 保持 `parameter_level -> tool_level -> replan` 的分层恢复顺序。
- patch 候选生成失败时进入 `WAITING_REPLAN` 并返回受控 outcome，写入 recovery 元数据，不再在状态升级后继续抛出原始异常。
- PlanRunner 识别带 `recovery.upgrade_reason` 的受控恢复升级，避免重复 post-step safety block 干扰自动 replan。
- 更新相关单测，锁定新的恢复契约。

## 验证

- `uv run pytest tests/integration/test_recovery_layered_patch.py::test_layered_patch_promotes_from_parameter_to_tool_level tests/integration/test_recovery_layered_patch.py::test_layered_patch_promotes_remote_to_local_tool_level tests/integration/test_recovery_layered_patch.py::test_high_risk_patch_escalates_to_replan tests/unit/test_planner_patch_agent.py::test_patch_prefers_parameter_level_retry_before_tool_swap -vv`
- `uv run pytest tests/integration/test_recovery_layered_patch.py tests/unit/test_planner_patch_agent.py tests/unit/test_patch_runner.py tests/unit/test_planner_agent.py::TestPlannerAgent::test_patch_top_k_candidates_sorted_by_layer_then_overall tests/unit/test_planner_agent.py::TestPlannerAgent::test_patch_top_k_uses_layered_priority_and_matrix_metadata tests/unit/test_planner_agent.py::TestPlannerAgent::test_patch_top_k_respects_structure_prediction_tool_override -vv`
- `uv run pytest tests/unit/test_plan_runner.py::test_auto_replan_resolves_pending_action tests/unit/test_visualization_adapter.py::test_invalid_pdb_ref_enters_waiting_replan -vv`
- `uv run pytest --ignore=tests/integration/test_nextflow_failure_fsm.py`

结果：排除当前确认暂未实现的 Nextflow 集成测试文件后，全量回归 `792 passed, 11 skipped`。