### PR TITLE
feat(planner): 接入 ConfirmedTaskSpec 并移除未确认自由文本依赖

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,138 +1,44 @@
 # CLAUDE.md
 
-Instructions for Claude Code when operating in this repository.
+Claude Code operational guidance for this repository.
+AGENTS.md defines Codex-common rules; this file adds Claude-specific differences only.
 
-This file defines **Claude-specific operational guidance only**.
-It does NOT define system architecture or behavioral rules.
+## 1. Priority
 
-All system-level invariants are defined in `AGENT_CONTRACT.md`
-and MUST be respected.
+1. `AGENT_CONTRACT.md` — system invariants
+2. `../thesis-project.design/docs/design/` — architectural authority
+3. `AGENTS.md` — common operational rules
+4. This file — Claude-specific additions
 
----
+Conflicts are resolved in this order.
 
-## 0. Mandatory Reading (Before Any Code Change)
-
-Before editing or generating code, Claude MUST read and comply with:
-
-1. `AGENT_CONTRACT.md`  
-   → Defines non-negotiable system invariants
-
-2. Authoritative design specs (retrieved in minimal slices):
-   - Prefer precise spec fragments (SID/topic/ref) over full-document reads
-   - Use only the fragments needed for the requested change
-
-If any instruction conflicts:
-**AGENT_CONTRACT.md and design documents take precedence.**
-
----
-
-## 1. Role of Claude Code in This Project
-
-Claude acts as a **controlled coding assistant**.
-
-Claude is expected to:
-- implement user-requested changes precisely,
-- respect existing architecture and contracts,
-- reason carefully about side effects,
-- explain changes clearly.
-
-Claude MUST NOT:
-- reinterpret system design,
-- introduce new agent behaviors or FSM states,
-- perform architectural refactors unless explicitly instructed.
-
-Claude should assume the system is **intentionally constrained**.
-
----
-
-## 2. Scope Discipline
-
-Claude should only modify:
-- files explicitly mentioned by the user, or
-- files strictly required to complete the requested task.
-
-If a change may affect:
-- FSM transitions,
-- agent responsibility boundaries,
-- execution or recovery semantics,
-
-Claude MUST pause and ask for confirmation
-before proceeding.
-
----
-
-## 3. Coding Expectations
-
-### 3.1 Style and structure
-- Primary language: Python
-- Follow existing project conventions
-- Preserve naming, module boundaries, and patterns
-- Prefer minimal, localized changes
-
-### 3.2 State and side effects
-- Do NOT introduce hidden state mutation
-- Do NOT bypass workflow controllers
-- Ensure all state-related changes remain explicit and traceable
-
-### 3.3 Logging
-- Preserve existing logging structure
-- Logs must remain consistent with execution flow and task state
-- Do NOT log secrets or credentials
-
----
-
-## 4. Testing Responsibilities
-
-When Claude changes observable behavior, it MUST:
-- add or update tests as appropriate,
-- ensure all existing tests continue to pass.
-
-Relevant test areas include:
-- FSM transition validation
-- Agent behavior isolation
-- Retry / patch / replan execution paths
-- Schema compatibility
-
-If tests are missing:
-- add minimal tests to lock behavior,
-- avoid introducing unnecessary test abstractions.
-
----
-
-## 5. Interaction Expectations
+## 2. Behavior
 
 Claude should:
-- reason step-by-step internally,
-- present conclusions and code clearly,
-- highlight assumptions when unavoidable.
+- Implement user requests precisely, respecting existing architecture and contracts
+- Scope changes to files mentioned by the user or modules strictly required
+- Keep side effects explicit; no hidden state mutation
 
-Claude should NOT:
-- silently make large or cross-cutting changes,
-- “optimize” or “simplify” architecture proactively,
-- assume permission for refactors.
+Claude must not:
+- Reinterpret system design, introduce new agent behaviors or FSM states
+- Proactively "optimize" or "simplify" architecture
+- Refactor without explicit instruction
+- Substitute inference for human-confirmation steps
 
-When uncertain, Claude should ask.
+## 3. Coding
 
----
+- Python 3.12; use `uv` for dependency and run commands
+- Follow existing project style, naming, and module boundaries
+- Satisfy `basedpyright`; no `Any`, bare generics, or untyped containers
+- Logs consistent with execution flow; never log secrets
 
-## 6. Safe Defaults
+## 4. Testing
 
-If intent or design meaning is ambiguous:
-- prefer conservative implementation,
-- avoid introducing new abstractions,
-- defer to existing patterns,
-- request clarification before continuing.
+When behavior changes:
+- Add or update focused tests
+- `uv run pytest ...` to verify
+- `uv run basedpyright ...` for type checks when practical
 
-Claude must treat ambiguity as a signal to stop,
-not as permission to improvise.
+## 5. Ambiguity → Stop
 
----
-
-## 7. Summary
-
-- `CLAUDE.md` = Claude Code operational entrypoint
-- `AGENT_CONTRACT.md` = system-level, non-negotiable invariants
-- Design documents = architectural authority
-
-Claude is expected to assist implementation
-within clearly defined boundaries.
+When intent is unclear, prefer conservative implementation, defer to existing patterns, and request clarification before continuing.

--- a/configs/llm_providers.json
+++ b/configs/llm_providers.json
@@ -36,7 +36,7 @@
     "deepseek-chat": {
       "provider_type": "openai_compatible",
       "description": "DeepSeek Chat via OpenAI-compatible API",
-      "model_name": "deepseek-chat",
+      "model_name": "deepseek-v4-pro",
       "api_key_env": "DEEPSEEK_API_KEY",
       "endpoint": "https://api.deepseek.com/v1",
       "timeout": 60,
@@ -83,8 +83,8 @@
       "provider_type": "anthropic_messages",
       "description": "MiniMax M2.7 via Anthropic-compatible Messages API",
       "model_name": "MiniMax-M2.7",
-      "api_key_env": "ANTHROPIC_API_KEY",
-      "endpoint_env": "ANTHROPIC_BASE_URL",
+      "api_key_env": "MINIMAX_API_KEY",
+      "endpoint_env": "MINIMAX_BASE_URL",
       "timeout": 60,
       "max_tokens": 4000,
       "temperature": 0.2,
@@ -125,7 +125,7 @@
     "deepseek-reasoner": {
       "provider_type": "openai_compatible",
       "description": "DeepSeek Reasoner",
-      "model_name": "deepseek-reasoner",
+      "model_name": "deepseek-v4-pro",
       "api_key_env": "DEEPSEEK_API_KEY",
       "endpoint": "https://api.deepseek.com/v1",
       "timeout": 300,

--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -146,8 +146,12 @@ class CandidateBuilder:
                 "confirmed_task_spec_present": request.confirmed_task_spec is not None,
             },
             "s5_contract": self._hooks.build_s5_scoring_contract(score_weights),
-            STATIC_SCORE_METADATA_KEY: self._hooks.build_static_score_summary(score_breakdown),
-            ACTION_SCORE_METADATA_KEY: self._hooks.build_action_score_summary(score_breakdown),
+            STATIC_SCORE_METADATA_KEY: self._hooks.build_static_score_summary(
+                score_breakdown
+            ),
+            ACTION_SCORE_METADATA_KEY: self._hooks.build_action_score_summary(
+                score_breakdown
+            ),
         }
         metadata.update(
             self._hooks.candidate_readiness_metadata(
@@ -164,7 +168,9 @@ class CandidateBuilder:
         if payload.recovery_reason:
             metadata["recovery_reason"] = payload.recovery_reason
         if isinstance(payload.payload, PlanPatch):
-            metadata.update(self._hooks.extract_patch_candidate_metadata(payload.payload))
+            metadata.update(
+                self._hooks.extract_patch_candidate_metadata(payload.payload)
+            )
         if isinstance(payload.payload, Plan):
             plan_metadata = self._hooks.extract_plan_candidate_metadata(payload.payload)
             if plan_metadata:
@@ -224,10 +230,13 @@ class CandidateBuilder:
         policy_adjustment = 0.0
         if policy_mode in {"conservative", "safe", "low_risk"}:
             policy_adjustment = 0.02 * adjusted.get("risk", 0.0)
-        elif policy_mode in {"low_cost", "budget", "cheap"}:
+        elif policy_mode in {"low_cost", "budget", "cheap", "fast_smoke"}:
             policy_adjustment = 0.02 * adjusted.get("cost", 0.0)
-        elif policy_mode in {"exploratory", "aggressive"}:
-            policy_adjustment = 0.02 * adjusted.get("objective", 0.0)
+        elif policy_mode in {"exploratory", "aggressive", "high_accuracy"}:
+            policy_adjustment = 0.02 * (
+                0.6 * adjusted.get("objective", 0.0)
+                + 0.4 * adjusted.get("tool_readiness", 0.0)
+            )
         adjusted["policy_mode_fit"] = round(policy_adjustment, 6)
         adjusted["overall"] = round(
             min(
@@ -242,7 +251,4 @@ class CandidateBuilder:
             ),
             6,
         )
-        return {
-            key: round(value, 6)
-            for key, value in adjusted.items()
-        }
+        return {key: round(value, 6) for key, value in adjusted.items()}

--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -57,7 +57,6 @@ class CandidateGenerator:
             spec.id: spec for spec in request.registry
         }
         unique_payloads = self._dedupe_payloads(request.payloads)
-        scored_rows: list[ScoredRow] = []
         filtered_rows: list[ScoredRow] = []
         soft_filtered_rows: list[ScoredRow] = []
         filter_reasons: list[str] = []
@@ -95,7 +94,6 @@ class CandidateGenerator:
                 effective_sort_key,
                 candidate.capability_id or "unknown",
             )
-            scored_rows.append(row)
             reason = self._filter_reason(candidate, payload.payload, request, registry_map)
             if reason is not None:
                 filter_reasons.append(reason)
@@ -107,7 +105,6 @@ class CandidateGenerator:
         available_rows = self._available_rows(
             filtered_rows=filtered_rows,
             soft_filtered_rows=soft_filtered_rows,
-            scored_rows=scored_rows,
             top_k=request.top_k,
         )
         if not available_rows:
@@ -144,7 +141,7 @@ class CandidateGenerator:
             default_candidate.candidate_id if default_candidate is not None else None
         )
         if default_candidate is not None:
-            default_metadata = cast(Metadata, default_candidate.metadata)
+            default_metadata = default_candidate.metadata
             default_metadata[DEFAULT_RECOMMENDATION_REASON_METADATA_KEY] = (
                 self._hooks.build_default_recommendation_reason(
                     candidate_kind=request.candidate_kind,
@@ -281,7 +278,6 @@ class CandidateGenerator:
         *,
         filtered_rows: Sequence[ScoredRow],
         soft_filtered_rows: Sequence[ScoredRow],
-        scored_rows: Sequence[ScoredRow],
         top_k: int,
     ) -> list[ScoredRow]:
         available_rows = list(filtered_rows)
@@ -296,8 +292,6 @@ class CandidateGenerator:
                     break
         if not available_rows and soft_filtered_rows:
             return list(soft_filtered_rows)
-        if not available_rows:
-            return list(scored_rows)
         return available_rows
 
     def _select_diverse_top_k(

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -5,7 +5,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, List, Literal, Optional, Sequence, Set, cast
+from typing import Any, Iterable, List, Literal, Mapping, Optional, Sequence, Set, cast
 
 from src.infra.active_tool_metadata import metadata_by_tool_id
 from src.infra.tool_readiness import (
@@ -177,6 +177,22 @@ _CONSTRAINT_OVERRIDE_BY_CAPABILITY: dict[str, str] = {
     "structure_prediction": "structure_prediction_tool_override",
     "secondary_structure_annotation": "secondary_structure_annotation_tool_override",
 }
+_P0_TASK_KINDS: set[str] = {
+    "de_novo_design",
+    "sequence_evaluation",
+    "template_constrained_design",
+}
+_CONFIRMED_CONSTRAINT_GROUPS: tuple[str, ...] = (
+    "design_constraints",
+    "quality_constraints",
+    "structure_constraints",
+    "function_constraints",
+    "safety_constraints",
+    "execution_preferences",
+    "planner_policy",
+)
+_TOOL_POLICY_ALLOWED_KEYS: tuple[str, ...] = ("tools_allowed", "allowed_tools")
+_TOOL_POLICY_EXCLUDED_KEYS: tuple[str, ...] = ("tools_excluded", "blocked_tools")
 
 _DEFAULT_EXTERNAL_PROVIDER_NAME = "external_baseline"
 _DEFAULT_PROVIDER_CATALOG_PATH = (
@@ -252,8 +268,12 @@ class PlannerAgent:
         Returns:
             Plan: 包含步骤列表的执行计划
         """
-        enriched_task = enrich_task_from_goal(task)
-        return self._plan_from_route(enriched_task, use_external=use_external)
+        prepared_task = _prepare_task_for_planning(task)
+        _validate_tool_policy_against_registry(
+            prepared_task.constraints,
+            self._tool_registry,
+        )
+        return self._plan_from_route(prepared_task, use_external=use_external)
 
     def plan_top_k(
         self,
@@ -435,12 +455,19 @@ class PlannerAgent:
         生成一个单步骤计划，调用第一个可用工具（或 dummy_tool）
         保持与原始 PlannerAgent 行为一致
         """
-        if _is_de_novo_task(task):
-            plan = _build_de_novo_plan(task, self._tool_registry)
+        registry = _filter_registry_by_tool_policy(self._tool_registry, task.constraints)
+        task_kind = _extract_task_kind(task)
+        if task_kind in _P0_TASK_KINDS:
+            if task_kind == "sequence_evaluation":
+                plan = _build_sequence_evaluation_plan(task, registry)
+            elif task_kind == "template_constrained_design":
+                plan = _build_template_constrained_plan(task, registry)
+            else:
+                plan = _build_de_novo_plan(task, registry)
             return _attach_kg_explanation(plan)
-        if not self._tool_registry:
+        if not registry:
             raise ValueError("Tool registry is empty; cannot build default plan.")
-        tool_id = self._tool_registry[0].id
+        tool_id = registry[0].id
 
         # 从任务约束中提取 sequence，或使用默认值
         sequence = task.constraints.get(
@@ -553,6 +580,7 @@ class PlannerAgent:
             task,
         )
         _ensure_plan_tools_in_registry(plan, self._tool_registry)
+        _ensure_plan_satisfies_tool_policy(plan, task.constraints)
         return _attach_kg_explanation(plan)
 
     def _attach_route_metadata(
@@ -600,7 +628,7 @@ class PlannerAgent:
         record: TaskRecord | None = None,
     ) -> Plan:
         """生成 Plan 并驱动 PLANNING → PLANNED/WAITING_PLAN_CONFIRM 状态变更。"""
-        task = enrich_task_from_goal(task)
+        task = _prepare_task_for_planning(task)
         context.task = task
         if record is not None:
             record.goal = task.goal
@@ -2108,6 +2136,8 @@ def _build_top_k_result(
     runtime_state: RuntimeState | RuntimeStateSummary | dict[str, Any] | None = None,
 ) -> TopKResult:
     constraints = task_constraints or {}
+    _validate_tool_policy_against_registry(constraints, registry)
+    registry = _filter_registry_by_tool_policy(registry, constraints)
     generator = CandidateGenerator(_candidate_generator_hooks())
     return generator.generate(
         CandidateGenerationInput(
@@ -2125,6 +2155,196 @@ def _build_top_k_result(
             policy_mode=_extract_policy_mode(constraints),
         )
     )
+
+
+def _prepare_task_for_planning(task: ProteinDesignTask) -> ProteinDesignTask:
+    projected = _project_confirmed_task_for_planner(task)
+    if _confirmed_task_spec_for_task(projected) is not None:
+        return projected
+    return enrich_task_from_goal(projected)
+
+
+def _project_confirmed_task_for_planner(task: ProteinDesignTask) -> ProteinDesignTask:
+    confirmed = _confirmed_task_spec_for_task(task)
+    if confirmed is None:
+        return task
+
+    constraints = dict(task.constraints or {})
+    metadata = dict(task.metadata or {})
+    metadata["confirmed_task_spec"] = dict(confirmed)
+    constraints["confirmed_task_spec"] = dict(confirmed)
+
+    confirmed_goal = confirmed.get("goal")
+    goal = task.goal
+    if isinstance(confirmed_goal, str) and confirmed_goal.strip():
+        goal = confirmed_goal.strip()
+
+    objective = _object_dict(confirmed.get("objective"))
+    if objective:
+        constraints["objective"] = dict(objective)
+        _merge_confirmed_values(constraints, objective)
+
+    inputs = _object_dict(confirmed.get("inputs"))
+    if inputs:
+        constraints["inputs"] = dict(inputs)
+        _merge_confirmed_values(constraints, inputs)
+
+    confirmed_constraints = _object_dict(confirmed.get("constraints"))
+    if confirmed_constraints:
+        _merge_confirmed_constraints(constraints, confirmed_constraints)
+
+    confirmed_metadata = _object_dict(confirmed.get("metadata"))
+    if confirmed_metadata:
+        intake_summary = confirmed_metadata.get("intake_summary")
+        if isinstance(intake_summary, dict):
+            metadata["intake_summary"] = dict(intake_summary)
+        hints = confirmed_metadata.get("planner_capability_hints")
+        if isinstance(hints, (list, tuple, set)):
+            constraints["capability_hints"] = [str(item) for item in hints if str(item)]
+
+    artifacts = confirmed.get("initial_artifacts")
+    if isinstance(artifacts, list):
+        constraints["initial_artifacts"] = list(artifacts)
+
+    return task.model_copy(
+        update={
+            "goal": goal,
+            "constraints": constraints,
+            "metadata": metadata,
+        },
+        deep=True,
+    )
+
+
+def _confirmed_task_spec_for_task(
+    task: ProteinDesignTask,
+) -> dict[str, object] | None:
+    metadata_confirmed = _object_dict((task.metadata or {}).get("confirmed_task_spec"))
+    if metadata_confirmed:
+        return metadata_confirmed
+    constraints_confirmed = _object_dict(
+        (task.constraints or {}).get("confirmed_task_spec")
+    )
+    if constraints_confirmed:
+        return constraints_confirmed
+    metadata_block = _object_dict((task.constraints or {}).get("metadata"))
+    metadata_nested = _object_dict(metadata_block.get("confirmed_task_spec"))
+    return metadata_nested or None
+
+
+def _object_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return {str(key): item for key, item in value.items() if isinstance(key, str)}
+    return {}
+
+
+def _merge_confirmed_values(
+    target: dict[str, Any],
+    values: dict[str, object],
+) -> None:
+    for key, value in values.items():
+        target[key] = value
+
+
+def _merge_confirmed_constraints(
+    target: dict[str, Any],
+    values: dict[str, object],
+) -> None:
+    for key, value in values.items():
+        if key in _CONFIRMED_CONSTRAINT_GROUPS and isinstance(value, dict):
+            grouped = _object_dict(value)
+            target[key] = dict(grouped)
+            _merge_confirmed_values(target, grouped)
+        else:
+            target[key] = value
+
+
+def _tool_policy_sets(
+    constraints: Mapping[str, object] | dict[str, Any],
+) -> tuple[set[str], set[str]]:
+    allowed: set[str] = set()
+    excluded: set[str] = set()
+    containers: list[Mapping[str, object]] = []
+    if isinstance(constraints, dict):
+        containers.append(cast(Mapping[str, object], constraints))
+        for group_key in ("planner_policy", "execution_preferences"):
+            group = constraints.get(group_key)
+            if isinstance(group, dict):
+                containers.append(cast(Mapping[str, object], group))
+
+        confirmed = _object_dict(constraints.get("confirmed_task_spec"))
+        confirmed_constraints = _object_dict(confirmed.get("constraints"))
+        if confirmed_constraints:
+            containers.append(confirmed_constraints)
+            for group_key in ("planner_policy", "execution_preferences"):
+                group = confirmed_constraints.get(group_key)
+                if isinstance(group, dict):
+                    containers.append(cast(Mapping[str, object], group))
+
+    for container in containers:
+        for key in _TOOL_POLICY_ALLOWED_KEYS:
+            allowed.update(_string_values(container.get(key)))
+        for key in _TOOL_POLICY_EXCLUDED_KEYS:
+            excluded.update(_string_values(container.get(key)))
+    return allowed, excluded
+
+
+def _string_values(value: object) -> set[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return {stripped} if stripped else set()
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value if str(item)}
+    return set()
+
+
+def _validate_tool_policy_against_registry(
+    constraints: Mapping[str, object] | dict[str, Any],
+    registry: Sequence[ToolSpec],
+) -> None:
+    allowed, excluded = _tool_policy_sets(constraints)
+    registry_ids = {spec.id for spec in registry}
+    unknown_allowed = sorted(allowed - registry_ids)
+    unknown_excluded = sorted(excluded - registry_ids)
+    if unknown_allowed:
+        raise ValueError(
+            "tools_allowed contains unknown ToolKG tool_id: "
+            f"{unknown_allowed}"
+        )
+    if unknown_excluded:
+        raise ValueError(
+            "tools_excluded contains unknown ToolKG tool_id: "
+            f"{unknown_excluded}"
+        )
+
+
+def _filter_registry_by_tool_policy(
+    registry: Sequence[ToolSpec],
+    constraints: Mapping[str, object] | dict[str, Any],
+) -> list[ToolSpec]:
+    allowed, excluded = _tool_policy_sets(constraints)
+    filtered = [
+        spec
+        for spec in registry
+        if (not allowed or spec.id in allowed) and spec.id not in excluded
+    ]
+    if not filtered:
+        raise ValueError("Tool policy excludes all ToolKG tools")
+    return filtered
+
+
+def _ensure_plan_satisfies_tool_policy(
+    plan: Plan,
+    constraints: Mapping[str, object] | dict[str, Any],
+) -> None:
+    allowed, excluded = _tool_policy_sets(constraints)
+    tool_ids = {step.tool for step in plan.steps}
+    disallowed = sorted(tool_ids - allowed) if allowed else []
+    blocked = sorted(tool_ids & excluded)
+    if disallowed:
+        raise ValueError(f"Plan references tools outside tools_allowed: {disallowed}")
+    if blocked:
+        raise ValueError(f"Plan references tools_excluded: {blocked}")
 
 
 def _candidate_generator_hooks() -> CandidateGeneratorHooks:
@@ -2212,11 +2432,26 @@ def _extract_budget_context(constraints: dict[str, Any]) -> dict[str, Any]:
     for key in ("budget_cap", "cost_cap", "max_runtime_min"):
         if key in constraints:
             extracted[key] = constraints[key]
+    execution_preferences = constraints.get("execution_preferences")
+    if isinstance(execution_preferences, dict):
+        for key in ("budget_cap", "cost_cap", "max_runtime_min"):
+            if key in execution_preferences and key not in extracted:
+                extracted[key] = execution_preferences[key]
     return extracted
 
 
 def _extract_policy_mode(constraints: dict[str, Any]) -> str:
     raw_mode = constraints.get("policy_mode") or constraints.get("run_profile")
+    if raw_mode is None and isinstance(constraints.get("execution_preferences"), dict):
+        raw_mode = constraints["execution_preferences"].get("run_profile")
+    if raw_mode is None and isinstance(constraints.get("confirmed_task_spec"), dict):
+        confirmed_constraints = constraints["confirmed_task_spec"].get("constraints")
+        if isinstance(confirmed_constraints, dict):
+            execution_preferences = confirmed_constraints.get("execution_preferences")
+            if isinstance(execution_preferences, dict):
+                raw_mode = execution_preferences.get("run_profile")
+            if raw_mode is None:
+                raw_mode = confirmed_constraints.get("run_profile")
     return str(raw_mode) if raw_mode is not None else "balanced"
 
 
@@ -4117,6 +4352,9 @@ _S1_OUTPUT_FIELDS = (
 def _extract_goal_type(task: ProteinDesignTask) -> str:
     for container in (task.constraints, task.metadata):
         if isinstance(container, dict):
+            task_kind = container.get("task_kind")
+            if isinstance(task_kind, str) and task_kind:
+                return task_kind
             goal_block = container.get("goal")
             if isinstance(goal_block, dict):
                 goal_type = goal_block.get("type")
@@ -4143,12 +4381,27 @@ def _extract_goal_type(task: ProteinDesignTask) -> str:
     return ""
 
 
+def _extract_task_kind(task: ProteinDesignTask) -> str:
+    goal_type = _extract_goal_type(task)
+    if goal_type:
+        return goal_type
+    confirmed = _confirmed_task_spec_for_task(task)
+    if confirmed is not None:
+        constraints = _object_dict(confirmed.get("constraints"))
+        task_kind = constraints.get("task_kind")
+        if isinstance(task_kind, str) and task_kind:
+            return task_kind
+    return ""
+
+
 def _is_de_novo_task(task: ProteinDesignTask) -> bool:
-    return _extract_goal_type(task) == _DE_NOVO_GOAL_TYPE
+    return _extract_task_kind(task) == _DE_NOVO_GOAL_TYPE
 
 
 def _extract_length_range(constraints: dict) -> List[int] | None:
     value = constraints.get("length_range")
+    if value is None and isinstance(constraints.get("design_constraints"), dict):
+        value = constraints["design_constraints"].get("length_range")
     if isinstance(value, (list, tuple)) and len(value) == 2:
         try:
             return [int(value[0]), int(value[1])]
@@ -4164,10 +4417,28 @@ def _extract_length_range(constraints: dict) -> List[int] | None:
 
 
 def _extract_template_pdb(constraints: dict) -> str | None:
-    for key in ("template", "structure_template_pdb", "pdb_path"):
+    inputs = constraints.get("inputs")
+    if isinstance(inputs, dict):
+        for key in ("template_pdb", "template", "structure_template_pdb", "pdb_path"):
+            value = inputs.get(key)
+            if isinstance(value, str) and value:
+                return value
+    for key in ("template_pdb", "template", "structure_template_pdb", "pdb_path"):
         value = constraints.get(key)
         if isinstance(value, str) and value:
             return value
+    return None
+
+
+def _extract_sequence_input(constraints: dict) -> str | None:
+    inputs = constraints.get("inputs")
+    if isinstance(inputs, dict):
+        value = inputs.get("sequence")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    value = constraints.get("sequence")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
     return None
 
 
@@ -4442,6 +4713,173 @@ def _is_sequence_exploration_step(
     if capability == "sequence_generation":
         return True
     return spec is not None and "sequence_generation" in set(spec.capabilities)
+
+
+def _build_sequence_evaluation_plan(
+    task: ProteinDesignTask,
+    registry: Sequence[ToolSpec],
+) -> Plan:
+    constraints = task.constraints or {}
+    sequence = _extract_sequence_input(constraints)
+    if sequence is None:
+        raise ValueError("sequence_evaluation requires confirmed inputs.sequence")
+
+    safety_level = constraints.get("safety_level")
+    prefer_remote = _prefers_remote_tools(constraints)
+    available_inputs: Set[str] = {"goal", "sequence"}
+    structure_tool = _select_tool_by_capability(
+        registry=registry,
+        capability="structure_prediction",
+        available_inputs=available_inputs,
+        safety_level=safety_level,
+        io_hint={"inputs": ["sequence"]},
+        prefer_remote=prefer_remote,
+    )
+    available_inputs.update(structure_tool.outputs)
+
+    steps: list[PlanStep] = [
+        PlanStep(
+            id="S1",
+            tool=structure_tool.id,
+            inputs={"sequence": sequence},
+            metadata={
+                "stage_id": "S2",
+                "stage_name": "structure_projection",
+                "task_kind": "sequence_evaluation",
+            },
+        )
+    ]
+    try:
+        qc_tool = _select_tool_by_capability(
+            registry=registry,
+            capability="quality_qc",
+            available_inputs=available_inputs,
+            safety_level=safety_level,
+            io_hint={"inputs": ["sequence", "pdb_path"]},
+            prefer_remote=prefer_remote,
+        )
+    except ValueError:
+        qc_tool = None
+    if qc_tool is not None:
+        steps.append(
+            PlanStep(
+                id="S2",
+                tool=qc_tool.id,
+                inputs={"sequence": sequence, "pdb_path": "S1.pdb_path"},
+                metadata={
+                    "stage_id": "S3",
+                    "stage_name": "quality_gate",
+                    "task_kind": "sequence_evaluation",
+                },
+            )
+        )
+
+    return Plan(
+        task_id=task.task_id,
+        steps=steps,
+        constraints=task.constraints,
+        metadata={},
+        explanation=(
+            "ProteinToolKG selected a sequence evaluation chain using "
+            f"{', '.join(step.tool for step in steps)}."
+        ),
+    )
+
+
+def _build_template_constrained_plan(
+    task: ProteinDesignTask,
+    registry: Sequence[ToolSpec],
+) -> Plan:
+    constraints = task.constraints or {}
+    template_pdb = _extract_template_pdb(constraints)
+    if template_pdb is None:
+        raise ValueError("template_constrained_design requires confirmed template_pdb")
+
+    safety_level = constraints.get("safety_level")
+    prefer_remote = _prefers_remote_tools(constraints)
+    available_inputs = _collect_sequence_exploration_inputs(constraints)
+    available_inputs.update({"template", "structure_template_pdb", "pdb_path"})
+    design_tool = _select_tool_by_capability(
+        registry=registry,
+        capability="sequence_design",
+        available_inputs=available_inputs,
+        safety_level=safety_level,
+        io_hint={"inputs": ["pdb_path"]},
+        prefer_remote=prefer_remote,
+    )
+    available_inputs.update(design_tool.outputs)
+    structure_tool = _select_tool_by_capability(
+        registry=registry,
+        capability="structure_prediction",
+        available_inputs=available_inputs,
+        safety_level=safety_level,
+        io_hint={"inputs": ["sequence"]},
+        prefer_remote=prefer_remote,
+    )
+    available_inputs.update(structure_tool.outputs)
+
+    s1_inputs: dict = {"pdb_path": template_pdb, "template": template_pdb}
+    length_range = _extract_length_range(constraints)
+    if length_range:
+        s1_inputs["length_range"] = length_range
+
+    steps: list[PlanStep] = [
+        PlanStep(
+            id="S1",
+            tool=design_tool.id,
+            inputs=s1_inputs,
+            metadata={
+                "stage_id": "S1",
+                "stage_name": "template_conditioned_sequence_design",
+                "task_kind": "template_constrained_design",
+            },
+        ),
+        PlanStep(
+            id="S2",
+            tool=structure_tool.id,
+            inputs={"sequence": "S1.sequence"},
+            metadata={
+                "stage_id": "S2",
+                "stage_name": "structure_projection",
+                "task_kind": "template_constrained_design",
+            },
+        ),
+    ]
+    try:
+        qc_tool = _select_tool_by_capability(
+            registry=registry,
+            capability="quality_qc",
+            available_inputs=available_inputs,
+            safety_level=safety_level,
+            io_hint={"inputs": ["sequence", "pdb_path"]},
+            prefer_remote=prefer_remote,
+        )
+    except ValueError:
+        qc_tool = None
+    if qc_tool is not None:
+        steps.append(
+            PlanStep(
+                id="S3",
+                tool=qc_tool.id,
+                inputs={"sequence": "S1.sequence", "pdb_path": "S2.pdb_path"},
+                metadata={
+                    "stage_id": "S3",
+                    "stage_name": "quality_gate",
+                    "task_kind": "template_constrained_design",
+                },
+            )
+        )
+
+    return Plan(
+        task_id=task.task_id,
+        steps=steps,
+        constraints=task.constraints,
+        metadata={},
+        explanation=(
+            "ProteinToolKG selected a template constrained chain using "
+            f"{', '.join(step.tool for step in steps)}."
+        ),
+    )
 
 
 def _build_de_novo_plan(

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -894,7 +894,7 @@ class PendingActionCandidate(BaseModel):
 
     @model_validator(mode="after")
     def _sync_tool_metadata(self):
-        metadata: JsonMap = Field(default_factory=dict)
+        metadata: JsonMap = dict(self.metadata or {})
         self.metadata = metadata
 
         self.tool_id = _sync_metadata_field(

--- a/tests/unit/test_planner_agent.py
+++ b/tests/unit/test_planner_agent.py
@@ -470,6 +470,175 @@ class TestPlannerAgent:
         assert plan.explanation
         assert "ProteinToolKG" in plan.explanation
 
+    def test_confirmed_task_spec_blocks_unconfirmed_goal_inference(self, monkeypatch):
+        """确认后的结构化字段优先于自由文本 goal。"""
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        confirmed = {
+            "goal": "Evaluate the confirmed input sequence",
+            "inputs": {"sequence": "MKTAYIAKQRQISFVKSHFSRQ"},
+            "constraints": {
+                "task_kind": "sequence_evaluation",
+                "run_profile": "fast_smoke",
+            },
+            "metadata": {
+                "intake_id": "intake_issue283_sequence",
+                "planner_capability_hints": [
+                    "sequence_evaluation",
+                    "quality_qc",
+                ],
+                "intake_summary": {"field_count": 3},
+            },
+        }
+        task = ProteinDesignTask(
+            task_id="issue283_confirmed_sequence",
+            goal="Design a de novo protein, length 200-300 aa, with not_in_kg_tool",
+            constraints={},
+            metadata={"confirmed_task_spec": confirmed},
+        )
+        planner = PlannerAgent(tool_registry=_topk_registry())
+
+        plan = planner.plan(task)
+
+        assert plan.constraints["task_kind"] == "sequence_evaluation"
+        assert plan.constraints["sequence"] == "MKTAYIAKQRQISFVKSHFSRQ"
+        assert "length_range" not in plan.constraints
+        assert "prompt" not in plan.constraints
+        assert "goal_type" not in plan.constraints
+        assert all(step.tool != "not_in_kg_tool" for step in plan.steps)
+        assert plan.steps[0].inputs["sequence"] == "MKTAYIAKQRQISFVKSHFSRQ"
+
+    @pytest.mark.parametrize(
+        ("task_kind", "spec_inputs", "spec_constraints", "expected_tools"),
+        [
+            (
+                "de_novo_design",
+                {},
+                {"length_range": [40, 60]},
+                {"seqgen_local", "protgpt2", "esmfold", "nim_esmfold", "protein_mpnn"},
+            ),
+            (
+                "sequence_evaluation",
+                {"sequence": "MKTAYIAKQRQISFVKSHFSRQ"},
+                {},
+                {"esmfold", "nim_esmfold", "biopython_qc"},
+            ),
+            (
+                "template_constrained_design",
+                {"template_pdb": "data/template.pdb"},
+                {"length_range": [80, 120]},
+                {"protein_mpnn", "esmfold", "nim_esmfold", "biopython_qc"},
+            ),
+        ],
+    )
+    def test_confirmed_task_spec_p0_task_kinds_plan_from_toolkg(
+        self,
+        monkeypatch,
+        task_kind,
+        spec_inputs,
+        spec_constraints,
+        expected_tools,
+    ):
+        """P0 场景从 ConfirmedTaskSpec 路由，且工具来自 ToolKG。"""
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        confirmed = {
+            "goal": f"Confirmed {task_kind}",
+            "inputs": spec_inputs,
+            "constraints": {
+                "task_kind": task_kind,
+                "run_profile": "balanced",
+                **spec_constraints,
+            },
+            "metadata": {
+                "intake_id": f"intake_issue283_{task_kind}",
+                "planner_capability_hints": ["structure_prediction"],
+            },
+        }
+        task = ProteinDesignTask(
+            task_id=f"issue283_{task_kind}",
+            goal="Free text should not select tools",
+            constraints={},
+            metadata={"confirmed_task_spec": confirmed},
+        )
+        planner = PlannerAgent(tool_registry=_topk_registry())
+
+        plan = planner.plan(task)
+
+        assert plan.constraints["task_kind"] == task_kind
+        assert {step.tool for step in plan.steps}.issubset(expected_tools)
+        assert all(step.tool in {spec.id for spec in _topk_registry()} for step in plan.steps)
+
+    def test_tool_policy_is_validated_against_toolkg(self, monkeypatch):
+        """tools_allowed / tools_excluded 必须是 ToolKG 中的 tool_id。"""
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        confirmed = {
+            "goal": "Confirmed de novo task",
+            "constraints": {
+                "task_kind": "de_novo_design",
+                "length_range": [40, 60],
+                "tools_allowed": ["missing_tool"],
+            },
+            "metadata": {
+                "intake_id": "intake_issue283_policy",
+                "planner_capability_hints": ["sequence_generation"],
+            },
+        }
+        task = ProteinDesignTask(
+            task_id="issue283_bad_policy",
+            goal="Confirmed task",
+            constraints={},
+            metadata={"confirmed_task_spec": confirmed},
+        )
+        planner = PlannerAgent(tool_registry=_topk_registry())
+
+        with pytest.raises(ValueError, match="tools_allowed contains unknown ToolKG tool_id"):
+            planner.plan(task)
+
+    def test_confirmed_hints_and_run_profile_only_adjust_candidates(self, monkeypatch):
+        """capability_hints / run_profile 进入候选元数据和评分，不直接绑定 tool_id。"""
+        monkeypatch.setattr(planner_module, "load_tool_kg", lambda: _topk_mock_kg())
+        confirmed = {
+            "goal": "Confirmed smoke de novo task",
+            "constraints": {
+                "task_kind": "de_novo_design",
+                "length_range": [40, 60],
+                "run_profile": "fast_smoke",
+                "tools_excluded": ["seqgen_local"],
+            },
+            "metadata": {
+                "intake_id": "intake_issue283_hints",
+                "planner_capability_hints": [
+                    "sequence_generation",
+                    "structure_prediction",
+                ],
+            },
+        }
+        task = ProteinDesignTask(
+            task_id="issue283_hints",
+            goal="Use seqgen_local directly",
+            constraints={},
+            metadata={"confirmed_task_spec": confirmed},
+        )
+        planner = PlannerAgent(tool_registry=_topk_registry())
+
+        topk = planner.plan_top_k(task, k=3)
+
+        assert topk.candidates
+        assert all(
+            "seqgen_local"
+            not in {step.tool for step in candidate.structured_payload.steps}
+            for candidate in topk.candidates
+            if isinstance(candidate.structured_payload, Plan)
+        )
+        for candidate in topk.candidates:
+            generator = candidate.metadata["candidate_generator"]
+            assert generator["policy_mode"] == "fast_smoke"
+            assert generator["confirmed_task_spec_present"] is True
+            assert generator["capability_hints"] == [
+                "sequence_generation",
+                "structure_prediction",
+            ]
+            assert "policy_mode_fit" in candidate.score_breakdown
+
     def test_plan_uses_default_sequence_when_missing(self):
         """测试当约束中没有序列时使用默认序列"""
         task = ProteinDesignTask(

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -81,9 +81,9 @@ def test_resolve_endpoint_from_env(monkeypatch):
     settings = ProviderSettings(
         provider_type="anthropic_messages",
         model_name="MiniMax-M2.7",
-        endpoint_env="ANTHROPIC_BASE_URL",
+        endpoint_env="MINIMAX_BASE_URL",
     )
-    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.minimaxi.com/anthropic")
+    monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimaxi.com/anthropic")
 
     assert resolve_endpoint(settings) == "https://api.minimaxi.com/anthropic"
 
@@ -109,7 +109,8 @@ def test_load_provider_catalog_keeps_minimax_entry():
     assert "minimax-m2.7" in catalog.providers
     assert catalog.providers["minimax-m2.7"].provider_type == "anthropic_messages"
     assert catalog.providers["minimax-m2.7"].model_name == "MiniMax-M2.7"
-    assert catalog.providers["minimax-m2.7"].endpoint_env == "ANTHROPIC_BASE_URL"
+    assert catalog.providers["minimax-m2.7"].api_key_env == "MINIMAX_API_KEY"
+    assert catalog.providers["minimax-m2.7"].endpoint_env == "MINIMAX_BASE_URL"
 
 
 def test_load_provider_catalog_keeps_glm_entries():


### PR DESCRIPTION
## Summary

让 Planner 从 query-first 路径收敛为 `ConfirmedTaskSpec`-first，确保 Planner 只消费确认后的结构化任务，移除对未确认自由文本的依赖。

Closes #283

## 核心实现

### 1. ConfirmedTaskSpec 投影 (`_project_confirmed_task_for_planner`)

从 `ConfirmedTaskSpec` 中提取并投影以下字段到 `ProteinDesignTask`:
- `goal` — 覆盖自由文本 goal
- `objective` — 写入 constraints
- `inputs` — 写入 constraints（sequence, template_pdb 等）
- `constraints` — 按确认组（design/quality/structure/function/safety/execution_preferences/planner_policy）合并
- `initial_artifacts` — 写入 constraints
- `metadata.intake_summary` + `metadata.planner_capability_hints` — 写入 task metadata

`_prepare_task_for_planning` 作为统一入口：有 ConfirmedTaskSpec 时投影，无 spec 时 fallback 到旧 `enrich_task_from_goal` 路径。

### 2. 工具策略校验 (`_validate_tool_policy_against_registry`)

`tools_allowed / tools_excluded` 必须来自 ToolKG 已知 tool_id，否则抛出 `ValueError`。支持从顶层 constraints、`planner_policy`、`execution_preferences` 及 ConfirmedTaskSpec 嵌套 constraints 中提取。

`_filter_registry_by_tool_policy` 按策略过滤 ToolKG 注册表，缩小可用工具范围。

`_ensure_plan_satisfies_tool_policy` 验证输出 Plan 的每个 step.tool 满足策略约束。

### 3. P0 场景专有规划路径

- `_build_sequence_evaluation_plan` — sequence_evaluation 场景：structure_prediction → quality_qc 链
- `_build_template_constrained_plan` — template_constrained_design 场景：sequence_design → structure_prediction → quality_qc 链
- `_build_de_novo_plan`（已有，增强 registry 过滤）

所有路径通过 `_select_tool_by_capability` 从 ToolKG 选择工具，不接受 prompt 推断。

### 4. run_profile 策略扩展

新增 `fast_smoke` 和 `high_accuracy` 策略模式，影响候选评分权重:
- `fast_smoke` → 倾向低成本工具
- `high_accuracy` → 综合 objective + tool_readiness 加权

`_extract_policy_mode` 增强为多层级查找：顶层 → execution_preferences → ConfirmedTaskSpec 嵌套 constraints。

### 5. 辅助清理

- `candidate_generator/generator.py`: 移除未使用的 `scored_rows` 中间列表及 fallback 路径
- `candidate_generator/builder.py`: 策略模式调整与格式化
- `contracts.py`: 修复 `PendingActionCandidate._sync_tool_metadata` 元数据初始化丢失

## 测试覆盖

| 测试 | 覆盖的验收标准 |
|------|-------------|
| `test_confirmed_task_spec_blocks_unconfirmed_goal_inference` | 未确认自由文本不能覆盖 confirmed constraints |
| `test_confirmed_task_spec_p0_task_kinds_plan_from_toolkg` (3 场景参数化) | P0 回归：de_novo_design / sequence_evaluation / template_constrained_design |
| `test_tool_policy_is_validated_against_toolkg` | 未知 tool_id 被拒绝 |
| `test_confirmed_hints_and_run_profile_only_adjust_candidates` | capability_hints / run_profile 影响评分而非直接绑定 tool |

## 边界保持

- 不新增 Workflow FSM 状态
- 不修改 PendingAction / Decision / TaskSnapshot 语义
- 不新增 Agent 角色
- Planner / Executor / Safety / Summarizer 职责边界不变

## 配置附带变更

- `llm_providers.json`: deepseek 模型更新为 v4-pro；minimax 环境变量引用修正
- `CLAUDE.md`: 精简为 44 行，去重 AGENTS.md 已有内容

🤖 Generated with [Claude Code](https://claude.com/claude-code)