### PR TITLE
对 candidate_generate 模块采用 basedpyright 修复

### DIFF
--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from typing import cast
 
-from src.agents.candidate_generator.filters import safe_float
+from src.agents.candidate_generator.filters import (
+    normalize_adapter_mode,
+    normalize_level,
+    object_mapping,
+    safe_float,
+)
 from src.agents.candidate_generator.models import (
     CandidateGenerationInput,
     CandidateGeneratorHooks,
     CandidatePayload,
+    Metadata,
+    RuntimeShadowDecisionLike,
+    ToolSpecLike,
 )
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
@@ -26,24 +35,30 @@ class CandidateBuilder:
     """构造 PendingActionCandidate 及其审计 metadata。"""
 
     def __init__(self, hooks: CandidateGeneratorHooks) -> None:
-        self._hooks = hooks
+        self._hooks: CandidateGeneratorHooks = hooks
 
     def build(
         self,
         *,
         payload: CandidatePayload,
         request: CandidateGenerationInput,
-        registry_map: dict[str, Any],
+        registry_map: Mapping[str, ToolSpecLike],
         score_weights: dict[str, float],
-        runtime_state_summary: dict[str, Any] | None,
+        runtime_state_summary: Metadata | None,
     ) -> PendingActionCandidate:
         primary_tool = registry_map.get(payload.primary_tool_id)
         capability_id = payload.capability_bucket or self._hooks.primary_capability(
             primary_tool
         )
         tool_id = payload.primary_tool_id
-        io_type = primary_tool.io_type if primary_tool and primary_tool.io_type else "unknown"
-        adapter_mode = primary_tool.adapter_mode if primary_tool else "unknown"
+        io_type = (
+            primary_tool.io_type
+            if primary_tool is not None and primary_tool.io_type
+            else "unknown"
+        )
+        adapter_mode = normalize_adapter_mode(
+            primary_tool.adapter_mode if primary_tool is not None else "unknown"
+        )
         score_breakdown = self._hooks.score_payload(
             payload.payload,
             request.registry,
@@ -86,8 +101,12 @@ class CandidateBuilder:
             ),
             structured_payload=payload.payload,
             score_breakdown=score_breakdown,
-            risk_level=self._hooks.derive_risk_level(payload.payload, request.registry),
-            cost_estimate=self._hooks.derive_cost_estimate(payload.payload, request.registry),
+            risk_level=normalize_level(
+                self._hooks.derive_risk_level(payload.payload, request.registry)
+            ),
+            cost_estimate=normalize_level(
+                self._hooks.derive_cost_estimate(payload.payload, request.registry)
+            ),
             explanation=explanation,
             summary=self._hooks.build_candidate_summary(payload.payload),
             tool_id=tool_id,
@@ -108,8 +127,8 @@ class CandidateBuilder:
         adapter_mode: str,
         score_breakdown: dict[str, float],
         score_weights: dict[str, float],
-    ) -> dict[str, Any]:
-        metadata: dict[str, Any] = {
+    ) -> Metadata:
+        metadata: Metadata = {
             "candidate_kind": request.candidate_kind,
             "capability_bucket": capability_id,
             "tool_id": tool_id,
@@ -121,7 +140,7 @@ class CandidateBuilder:
                 "module": "src.agents.candidate_generator",
                 "policy_mode": request.policy_mode,
                 "capability_hints": list(request.capability_hints),
-                "budget": dict(request.budget or {}),
+                "budget": object_mapping(request.budget),
                 "readiness_context_present": request.readiness is not None,
                 "completed_step_count": len(request.completed_step_results),
                 "confirmed_task_spec_present": request.confirmed_task_spec is not None,
@@ -136,11 +155,10 @@ class CandidateBuilder:
                 capability_id=capability_id,
             )
         )
-        payload_metadata = (
-            payload.payload.metadata if isinstance(payload.payload.metadata, dict) else {}
-        )
-        if isinstance(payload_metadata.get("planner_route"), dict):
-            metadata["planner_route"] = dict(payload_metadata["planner_route"])
+        payload_metadata = object_mapping(cast(object, payload.payload.metadata))
+        planner_route = payload_metadata.get("planner_route")
+        if isinstance(planner_route, dict):
+            metadata["planner_route"] = object_mapping(cast(object, planner_route))
         if payload.recovery_layer:
             metadata["recovery_layer"] = payload.recovery_layer
         if payload.recovery_reason:
@@ -159,14 +177,16 @@ class CandidateBuilder:
         *,
         payload: CandidatePayload,
         request: CandidateGenerationInput,
-        metadata: dict[str, Any],
+        metadata: Metadata,
         score_breakdown: dict[str, float],
-        runtime_state_summary: dict[str, Any] | None,
-    ) -> Any:
+        runtime_state_summary: Metadata | None,
+    ) -> RuntimeShadowDecisionLike:
         if runtime_state_summary is None:
             shadow = self._hooks.build_shadow_passthrough_decision(score_breakdown)
         else:
-            metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = dict(runtime_state_summary)
+            metadata[RUNTIME_STATE_SUMMARY_METADATA_KEY] = object_mapping(
+                runtime_state_summary
+            )
             shadow = self._hooks.build_runtime_shadow_decision(
                 candidate_kind=request.candidate_kind,
                 payload=payload.payload,
@@ -225,5 +245,4 @@ class CandidateBuilder:
         return {
             key: round(value, 6)
             for key, value in adjusted.items()
-            if isinstance(value, (int, float))
         }

--- a/src/agents/candidate_generator/filters.py
+++ b/src/agents/candidate_generator/filters.py
@@ -1,8 +1,43 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import cast
 
+from src.agents.candidate_generator.models import (
+    AdapterMode,
+    Level,
+    Metadata,
+    ToolSpecLike,
+)
 from src.models.contracts import PendingActionCandidate, Plan, PlanPatch
+
+
+def object_mapping(value: object) -> Metadata:
+    """将动态 mapping 收敛为字符串键元数据。"""
+    if not isinstance(value, Mapping):
+        return {}
+    mapping = cast(Mapping[object, object], value)
+    return {str(key): item for key, item in mapping.items()}
+
+
+def normalize_level(value: object) -> Level | None:
+    """归一化候选风险/成本等级。"""
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"low", "medium", "high"}:
+        return cast(Level, normalized)
+    return None
+
+
+def normalize_adapter_mode(value: object) -> AdapterMode:
+    """归一化候选 adapter_mode。"""
+    if not isinstance(value, str):
+        return "unknown"
+    normalized = value.strip().lower()
+    if normalized in {"local", "remote", "mock", "hybrid", "unknown"}:
+        return cast(AdapterMode, normalized)
+    return "unknown"
 
 
 def candidate_difference_explanation(
@@ -26,42 +61,31 @@ def candidate_difference_explanation(
 def payload_tool_ids(payload: Plan | PlanPatch) -> list[str]:
     if isinstance(payload, Plan):
         return [step.tool for step in payload.steps]
-    return [
-        operation.step.tool
-        for operation in payload.operations
-        if operation.step is not None
-    ]
+    return [operation.step.tool for operation in payload.operations]
 
 
 def payload_io_closed(
     payload: Plan | PlanPatch,
-    registry_map: dict[str, Any],
-    completed_step_results: Sequence[Any],
-    constraints: dict[str, Any],
+    registry_map: Mapping[str, ToolSpecLike],
+    completed_step_results: Sequence[object],
+    constraints: Mapping[str, object],
 ) -> bool:
     available = set(constraints.keys())
     available.add("goal")
-    inputs = constraints.get("inputs")
-    if isinstance(inputs, dict):
-        available.update(inputs.keys())
+    available.update(object_mapping(constraints.get("inputs")).keys())
     for result in completed_step_results:
         outputs = getattr(result, "outputs", None)
-        if isinstance(outputs, dict):
-            available.update(outputs.keys())
+        available.update(object_mapping(outputs).keys())
 
     steps = (
         payload.steps
         if isinstance(payload, Plan)
-        else [
-            operation.step
-            for operation in payload.operations
-            if operation.step is not None
-        ]
+        else [operation.step for operation in payload.operations]
     )
     for step in steps:
         spec = registry_map.get(step.tool)
-        required_inputs = set(getattr(spec, "inputs", ()) or ())
-        step_inputs = step.inputs if isinstance(step.inputs, dict) else {}
+        required_inputs = set(spec.inputs if spec is not None else ())
+        step_inputs = object_mapping(cast(object, step.inputs))
         for required in required_inputs:
             if required in step_inputs:
                 continue
@@ -73,20 +97,21 @@ def payload_io_closed(
                 _head, field = value.split(".", 1)
                 if field not in available:
                     return False
-        outputs = getattr(spec, "outputs", ()) if spec is not None else ()
-        available.update(outputs)
+        if spec is not None:
+            available.update(spec.outputs)
     return True
 
 
-def string_set(value: Any) -> set[str]:
+def string_set(value: object) -> set[str]:
     if isinstance(value, str):
         return {value}
     if isinstance(value, (list, tuple, set)):
-        return {str(item) for item in value if str(item)}
+        items = cast(Iterable[object], value)
+        return {str(item) for item in items if str(item)}
     return set()
 
 
-def parse_safety_level(value: Any) -> int | None:
+def parse_safety_level(value: object) -> int | None:
     if value is None:
         return None
     if isinstance(value, int):
@@ -100,7 +125,9 @@ def parse_safety_level(value: Any) -> int | None:
     return None
 
 
-def safe_float(value: Any) -> float | None:
+def safe_float(value: object) -> float | None:
+    if not isinstance(value, (str, int, float)):
+        return None
     try:
         return float(value)
     except (TypeError, ValueError):

--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Mapping, Sequence
+from typing import cast
 
 from src.agents.candidate_generator.builder import CandidateBuilder
 from src.agents.candidate_generator.filters import (
     candidate_difference_explanation,
     cost_level_exceeds,
+    object_mapping,
     parse_safety_level,
     payload_io_closed,
     payload_tool_ids,
@@ -15,6 +17,9 @@ from src.agents.candidate_generator.models import (
     CandidateGenerationInput,
     CandidateGeneratorHooks,
     CandidatePayload,
+    Metadata,
+    SortKey,
+    ToolSpecLike,
     TopKResult,
 )
 from src.models.contracts import (
@@ -28,6 +33,9 @@ from src.models.contracts import (
     TOOL_READINESS_METADATA_KEY,
 )
 
+ScoredRow = tuple[PendingActionCandidate, SortKey, SortKey, str]
+RankedRow = tuple[PendingActionCandidate, SortKey, str]
+
 
 class CandidateGenerator:
     """统一生成 Plan/Patch/Replan Top-K 候选。
@@ -37,19 +45,21 @@ class CandidateGenerator:
     """
 
     def __init__(self, hooks: CandidateGeneratorHooks) -> None:
-        self._hooks = hooks
-        self._builder = CandidateBuilder(hooks)
+        self._hooks: CandidateGeneratorHooks = hooks
+        self._builder: CandidateBuilder = CandidateBuilder(hooks)
 
     def generate(self, request: CandidateGenerationInput) -> TopKResult:
         """生成稳定 Top-K、default_suggestion 和候选差异解释。"""
         if not request.payloads:
             raise ValueError(f"No payload candidates generated for {request.candidate_kind}")
 
-        registry_map = {spec.id: spec for spec in request.registry}
+        registry_map: dict[str, ToolSpecLike] = {
+            spec.id: spec for spec in request.registry
+        }
         unique_payloads = self._dedupe_payloads(request.payloads)
-        scored_rows: list[tuple[PendingActionCandidate, tuple, tuple, str]] = []
-        filtered_rows: list[tuple[PendingActionCandidate, tuple, tuple, str]] = []
-        soft_filtered_rows: list[tuple[PendingActionCandidate, tuple, tuple, str]] = []
+        scored_rows: list[ScoredRow] = []
+        filtered_rows: list[ScoredRow] = []
+        soft_filtered_rows: list[ScoredRow] = []
         filter_reasons: list[str] = []
 
         score_weights = self._hooks.resolve_score_weights(request.task_constraints or {})
@@ -101,7 +111,9 @@ class CandidateGenerator:
             top_k=request.top_k,
         )
         if not available_rows:
-            raise ValueError(f"No feasible payload candidates generated for {request.candidate_kind}")
+            raise ValueError(
+                f"No feasible payload candidates generated for {request.candidate_kind}"
+            )
 
         static_rows = sorted(
             [(row[0], row[1], row[3]) for row in available_rows],
@@ -132,7 +144,8 @@ class CandidateGenerator:
             default_candidate.candidate_id if default_candidate is not None else None
         )
         if default_candidate is not None:
-            default_candidate.metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
+            default_metadata = cast(Metadata, default_candidate.metadata)
+            default_metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
                 self._hooks.build_default_recommendation_reason(
                     candidate_kind=request.candidate_kind,
                     candidate_id=default_candidate.candidate_id,
@@ -161,7 +174,7 @@ class CandidateGenerator:
         candidate: PendingActionCandidate,
         payload: Plan | PlanPatch,
         request: CandidateGenerationInput,
-        registry_map: dict[str, Any],
+        registry_map: Mapping[str, ToolSpecLike],
     ) -> str | None:
         constraints = request.task_constraints or {}
         tool_ids = payload_tool_ids(payload)
@@ -182,12 +195,15 @@ class CandidateGenerator:
         if max_safety_level is not None:
             for tool_id in tool_ids:
                 spec = registry_map.get(tool_id)
-                if spec is not None and int(getattr(spec, "safety_level", 1)) > max_safety_level:
+                if spec is not None and spec.safety_level > max_safety_level:
                     return "safety_level_exceeded"
         max_cost_level = constraints.get("max_cost_level") or constraints.get(
             "max_cost_estimate"
         )
-        if cost_level_exceeds(candidate.cost_estimate, max_cost_level):
+        normalized_max_cost_level = (
+            max_cost_level.strip() if isinstance(max_cost_level, str) else None
+        )
+        if cost_level_exceeds(candidate.cost_estimate, normalized_max_cost_level):
             return "cost_level_exceeded"
         if not payload_io_closed(
             payload,
@@ -201,11 +217,12 @@ class CandidateGenerator:
         return None
 
     def _candidate_unavailable(self, candidate: PendingActionCandidate) -> bool:
-        metadata = candidate.metadata if isinstance(candidate.metadata, dict) else {}
+        metadata = object_mapping(cast(object, candidate.metadata))
         tool_readiness = metadata.get(TOOL_READINESS_METADATA_KEY)
         capability_readiness = metadata.get(CAPABILITY_READINESS_METADATA_KEY)
         for item in (tool_readiness, capability_readiness):
-            if isinstance(item, dict) and item.get("status") == "unavailable":
+            readiness = object_mapping(item)
+            if readiness.get("status") == "unavailable":
                 return True
         return False
 
@@ -213,11 +230,13 @@ class CandidateGenerator:
         self,
         candidate_kind: str,
         candidate: PendingActionCandidate,
-        primary_tool: Any | None,
+        primary_tool: ToolSpecLike | None,
         payload: Plan | PlanPatch,
         score_metadata_key: str,
-    ) -> tuple:
-        priority_rank = self._hooks.priority_rank(primary_tool.priority if primary_tool else None)
+    ) -> SortKey:
+        priority_rank = self._hooks.priority_rank(
+            primary_tool.priority if primary_tool else None
+        )
         patch_layer_rank = self._hooks.patch_layer_rank(payload)
         score_value = self._hooks.extract_score_value(candidate, score_metadata_key)
         capability_id = candidate.capability_id or "unknown"
@@ -260,11 +279,11 @@ class CandidateGenerator:
     def _available_rows(
         self,
         *,
-        filtered_rows: Sequence[tuple[PendingActionCandidate, tuple, tuple, str]],
-        soft_filtered_rows: Sequence[tuple[PendingActionCandidate, tuple, tuple, str]],
-        scored_rows: Sequence[tuple[PendingActionCandidate, tuple, tuple, str]],
+        filtered_rows: Sequence[ScoredRow],
+        soft_filtered_rows: Sequence[ScoredRow],
+        scored_rows: Sequence[ScoredRow],
         top_k: int,
-    ) -> list[tuple[PendingActionCandidate, tuple, tuple, str]]:
+    ) -> list[ScoredRow]:
         available_rows = list(filtered_rows)
         if len(available_rows) < top_k:
             seen_ids = {row[0].candidate_id for row in available_rows}
@@ -284,10 +303,10 @@ class CandidateGenerator:
     def _select_diverse_top_k(
         self,
         *,
-        ranked_rows: Sequence[tuple[PendingActionCandidate, tuple, str]],
+        ranked_rows: Sequence[RankedRow],
         top_k: int,
-    ) -> list[tuple[PendingActionCandidate, tuple, str]]:
-        bucket_rows: dict[str, list[tuple[PendingActionCandidate, tuple, str]]] = {}
+    ) -> list[RankedRow]:
+        bucket_rows: dict[str, list[RankedRow]] = {}
         bucket_order: list[str] = []
         for row in ranked_rows:
             bucket = row[2] or "unknown"
@@ -296,7 +315,7 @@ class CandidateGenerator:
                 bucket_order.append(bucket)
             bucket_rows[bucket].append(row)
 
-        selected: list[tuple[PendingActionCandidate, tuple, str]] = []
+        selected: list[RankedRow] = []
         while len(selected) < top_k:
             progressed = False
             for bucket in bucket_order:
@@ -320,9 +339,11 @@ class CandidateGenerator:
         static_default_candidate: PendingActionCandidate | None,
         filter_reasons: Sequence[str],
         used_filtered_rows: bool,
-        runtime_state_summary: dict[str, Any] | None,
+        runtime_state_summary: Metadata | None,
     ) -> str:
-        ranking_basis = "final_score" if runtime_state_summary is not None else "static_score"
+        ranking_basis = (
+            "final_score" if runtime_state_summary is not None else "static_score"
+        )
         explanation = (
             f"{request.candidate_kind} Top-K generated by CandidateGenerator "
             f"(requested={request.top_k}, returned={len(candidates)}). "

--- a/src/agents/candidate_generator/models.py
+++ b/src/agents/candidate_generator/models.py
@@ -1,9 +1,50 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from typing import Literal, Protocol, TypeAlias
 
 from src.models.contracts import PendingActionCandidate, Plan, PlanPatch
+
+AdapterMode: TypeAlias = Literal["local", "remote", "mock", "hybrid", "unknown"]
+Level: TypeAlias = Literal["low", "medium", "high"]
+Metadata: TypeAlias = dict[str, object]
+MetadataMapping: TypeAlias = Mapping[str, object]
+SortKey: TypeAlias = (
+    tuple[int, float, int, str, str, str] | tuple[float, int, str, str, str]
+)
+
+
+class ToolSpecLike(Protocol):
+    """CandidateGenerator 使用的工具规格最小结构。"""
+
+    id: str
+    capabilities: Sequence[str]
+    inputs: Sequence[str]
+    outputs: Sequence[str]
+    cost: float
+    safety_level: int
+    io_type: str | None
+    adapter_mode: AdapterMode
+    priority: str | None
+
+
+class CompletedStepResultLike(Protocol):
+    """CandidateGenerator 读取已完成步骤结果时需要的最小结构。"""
+
+    outputs: Mapping[str, object]
+
+
+class RuntimeShadowDecisionLike(Protocol):
+    """Planner shadow rerank 决策对象的最小结构。"""
+
+    shadow_score: Metadata
+    final_score: Metadata
+    runtime_adjustment: Metadata
+    rerank_reason: Metadata
+    shadow_action: str
+    shadow_reason: str
+    explanation_fragment: str
 
 
 @dataclass(frozen=True)
@@ -38,15 +79,15 @@ class CandidateGenerationInput:
 
     candidate_kind: Literal["plan", "patch", "replan"]
     payloads: Sequence[CandidatePayload]
-    registry: Sequence[Any]
+    registry: Sequence[ToolSpecLike]
     top_k: int = 3
-    task_constraints: dict[str, Any] | None = None
-    confirmed_task_spec: dict[str, Any] | None = None
+    task_constraints: MetadataMapping | None = None
+    confirmed_task_spec: MetadataMapping | None = None
     capability_hints: Sequence[str] = ()
-    readiness: dict[str, Any] | None = None
-    completed_step_results: Sequence[Any] = ()
-    runtime_state: Any | None = None
-    budget: dict[str, Any] | None = None
+    readiness: MetadataMapping | None = None
+    completed_step_results: Sequence[CompletedStepResultLike] = ()
+    runtime_state: object | None = None
+    budget: MetadataMapping | None = None
     policy_mode: str = "balanced"
 
 
@@ -55,24 +96,26 @@ class CandidateGeneratorHooks:
     """Planner 既有评分与展示函数注入点。"""
 
     canonical_payload_fingerprint: Callable[[Plan | PlanPatch, str, str], str]
-    resolve_score_weights: Callable[[dict[str, Any]], dict[str, float]]
+    resolve_score_weights: Callable[[MetadataMapping], dict[str, float]]
     score_payload: Callable[..., dict[str, float]]
-    primary_capability: Callable[[Any | None], str]
-    derive_cost_estimate: Callable[[Plan | PlanPatch, Sequence[Any]], str]
-    derive_risk_level: Callable[[Plan | PlanPatch, Sequence[Any]], str]
+    primary_capability: Callable[[ToolSpecLike | None], str]
+    derive_cost_estimate: Callable[[Plan | PlanPatch, Sequence[ToolSpecLike]], str]
+    derive_risk_level: Callable[[Plan | PlanPatch, Sequence[ToolSpecLike]], str]
     stable_candidate_id: Callable[[str, Plan | PlanPatch, str, str], str]
-    build_s5_scoring_contract: Callable[[dict[str, float]], dict[str, Any]]
-    build_static_score_summary: Callable[[dict[str, float]], dict[str, Any]]
-    build_action_score_summary: Callable[[dict[str, float]], dict[str, Any]]
-    candidate_readiness_metadata: Callable[..., dict[str, Any]]
+    build_s5_scoring_contract: Callable[[dict[str, float]], Metadata]
+    build_static_score_summary: Callable[[dict[str, float]], Metadata]
+    build_action_score_summary: Callable[[dict[str, float]], Metadata]
+    candidate_readiness_metadata: Callable[..., Metadata]
     build_candidate_summary: Callable[[Plan | PlanPatch], str]
-    extract_patch_candidate_metadata: Callable[[PlanPatch], dict[str, Any]]
-    extract_plan_candidate_metadata: Callable[[Plan], dict[str, Any]]
-    normalize_runtime_state_summary_input: Callable[[Any | None], dict[str, Any] | None]
-    build_shadow_passthrough_decision: Callable[[dict[str, float]], Any]
-    build_runtime_shadow_decision: Callable[..., Any]
+    extract_patch_candidate_metadata: Callable[[PlanPatch], Metadata]
+    extract_plan_candidate_metadata: Callable[[Plan], Metadata]
+    normalize_runtime_state_summary_input: Callable[[object | None], Metadata | None]
+    build_shadow_passthrough_decision: Callable[
+        [dict[str, float]], RuntimeShadowDecisionLike
+    ]
+    build_runtime_shadow_decision: Callable[..., RuntimeShadowDecisionLike]
     priority_rank: Callable[[str | None], int]
     patch_layer_rank: Callable[[Plan | PlanPatch], int]
     extract_score_value: Callable[[PendingActionCandidate, str], float]
-    build_default_recommendation_reason: Callable[..., dict[str, Any]]
+    build_default_recommendation_reason: Callable[..., Metadata]
     summarize_rerank_reason: Callable[[PendingActionCandidate], str]


### PR DESCRIPTION
# 概述
针对 `src/agents/candiadate_generator` 模块采用 basedpyright 校验，移除了其中的Any型入口，并实现边界收敛。

# 实现内容
- `models.py`: 新增模块内类型别名与 Protocol，移除 `Any` 型入口。
- `fliters.py`: 增加 metadata/level/adapter_mode 的边界收敛函数。
- `builders.py`: 收紧 registry、metadata、shadow decision 类型。
- `generator.py`: 显式化 Top-K 排序行和 sort key 类型，收敛 readiness metadata 的 `Unknown` 。

验证已通过：

```bash
uv run basedpyright src/agents/candidate_generator
# 0 errors, 0 warnings, 0 notes

uv run pytest tests/unit/test_candidate_generator.py tests/unit/test_planner_agent.py tests/integration/test_candidate_score_gate.py -q
# 53 passed, 1 warning
```
