### PR TITLE
feat(algorithm): add source refs traceability

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-design-code-traceability.md
+++ b/docs/algorithm-and-llm/core-algorithm-design-code-traceability.md
@@ -23,7 +23,30 @@
 - posterior objective scoring 已有实现，但与静态 planner objective 和 belief-state evidence 更新的关系还比较松散；
 - 理论依据目前主要是工程直觉，尚未映射到 POMDP/belief-state planning、budgeted/risk-sensitive planning、workflow recovery、LLM/tool-use planning、protein design objective 等文献。
 
-## 2. 设计 SID ↔ 代码路径矩阵
+## 2. source_refs / SID 追踪规范（Issue #337）
+
+实现侧统一使用短字符串数组：
+
+```python
+"source_refs": ["sid:<design-sid>", "impl:<implementation-ref>"]
+```
+
+常量集中在 `src/models/source_refs.py`，运行时 metadata 不编码文档路径、URL、长公式或 `sid:...:proposed` 后缀。尚未进入设计 SSOT 的 SID 通过同模块 `design_ref_status_for()` / `PROPOSED_DESIGN_REF_STATUS` 或本文集中标注 proposed 状态。
+
+| metadata 对象 | source refs 常量 | SID 状态 |
+|---|---|---|
+| `metadata.candidate_feasibility` | `SOURCE_REF_FEASIBILITY` = `sid:algo.adaptive.feasibility_filter`, `impl:candidate_generator.feasibility.v1` | `algo.adaptive.feasibility_filter` proposed |
+| `metadata.static_score` / `metadata.action_score` / `score_breakdown` | `SOURCE_REF_STATIC_SCORE` = `sid:algo.adaptive.optimization_objective`, `sid:planner.algorithm.candidate_scoring`, `impl:planner.score_breakdown.v1` | existing |
+| `posterior_score` / `metadata.posterior_objective` | `SOURCE_REF_POSTERIOR_OBJECTIVE` = `sid:algo.posterior_objective_scoring`, `impl:posterior_score.v1`, `impl:posterior_objective.v1` | `algo.posterior_objective_scoring` proposed |
+| `metadata.runtime_adjustment` / runtime final/shadow score | `SOURCE_REF_RUNTIME_ADJUSTMENT` = `sid:planner.algorithm.runtime_adjustment_formula`, `sid:planner.algorithm.runtime_reranking`, `impl:planner.runtime_adjustment.v1` | existing |
+| `ActionUtility.source_refs` | `SOURCE_REF_ACTION_UTILITY` = `sid:algo.schema.action_utility`, `sid:algo.action_feature_derivation`, `impl:runtime_evaluator.action_utility.v1`, `impl:workflow.action_features.v1` | `algo.schema.action_utility` existing; `algo.action_feature_derivation` proposed |
+| default `ActionUtility.source_refs` | `SOURCE_REF_DEFAULT_ACTION_UTILITY` = `sid:algo.schema.action_utility`, `impl:runtime_evaluator.default.v1` | existing |
+| recovery action selection metadata | `SOURCE_REF_ACTION_SELECTION` = `sid:algo.recovery_aware_action_selection`, `sid:planner.algorithm.action_priority_resolution`, `impl:recovery.select_workflow_action.v1` | `algo.recovery_aware_action_selection` proposed; `planner.algorithm.action_priority_resolution` existing |
+| terminal stop metadata | `SOURCE_REF_TERMINAL_STOP` = `sid:algo.terminal_stop_policy`, `sid:planner.algorithm.stop_semantics`, `impl:recovery.terminal_stop.v1` | `algo.terminal_stop_policy` proposed; `planner.algorithm.stop_semantics` existing |
+
+设计仓库 `../thesis-project.design` 未在本实现中修改；proposed SID 仍需后续设计同步。
+
+## 3. 设计 SID ↔ 代码路径矩阵
 
 | 设计 SID | 设计含义 | 主要代码位置 | 当前实现状态 | 对齐判断 |
 |---|---|---|---|---|

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -62,6 +62,11 @@ from src.models.validation import (
     validate_candidate_set_output,
     validate_plan_executability,
 )
+from src.models.source_refs import (
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+    as_source_refs,
+)
 from src.models.db import (
     InternalStatus,
     TaskRecord,
@@ -2460,6 +2465,7 @@ def _build_action_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
         source="score_breakdown.overall",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     return summary.model_dump()
 
@@ -2468,6 +2474,7 @@ def _build_static_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
         source="score_breakdown.overall.static.v1",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     return summary.model_dump()
 
@@ -2476,6 +2483,7 @@ def _build_shadow_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
         source="score_breakdown.overall_passthrough",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     return summary.model_dump()
 
@@ -2503,10 +2511,15 @@ def _build_shadow_passthrough_decision(
     final_score = ScoreSummary(
         value=static_value,
         source="static_score+runtime_adjustment.shadow_passthrough.v1",
+        source_refs=as_source_refs(
+            *SOURCE_REF_STATIC_SCORE,
+            *SOURCE_REF_RUNTIME_ADJUSTMENT,
+        ),
     )
     runtime_adjustment = RuntimeAdjustmentSummary(
         value=0.0,
         source="planner.runtime_adjustment.shadow_passthrough.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=True,
     )
@@ -2584,14 +2597,20 @@ def _build_runtime_shadow_decision(
     final_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"static_score+runtime_adjustment.{action}.v1",
+        source_refs=as_source_refs(
+            *SOURCE_REF_STATIC_SCORE,
+            *SOURCE_REF_RUNTIME_ADJUSTMENT,
+        ),
     )
     shadow_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"score_breakdown.overall+runtime_state.{action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
     )
     runtime_adjustment = RuntimeAdjustmentSummary(
         value=round(delta, 6),
         source=f"planner.runtime_adjustment.{action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=False,
     )

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -547,6 +547,7 @@ class ScoreSummary(BaseModel):
 
     value: float
     source: str
+    source_refs: list[str] = Field(default_factory=list)
 
     @field_validator("value")
     @classmethod
@@ -560,6 +561,14 @@ class ScoreSummary(BaseModel):
     @classmethod
     def _validate_source(cls, value: str) -> str:
         return _validate_non_empty_text(value, field_name="source")
+
+    @field_validator("source_refs")
+    @classmethod
+    def _validate_source_refs(cls, value: list[str]) -> list[str]:
+        return [
+            _validate_non_empty_text(item, field_name="source_refs")
+            for item in value
+        ]
 
 
 class RuntimeAdjustmentFactor(BaseModel):
@@ -591,6 +600,7 @@ class RuntimeAdjustmentSummary(BaseModel):
 
     value: float
     source: str
+    source_refs: list[str] = Field(default_factory=list)
     formula_version: str = "v1"
     shadow_only: bool = True
 
@@ -606,6 +616,14 @@ class RuntimeAdjustmentSummary(BaseModel):
     @classmethod
     def _validate_text(cls, value: str, info) -> str:
         return _validate_non_empty_text(value, field_name=info.field_name)
+
+    @field_validator("source_refs")
+    @classmethod
+    def _validate_source_refs(cls, value: list[str]) -> list[str]:
+        return [
+            _validate_non_empty_text(item, field_name="source_refs")
+            for item in value
+        ]
 
 
 class RerankReason(BaseModel):

--- a/src/models/source_refs.py
+++ b/src/models/source_refs.py
@@ -1,0 +1,97 @@
+"""Source refs 常量与轻量 helper。
+
+本模块只承载设计 SID 与实现引用的短字符串常量，避免在 runtime
+metadata 中散落不可追踪的裸字符串。
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal, TypeAlias
+
+DesignRefStatus: TypeAlias = Literal["existing", "proposed"]
+DesignRefStatusMap: TypeAlias = dict[str, DesignRefStatus]
+
+SOURCE_REF_FEASIBILITY: Final[tuple[str, ...]] = (
+    "sid:algo.adaptive.feasibility_filter",
+    "impl:candidate_generator.feasibility.v1",
+)
+
+SOURCE_REF_POSTERIOR_OBJECTIVE: Final[tuple[str, ...]] = (
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+    "impl:posterior_objective.v1",
+)
+
+SOURCE_REF_STATIC_SCORE: Final[tuple[str, ...]] = (
+    "sid:algo.adaptive.optimization_objective",
+    "sid:planner.algorithm.candidate_scoring",
+    "impl:planner.score_breakdown.v1",
+)
+
+SOURCE_REF_RUNTIME_ADJUSTMENT: Final[tuple[str, ...]] = (
+    "sid:planner.algorithm.runtime_adjustment_formula",
+    "sid:planner.algorithm.runtime_reranking",
+    "impl:planner.runtime_adjustment.v1",
+)
+
+SOURCE_REF_ACTION_UTILITY: Final[tuple[str, ...]] = (
+    "sid:algo.schema.action_utility",
+    "sid:algo.action_feature_derivation",
+    "impl:runtime_evaluator.action_utility.v1",
+    "impl:workflow.action_features.v1",
+)
+
+SOURCE_REF_DEFAULT_ACTION_UTILITY: Final[tuple[str, ...]] = (
+    "sid:algo.schema.action_utility",
+    "impl:runtime_evaluator.default.v1",
+)
+
+SOURCE_REF_ACTION_SELECTION: Final[tuple[str, ...]] = (
+    "sid:algo.recovery_aware_action_selection",
+    "sid:planner.algorithm.action_priority_resolution",
+    "impl:recovery.select_workflow_action.v1",
+)
+
+SOURCE_REF_TERMINAL_STOP: Final[tuple[str, ...]] = (
+    "sid:algo.terminal_stop_policy",
+    "sid:planner.algorithm.stop_semantics",
+    "impl:recovery.terminal_stop.v1",
+)
+
+PROPOSED_DESIGN_REF_STATUS: Final[DesignRefStatusMap] = {
+    "sid:algo.adaptive.feasibility_filter": "proposed",
+    "sid:algo.posterior_objective_scoring": "proposed",
+    "sid:algo.action_feature_derivation": "proposed",
+    "sid:algo.recovery_aware_action_selection": "proposed",
+    "sid:algo.terminal_stop_policy": "proposed",
+}
+
+
+def as_source_refs(*refs: str) -> list[str]:
+    """返回去重后的 source_refs 列表。
+
+    保持输入顺序并拒绝空字符串；不做复杂 SID/impl 校验，避免在运行期
+    引入额外语义判断。
+    """
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for ref in refs:
+        text = ref.strip()
+        if not text:
+            raise ValueError("source_refs items must not be empty")
+        if text in seen:
+            continue
+        seen.add(text)
+        normalized.append(text)
+    return normalized
+
+
+def design_ref_status_for(*refs: str) -> DesignRefStatusMap:
+    """返回 refs 中 proposed SID 的状态映射。"""
+
+    return {
+        ref: status
+        for ref, status in PROPOSED_DESIGN_REF_STATUS.items()
+        if ref in refs
+    }

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -26,6 +26,13 @@ from src.models.runtime_schemas import (
     ActionUtility,
     RuntimeStateSchema,
 )
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_DEFAULT_ACTION_UTILITY,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+    as_source_refs,
+)
 
 __all__ = [
     "DYNAMIC_OBSERVATION_ONLY",
@@ -348,19 +355,19 @@ class RuntimeEvaluator:
                 action="continue",
                 utility=round(max(0.0, min(1.0, 0.38 * s + 0.14 * e_suff + 0.12 * r_margin - 0.22 * f_param - 0.14 * b)), 6),
                 budget_pressure=bp,
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
             "patch_local": ActionUtility(
                 action="patch_local",
                 utility=round(max(0.0, min(1.0, 0.20 * s + 0.24 * r_margin + 0.18 * lp + 0.12 * er_val - 0.14 * f_param - 0.12 * b)), 6),
                 budget_pressure=bp,
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
             "suffix_replan": ActionUtility(
                 action="suffix_replan",
                 utility=round(max(0.0, min(1.0, 0.18 * (1.0 - s) + 0.20 * f_param + 0.16 * (1.0 - r_margin) + 0.18 * pp + 0.14 * br + 0.14 * gr)), 6),
                 budget_pressure=bp,
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
             "stop": ActionUtility(
                 action="stop",
@@ -368,7 +375,7 @@ class RuntimeEvaluator:
                 budget_pressure=bp,
                 intervention_value=round(iv, 6),
                 terminal_reason="auto_stop: low success, high budget pressure, exhausted recovery margin",
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
         }
 
@@ -420,7 +427,7 @@ class RuntimeEvaluator:
         return ActionUtility(
             action=action,
             utility=0.5,
-            source_refs=["runtime_evaluator.default.v1"],
+            source_refs=as_source_refs(*SOURCE_REF_DEFAULT_ACTION_UTILITY),
             metadata={"default_reason": reason},
         )
 
@@ -571,18 +578,25 @@ def _attach_rerank_metadata(
     static_score = ScoreSummary(
         value=round(overall, 6),
         source="score_breakdown.overall.static.v1",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     final_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"static_score+runtime_adjustment.{shadow_action}.v1",
+        source_refs=as_source_refs(
+            *SOURCE_REF_STATIC_SCORE,
+            *SOURCE_REF_RUNTIME_ADJUSTMENT,
+        ),
     )
     shadow_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"score_breakdown.overall+runtime_state.{shadow_action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
     )
     runtime_adjustment = RuntimeAdjustmentSummary(
         value=round(delta, 6),
         source=f"planner.runtime_adjustment.{shadow_action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=False,
     )

--- a/tests/unit/test_contract_source_refs.py
+++ b/tests/unit/test_contract_source_refs.py
@@ -1,0 +1,41 @@
+"""ScoreSummary / RuntimeAdjustmentSummary source_refs 兼容性测试。"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.contracts import RuntimeAdjustmentSummary, ScoreSummary
+from src.models.source_refs import SOURCE_REF_RUNTIME_ADJUSTMENT, as_source_refs
+
+
+def test_score_summary_source_refs_default_factory_keeps_old_constructors() -> None:
+    summary = ScoreSummary(value=0.5, source="score_breakdown.overall.static.v1")
+    assert summary.source_refs == []
+
+
+def test_runtime_adjustment_source_refs_default_factory_keeps_old_constructors() -> None:
+    summary = RuntimeAdjustmentSummary(
+        value=0.1,
+        source="planner.runtime_adjustment.continue.v1",
+    )
+    assert summary.source_refs == []
+
+
+def test_runtime_adjustment_accepts_source_refs() -> None:
+    summary = RuntimeAdjustmentSummary(
+        value=0.1,
+        source="planner.runtime_adjustment.continue.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
+    )
+    assert "sid:planner.algorithm.runtime_adjustment_formula" in summary.source_refs
+    assert "impl:planner.runtime_adjustment.v1" in summary.source_refs
+
+
+def test_score_summary_rejects_empty_source_ref() -> None:
+    with pytest.raises(ValidationError):
+        _ = ScoreSummary(
+            value=0.5,
+            source="score_breakdown.overall.static.v1",
+            source_refs=["sid:algo.adaptive.optimization_objective", " "],
+        )

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -12,6 +12,10 @@ from src.models.contracts import (
     RUNTIME_ADJUSTMENT_METADATA_KEY,
 )
 from src.models.runtime_schemas import RuntimeStateSchema
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+)
 from src.workflow.runtime_evaluator import (
     DYNAMIC_OBSERVATION_ONLY,
     LITE_BELIEF_STATE,
@@ -193,6 +197,10 @@ class TestRerank:
         assert isinstance(adj, dict)
         # 高 p_success 应产生正调整
         assert adj["value"] > 0.01
+        refs = cast(list[str], adj["source_refs"])
+        assert "sid:planner.algorithm.runtime_adjustment_formula" in refs
+        assert "impl:planner.runtime_adjustment.v1" in refs
+        assert set(SOURCE_REF_RUNTIME_ADJUSTMENT).issubset(refs)
 
     def test_high_risk_reduces_score(self) -> None:
         e = RuntimeEvaluator()
@@ -279,6 +287,11 @@ class TestActionUtility:
         assert set(utilities.keys()) == {"continue", "patch_local", "suffix_replan", "stop"}
         for u in utilities.values():
             assert 0.0 <= u.utility <= 1.0
+            assert "sid:algo.schema.action_utility" in u.source_refs
+            assert "impl:runtime_evaluator.action_utility.v1" in u.source_refs
+            assert set(SOURCE_REF_ACTION_UTILITY).issubset(u.source_refs)
+            assert any(ref.startswith("sid:") for ref in u.source_refs)
+            assert any(ref.startswith("impl:") for ref in u.source_refs)
 
     def test_stop_utility_higher_under_pressure(self) -> None:
         e = RuntimeEvaluator()

--- a/tests/unit/test_source_refs.py
+++ b/tests/unit/test_source_refs.py
@@ -1,0 +1,52 @@
+"""source_refs 常量与 helper 测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_SELECTION,
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_DEFAULT_ACTION_UTILITY,
+    SOURCE_REF_FEASIBILITY,
+    SOURCE_REF_POSTERIOR_OBJECTIVE,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+    SOURCE_REF_TERMINAL_STOP,
+    as_source_refs,
+    design_ref_status_for,
+)
+
+_REF_GROUPS = (
+    SOURCE_REF_FEASIBILITY,
+    SOURCE_REF_POSTERIOR_OBJECTIVE,
+    SOURCE_REF_STATIC_SCORE,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_DEFAULT_ACTION_UTILITY,
+    SOURCE_REF_ACTION_SELECTION,
+    SOURCE_REF_TERMINAL_STOP,
+)
+
+
+def test_source_ref_groups_have_sid_and_impl() -> None:
+    for refs in _REF_GROUPS:
+        assert all(ref for ref in refs)
+        assert any(ref.startswith("sid:") for ref in refs)
+        assert any(ref.startswith("impl:") for ref in refs)
+        assert all(":proposed" not in ref for ref in refs)
+
+
+def test_as_source_refs_deduplicates_in_order() -> None:
+    assert as_source_refs(" sid:a ", "impl:x", "sid:a") == ["sid:a", "impl:x"]
+
+
+def test_as_source_refs_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="source_refs items must not be empty"):
+        _ = as_source_refs("sid:a", " ")
+
+
+def test_design_ref_status_for_reports_proposed_separately() -> None:
+    assert design_ref_status_for(*SOURCE_REF_ACTION_UTILITY) == {
+        "sid:algo.action_feature_derivation": "proposed",
+    }


### PR DESCRIPTION
## 背景 / 对应 Issue

- 对应 GitHub Issue: #337
- 本 PR 合入目标分支：`wave1-integration`
- Wave1 Lane C：设计 SID 与实现 source_refs 追踪规范
- 实现依据：
  - `docs/algorithm-and-llm/issues/2026-05-05-p0-05-source-refs-design-sids.md`
  - `docs/algorithm-and-llm/implementation/2026-05-05-wave1-parallel-agent-guidance.md`
  - `docs/algorithm-and-llm/core-algorithm-design-code-traceability.md`

## 目标

为 CEBRA-WP 的核心算法 metadata 建立统一 source refs 规范：

```text
sid:<design-sid>
impl:<implementation-ref>
```

解决当前算法表达中“公式 / 设计文档 / 代码实现”之间缺少稳定追踪锚点的问题。

## 主要改动

- 新增 `src/models/source_refs.py`：
  - 集中定义 design SID 与 implementation refs；
  - 提供 `as_source_refs(...)` helper；
  - 提供 `design_ref_status_for(...)`，用于区分 existing / proposed SID。
- `ScoreSummary` / `RuntimeAdjustmentSummary` 增加 additive `source_refs: list[str]` 字段：
  - 使用 `Field(default_factory=list)`；
  - 保留旧 `source` 字段，避免破坏旧构造。
- `RuntimeEvaluator.compute_action_utilities()` 的 `ActionUtility.source_refs` 增加 `sid:` + `impl:` 双引用。
- `planner.py` 中静态 / action score summary 增加 source refs。
- 更新 `docs/algorithm-and-llm/core-algorithm-design-code-traceability.md`，记录新约定。
- 新增/扩展单元测试：
  - `tests/unit/test_source_refs.py`
  - `tests/unit/test_contract_source_refs.py`
  - `tests/unit/test_runtime_evaluator.py`

## 关键约束

- 没有修改 `../thesis-project.design`。
- 未确认已经进入设计 SSOT 的 SID 不写成 `sid:xxx:proposed`；proposed 状态通过 `design_ref_status_for()` 表达。
- 没有改变评分公式、action selection、HITL、FSM 或 recovery 语义。
- source refs 只覆盖本轮触达的核心对象，不做全仓库强制补齐。

## 测试

已在 Lane C worktree 运行：

```bash
uv run pytest tests/unit/test_source_refs.py tests/unit/test_contract_source_refs.py tests/unit/test_runtime_evaluator.py tests/unit/test_runtime_schemas.py
uv run basedpyright src/models/source_refs.py src/workflow/runtime_evaluator.py tests/unit/test_source_refs.py tests/unit/test_contract_source_refs.py tests/unit/test_runtime_evaluator.py
```

结果：

```text
37 passed, 1 warning
0 errors, 0 warnings, 0 notes
```

## 合并提示

建议本 PR 作为 Wave1 第一个合入 `wave1-integration` 的 PR：

```text
#337 source refs -> #334 feasibility -> #335 posterior objective
```

原因：#335 后续会在 `planner.py` / `objective_ranker_adapter.py` 中继续消费或整合 source refs。