### PR TITLE
feat(planner): 抽离 capability-aware CandidateGenerator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,8 @@ design = "src.cli:main"
 [build-system]
 requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = [
+    "basedpyright>=1.39.3",
+]

--- a/src/agents/candidate_generator/__init__.py
+++ b/src/agents/candidate_generator/__init__.py
@@ -1,0 +1,15 @@
+from src.agents.candidate_generator.generator import CandidateGenerator
+from src.agents.candidate_generator.models import (
+    CandidateGenerationInput,
+    CandidateGeneratorHooks,
+    CandidatePayload,
+    TopKResult,
+)
+
+__all__ = [
+    "CandidateGenerationInput",
+    "CandidateGenerator",
+    "CandidateGeneratorHooks",
+    "CandidatePayload",
+    "TopKResult",
+]

--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -200,6 +200,15 @@ class CandidateBuilder:
             adjusted["budget_fit"] = 0.0
         elif budget_cap is not None:
             adjusted["budget_fit"] = 1.0
+        policy_mode = str(request.policy_mode or "balanced").strip().lower()
+        policy_adjustment = 0.0
+        if policy_mode in {"conservative", "safe", "low_risk"}:
+            policy_adjustment = 0.02 * adjusted.get("risk", 0.0)
+        elif policy_mode in {"low_cost", "budget", "cheap"}:
+            policy_adjustment = 0.02 * adjusted.get("cost", 0.0)
+        elif policy_mode in {"exploratory", "aggressive"}:
+            policy_adjustment = 0.02 * adjusted.get("objective", 0.0)
+        adjusted["policy_mode_fit"] = round(policy_adjustment, 6)
         adjusted["overall"] = round(
             min(
                 1.0,
@@ -207,7 +216,8 @@ class CandidateBuilder:
                     0.0,
                     adjusted.get("overall", 0.0)
                     + 0.03 * adjusted.get("capability_hint_match", 0.0)
-                    + 0.02 * adjusted.get("budget_fit", 0.0),
+                    + 0.02 * adjusted.get("budget_fit", 0.0)
+                    + policy_adjustment,
                 ),
             ),
             6,

--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.agents.candidate_generator.filters import safe_float
+from src.agents.candidate_generator.models import (
+    CandidateGenerationInput,
+    CandidateGeneratorHooks,
+    CandidatePayload,
+)
+from src.models.contracts import (
+    ACTION_SCORE_METADATA_KEY,
+    FINAL_SCORE_METADATA_KEY,
+    PendingActionCandidate,
+    Plan,
+    PlanPatch,
+    RERANK_REASON_METADATA_KEY,
+    RUNTIME_ADJUSTMENT_METADATA_KEY,
+    RUNTIME_STATE_SUMMARY_METADATA_KEY,
+    SHADOW_SCORE_METADATA_KEY,
+    STATIC_SCORE_METADATA_KEY,
+)
+
+
+class CandidateBuilder:
+    """构造 PendingActionCandidate 及其审计 metadata。"""
+
+    def __init__(self, hooks: CandidateGeneratorHooks) -> None:
+        self._hooks = hooks
+
+    def build(
+        self,
+        *,
+        payload: CandidatePayload,
+        request: CandidateGenerationInput,
+        registry_map: dict[str, Any],
+        score_weights: dict[str, float],
+        runtime_state_summary: dict[str, Any] | None,
+    ) -> PendingActionCandidate:
+        primary_tool = registry_map.get(payload.primary_tool_id)
+        capability_id = payload.capability_bucket or self._hooks.primary_capability(
+            primary_tool
+        )
+        tool_id = payload.primary_tool_id
+        io_type = primary_tool.io_type if primary_tool and primary_tool.io_type else "unknown"
+        adapter_mode = primary_tool.adapter_mode if primary_tool else "unknown"
+        score_breakdown = self._hooks.score_payload(
+            payload.payload,
+            request.registry,
+            score_weights=score_weights,
+        )
+        score_breakdown = self._apply_generation_score_adjustments(
+            score_breakdown,
+            capability_id=capability_id,
+            request=request,
+        )
+        metadata = self._build_metadata(
+            payload=payload,
+            request=request,
+            capability_id=capability_id,
+            tool_id=tool_id,
+            io_type=io_type,
+            adapter_mode=adapter_mode,
+            score_breakdown=score_breakdown,
+            score_weights=score_weights,
+        )
+        shadow = self._build_shadow_metadata(
+            payload=payload,
+            request=request,
+            metadata=metadata,
+            score_breakdown=score_breakdown,
+            runtime_state_summary=runtime_state_summary,
+        )
+        explanation = (
+            f"{request.candidate_kind} candidate with primary tool "
+            f"{tool_id} in capability bucket {capability_id}."
+        )
+        if runtime_state_summary is not None:
+            explanation = f"{explanation} {shadow.explanation_fragment}"
+        return PendingActionCandidate(
+            candidate_id=self._hooks.stable_candidate_id(
+                request.candidate_kind,
+                payload.payload,
+                payload.primary_tool_id,
+                payload.capability_bucket,
+            ),
+            structured_payload=payload.payload,
+            score_breakdown=score_breakdown,
+            risk_level=self._hooks.derive_risk_level(payload.payload, request.registry),
+            cost_estimate=self._hooks.derive_cost_estimate(payload.payload, request.registry),
+            explanation=explanation,
+            summary=self._hooks.build_candidate_summary(payload.payload),
+            tool_id=tool_id,
+            capability_id=capability_id,
+            io_type=io_type,
+            adapter_mode=adapter_mode,
+            metadata=metadata,
+        )
+
+    def _build_metadata(
+        self,
+        *,
+        payload: CandidatePayload,
+        request: CandidateGenerationInput,
+        capability_id: str,
+        tool_id: str,
+        io_type: str,
+        adapter_mode: str,
+        score_breakdown: dict[str, float],
+        score_weights: dict[str, float],
+    ) -> dict[str, Any]:
+        metadata: dict[str, Any] = {
+            "candidate_kind": request.candidate_kind,
+            "capability_bucket": capability_id,
+            "tool_id": tool_id,
+            "capability_id": capability_id,
+            "io_type": io_type,
+            "adapter_mode": adapter_mode,
+            "generation_note": payload.note,
+            "candidate_generator": {
+                "module": "src.agents.candidate_generator",
+                "policy_mode": request.policy_mode,
+                "capability_hints": list(request.capability_hints),
+                "budget": dict(request.budget or {}),
+                "readiness_context_present": request.readiness is not None,
+                "completed_step_count": len(request.completed_step_results),
+                "confirmed_task_spec_present": request.confirmed_task_spec is not None,
+            },
+            "s5_contract": self._hooks.build_s5_scoring_contract(score_weights),
+            STATIC_SCORE_METADATA_KEY: self._hooks.build_static_score_summary(score_breakdown),
+            ACTION_SCORE_METADATA_KEY: self._hooks.build_action_score_summary(score_breakdown),
+        }
+        metadata.update(
+            self._hooks.candidate_readiness_metadata(
+                tool_id=tool_id,
+                capability_id=capability_id,
+            )
+        )
+        payload_metadata = (
+            payload.payload.metadata if isinstance(payload.payload.metadata, dict) else {}
+        )
+        if isinstance(payload_metadata.get("planner_route"), dict):
+            metadata["planner_route"] = dict(payload_metadata["planner_route"])
+        if payload.recovery_layer:
+            metadata["recovery_layer"] = payload.recovery_layer
+        if payload.recovery_reason:
+            metadata["recovery_reason"] = payload.recovery_reason
+        if isinstance(payload.payload, PlanPatch):
+            metadata.update(self._hooks.extract_patch_candidate_metadata(payload.payload))
+        if isinstance(payload.payload, Plan):
+            plan_metadata = self._hooks.extract_plan_candidate_metadata(payload.payload)
+            if plan_metadata:
+                metadata.update(plan_metadata)
+                metadata["sequence_confidence"] = score_breakdown.get("confidence")
+        return metadata
+
+    def _build_shadow_metadata(
+        self,
+        *,
+        payload: CandidatePayload,
+        request: CandidateGenerationInput,
+        metadata: dict[str, Any],
+        score_breakdown: dict[str, float],
+        runtime_state_summary: dict[str, Any] | None,
+    ) -> Any:
+        if runtime_state_summary is None:
+            shadow = self._hooks.build_shadow_passthrough_decision(score_breakdown)
+        else:
+            metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = dict(runtime_state_summary)
+            shadow = self._hooks.build_runtime_shadow_decision(
+                candidate_kind=request.candidate_kind,
+                payload=payload.payload,
+                score_breakdown=score_breakdown,
+                runtime_state_summary=runtime_state_summary,
+            )
+            metadata["shadow_action"] = shadow.shadow_action
+            metadata["shadow_action_reason"] = shadow.shadow_reason
+        metadata[RUNTIME_ADJUSTMENT_METADATA_KEY] = shadow.runtime_adjustment
+        metadata[FINAL_SCORE_METADATA_KEY] = shadow.final_score
+        metadata[RERANK_REASON_METADATA_KEY] = shadow.rerank_reason
+        metadata[SHADOW_SCORE_METADATA_KEY] = shadow.shadow_score
+        return shadow
+
+    def _apply_generation_score_adjustments(
+        self,
+        score_breakdown: dict[str, float],
+        *,
+        capability_id: str,
+        request: CandidateGenerationInput,
+    ) -> dict[str, float]:
+        adjusted = dict(score_breakdown)
+        hints = {str(item) for item in request.capability_hints if str(item)}
+        if capability_id in hints:
+            adjusted["objective"] = min(1.0, adjusted.get("objective", 0.0) + 0.05)
+            adjusted["capability_hint_match"] = 1.0
+        elif hints:
+            adjusted["capability_hint_match"] = 0.0
+        budget_cap = safe_float((request.budget or {}).get("cost_cap"))
+        if budget_cap is not None and adjusted.get("cost", 1.0) < budget_cap:
+            adjusted["budget_fit"] = 0.0
+        elif budget_cap is not None:
+            adjusted["budget_fit"] = 1.0
+        adjusted["overall"] = round(
+            min(
+                1.0,
+                max(
+                    0.0,
+                    adjusted.get("overall", 0.0)
+                    + 0.03 * adjusted.get("capability_hint_match", 0.0)
+                    + 0.02 * adjusted.get("budget_fit", 0.0),
+                ),
+            ),
+            6,
+        )
+        return {
+            key: round(value, 6)
+            for key, value in adjusted.items()
+            if isinstance(value, (int, float))
+        }

--- a/src/agents/candidate_generator/filters.py
+++ b/src/agents/candidate_generator/filters.py
@@ -105,3 +105,14 @@ def safe_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def cost_level_exceeds(candidate_level: str | None, max_level: str | None) -> bool:
+    if max_level is None:
+        return False
+    rank = {"low": 0, "medium": 1, "high": 2}
+    normalized_candidate = str(candidate_level or "medium").strip().lower()
+    normalized_max = str(max_level).strip().lower()
+    if normalized_max not in rank:
+        return False
+    return rank.get(normalized_candidate, 1) > rank[normalized_max]

--- a/src/agents/candidate_generator/filters.py
+++ b/src/agents/candidate_generator/filters.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from src.models.contracts import PendingActionCandidate, Plan, PlanPatch
+
+
+def candidate_difference_explanation(
+    candidates: Sequence[PendingActionCandidate],
+) -> str:
+    if not candidates:
+        return ""
+    tools = sorted({candidate.tool_id or "unknown" for candidate in candidates})
+    capabilities = sorted({candidate.capability_id or "unknown" for candidate in candidates})
+    risks = sorted({candidate.risk_level or "unknown" for candidate in candidates})
+    costs = sorted({candidate.cost_estimate or "unknown" for candidate in candidates})
+    parts = [
+        f"tools={','.join(tools)}",
+        f"capabilities={','.join(capabilities)}",
+        f"risk={','.join(risks)}",
+        f"cost={','.join(costs)}",
+    ]
+    return "; ".join(parts)
+
+
+def payload_tool_ids(payload: Plan | PlanPatch) -> list[str]:
+    if isinstance(payload, Plan):
+        return [step.tool for step in payload.steps]
+    return [
+        operation.step.tool
+        for operation in payload.operations
+        if operation.step is not None
+    ]
+
+
+def payload_io_closed(
+    payload: Plan | PlanPatch,
+    registry_map: dict[str, Any],
+    completed_step_results: Sequence[Any],
+    constraints: dict[str, Any],
+) -> bool:
+    available = set(constraints.keys())
+    available.add("goal")
+    inputs = constraints.get("inputs")
+    if isinstance(inputs, dict):
+        available.update(inputs.keys())
+    for result in completed_step_results:
+        outputs = getattr(result, "outputs", None)
+        if isinstance(outputs, dict):
+            available.update(outputs.keys())
+
+    steps = (
+        payload.steps
+        if isinstance(payload, Plan)
+        else [
+            operation.step
+            for operation in payload.operations
+            if operation.step is not None
+        ]
+    )
+    for step in steps:
+        spec = registry_map.get(step.tool)
+        required_inputs = set(getattr(spec, "inputs", ()) or ())
+        step_inputs = step.inputs if isinstance(step.inputs, dict) else {}
+        for required in required_inputs:
+            if required in step_inputs:
+                continue
+            if required in available:
+                continue
+            return False
+        for value in step_inputs.values():
+            if isinstance(value, str) and "." in value:
+                _head, field = value.split(".", 1)
+                if field not in available:
+                    return False
+        outputs = getattr(spec, "outputs", ()) if spec is not None else ()
+        available.update(outputs)
+    return True
+
+
+def string_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value if str(item)}
+    return set()
+
+
+def parse_safety_level(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().upper()
+        if normalized.startswith("S") and normalized[1:].isdigit():
+            return int(normalized[1:])
+        if normalized.isdigit():
+            return int(normalized)
+    return None
+
+
+def safe_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from src.agents.candidate_generator.builder import CandidateBuilder
+from src.agents.candidate_generator.filters import (
+    candidate_difference_explanation,
+    parse_safety_level,
+    payload_io_closed,
+    payload_tool_ids,
+    string_set,
+)
+from src.agents.candidate_generator.models import (
+    CandidateGenerationInput,
+    CandidateGeneratorHooks,
+    CandidatePayload,
+    TopKResult,
+)
+from src.models.contracts import (
+    CAPABILITY_READINESS_METADATA_KEY,
+    DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
+    FINAL_SCORE_METADATA_KEY,
+    PendingActionCandidate,
+    Plan,
+    PlanPatch,
+    STATIC_SCORE_METADATA_KEY,
+    TOOL_READINESS_METADATA_KEY,
+)
+
+
+class CandidateGenerator:
+    """统一生成 Plan/Patch/Replan Top-K 候选。
+
+    CandidateGenerator 只负责候选过滤、评分、排序和 HITL 展示元数据；
+    原始 payload 的领域构造仍由 PlannerAgent 完成，避免改变 Agent 边界。
+    """
+
+    def __init__(self, hooks: CandidateGeneratorHooks) -> None:
+        self._hooks = hooks
+        self._builder = CandidateBuilder(hooks)
+
+    def generate(self, request: CandidateGenerationInput) -> TopKResult:
+        """生成稳定 Top-K、default_suggestion 和候选差异解释。"""
+        if not request.payloads:
+            raise ValueError(f"No payload candidates generated for {request.candidate_kind}")
+
+        registry_map = {spec.id: spec for spec in request.registry}
+        unique_payloads = self._dedupe_payloads(request.payloads)
+        scored_rows: list[tuple[PendingActionCandidate, tuple, tuple, str]] = []
+        filtered_rows: list[tuple[PendingActionCandidate, tuple, tuple, str]] = []
+        soft_filtered_rows: list[tuple[PendingActionCandidate, tuple, tuple, str]] = []
+        filter_reasons: list[str] = []
+
+        score_weights = self._hooks.resolve_score_weights(request.task_constraints or {})
+        runtime_state_summary = self._hooks.normalize_runtime_state_summary_input(
+            request.runtime_state
+        )
+
+        for payload in unique_payloads:
+            candidate = self._builder.build(
+                payload=payload,
+                request=request,
+                registry_map=registry_map,
+                score_weights=score_weights,
+                runtime_state_summary=runtime_state_summary,
+            )
+            static_sort_key = self._sort_key(
+                request.candidate_kind,
+                candidate,
+                registry_map.get(payload.primary_tool_id),
+                payload.payload,
+                score_metadata_key=STATIC_SCORE_METADATA_KEY,
+            )
+            effective_sort_key = self._sort_key(
+                request.candidate_kind,
+                candidate,
+                registry_map.get(payload.primary_tool_id),
+                payload.payload,
+                score_metadata_key=FINAL_SCORE_METADATA_KEY,
+            )
+            row = (
+                candidate,
+                static_sort_key,
+                effective_sort_key,
+                candidate.capability_id or "unknown",
+            )
+            scored_rows.append(row)
+            reason = self._filter_reason(candidate, payload.payload, request, registry_map)
+            if reason is not None:
+                filter_reasons.append(reason)
+                if reason in {"io_not_closed", "tool_unavailable"}:
+                    soft_filtered_rows.append(row)
+                continue
+            filtered_rows.append(row)
+
+        available_rows = self._available_rows(
+            filtered_rows=filtered_rows,
+            soft_filtered_rows=soft_filtered_rows,
+            scored_rows=scored_rows,
+            top_k=request.top_k,
+        )
+        if not available_rows:
+            raise ValueError(f"No feasible payload candidates generated for {request.candidate_kind}")
+
+        static_rows = sorted(
+            [(row[0], row[1], row[3]) for row in available_rows],
+            key=lambda row: row[1],
+        )
+        static_selected_rows = self._select_diverse_top_k(
+            ranked_rows=static_rows,
+            top_k=request.top_k,
+        )
+        static_selected_rows = sorted(static_selected_rows, key=lambda row: row[1])
+        selected_rows = static_selected_rows
+        if runtime_state_summary is not None:
+            effective_rows = sorted(
+                [(row[0], row[2], row[3]) for row in available_rows],
+                key=lambda row: row[1],
+            )
+            selected_rows = self._select_diverse_top_k(
+                ranked_rows=effective_rows,
+                top_k=request.top_k,
+            )
+            selected_rows = sorted(selected_rows, key=lambda row: row[1])
+
+        candidates = [row[0] for row in selected_rows]
+        static_candidates = [row[0] for row in static_selected_rows]
+        default_candidate = candidates[0] if candidates else None
+        static_default_candidate = static_candidates[0] if static_candidates else None
+        default_recommendation = (
+            default_candidate.candidate_id if default_candidate is not None else None
+        )
+        if default_candidate is not None:
+            default_candidate.metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
+                self._hooks.build_default_recommendation_reason(
+                    candidate_kind=request.candidate_kind,
+                    candidate_id=default_candidate.candidate_id,
+                    default_candidate=default_candidate,
+                    static_candidate=static_default_candidate,
+                    rerank_applied=runtime_state_summary is not None,
+                )
+            )
+
+        return TopKResult(
+            candidates=candidates,
+            default_recommendation=default_recommendation,
+            explanation=self._build_explanation(
+                request=request,
+                candidates=candidates,
+                default_candidate=default_candidate,
+                static_default_candidate=static_default_candidate,
+                filter_reasons=filter_reasons,
+                used_filtered_rows=bool(filtered_rows),
+                runtime_state_summary=runtime_state_summary,
+            ),
+        )
+
+    def _filter_reason(
+        self,
+        candidate: PendingActionCandidate,
+        payload: Plan | PlanPatch,
+        request: CandidateGenerationInput,
+        registry_map: dict[str, Any],
+    ) -> str | None:
+        constraints = request.task_constraints or {}
+        tool_ids = payload_tool_ids(payload)
+        missing_tools = [tool_id for tool_id in tool_ids if tool_id not in registry_map]
+        if missing_tools:
+            return f"missing_tools:{','.join(sorted(missing_tools))}"
+        allowed_tools = string_set(
+            constraints.get("allowed_tools") or constraints.get("tools_allowed")
+        )
+        if allowed_tools and any(tool_id not in allowed_tools for tool_id in tool_ids):
+            return "tool_not_allowed"
+        blocked_tools = string_set(
+            constraints.get("blocked_tools") or constraints.get("tools_excluded")
+        )
+        if blocked_tools and any(tool_id in blocked_tools for tool_id in tool_ids):
+            return "tool_blocked"
+        max_safety_level = parse_safety_level(constraints.get("safety_level"))
+        if max_safety_level is not None:
+            for tool_id in tool_ids:
+                spec = registry_map.get(tool_id)
+                if spec is not None and int(getattr(spec, "safety_level", 1)) > max_safety_level:
+                    return "safety_level_exceeded"
+        if not payload_io_closed(
+            payload,
+            registry_map,
+            request.completed_step_results,
+            constraints,
+        ):
+            return "io_not_closed"
+        if self._candidate_unavailable(candidate):
+            return "tool_unavailable"
+        return None
+
+    def _candidate_unavailable(self, candidate: PendingActionCandidate) -> bool:
+        metadata = candidate.metadata if isinstance(candidate.metadata, dict) else {}
+        tool_readiness = metadata.get(TOOL_READINESS_METADATA_KEY)
+        capability_readiness = metadata.get(CAPABILITY_READINESS_METADATA_KEY)
+        for item in (tool_readiness, capability_readiness):
+            if isinstance(item, dict) and item.get("status") == "unavailable":
+                return True
+        return False
+
+    def _sort_key(
+        self,
+        candidate_kind: str,
+        candidate: PendingActionCandidate,
+        primary_tool: Any | None,
+        payload: Plan | PlanPatch,
+        score_metadata_key: str,
+    ) -> tuple:
+        priority_rank = self._hooks.priority_rank(primary_tool.priority if primary_tool else None)
+        patch_layer_rank = self._hooks.patch_layer_rank(payload)
+        score_value = self._hooks.extract_score_value(candidate, score_metadata_key)
+        capability_id = candidate.capability_id or "unknown"
+        tool_id = candidate.tool_id or "unknown"
+        if candidate_kind == "patch":
+            return (
+                patch_layer_rank,
+                -score_value,
+                priority_rank,
+                capability_id,
+                tool_id,
+                candidate.candidate_id,
+            )
+        return (
+            -score_value,
+            priority_rank,
+            capability_id,
+            tool_id,
+            candidate.candidate_id,
+        )
+
+    def _dedupe_payloads(
+        self,
+        payloads: Sequence[CandidatePayload],
+    ) -> list[CandidatePayload]:
+        unique_payloads: list[CandidatePayload] = []
+        seen_fingerprints: set[str] = set()
+        for payload in payloads:
+            fingerprint = self._hooks.canonical_payload_fingerprint(
+                payload.payload,
+                payload.primary_tool_id,
+                payload.capability_bucket,
+            )
+            if fingerprint in seen_fingerprints:
+                continue
+            seen_fingerprints.add(fingerprint)
+            unique_payloads.append(payload)
+        return unique_payloads
+
+    def _available_rows(
+        self,
+        *,
+        filtered_rows: Sequence[tuple[PendingActionCandidate, tuple, tuple, str]],
+        soft_filtered_rows: Sequence[tuple[PendingActionCandidate, tuple, tuple, str]],
+        scored_rows: Sequence[tuple[PendingActionCandidate, tuple, tuple, str]],
+        top_k: int,
+    ) -> list[tuple[PendingActionCandidate, tuple, tuple, str]]:
+        available_rows = list(filtered_rows)
+        if len(available_rows) < top_k:
+            seen_ids = {row[0].candidate_id for row in available_rows}
+            for row in soft_filtered_rows:
+                if row[0].candidate_id in seen_ids:
+                    continue
+                available_rows.append(row)
+                seen_ids.add(row[0].candidate_id)
+                if len(available_rows) >= top_k:
+                    break
+        if not available_rows and soft_filtered_rows:
+            return list(soft_filtered_rows)
+        if not available_rows:
+            return list(scored_rows)
+        return available_rows
+
+    def _select_diverse_top_k(
+        self,
+        *,
+        ranked_rows: Sequence[tuple[PendingActionCandidate, tuple, str]],
+        top_k: int,
+    ) -> list[tuple[PendingActionCandidate, tuple, str]]:
+        bucket_rows: dict[str, list[tuple[PendingActionCandidate, tuple, str]]] = {}
+        bucket_order: list[str] = []
+        for row in ranked_rows:
+            bucket = row[2] or "unknown"
+            if bucket not in bucket_rows:
+                bucket_rows[bucket] = []
+                bucket_order.append(bucket)
+            bucket_rows[bucket].append(row)
+
+        selected: list[tuple[PendingActionCandidate, tuple, str]] = []
+        while len(selected) < top_k:
+            progressed = False
+            for bucket in bucket_order:
+                rows = bucket_rows[bucket]
+                if not rows:
+                    continue
+                selected.append(rows.pop(0))
+                progressed = True
+                if len(selected) >= top_k:
+                    break
+            if not progressed:
+                break
+        return selected
+
+    def _build_explanation(
+        self,
+        *,
+        request: CandidateGenerationInput,
+        candidates: Sequence[PendingActionCandidate],
+        default_candidate: PendingActionCandidate | None,
+        static_default_candidate: PendingActionCandidate | None,
+        filter_reasons: Sequence[str],
+        used_filtered_rows: bool,
+        runtime_state_summary: dict[str, Any] | None,
+    ) -> str:
+        ranking_basis = "final_score" if runtime_state_summary is not None else "static_score"
+        explanation = (
+            f"{request.candidate_kind} Top-K generated by CandidateGenerator "
+            f"(requested={request.top_k}, returned={len(candidates)}). "
+            f"Ranking uses {ranking_basis} desc + stable tie-break; "
+            "selection uses capability-bucket round-robin."
+        )
+        if default_candidate is not None:
+            explanation = (
+                f"{explanation} default_suggestion={default_candidate.candidate_id}."
+            )
+            if runtime_state_summary is not None:
+                explanation = self._append_rerank_explanation(
+                    explanation=explanation,
+                    default_candidate=default_candidate,
+                    static_default_candidate=static_default_candidate,
+                )
+        difference = candidate_difference_explanation(candidates)
+        if difference:
+            explanation = f"{explanation} Candidate differences: {difference}."
+        if filter_reasons and used_filtered_rows:
+            explanation = (
+                f"{explanation} Filtered candidates before ranking by "
+                f"{', '.join(sorted(set(filter_reasons)))}."
+            )
+        elif filter_reasons:
+            explanation = (
+                f"{explanation} Filtering would remove all candidates, so the generator "
+                "returned the scored fallback set for compatibility."
+            )
+        if len(candidates) < request.top_k:
+            explanation = (
+                f"{explanation} Degraded to available candidates because registry "
+                "constraints did not produce enough unique options."
+            )
+        return explanation
+
+    def _append_rerank_explanation(
+        self,
+        *,
+        explanation: str,
+        default_candidate: PendingActionCandidate,
+        static_default_candidate: PendingActionCandidate | None,
+    ) -> str:
+        if (
+            static_default_candidate is not None
+            and static_default_candidate.candidate_id != default_candidate.candidate_id
+        ):
+            explanation = (
+                f"{explanation} Runtime rerank updated default recommendation "
+                f"from {static_default_candidate.candidate_id} "
+                f"to {default_candidate.candidate_id}."
+            )
+        else:
+            explanation = (
+                f"{explanation} Runtime rerank kept default recommendation "
+                f"at {default_candidate.candidate_id}."
+            )
+        return f"{explanation} {self._hooks.summarize_rerank_reason(default_candidate)}"

--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -5,6 +5,7 @@ from typing import Any, Sequence
 from src.agents.candidate_generator.builder import CandidateBuilder
 from src.agents.candidate_generator.filters import (
     candidate_difference_explanation,
+    cost_level_exceeds,
     parse_safety_level,
     payload_io_closed,
     payload_tool_ids,
@@ -183,6 +184,11 @@ class CandidateGenerator:
                 spec = registry_map.get(tool_id)
                 if spec is not None and int(getattr(spec, "safety_level", 1)) > max_safety_level:
                     return "safety_level_exceeded"
+        max_cost_level = constraints.get("max_cost_level") or constraints.get(
+            "max_cost_estimate"
+        )
+        if cost_level_exceeds(candidate.cost_estimate, max_cost_level):
+            return "cost_level_exceeded"
         if not payload_io_closed(
             payload,
             registry_map,

--- a/src/agents/candidate_generator/models.py
+++ b/src/agents/candidate_generator/models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Sequence
+
+from src.models.contracts import PendingActionCandidate, Plan, PlanPatch
+
+
+@dataclass(frozen=True)
+class TopKResult:
+    """Planner Top-K 候选输出（CandidateSetOutput v1 对齐）。"""
+
+    candidates: list[PendingActionCandidate]
+    default_recommendation: str | None
+    explanation: str
+
+    @property
+    def default_suggestion(self) -> str | None:
+        """兼容 HITL/UI 文案中的 default_suggestion 命名。"""
+        return self.default_recommendation
+
+
+@dataclass(frozen=True)
+class CandidatePayload:
+    """CandidateGenerator 的统一候选载荷。"""
+
+    payload: Plan | PlanPatch
+    primary_tool_id: str
+    capability_bucket: str
+    note: str
+    recovery_layer: str | None = None
+    recovery_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class CandidateGenerationInput:
+    """候选生成统一入口输入。"""
+
+    candidate_kind: Literal["plan", "patch", "replan"]
+    payloads: Sequence[CandidatePayload]
+    registry: Sequence[Any]
+    top_k: int = 3
+    task_constraints: dict[str, Any] | None = None
+    confirmed_task_spec: dict[str, Any] | None = None
+    capability_hints: Sequence[str] = ()
+    readiness: dict[str, Any] | None = None
+    completed_step_results: Sequence[Any] = ()
+    runtime_state: Any | None = None
+    budget: dict[str, Any] | None = None
+    policy_mode: str = "balanced"
+
+
+@dataclass(frozen=True)
+class CandidateGeneratorHooks:
+    """Planner 既有评分与展示函数注入点。"""
+
+    canonical_payload_fingerprint: Callable[[Plan | PlanPatch, str, str], str]
+    resolve_score_weights: Callable[[dict[str, Any]], dict[str, float]]
+    score_payload: Callable[..., dict[str, float]]
+    primary_capability: Callable[[Any | None], str]
+    derive_cost_estimate: Callable[[Plan | PlanPatch, Sequence[Any]], str]
+    derive_risk_level: Callable[[Plan | PlanPatch, Sequence[Any]], str]
+    stable_candidate_id: Callable[[str, Plan | PlanPatch, str, str], str]
+    build_s5_scoring_contract: Callable[[dict[str, float]], dict[str, Any]]
+    build_static_score_summary: Callable[[dict[str, float]], dict[str, Any]]
+    build_action_score_summary: Callable[[dict[str, float]], dict[str, Any]]
+    candidate_readiness_metadata: Callable[..., dict[str, Any]]
+    build_candidate_summary: Callable[[Plan | PlanPatch], str]
+    extract_patch_candidate_metadata: Callable[[PlanPatch], dict[str, Any]]
+    extract_plan_candidate_metadata: Callable[[Plan], dict[str, Any]]
+    normalize_runtime_state_summary_input: Callable[[Any | None], dict[str, Any] | None]
+    build_shadow_passthrough_decision: Callable[[dict[str, float]], Any]
+    build_runtime_shadow_decision: Callable[..., Any]
+    priority_rank: Callable[[str | None], int]
+    patch_layer_rank: Callable[[Plan | PlanPatch], int]
+    extract_score_value: Callable[[PendingActionCandidate, str], float]
+    build_default_recommendation_reason: Callable[..., dict[str, Any]]
+    summarize_rerank_reason: Callable[[PendingActionCandidate], str]

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -5,7 +5,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, List, Literal, Optional, Sequence, Set, Tuple
+from typing import Any, Iterable, List, Literal, Optional, Sequence, Set, cast
 
 from src.infra.active_tool_metadata import metadata_by_tool_id
 from src.infra.tool_readiness import (
@@ -18,6 +18,13 @@ from src.llm.baseline_provider import BaselineProvider
 from src.llm.provider_payload_parser import ProviderPayloadValidationError
 from src.llm.provider_registry import create_provider, load_provider_catalog
 from src.agents.task_goal_parser import enrich_task_from_goal
+from src.agents.candidate_generator import (
+    CandidateGenerationInput,
+    CandidateGenerator,
+    CandidateGeneratorHooks,
+    CandidatePayload,
+    TopKResult,
+)
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     CAPABILITY_READINESS_METADATA_KEY,
@@ -83,15 +90,6 @@ class ToolSpec:
 
 
 @dataclass(frozen=True)
-class TopKResult:
-    """Planner Top-K 候选输出（CandidateSetOutput v1 对齐）。"""
-
-    candidates: List[PendingActionCandidate]
-    default_recommendation: str | None
-    explanation: str
-
-
-@dataclass(frozen=True)
 class CandidateGateDecision:
     """候选门控决策结果。"""
 
@@ -100,6 +98,9 @@ class CandidateGateDecision:
     selected_candidate_id: str | None
     confidence: float
     overall: float
+
+
+_CandidatePayload = CandidatePayload
 
 
 @dataclass(frozen=True)
@@ -111,16 +112,6 @@ class _RuntimeShadowDecision:
     shadow_action: str
     shadow_reason: str
     explanation_fragment: str
-
-
-@dataclass(frozen=True)
-class _CandidatePayload:
-    payload: Plan | PlanPatch
-    primary_tool_id: str
-    capability_bucket: str
-    note: str
-    recovery_layer: str | None = None
-    recovery_reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -296,7 +287,10 @@ class PlannerAgent:
             registry=self._tool_registry,
             candidate_kind="plan",
             top_k=k,
-            task_constraints=task.constraints,
+            task_constraints=_candidate_generation_constraints(
+                constraints=task.constraints,
+                metadata=task.metadata,
+            ),
             runtime_state=runtime_state,
         )
 
@@ -309,7 +303,7 @@ class PlannerAgent:
     ) -> TopKResult:
         """生成 Patch Top-K 候选（统一 CandidateSetOutput v1 字段）。"""
         _ensure_task_match(request)
-        payloads: list[_CandidatePayload] = []
+        payloads: list[CandidatePayload] = []
         payloads.extend(
             self._build_provider_patch_candidates(
                 request=request,
@@ -328,7 +322,11 @@ class PlannerAgent:
             registry=self._tool_registry,
             candidate_kind="patch",
             top_k=_normalize_top_k(k),
-            task_constraints=request.original_plan.constraints,
+            task_constraints=_candidate_generation_constraints(
+                constraints=request.original_plan.constraints,
+                metadata=request.original_plan.metadata,
+            ),
+            completed_step_results=request.context_step_results,
             runtime_state=runtime_state,
         )
 
@@ -341,7 +339,7 @@ class PlannerAgent:
     ) -> TopKResult:
         """生成 Replan Top-K 候选（统一 CandidateSetOutput v1 字段）。"""
         _ensure_replan_task_match(request)
-        payloads: list[_CandidatePayload] = []
+        payloads: list[CandidatePayload] = []
         payloads.extend(
             self._build_provider_replan_candidates(
                 request=request,
@@ -360,7 +358,10 @@ class PlannerAgent:
             registry=self._tool_registry,
             candidate_kind="replan",
             top_k=_normalize_top_k(k),
-            task_constraints=request.original_plan.constraints,
+            task_constraints=_candidate_generation_constraints(
+                constraints=request.original_plan.constraints,
+                metadata=request.original_plan.metadata,
+            ),
             runtime_state=runtime_state,
         )
 
@@ -817,7 +818,7 @@ class PlannerAgent:
         *,
         request: PatchRequest,
         top_k: int,
-    ) -> list[_CandidatePayload]:
+    ) -> list[CandidatePayload]:
         provider = self._llm_provider
         if provider is None:
             return []
@@ -852,7 +853,7 @@ class PlannerAgent:
         )
         patch = _attach_provider_metadata_to_patch(patch, provider_name=route_name)
         return [
-            _CandidatePayload(
+            CandidatePayload(
                 payload=patch,
                 primary_tool_id=primary_tool_id,
                 capability_bucket=capability_bucket,
@@ -867,7 +868,7 @@ class PlannerAgent:
         *,
         request: ReplanRequest,
         top_k: int,
-    ) -> list[_CandidatePayload]:
+    ) -> list[CandidatePayload]:
         provider = self._llm_provider
         if provider is None:
             return []
@@ -903,7 +904,7 @@ class PlannerAgent:
         primary_tool = plan.steps[-1].tool if plan.steps else request.original_plan.steps[-1].tool
         primary_spec = _find_tool_spec(self._tool_registry, primary_tool)
         return [
-            _CandidatePayload(
+            CandidatePayload(
                 payload=plan,
                 primary_tool_id=primary_tool,
                 capability_bucket=_primary_capability(primary_spec),
@@ -1444,7 +1445,7 @@ def _build_plan_candidate_payloads(
     base_plan: Plan,
     registry: Sequence[ToolSpec],
     top_k: int,
-) -> List[_CandidatePayload]:
+) -> List[CandidatePayload]:
     if not base_plan.steps:
         raise ValueError("Plan is empty; cannot build Top-K candidates")
 
@@ -1456,8 +1457,8 @@ def _build_plan_candidate_payloads(
         registry=registry,
     )
     primary_s1_tool_id = _extract_primary_s1_tool_id(base_plan)
-    payloads: List[_CandidatePayload] = [
-        _CandidatePayload(
+    payloads: List[CandidatePayload] = [
+        CandidatePayload(
             payload=base_plan,
             primary_tool_id=base_plan.steps[0].tool,
             capability_bucket=(
@@ -1545,7 +1546,7 @@ def _build_plan_candidate_payloads(
             )
             candidate_plan = _attach_kg_explanation(candidate_plan)
             payloads.append(
-                _CandidatePayload(
+                CandidatePayload(
                     payload=candidate_plan,
                     primary_tool_id=alternative.id,
                     capability_bucket=_primary_capability(alternative),
@@ -1564,7 +1565,7 @@ def _build_patch_candidate_payloads(
     request: PatchRequest,
     registry: Sequence[ToolSpec],
     top_k: int,
-) -> List[_CandidatePayload]:
+) -> List[CandidatePayload]:
     target_step = _locate_target_step(request)
     target_spec = _find_tool_spec(registry, target_step.tool)
     capability = _primary_capability(target_spec)
@@ -1597,7 +1598,7 @@ def _build_patch_candidate_payloads(
         current_tool=target_step.tool,
     )
 
-    payloads: List[_CandidatePayload] = []
+    payloads: List[CandidatePayload] = []
     parameter_patch = _build_parameter_level_patch(
         request=request,
         target_step=target_step,
@@ -1606,7 +1607,7 @@ def _build_patch_candidate_payloads(
     )
     if parameter_patch is not None:
         payloads.append(
-            _CandidatePayload(
+            CandidatePayload(
                 payload=parameter_patch,
                 primary_tool_id=target_step.tool,
                 capability_bucket=capability,
@@ -1657,7 +1658,7 @@ def _build_patch_candidate_payloads(
             [patched_step]
         )
         payloads.append(
-            _CandidatePayload(
+            CandidatePayload(
                 payload=patch,
                 primary_tool_id=alternative.id,
                 capability_bucket=_primary_capability(alternative),
@@ -1675,7 +1676,7 @@ def _build_patch_candidate_payloads(
     )
     if structure_patch is not None:
         payloads.append(
-            _CandidatePayload(
+            CandidatePayload(
                 payload=structure_patch,
                 primary_tool_id=target_step.tool,
                 capability_bucket=capability,
@@ -1949,7 +1950,7 @@ def _build_replan_candidate_payloads(
     request: ReplanRequest,
     registry: Sequence[ToolSpec],
     top_k: int,
-) -> List[_CandidatePayload]:
+) -> List[CandidatePayload]:
     if not request.original_plan.steps:
         raise ValueError("Original plan is empty, cannot replan")
 
@@ -1989,7 +1990,7 @@ def _build_replan_candidate_payloads(
     )
     prefix_index = target_index - 1
 
-    payloads: List[_CandidatePayload] = []
+    payloads: List[CandidatePayload] = []
     max_candidates = max(1, top_k * 2)
     for alternative in alternatives[:max_candidates]:
         replanned_step = target_step.model_copy(
@@ -2016,7 +2017,7 @@ def _build_replan_candidate_payloads(
             },
         )
         payloads.append(
-            _CandidatePayload(
+            CandidatePayload(
                 payload=_attach_kg_explanation(replanned),
                 primary_tool_id=alternative.id,
                 capability_bucket=_primary_capability(alternative),
@@ -2028,229 +2029,123 @@ def _build_replan_candidate_payloads(
 
 def _build_top_k_result(
     *,
-    payloads: Sequence[_CandidatePayload],
+    payloads: Sequence[CandidatePayload],
     registry: Sequence[ToolSpec],
     candidate_kind: str,
     top_k: int,
     task_constraints: dict[str, Any] | None = None,
+    completed_step_results: Sequence[StepResult] = (),
     runtime_state: RuntimeState | RuntimeStateSummary | dict[str, Any] | None = None,
 ) -> TopKResult:
-    if not payloads:
-        raise ValueError(f"No payload candidates generated for {candidate_kind}")
-
-    registry_map = {spec.id: spec for spec in registry}
-    unique_payloads: List[_CandidatePayload] = []
-    seen_fingerprints: Set[str] = set()
-    for payload in payloads:
-        fingerprint = _canonical_payload_fingerprint(
-            payload.payload,
-            payload.primary_tool_id,
-            payload.capability_bucket,
-        )
-        if fingerprint in seen_fingerprints:
-            continue
-        seen_fingerprints.add(fingerprint)
-        unique_payloads.append(payload)
-
-    score_weights = _resolve_score_weights(task_constraints or {})
-    runtime_state_summary = _normalize_runtime_state_summary_input(runtime_state)
-    static_ranked_rows: List[Tuple[PendingActionCandidate, Tuple, str]] = []
-    effective_ranked_rows: List[Tuple[PendingActionCandidate, Tuple, str]] = []
-    for payload in unique_payloads:
-        score_breakdown = _score_payload(
-            payload.payload,
-            registry,
-            score_weights=score_weights,
-        )
-        primary_tool = registry_map.get(payload.primary_tool_id)
-        capability_id = payload.capability_bucket or _primary_capability(primary_tool)
-        tool_id = payload.primary_tool_id
-        io_type = primary_tool.io_type if primary_tool and primary_tool.io_type else "unknown"
-        adapter_mode = primary_tool.adapter_mode if primary_tool else "unknown"
-        cost_estimate = _derive_cost_estimate(payload.payload, registry)
-        risk_level = _derive_risk_level(payload.payload, registry)
-        candidate_id = _stable_candidate_id(
-            candidate_kind,
-            payload.payload,
-            payload.primary_tool_id,
-            payload.capability_bucket,
-        )
-        metadata = {
-            "candidate_kind": candidate_kind,
-            "capability_bucket": capability_id,
-            "tool_id": tool_id,
-            "capability_id": capability_id,
-            "io_type": io_type,
-            "adapter_mode": adapter_mode,
-            "generation_note": payload.note,
-            "s5_contract": _build_s5_scoring_contract(score_weights),
-            STATIC_SCORE_METADATA_KEY: _build_static_score_summary(score_breakdown),
-            ACTION_SCORE_METADATA_KEY: _build_action_score_summary(score_breakdown),
-        }
-        readiness_metadata = _candidate_readiness_metadata(
-            tool_id=tool_id,
-            capability_id=capability_id,
-        )
-        metadata.update(readiness_metadata)
-        explanation = (
-            f"{candidate_kind} candidate with primary tool "
-            f"{tool_id} in capability bucket {capability_id}."
-        )
-        payload_metadata = payload.payload.metadata if isinstance(payload.payload.metadata, dict) else {}
-        planner_route = payload_metadata.get("planner_route")
-        if isinstance(planner_route, dict):
-            metadata["planner_route"] = dict(planner_route)
-        if payload.recovery_layer:
-            metadata["recovery_layer"] = payload.recovery_layer
-        if payload.recovery_reason:
-            metadata["recovery_reason"] = payload.recovery_reason
-        if isinstance(payload.payload, PlanPatch):
-            patch_meta = _extract_patch_candidate_metadata(payload.payload)
-            if patch_meta:
-                metadata.update(patch_meta)
-        if isinstance(payload.payload, Plan):
-            s1_metadata = _extract_s1_candidate_metadata(payload.payload)
-            if s1_metadata:
-                metadata.update(s1_metadata)
-                metadata["sequence_confidence"] = score_breakdown.get("confidence")
-        if runtime_state_summary is None:
-            shadow = _build_shadow_passthrough_decision(score_breakdown)
-        else:
-            metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = dict(runtime_state_summary)
-            shadow = _build_runtime_shadow_decision(
-                candidate_kind=candidate_kind,
-                payload=payload.payload,
-                score_breakdown=score_breakdown,
-                runtime_state_summary=runtime_state_summary,
-            )
-            metadata["shadow_action"] = shadow.shadow_action
-            metadata["shadow_action_reason"] = shadow.shadow_reason
-            explanation = f"{explanation} {shadow.explanation_fragment}"
-        metadata[RUNTIME_ADJUSTMENT_METADATA_KEY] = shadow.runtime_adjustment
-        metadata[FINAL_SCORE_METADATA_KEY] = shadow.final_score
-        metadata[RERANK_REASON_METADATA_KEY] = shadow.rerank_reason
-        metadata[SHADOW_SCORE_METADATA_KEY] = shadow.shadow_score
-        candidate = PendingActionCandidate(
-            candidate_id=candidate_id,
-            structured_payload=payload.payload,
-            score_breakdown=score_breakdown,
-            risk_level=risk_level,
-            cost_estimate=cost_estimate,
-            explanation=explanation,
-            summary=_build_candidate_summary(payload.payload),
-            tool_id=tool_id,
-            capability_id=capability_id,
-            io_type=io_type,
-            adapter_mode=adapter_mode,
-            metadata=metadata,
-        )
-        priority_rank = _priority_rank(primary_tool.priority if primary_tool else None)
-        patch_layer_rank = _patch_layer_rank(payload.payload)
-        static_score_value = _extract_score_value(candidate, STATIC_SCORE_METADATA_KEY)
-        final_score_value = _extract_score_value(candidate, FINAL_SCORE_METADATA_KEY)
-        if candidate_kind == "patch":
-            static_sort_key = (
-                patch_layer_rank,
-                -static_score_value,
-                priority_rank,
-                capability_id,
-                tool_id,
-                candidate_id,
-            )
-            effective_sort_key = (
-                patch_layer_rank,
-                -final_score_value,
-                priority_rank,
-                capability_id,
-                tool_id,
-                candidate_id,
-            )
-        else:
-            static_sort_key = (
-                -static_score_value,
-                priority_rank,
-                capability_id,
-                tool_id,
-                candidate_id,
-            )
-            effective_sort_key = (
-                -final_score_value,
-                priority_rank,
-                capability_id,
-                tool_id,
-                candidate_id,
-            )
-        static_ranked_rows.append((candidate, static_sort_key, capability_id))
-        effective_ranked_rows.append((candidate, effective_sort_key, capability_id))
-
-    static_ranked_rows.sort(key=lambda row: row[1])
-    static_selected_rows = _select_diverse_top_k(
-        ranked_rows=static_ranked_rows,
-        top_k=top_k,
-    )
-    static_selected_rows = sorted(static_selected_rows, key=lambda row: row[1])
-    selected_rows = static_selected_rows
-    if runtime_state_summary is not None:
-        effective_ranked_rows.sort(key=lambda row: row[1])
-        selected_rows = _select_diverse_top_k(
-            ranked_rows=effective_ranked_rows,
+    constraints = task_constraints or {}
+    generator = CandidateGenerator(_candidate_generator_hooks())
+    return generator.generate(
+        CandidateGenerationInput(
+            candidate_kind=cast(Literal["plan", "patch", "replan"], candidate_kind),
+            payloads=payloads,
+            registry=registry,
             top_k=top_k,
+            task_constraints=constraints,
+            confirmed_task_spec=_extract_confirmed_task_spec(constraints),
+            capability_hints=_extract_capability_hints(constraints),
+            readiness=_extract_readiness_context(constraints),
+            completed_step_results=completed_step_results,
+            runtime_state=runtime_state,
+            budget=_extract_budget_context(constraints),
+            policy_mode=_extract_policy_mode(constraints),
         )
-        selected_rows = sorted(selected_rows, key=lambda row: row[1])
-    candidates = [row[0] for row in selected_rows]
-    static_candidates = [row[0] for row in static_selected_rows]
-    default_candidate = candidates[0] if candidates else None
-    static_default_candidate = static_candidates[0] if static_candidates else None
-    default_recommendation = default_candidate.candidate_id if default_candidate else None
-    if candidates:
-        default_candidate.metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
-            _build_default_recommendation_reason(
-                candidate_kind=candidate_kind,
-                candidate_id=default_candidate.candidate_id,
-                default_candidate=default_candidate,
-                static_candidate=static_default_candidate,
-                rerank_applied=runtime_state_summary is not None,
-            )
-        )
-    explanation = (
-        f"{candidate_kind} Top-K generated with deterministic sort "
-        f"(requested={top_k}, returned={len(candidates)}). "
-        "Ranking uses overall score desc + stable tie-break; "
-        "selection uses capability-bucket round-robin."
     )
-    if candidates and runtime_state_summary is not None and default_candidate is not None:
-        shadow_action = str(default_candidate.metadata.get("shadow_action") or "continue")
-        rerank_summary = _summarize_rerank_reason(default_candidate)
-        explanation = (
-            f"{candidate_kind} Top-K generated with deterministic sort "
-            f"(requested={top_k}, returned={len(candidates)}). "
-            "Ranking uses final_score desc + stable tie-break; "
-            "selection uses capability-bucket round-robin."
-        )
-        if (
-            static_default_candidate is not None
-            and static_default_candidate.candidate_id != default_candidate.candidate_id
-        ):
-            explanation = (
-                f"{explanation} Runtime rerank updated default recommendation "
-                f"from {static_default_candidate.candidate_id} to {default_candidate.candidate_id}. "
-                f"{rerank_summary} action={shadow_action}."
-            )
-        else:
-            explanation = (
-                f"{explanation} Runtime rerank kept default recommendation "
-                f"at {default_candidate.candidate_id}. {rerank_summary} action={shadow_action}."
-            )
-    if len(candidates) < top_k:
-        explanation = (
-            f"{explanation} Degraded to available candidates because "
-            "registry constraints did not produce enough unique options."
-        )
-    return TopKResult(
-        candidates=candidates,
-        default_recommendation=default_recommendation,
-        explanation=explanation,
+
+
+def _candidate_generator_hooks() -> CandidateGeneratorHooks:
+    return CandidateGeneratorHooks(
+        canonical_payload_fingerprint=_canonical_payload_fingerprint,
+        resolve_score_weights=_resolve_score_weights,
+        score_payload=_score_payload,
+        primary_capability=_primary_capability,
+        derive_cost_estimate=_derive_cost_estimate,
+        derive_risk_level=_derive_risk_level,
+        stable_candidate_id=_stable_candidate_id,
+        build_s5_scoring_contract=_build_s5_scoring_contract,
+        build_static_score_summary=_build_static_score_summary,
+        build_action_score_summary=_build_action_score_summary,
+        candidate_readiness_metadata=_candidate_readiness_metadata,
+        build_candidate_summary=_build_candidate_summary,
+        extract_patch_candidate_metadata=_extract_patch_candidate_metadata,
+        extract_plan_candidate_metadata=_extract_s1_candidate_metadata,
+        normalize_runtime_state_summary_input=_normalize_runtime_state_summary_input,
+        build_shadow_passthrough_decision=_build_shadow_passthrough_decision,
+        build_runtime_shadow_decision=_build_runtime_shadow_decision,
+        priority_rank=_priority_rank,
+        patch_layer_rank=_patch_layer_rank,
+        extract_score_value=_extract_score_value,
+        build_default_recommendation_reason=_build_default_recommendation_reason,
+        summarize_rerank_reason=_summarize_rerank_reason,
     )
+
+
+def _extract_confirmed_task_spec(constraints: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = constraints.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("confirmed_task_spec"), dict):
+        return dict(metadata["confirmed_task_spec"])
+    confirmed = constraints.get("confirmed_task_spec")
+    return dict(confirmed) if isinstance(confirmed, dict) else None
+
+
+def _candidate_generation_constraints(
+    *,
+    constraints: dict[str, Any],
+    metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    generation_constraints = dict(constraints)
+    if isinstance(metadata, dict) and metadata:
+        generation_constraints["metadata"] = dict(metadata)
+        confirmed = metadata.get("confirmed_task_spec")
+        if isinstance(confirmed, dict):
+            generation_constraints.setdefault("confirmed_task_spec", dict(confirmed))
+        hints = metadata.get("planner_capability_hints")
+        if isinstance(hints, (list, tuple, set)):
+            generation_constraints.setdefault("capability_hints", list(hints))
+    return generation_constraints
+
+
+def _extract_capability_hints(constraints: dict[str, Any]) -> tuple[str, ...]:
+    raw_hints: Any = constraints.get("capability_hints")
+    metadata = constraints.get("metadata")
+    if raw_hints is None and isinstance(metadata, dict):
+        raw_hints = metadata.get("planner_capability_hints")
+    if raw_hints is None:
+        confirmed = constraints.get("confirmed_task_spec")
+        if isinstance(confirmed, dict):
+            confirmed_metadata = confirmed.get("metadata")
+            if isinstance(confirmed_metadata, dict):
+                raw_hints = confirmed_metadata.get("planner_capability_hints")
+    if isinstance(raw_hints, str):
+        return (raw_hints,)
+    if isinstance(raw_hints, (list, tuple, set)):
+        return tuple(str(item) for item in raw_hints if str(item))
+    return ()
+
+
+def _extract_readiness_context(constraints: dict[str, Any]) -> dict[str, Any] | None:
+    readiness = constraints.get("readiness")
+    return dict(readiness) if isinstance(readiness, dict) else None
+
+
+def _extract_budget_context(constraints: dict[str, Any]) -> dict[str, Any]:
+    budget = constraints.get("budget")
+    if isinstance(budget, dict):
+        return dict(budget)
+    extracted: dict[str, Any] = {}
+    for key in ("budget_cap", "cost_cap", "max_runtime_min"):
+        if key in constraints:
+            extracted[key] = constraints[key]
+    return extracted
+
+
+def _extract_policy_mode(constraints: dict[str, Any]) -> str:
+    raw_mode = constraints.get("policy_mode") or constraints.get("run_profile")
+    return str(raw_mode) if raw_mode is not None else "balanced"
 
 
 def _build_action_score_summary(score_breakdown: dict[str, float]) -> dict[str, Any]:
@@ -2748,36 +2643,6 @@ def _build_pending_action_runtime_metadata(
     return metadata
 
 
-def _select_diverse_top_k(
-    *,
-    ranked_rows: Sequence[Tuple[PendingActionCandidate, Tuple, str]],
-    top_k: int,
-) -> List[Tuple[PendingActionCandidate, Tuple, str]]:
-    bucket_rows: dict[str, List[Tuple[PendingActionCandidate, Tuple, str]]] = {}
-    bucket_order: List[str] = []
-    for row in ranked_rows:
-        bucket = row[2] or "unknown"
-        if bucket not in bucket_rows:
-            bucket_rows[bucket] = []
-            bucket_order.append(bucket)
-        bucket_rows[bucket].append(row)
-
-    selected: List[Tuple[PendingActionCandidate, Tuple, str]] = []
-    while len(selected) < top_k:
-        progressed = False
-        for bucket in bucket_order:
-            rows = bucket_rows[bucket]
-            if not rows:
-                continue
-            selected.append(rows.pop(0))
-            progressed = True
-            if len(selected) >= top_k:
-                break
-        if not progressed:
-            break
-    return selected
-
-
 def _build_candidate_summary(payload: Plan | PlanPatch) -> str:
     if isinstance(payload, Plan):
         tools = [step.tool for step in payload.steps]
@@ -2862,6 +2727,7 @@ def _score_payload(
     )
     tool_coverage = _tool_coverage_score(tool_ids, capabilities)
     fallback_depth = _fallback_depth_score(tool_ids, registry_map, registry)
+    recovery_complexity = max(0.0, min(1.0, 1.0 - fallback_depth))
 
     feasibility = min(1.0, max(0.0, 0.5 + 0.25 * tool_coverage + 0.25 * fallback_depth))
     objective = min(
@@ -2899,6 +2765,7 @@ def _score_payload(
         "tool_readiness": round(tool_readiness, 6),
         "tool_coverage": round(tool_coverage, 6),
         "fallback_depth": round(fallback_depth, 6),
+        "recovery_complexity": round(recovery_complexity, 6),
         "overall": round(overall, 6),
     }
 
@@ -2921,6 +2788,7 @@ def _build_s5_scoring_contract(
             "score_breakdown": "dict[str,float]",
             "top_k": "list[PendingActionCandidate]",
             "default_recommendation": "str",
+            "default_suggestion": "str",
             "explanation": "str",
         },
         "weights": dict(score_weights),

--- a/tests/unit/test_candidate_generator.py
+++ b/tests/unit/test_candidate_generator.py
@@ -134,3 +134,33 @@ def test_plan_top_k_filters_blocked_tools_before_default_selection(monkeypatch):
     assert all(candidate.tool_id != "seqgen_a" for candidate in topk.candidates)
     assert topk.default_recommendation == topk.candidates[0].candidate_id
     assert "Filtered candidates before ranking" in topk.explanation
+
+
+def test_plan_top_k_applies_policy_mode_and_cost_filter(monkeypatch):
+    monkeypatch.setenv("PLANNER_LLM_PROVIDER", "none")
+    monkeypatch.setattr(planner_module, "load_tool_kg", _kg)
+    monkeypatch.setattr(
+        planner_module,
+        "build_capability_readiness_snapshot",
+        _ready_capability,
+    )
+    planner = PlannerAgent(tool_registry=_registry())
+    task = ProteinDesignTask(
+        task_id="candidate_generator_policy_cost",
+        goal="design stable peptide",
+        constraints={
+            "goal_type": "sequence_evaluation",
+            "policy_mode": "low_cost",
+            "max_cost_level": "medium",
+        },
+        metadata={},
+    )
+
+    topk = planner.plan_top_k(task, k=3)
+
+    assert topk.candidates
+    assert all(candidate.cost_estimate != "high" for candidate in topk.candidates)
+    assert all(
+        "policy_mode_fit" in candidate.score_breakdown
+        for candidate in topk.candidates
+    )

--- a/tests/unit/test_candidate_generator.py
+++ b/tests/unit/test_candidate_generator.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import src.agents.planner as planner_module
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.models.contracts import ProteinDesignTask
+
+
+def _registry() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            id="seqgen_a",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence",),
+            cost=0.2,
+            safety_level=1,
+            io_type="goal_to_sequence",
+            adapter_mode="local",
+            priority="P0",
+        ),
+        ToolSpec(
+            id="seqgen_b",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence",),
+            cost=0.3,
+            safety_level=1,
+            io_type="goal_to_sequence",
+            adapter_mode="local",
+            priority="P1",
+        ),
+    ]
+
+
+def _ready_capability(capability_id: str) -> dict:
+    return {
+        "capability_id": capability_id,
+        "status": "ready",
+        "reason": "unit test readiness",
+        "degraded_reasons": [],
+        "tools": [
+            {
+                "tool_id": "seqgen_a",
+                "status": "ready",
+                "reason": "ready",
+            },
+            {
+                "tool_id": "seqgen_b",
+                "status": "ready",
+                "reason": "ready",
+            },
+        ],
+    }
+
+
+def _kg() -> dict:
+    return {
+        "tools": [
+            {
+                "id": "seqgen_a",
+                "capabilities": ["sequence_generation"],
+                "io": {
+                    "io_type_id": "goal_to_sequence",
+                    "inputs": {"goal": "str"},
+                    "outputs": {"sequence": "str"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+            {
+                "id": "seqgen_b",
+                "capabilities": ["sequence_generation"],
+                "io": {
+                    "io_type_id": "goal_to_sequence",
+                    "inputs": {"goal": "str"},
+                    "outputs": {"sequence": "str"},
+                },
+                "execution": "python",
+                "constraints": {},
+            },
+        ]
+    }
+
+
+def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
+    monkeypatch.setenv("PLANNER_LLM_PROVIDER", "none")
+    monkeypatch.setattr(planner_module, "load_tool_kg", _kg)
+    monkeypatch.setattr(
+        planner_module,
+        "build_capability_readiness_snapshot",
+        _ready_capability,
+    )
+    planner = PlannerAgent(tool_registry=_registry())
+    task = ProteinDesignTask(
+        task_id="candidate_generator_context",
+        goal="design stable peptide",
+        constraints={"goal_type": "sequence_evaluation", "budget": {"cost_cap": 0.5}},
+        metadata={"planner_capability_hints": ["sequence_generation"]},
+    )
+
+    topk = planner.plan_top_k(task, k=3)
+
+    assert topk.default_suggestion == topk.default_recommendation
+    assert "CandidateGenerator" in topk.explanation
+    assert "Candidate differences:" in topk.explanation
+    assert topk.candidates
+    candidate = topk.candidates[0]
+    assert candidate.metadata["candidate_generator"]["capability_hints"] == [
+        "sequence_generation"
+    ]
+    assert candidate.score_breakdown["recovery_complexity"] >= 0.0
+    assert candidate.score_breakdown["capability_hint_match"] == 1.0
+
+
+def test_plan_top_k_filters_blocked_tools_before_default_selection(monkeypatch):
+    monkeypatch.setenv("PLANNER_LLM_PROVIDER", "none")
+    monkeypatch.setattr(planner_module, "load_tool_kg", _kg)
+    monkeypatch.setattr(
+        planner_module,
+        "build_capability_readiness_snapshot",
+        _ready_capability,
+    )
+    planner = PlannerAgent(tool_registry=_registry())
+    task = ProteinDesignTask(
+        task_id="candidate_generator_filter",
+        goal="design stable peptide",
+        constraints={"goal_type": "sequence_evaluation", "blocked_tools": ["seqgen_a"]},
+        metadata={},
+    )
+
+    topk = planner.plan_top_k(task, k=3)
+
+    assert topk.candidates
+    assert all(candidate.tool_id != "seqgen_a" for candidate in topk.candidates)
+    assert topk.default_recommendation == topk.candidates[0].candidate_id
+    assert "Filtered candidates before ranking" in topk.explanation


### PR DESCRIPTION
## 概述

实现 issue #264：将 Planner 的候选生成抽离为独立 `CandidateGenerator` 模块，并让初始规划、patch、replan 共用统一 Top-K 候选生成入口。

Closes #264

## 实现内容

- 新增 `src/agents/candidate_generator/` package，按职责拆分为：
  - `models.py`：候选生成输入、payload、TopKResult、hooks 契约
  - `builder.py`：构造 `PendingActionCandidate`、score metadata、runtime shadow metadata
  - `filters.py`：I/O 闭包、tool/safety/cost 过滤辅助
  - `generator.py`：统一 Top-K 编排、排序、default_suggestion、候选差异解释
- 更新 `PlannerAgent` 的 plan / patch / replan Top-K 路径，统一委托给 `CandidateGenerator`。
- 保持既有 `Plan` / `PlanPatch` / `PendingActionCandidate` / `TopKResult` 对外兼容。
- 补充 `score_breakdown.recovery_complexity` 与 `default_suggestion` 输出契约。
- 让 readiness、I/O 闭包、capability hints、budget、policy_mode、runtime_state 参与过滤、评分或审计 metadata。
- 保留 Web / CLI 通过 PendingAction API 消费候选比较结构的既有路径。

## 对照验收

- CandidateGenerator 已独立成模块，并拆分为可维护 package。
- 初始规划、patch、replan 共用统一入口 `_build_top_k_result -> CandidateGenerator.generate`。
- I/O 闭包、tool availability、blocked/allowed tools、safety level、cost level 在进入 Top-K 选择前参与过滤。
- capability hints、budget、policy_mode、readiness、runtime_state 参与评分或候选审计 metadata。
- Top-K 默认 K=3，输出 default_suggestion/default_recommendation 与候选差异解释。
- 未新增 Workflow FSM 状态，未新增 Agent 角色，未改变 PendingAction / Decision / TaskSnapshot 核心语义。

## 验证

- `uv run pytest tests/unit/test_candidate_generator.py tests/unit/test_planner_agent.py tests/integration/test_candidate_score_gate.py -q`
  - 结果：`53 passed, 1 warning`
