### PR TITLE
feat(planner): add candidate feasibility metadata

### DIFF
--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -36,6 +36,91 @@ from src.models.contracts import (
 ScoredRow = tuple[PendingActionCandidate, SortKey, SortKey, str]
 RankedRow = tuple[PendingActionCandidate, SortKey, str]
 
+CANDIDATE_FEASIBILITY_METADATA_KEY = "candidate_feasibility"
+_SOFT_FEASIBILITY_REASONS = {"io_not_closed", "tool_unavailable"}
+_FEASIBILITY_SOURCE_REFS = [
+    "sid:algo.adaptive.feasibility_filter",
+    "impl:candidate_generator.feasibility.v1",
+]
+_FEASIBILITY_DESIGN_REF_STATUS = {
+    "sid:algo.adaptive.feasibility_filter": "proposed",
+}
+_HARD_FEASIBILITY_CONSTRAINT_CODES = {
+    "tool_not_allowed": "tool.not_allowed",
+    "tool_blocked": "tool.blocked",
+    "safety_level_exceeded": "safety.exceeded",
+    "cost_level_exceeded": "cost.exceeded",
+}
+
+
+def _build_candidate_feasibility_metadata(reason: str | None) -> Metadata:
+    """构造候选硬/软可行性审计元数据。"""
+    constraint_codes = _constraint_codes_for_filter_reason(reason)
+    filter_class = _filter_class_for_reason(reason)
+    hard_feasible = reason is None
+    degraded_feasible = filter_class == "soft"
+    requires_hitl = degraded_feasible
+    auto_executable = hard_feasible and not requires_hitl
+    allowed_for_top_k = filter_class in {"eligible", "soft"}
+    allowed_for_default_recommendation = auto_executable
+    return {
+        "schema_version": "candidate_feasibility.v1",
+        "hard_feasible": hard_feasible,
+        "soft_feasible": filter_class in {"eligible", "soft"},
+        "degraded_feasible": degraded_feasible,
+        "requires_hitl": requires_hitl,
+        "auto_executable": auto_executable,
+        "filter_class": filter_class,
+        "filter_reason": reason,
+        "constraint_codes": constraint_codes,
+        "blocked_by": _blocked_by_for_filter_reason(reason),
+        "allowed_for_top_k": allowed_for_top_k,
+        "allowed_for_default_recommendation": allowed_for_default_recommendation,
+        "explanation": _feasibility_explanation(reason, filter_class),
+        "source_refs": list(_FEASIBILITY_SOURCE_REFS),
+        "design_ref_status": dict(_FEASIBILITY_DESIGN_REF_STATUS),
+    }
+
+
+def _filter_class_for_reason(reason: str | None) -> str:
+    if reason is None:
+        return "eligible"
+    if reason in _SOFT_FEASIBILITY_REASONS:
+        return "soft"
+    return "hard"
+
+
+def _constraint_codes_for_filter_reason(reason: str | None) -> list[str]:
+    if reason is None:
+        return []
+    if reason == "io_not_closed":
+        return ["schema.io_open"]
+    if reason == "tool_unavailable":
+        return ["tool.unavailable"]
+    if reason.startswith("missing_tools:"):
+        return ["tool.missing"]
+    return [_HARD_FEASIBILITY_CONSTRAINT_CODES.get(reason, "unknown")]
+
+
+def _blocked_by_for_filter_reason(reason: str | None) -> list[str]:
+    if reason is None:
+        return []
+    if reason.startswith("missing_tools:"):
+        missing = reason.split(":", 1)[1]
+        return [tool_id for tool_id in missing.split(",") if tool_id]
+    return [reason]
+
+
+def _feasibility_explanation(reason: str | None, filter_class: str) -> str:
+    if filter_class == "eligible":
+        return "Candidate satisfies hard feasibility constraints and can be auto defaulted."
+    if filter_class == "soft":
+        return (
+            "Candidate is degraded feasible for Top-K display only; "
+            f"requires HITL because {reason}."
+        )
+    return f"Candidate is hard infeasible and excluded from Top-K because {reason}."
+
 
 class CandidateGenerator:
     """统一生成 Plan/Patch/Replan Top-K 候选。
@@ -88,16 +173,17 @@ class CandidateGenerator:
                 payload.payload,
                 score_metadata_key=FINAL_SCORE_METADATA_KEY,
             )
+            reason = self._filter_reason(candidate, payload.payload, request, registry_map)
+            candidate = self._with_candidate_feasibility(candidate, reason)
             row = (
                 candidate,
                 static_sort_key,
                 effective_sort_key,
                 candidate.capability_id or "unknown",
             )
-            reason = self._filter_reason(candidate, payload.payload, request, registry_map)
             if reason is not None:
                 filter_reasons.append(reason)
-                if reason in {"io_not_closed", "tool_unavailable"}:
+                if reason in _SOFT_FEASIBILITY_REASONS:
                     soft_filtered_rows.append(row)
                 continue
             filtered_rows.append(row)
@@ -135,8 +221,10 @@ class CandidateGenerator:
 
         candidates = [row[0] for row in selected_rows]
         static_candidates = [row[0] for row in static_selected_rows]
-        default_candidate = candidates[0] if candidates else None
-        static_default_candidate = static_candidates[0] if static_candidates else None
+        default_candidate = self._first_default_recommendation_candidate(candidates)
+        static_default_candidate = self._first_default_recommendation_candidate(
+            static_candidates
+        )
         default_recommendation = (
             default_candidate.candidate_id if default_candidate is not None else None
         )
@@ -165,6 +253,48 @@ class CandidateGenerator:
                 runtime_state_summary=runtime_state_summary,
             ),
         )
+
+    def _with_candidate_feasibility(
+        self,
+        candidate: PendingActionCandidate,
+        reason: str | None,
+    ) -> PendingActionCandidate:
+        metadata = dict(candidate.metadata or {})
+        metadata[CANDIDATE_FEASIBILITY_METADATA_KEY] = (
+            _build_candidate_feasibility_metadata(reason)
+        )
+        return candidate.model_copy(update={"metadata": metadata})
+
+    def _first_default_recommendation_candidate(
+        self,
+        candidates: Sequence[PendingActionCandidate],
+    ) -> PendingActionCandidate | None:
+        for candidate in candidates:
+            metadata = object_mapping(cast(object, candidate.metadata))
+            feasibility = object_mapping(
+                metadata.get(CANDIDATE_FEASIBILITY_METADATA_KEY)
+            )
+            if feasibility.get("allowed_for_default_recommendation") is True:
+                return candidate
+        return None
+
+    def _degraded_candidate_reasons(
+        self,
+        candidates: Sequence[PendingActionCandidate],
+    ) -> list[str]:
+        reasons: list[str] = []
+        for candidate in candidates:
+            metadata = object_mapping(cast(object, candidate.metadata))
+            feasibility = object_mapping(
+                metadata.get(CANDIDATE_FEASIBILITY_METADATA_KEY)
+            )
+            if feasibility.get("degraded_feasible") is not True:
+                continue
+            raw_reason = feasibility.get("filter_reason")
+            reason = raw_reason if isinstance(raw_reason, str) else "unknown"
+            if reason not in reasons:
+                reasons.append(reason)
+        return reasons
 
     def _filter_reason(
         self,
@@ -354,6 +484,17 @@ class CandidateGenerator:
                     default_candidate=default_candidate,
                     static_default_candidate=static_default_candidate,
                 )
+        elif candidates:
+            explanation = (
+                f"{explanation} No hard-feasible default recommendation exists; "
+                "returned degraded candidates require HITL."
+            )
+        degraded_reasons = self._degraded_candidate_reasons(candidates)
+        if degraded_reasons:
+            explanation = (
+                f"{explanation} Returned degraded candidates require HITL because: "
+                f"{', '.join(degraded_reasons)}."
+            )
         difference = candidate_difference_explanation(candidates)
         if difference:
             explanation = f"{explanation} Candidate differences: {difference}."
@@ -364,8 +505,8 @@ class CandidateGenerator:
             )
         elif filter_reasons:
             explanation = (
-                f"{explanation} Filtering would remove all candidates, so the generator "
-                "returned the scored fallback set for compatibility."
+                f"{explanation} Filtering found only degraded soft fallback candidates; "
+                "returned candidates require HITL and are not eligible for automatic default."
             )
         if len(candidates) < request.top_k:
             explanation = (

--- a/tests/unit/test_candidate_generator.py
+++ b/tests/unit/test_candidate_generator.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import src.agents.planner as planner_module
+from src.agents.candidate_generator.generator import (
+    CANDIDATE_FEASIBILITY_METADATA_KEY,
+    CandidateGenerator,
+)
+from src.agents.candidate_generator.models import (
+    CandidateGenerationInput,
+    CandidateGeneratorHooks,
+    CandidatePayload,
+)
 from src.agents.planner import PlannerAgent, ToolSpec
-from src.models.contracts import ProteinDesignTask
+from src.models.contracts import (
+    TOOL_READINESS_METADATA_KEY,
+    Plan,
+    PlanStep,
+    ProteinDesignTask,
+)
+
+
+@dataclass(frozen=True)
+class _ShadowDecision:
+    shadow_score: dict[str, object]
+    final_score: dict[str, object]
+    runtime_adjustment: dict[str, object]
+    rerank_reason: dict[str, object]
+    shadow_action: str
+    shadow_reason: str
+    explanation_fragment: str
 
 
 def _registry() -> list[ToolSpec]:
@@ -82,6 +109,100 @@ def _kg() -> dict:
     }
 
 
+def _direct_generator(
+    *,
+    readiness_status: str = "ready",
+    unavailable_tools: set[str] | None = None,
+) -> CandidateGenerator:
+    unavailable_tool_ids = unavailable_tools or set()
+    def score_payload(payload: Plan, *_args: object, **_kwargs: object) -> dict[str, float]:
+        primary_tool = payload.steps[0].tool
+        overall = 0.9 if primary_tool == "seqgen_a" else 0.8
+        return {
+            "feasibility": 0.9,
+            "objective": 0.8,
+            "risk": 0.8,
+            "cost": 0.8,
+            "confidence": 0.8,
+            "overall": overall,
+        }
+
+    def score_summary(score_breakdown: dict[str, float]) -> dict[str, object]:
+        return {"value": score_breakdown["overall"], "source": "unit_test"}
+
+    def readiness_metadata(*, tool_id: str, capability_id: str) -> dict[str, object]:
+        status = "unavailable" if tool_id in unavailable_tool_ids else readiness_status
+        return {
+            TOOL_READINESS_METADATA_KEY: {
+                "tool_id": tool_id,
+                "status": status,
+                "capability_id": capability_id,
+            }
+        }
+
+    def passthrough_shadow(score_breakdown: dict[str, float]) -> _ShadowDecision:
+        return _ShadowDecision(
+            shadow_score={"value": score_breakdown["overall"], "source": "unit_test"},
+            final_score={"value": score_breakdown["overall"], "source": "unit_test"},
+            runtime_adjustment={"value": 0.0, "source": "unit_test"},
+            rerank_reason={"code": "passthrough", "message": "passthrough"},
+            shadow_action="continue",
+            shadow_reason="no runtime state",
+            explanation_fragment="No runtime rerank applied.",
+        )
+
+    def extract_score_value(candidate: object, key: str) -> float:
+        metadata = getattr(candidate, "metadata")
+        summary = metadata[key]
+        if isinstance(summary, dict):
+            value = summary.get("value")
+            if isinstance(value, (int, float)):
+                return float(value)
+        return 0.0
+
+    return CandidateGenerator(
+        CandidateGeneratorHooks(
+            canonical_payload_fingerprint=lambda payload, tool_id, bucket: (
+                f"{tool_id}:{bucket}:{payload.steps[0].id}"
+            ),
+            resolve_score_weights=lambda _constraints: {},
+            score_payload=score_payload,
+            primary_capability=lambda spec: spec.capabilities[0] if spec else "unknown",
+            derive_cost_estimate=lambda _payload, _registry: "low",
+            derive_risk_level=lambda _payload, _registry: "low",
+            stable_candidate_id=lambda kind, _payload, tool_id, bucket: (
+                f"{kind}:{tool_id}:{bucket}"
+            ),
+            build_s5_scoring_contract=lambda _weights: {"weights": {}},
+            build_static_score_summary=score_summary,
+            build_action_score_summary=score_summary,
+            candidate_readiness_metadata=readiness_metadata,
+            build_candidate_summary=lambda payload: payload.steps[0].tool,
+            extract_patch_candidate_metadata=lambda _payload: {},
+            extract_plan_candidate_metadata=lambda _payload: {},
+            normalize_runtime_state_summary_input=lambda _state: None,
+            build_shadow_passthrough_decision=passthrough_shadow,
+            build_runtime_shadow_decision=lambda **_kwargs: passthrough_shadow(
+                {"overall": 0.0}
+            ),
+            priority_rank=lambda _priority: 0,
+            patch_layer_rank=lambda _payload: 0,
+            extract_score_value=extract_score_value,
+            build_default_recommendation_reason=lambda **kwargs: {
+                "candidate_id": kwargs["candidate_id"]
+            },
+            summarize_rerank_reason=lambda _candidate: "rerank summary",
+        )
+    )
+
+
+def _plan(tool_id: str, *, inputs: dict[str, object] | None = None) -> Plan:
+    return Plan(
+        task_id="direct_candidate_generator",
+        steps=[PlanStep(id=f"S_{tool_id}", tool=tool_id, inputs=inputs or {})],
+    )
+
+
 def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     monkeypatch.setenv("PLANNER_LLM_PROVIDER", "none")
     monkeypatch.setattr(planner_module, "load_tool_kg", _kg)
@@ -94,7 +215,11 @@ def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     task = ProteinDesignTask(
         task_id="candidate_generator_context",
         goal="design stable peptide",
-        constraints={"goal_type": "sequence_evaluation", "budget": {"cost_cap": 0.5}},
+        constraints={
+            "goal_type": "legacy_sequence_generation",
+            "inputs": {"sequence": "AAAA"},
+            "budget": {"cost_cap": 0.5},
+        },
         metadata={"planner_capability_hints": ["sequence_generation"]},
     )
 
@@ -108,6 +233,12 @@ def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     assert candidate.metadata["candidate_generator"]["capability_hints"] == [
         "sequence_generation"
     ]
+    feasibility = candidate.metadata[CANDIDATE_FEASIBILITY_METADATA_KEY]
+    assert isinstance(feasibility, dict)
+    assert feasibility["hard_feasible"] is True
+    assert feasibility["auto_executable"] is True
+    assert feasibility["allowed_for_default_recommendation"] is True
+    assert "feasibility" not in candidate.metadata
     assert candidate.score_breakdown["recovery_complexity"] >= 0.0
     assert candidate.score_breakdown["capability_hint_match"] == 1.0
 
@@ -124,7 +255,11 @@ def test_plan_top_k_filters_blocked_tools_before_default_selection(monkeypatch):
     task = ProteinDesignTask(
         task_id="candidate_generator_filter",
         goal="design stable peptide",
-        constraints={"goal_type": "sequence_evaluation", "blocked_tools": ["seqgen_a"]},
+        constraints={
+            "goal_type": "legacy_sequence_generation",
+            "inputs": {"sequence": "AAAA"},
+            "blocked_tools": ["seqgen_a"],
+        },
         metadata={},
     )
 
@@ -133,7 +268,110 @@ def test_plan_top_k_filters_blocked_tools_before_default_selection(monkeypatch):
     assert topk.candidates
     assert all(candidate.tool_id != "seqgen_a" for candidate in topk.candidates)
     assert topk.default_recommendation == topk.candidates[0].candidate_id
+    candidate = topk.candidates[0]
+    feasibility = candidate.metadata[CANDIDATE_FEASIBILITY_METADATA_KEY]
+    assert isinstance(feasibility, dict)
+    assert feasibility["hard_feasible"] is True
+    assert feasibility["auto_executable"] is True
+    assert feasibility["allowed_for_default_recommendation"] is True
+    assert "feasibility" not in candidate.metadata
     assert "Filtered candidates before ranking" in topk.explanation
+
+
+def test_generator_returns_degraded_soft_fallback_without_default():
+    registry = [
+        ToolSpec(
+            id="seqgen_a",
+            capabilities=("sequence_generation",),
+            inputs=("target",),
+            outputs=("sequence",),
+            cost=0.2,
+            safety_level=1,
+            io_type="target_to_sequence",
+            adapter_mode="local",
+            priority="P0",
+        )
+    ]
+    result = _direct_generator().generate(
+        CandidateGenerationInput(
+            candidate_kind="plan",
+            payloads=[
+                CandidatePayload(
+                    payload=_plan("seqgen_a"),
+                    primary_tool_id="seqgen_a",
+                    capability_bucket="sequence_generation",
+                    note="missing target input",
+                )
+            ],
+            registry=registry,
+            top_k=1,
+            task_constraints={},
+        )
+    )
+
+    assert result.candidates
+    assert result.default_recommendation is None
+    candidate = result.candidates[0]
+    feasibility = candidate.metadata[CANDIDATE_FEASIBILITY_METADATA_KEY]
+    assert isinstance(feasibility, dict)
+    assert feasibility["filter_reason"] == "io_not_closed"
+    assert feasibility["filter_class"] == "soft"
+    assert feasibility["hard_feasible"] is False
+    assert feasibility["soft_feasible"] is True
+    assert feasibility["degraded_feasible"] is True
+    assert feasibility["requires_hitl"] is True
+    assert feasibility["auto_executable"] is False
+    assert feasibility["allowed_for_top_k"] is True
+    assert feasibility["allowed_for_default_recommendation"] is False
+    assert feasibility["constraint_codes"] == ["schema.io_open"]
+    assert "feasibility" not in candidate.metadata
+    assert "No hard-feasible default recommendation exists" in result.explanation
+    assert "require HITL" in result.explanation
+
+
+def test_generator_backfills_degraded_candidate_but_keeps_eligible_default():
+    result = _direct_generator(unavailable_tools={"seqgen_b"}).generate(
+        CandidateGenerationInput(
+            candidate_kind="plan",
+            payloads=[
+                CandidatePayload(
+                    payload=_plan("seqgen_a", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_a",
+                    capability_bucket="sequence_generation",
+                    note="eligible candidate",
+                ),
+                CandidatePayload(
+                    payload=_plan("seqgen_b", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_b",
+                    capability_bucket="sequence_generation",
+                    note="degraded candidate",
+                ),
+            ],
+            registry=_registry(),
+            top_k=2,
+            task_constraints={},
+        )
+    )
+
+    assert [candidate.tool_id for candidate in result.candidates] == [
+        "seqgen_a",
+        "seqgen_b",
+    ]
+    assert result.default_recommendation == result.candidates[0].candidate_id
+    eligible_feasibility = result.candidates[0].metadata[
+        CANDIDATE_FEASIBILITY_METADATA_KEY
+    ]
+    assert isinstance(eligible_feasibility, dict)
+    assert eligible_feasibility["allowed_for_default_recommendation"] is True
+    degraded_feasibility = result.candidates[1].metadata[
+        CANDIDATE_FEASIBILITY_METADATA_KEY
+    ]
+    assert isinstance(degraded_feasibility, dict)
+    assert degraded_feasibility["filter_reason"] == "tool_unavailable"
+    assert degraded_feasibility["constraint_codes"] == ["tool.unavailable"]
+    assert degraded_feasibility["requires_hitl"] is True
+    assert degraded_feasibility["auto_executable"] is False
+    assert degraded_feasibility["allowed_for_default_recommendation"] is False
 
 
 def test_plan_top_k_applies_policy_mode_and_cost_filter(monkeypatch):
@@ -149,7 +387,8 @@ def test_plan_top_k_applies_policy_mode_and_cost_filter(monkeypatch):
         task_id="candidate_generator_policy_cost",
         goal="design stable peptide",
         constraints={
-            "goal_type": "sequence_evaluation",
+            "goal_type": "legacy_sequence_generation",
+            "inputs": {"sequence": "AAAA"},
             "policy_mode": "low_cost",
             "max_cost_level": "medium",
         },


### PR DESCRIPTION
## 背景 / 对应 Issue

- 对应 GitHub Issue: #334
- 本 PR 合入目标分支：`wave1-integration`
- Wave1 Lane A：候选可行性元数据显式化
- 实现依据：
  - `docs/algorithm-and-llm/issues/2026-05-05-p0-02-feasibility-metadata.md`
  - `docs/algorithm-and-llm/implementation/2026-05-05-wave1-parallel-agent-guidance.md`
  - `docs/algorithm-and-llm/core-algorithm-code-gap-review.md`

## 目标

为 `PendingActionCandidate.metadata` 增加机器可审计的：

```text
metadata.candidate_feasibility
```

用于显式表达 CEBRA-WP 中 hard feasibility / soft feasibility / degraded feasibility 的区分，避免候选排序中的 `score_breakdown["feasibility"]` 被误读为约束满足证明。

## 主要改动

- 在 `src/agents/candidate_generator/generator.py` 中为返回候选注入 `metadata.candidate_feasibility`。
- 将 soft fallback 候选标记为 degraded feasible：
  - `degraded_feasible = true`
  - `requires_hitl = true`
  - `auto_executable = false`
  - `allowed_for_default_recommendation = false`
- `default_recommendation` 不再无条件取 `candidates[0]`，而是只从允许默认推荐的候选中选择。
- 保留 hard-infeasible 候选不进入 returned candidates 的现有语义。
- 扩展 `tests/unit/test_candidate_generator.py`，覆盖 hard / degraded / default fallback 场景。

## 关键约束

- 没有引入 `metadata.feasibility`，字段名固定为 `metadata.candidate_feasibility`。
- 没有改变 planner 总评分公式。
- 没有改变 HITL / FSM / recovery 语义。
- degraded candidate 仍可作为候选展示，但不能成为自动 default recommendation。

## 测试

已在 Lane A worktree 运行：

```bash
uv run pytest tests/unit/test_candidate_generator.py
uv run basedpyright src/agents/candidate_generator/generator.py
```

结果：

```text
5 passed, 1 warning
0 errors, 0 warnings, 0 notes
```

## 合并提示

建议在 `wave1-integration` 中按以下顺序合并：

```text
#337 source refs -> #334 feasibility -> #335 posterior objective
```

本 PR 与 #337 / #335 的直接冲突风险较低。主要修改集中在 candidate generator。