### PR TITLE
docs: gh issue develop 默认 base dev，除非用户指定

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Check the remote baseline document before relying on exact startup commands, por
 ## 6. Git And GitHub
 
 - Prepare issues, PRs, or `gh` operations only when explicitly requested.
+- When creating a branch from an issue with `gh issue develop`, default to `--base dev` unless the user specifies a different base branch.
 - Use Conventional Commits for commits, for example `feat(scope): short summary`.
 - Commit bodies may be Chinese when useful.
 


### PR DESCRIPTION
## 变更

AGENTS.md §6: 明确 `gh issue develop` 创建分支时的 base 策略：
- 默认 `--base dev`
- 用户指定其他分支时按用户需求

此前未写明 base 策略，导致 `gh issue develop` 从 GitHub 默认分支 (master) 签出，缺少已合入 dev 的最新代码。