### PR TITLE
fix: 修正 llm 核心模块的类型问题

### DIFF
--- a/src/llm/base_llm_provider.py
+++ b/src/llm/base_llm_provider.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, ValidationError
 
 from src.models.contracts import (
@@ -15,12 +16,17 @@ from src.models.contracts import (
 if TYPE_CHECKING:
     from src.agents.planner import ToolSpec
 
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | JsonObject | JsonArray
+type JsonObject = dict[str, JsonValue]
+type JsonArray = list[JsonValue]
+
 
 class ProviderConfig(BaseModel):
     """LLM Provider配置"""
 
     model_name: str
-    api_key: Optional[str] = None
+    api_key: str | None = None
     timeout: int = 300
     max_tokens: int | None = 2000
     temperature: float = 0.7
@@ -32,10 +38,10 @@ class ProviderConfig(BaseModel):
     supports_patch: bool = True
     supports_replan: bool = True
     supports_reasoning: bool = False
-    headers: Optional[Dict[str, str]] = None
+    headers: dict[str, str] | None = None
     organization: str | None = None
     anthropic_version: str | None = None
-    extra_body: Optional[Dict[str, Any]] = None
+    extra_body: JsonObject | None = None
     use_response_format: bool = True
 
 
@@ -44,35 +50,39 @@ class BaseProvider(ABC):
 
     @abstractmethod
     def call_planner(
-        self, task: ProteinDesignTask, tool_registry: List["ToolSpec"]
-    ) -> Dict:
+        self, task: ProteinDesignTask, tool_registry: list["ToolSpec"]
+    ) -> JsonObject:
         """生成 Plan, 返回 Plan schema 的 dict"""
         pass
 
     def call_patch(
-        self, request: PatchRequest, tool_registry: List["ToolSpec"]
-    ) -> Dict | None:
+        self, request: PatchRequest, tool_registry: list["ToolSpec"]
+    ) -> JsonObject | None:
         """可选：生成 PlanPatch，默认不实现。"""
+        _ = request
+        _ = tool_registry
         return None
 
     def call_replan(
-        self, request: ReplanRequest, tool_registry: List["ToolSpec"]
-    ) -> Dict | None:
+        self, request: ReplanRequest, tool_registry: list["ToolSpec"]
+    ) -> JsonObject | None:
         """可选：生成 Replan Plan，默认不实现。"""
+        _ = request
+        _ = tool_registry
         return None
 
-    def validate_plan(self, plan_dict: Dict) -> bool:
+    def validate_plan(self, plan_dict: JsonObject) -> bool:
         """验证生成的计划是否符合 Plan schema"""
         try:
-            Plan.model_validate(plan_dict)
+            _ = Plan.model_validate(plan_dict)
             return True
         except ValidationError:
             return False
 
-    def validate_patch(self, patch_dict: Dict) -> bool:
+    def validate_patch(self, patch_dict: JsonObject) -> bool:
         """验证生成的 patch 是否符合 PlanPatch schema"""
         try:
-            PlanPatch.model_validate(patch_dict)
+            _ = PlanPatch.model_validate(patch_dict)
             return True
         except ValidationError:
             return False

--- a/src/llm/baseline_provider.py
+++ b/src/llm/baseline_provider.py
@@ -6,9 +6,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, TypeGuard, cast, override
 
-from src.llm.base_llm_provider import BaseProvider, ProviderConfig
+from src.llm.base_llm_provider import BaseProvider, JsonObject, JsonValue, ProviderConfig
 from src.models.contracts import ProteinDesignTask
 
 if TYPE_CHECKING:
@@ -29,19 +30,20 @@ class BaselineProvider(BaseProvider):
     - LLM providers 不可用时的回退
     """
 
-    def __init__(self, config: ProviderConfig | None = None):
+    def __init__(self, config: ProviderConfig | None = None) -> None:
         """初始化基线 provider
 
         Args:
             config: Provider 配置（基线版本未使用，为接口兼容性保留）
         """
-        self.config = config or ProviderConfig(model_name="baseline")
+        self.config: ProviderConfig = config or ProviderConfig(model_name="baseline")
 
+    @override
     def call_planner(
         self,
         task: ProteinDesignTask,
-        tool_registry: List["ToolSpec"]
-    ) -> Dict:
+        tool_registry: list["ToolSpec"],
+    ) -> JsonObject:
         """生成简单的单步计划
 
         策略:
@@ -63,27 +65,52 @@ class BaselineProvider(BaseProvider):
         tool_id = tool_registry[0].id
 
         # 从任务约束中提取 sequence 或使用默认值
-        sequence = task.constraints.get(
+        constraints = cast(dict[str, object], task.constraints)
+        sequence_value = constraints.get(
             "sequence",
-            "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR"
+            "MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQLR",
         )
+        sequence = sequence_value if isinstance(sequence_value, str) else str(sequence_value)
 
         # 构建单步计划
-        step = {
+        step: JsonObject = {
             "id": "S1",
             "tool": tool_id,
             "inputs": {"sequence": sequence},
-            "metadata": {"provider": "baseline", "strategy": "single_step"}
+            "metadata": {"provider": "baseline", "strategy": "single_step"},
         }
 
-        plan_dict = {
+        plan_dict: JsonObject = {
             "task_id": task.task_id,
             "steps": [step],
-            "constraints": task.constraints,
+            "constraints": _json_object_from_mapping(constraints),
             "metadata": {
                 "provider": "baseline",
-                "model": self.config.model_name
-            }
+                "model": self.config.model_name,
+            },
         }
 
         return plan_dict
+
+
+def _json_object_from_mapping(mapping: dict[str, object]) -> JsonObject:
+    result: JsonObject = {}
+    for key, value in mapping.items():
+        if _is_json_value(value):
+            result[key] = value
+        else:
+            result[key] = str(value)
+    return result
+
+
+def _is_json_value(value: object) -> TypeGuard[JsonValue]:
+    if value is None or isinstance(value, str | int | float | bool):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in cast(list[object], value))
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_value(item)
+            for key, item in cast(Mapping[object, object], value).items()
+        )
+    return False

--- a/src/llm/provider_registry.py
+++ b/src/llm/provider_registry.py
@@ -2,28 +2,33 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import cast
 
 from pydantic import BaseModel, Field
 
-from src.llm.base_llm_provider import BaseProvider, ProviderConfig
+from src.llm.base_llm_provider import BaseProvider, JsonObject, ProviderConfig
 from src.llm.baseline_provider import BaselineProvider
 
 
-ProviderFactory = Callable[[ProviderConfig, Optional[str]], BaseProvider]
+ProviderFactory = Callable[[ProviderConfig, str | None], BaseProvider]
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | JsonObject | JsonArray
+type JsonArray = list[JsonValue]
 
 
 class ProviderSettings(BaseModel):
     """Provider configuration loaded from a shared catalog."""
 
     provider_type: str = "openai_compatible"
-    description: Optional[str] = None
+    description: str | None = None
     model_name: str
-    api_key: Optional[str] = None
-    api_key_env: Optional[str] = None
-    endpoint: Optional[str] = None
-    endpoint_env: Optional[str] = None
+    api_key: str | None = None
+    api_key_env: str | None = None
+    endpoint: str | None = None
+    endpoint_env: str | None = None
     timeout: int = 30
     max_tokens: int | None = 2000
     temperature: float = 0.7
@@ -35,32 +40,32 @@ class ProviderSettings(BaseModel):
     supports_patch: bool = True
     supports_replan: bool = True
     supports_reasoning: bool = False
-    headers: Optional[Dict[str, str]] = None
+    headers: dict[str, str] | None = None
     organization: str | None = None
     anthropic_version: str | None = None
-    extra_body: Optional[Dict[str, Any]] = None
+    extra_body: JsonObject | None = None
     use_response_format: bool = True
 
 
 class ProviderCatalog(BaseModel):
     """Provider catalog loaded from JSON."""
 
-    providers: Dict[str, ProviderSettings] = Field(default_factory=dict)
+    providers: dict[str, ProviderSettings] = Field(default_factory=dict)
 
 
-_PROVIDER_FACTORIES: Dict[str, ProviderFactory] = {}
-_REGISTERED = False
+_provider_factories: dict[str, ProviderFactory] = {}
+_registered = False
 
 
 def load_provider_catalog(path: Path) -> ProviderCatalog:
     """Load provider settings from a JSON file."""
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = cast(object, json.loads(path.read_text(encoding="utf-8")))
     return ProviderCatalog.model_validate(data)
 
 
 def resolve_api_key(
-    settings: ProviderSettings, *, api_key_override: Optional[str] = None
-) -> Optional[str]:
+    settings: ProviderSettings, *, api_key_override: str | None = None
+) -> str | None:
     """Resolve API key from override, inline value, or environment variable."""
     if api_key_override:
         return api_key_override
@@ -71,7 +76,7 @@ def resolve_api_key(
     return None
 
 
-def resolve_endpoint(settings: ProviderSettings) -> Optional[str]:
+def resolve_endpoint(settings: ProviderSettings) -> str | None:
     """Resolve endpoint from inline value or environment variable."""
     if settings.endpoint:
         return settings.endpoint
@@ -82,7 +87,7 @@ def resolve_endpoint(settings: ProviderSettings) -> Optional[str]:
 
 def register_provider(provider_type: str, factory: ProviderFactory) -> None:
     """Register a provider factory for extension."""
-    _PROVIDER_FACTORIES[provider_type] = factory
+    _provider_factories[provider_type] = factory
 
 
 def _register_builtins() -> None:
@@ -93,21 +98,22 @@ def _register_builtins() -> None:
 
 
 def _ensure_registry() -> None:
-    global _REGISTERED
-    if _REGISTERED:
+    global _registered
+    if _registered:
         return
     _register_builtins()
-    _REGISTERED = True
+    _registered = True
 
 
 def _create_baseline_provider(
-    config: ProviderConfig, endpoint: Optional[str]
+    config: ProviderConfig, endpoint: str | None,
 ) -> BaseProvider:
+    _ = endpoint
     return BaselineProvider(config)
 
 
 def _create_openai_provider(
-    config: ProviderConfig, endpoint: Optional[str]
+    config: ProviderConfig, endpoint: str | None,
 ) -> BaseProvider:
     from src.llm.openai_compatible_provider import OpenAICompatibleProvider
 
@@ -115,7 +121,7 @@ def _create_openai_provider(
 
 
 def _create_anthropic_provider(
-    config: ProviderConfig, endpoint: Optional[str]
+    config: ProviderConfig, endpoint: str | None,
 ) -> BaseProvider:
     from src.llm.anthropic_messages_provider import AnthropicMessagesProvider
 
@@ -123,7 +129,7 @@ def _create_anthropic_provider(
 
 
 def _create_zai_provider(
-    config: ProviderConfig, endpoint: Optional[str]
+    config: ProviderConfig, endpoint: str | None,
 ) -> BaseProvider:
     from src.llm.zai_chat_provider import ZaiChatProvider
 
@@ -131,7 +137,7 @@ def _create_zai_provider(
 
 
 def create_provider(
-    settings: ProviderSettings, *, api_key_override: Optional[str] = None
+    settings: ProviderSettings, *, api_key_override: str | None = None,
 ) -> BaseProvider:
     """Create a provider instance from settings."""
     _ensure_registry()
@@ -157,7 +163,7 @@ def create_provider(
         use_response_format=settings.use_response_format,
     )
     endpoint = resolve_endpoint(settings)
-    factory = _PROVIDER_FACTORIES.get(settings.provider_type)
+    factory = _provider_factories.get(settings.provider_type)
     if factory is None:
         raise ValueError(f"Unknown provider type: {settings.provider_type}")
     return factory(config, endpoint)


### PR DESCRIPTION
# 概述
使用 `basedpyright` 检查 `src/llm` 中的核心文件，并进行修复。
# 实现内容：

## 修改文件：
 
- src/llm/base_llm_provider.py
- src/llm/baseline_provider.py
- src/llm/provider_registry.py

## 主要处理：

- 增加共享 JsonValue/JsonObject 类型边界。
- 移除旧式 Dict/List/Optional 和 Any。
- 收紧 ProviderConfig.extra_body、provider catalog 读取、baseline plan 返回类型。
- 给 BaselineProvider.call_planner 标注 override，并保持原 baseline 计划结构不变。
- 将 provider registry 内部注册状态改为非大写变量，避免常量重定义报错。

## 验证通过：

- `uv run basedpyright src/llm/base_llm_provider.py src/llm/baseline_provider.py src/llm/provider_registry.py`：0 errors
- `uv run pytest tests/unit/test_provider_registry.py tests/unit/test_planner_with_provider.py::TestPlannerWithBaselineProvider`：11 passed
