### PR TITLE
fix(ui): Inspector header 添加 flex-wrap 防止按钮溢出

### DIFF
--- a/src/api/frontend/src/components/InspectorPanel.tsx
+++ b/src/api/frontend/src/components/InspectorPanel.tsx
@@ -332,41 +332,43 @@ export function InspectorPanel({ cards, pageKey }: InspectorPanelProps) {
               >
                 <div className="inspector-card__header">
                   <h2 className="inspector-card__title">{card.title}</h2>
-                  {card.statusBadge}
-                  {showControls ? (
-                    <>
-                      <button
-                        type="button"
-                        className="inspector-card__move"
-                        aria-label={`Move ${card.title} up`}
-                        disabled={index === 0}
-                        onClick={() => moveCard(index, index - 1)}
-                      >
-                        ↑
-                      </button>
-                      <button
-                        type="button"
-                        className="inspector-card__move"
-                        aria-label={`Move ${card.title} down`}
-                        disabled={index === order.length - 1}
-                        onClick={() => moveCard(index, index + 1)}
-                      >
-                        ↓
-                      </button>
-                      <button
-                        type="button"
-                        className="drag-handle"
-                        aria-label={`Reorder ${card.title}`}
-                        aria-describedby="inspector-reorder-help"
-                        onPointerDown={handlePointerDown}
-                        onPointerMove={handlePointerMove}
-                        onPointerUp={handlePointerUp}
-                        onPointerCancel={handlePointerCancel}
-                      >
-                        ↕
-                      </button>
-                    </>
-                  ) : null}
+                  <div className="inspector-card__header-actions">
+                    {card.statusBadge}
+                    {showControls ? (
+                      <>
+                        <button
+                          type="button"
+                          className="inspector-card__move"
+                          aria-label={`Move ${card.title} up`}
+                          disabled={index === 0}
+                          onClick={() => moveCard(index, index - 1)}
+                        >
+                          ↑
+                        </button>
+                        <button
+                          type="button"
+                          className="inspector-card__move"
+                          aria-label={`Move ${card.title} down`}
+                          disabled={index === order.length - 1}
+                          onClick={() => moveCard(index, index + 1)}
+                        >
+                          ↓
+                        </button>
+                        <button
+                          type="button"
+                          className="drag-handle"
+                          aria-label={`Reorder ${card.title}`}
+                          aria-describedby="inspector-reorder-help"
+                          onPointerDown={handlePointerDown}
+                          onPointerMove={handlePointerMove}
+                          onPointerUp={handlePointerUp}
+                          onPointerCancel={handlePointerCancel}
+                        >
+                          ↕
+                        </button>
+                      </>
+                    ) : null}
+                  </div>
                 </div>
                 <div className="inspector-card__body">{card.children}</div>
               </section>

--- a/src/api/frontend/src/styles/app.css
+++ b/src/api/frontend/src/styles/app.css
@@ -1817,7 +1817,15 @@ pre {
 .inspector-card__header {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+}
+
+.inspector-card__header-actions {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
 }
 
 .inspector-card__title {


### PR DESCRIPTION
## 概述

修复 Inspector 卡片 header 中按钮被 statusBadge 挤出可视区域的问题。

## 问题

当 statusBadge 文本较长（如 `needs_confirmation`）时，`.inspector-card__header` 内的 ↑↓↕ 按钮被挤出卡片右侧，被 `overflow: hidden` 裁剪，用户无法操作拖拽排序。

## 根因

`.inspector-card__header` 使用 `display: flex` 但缺少 `flex-wrap: wrap`，所有子元素强制在同一行。

## 修复

### CSS (`app.css`)
- `.inspector-card__header` 新增 `flex-wrap: wrap`
- 新增 `.inspector-card__header-actions` 包裹 statusBadge + 按钮，`margin-left: auto` 保持按钮右对齐

### JSX (`InspectorPanel.tsx`)
- statusBadge 和 ↑↓↕ 按钮包裹进 `<div className="inspector-card__header-actions">`

### 效果
- 空间充足时：全在一行，无变化
- 空间不足时：按钮换到第二行并右对齐，不再被裁剪

## 验证

```bash
npm run build:ui  # passed
```

## 关联

- Closes #317 (header 按钮裁剪部分；Profile chips 换行另案处理)
