### PR TITLE
feat(objective): connect posterior objective scoring

### DIFF
--- a/src/adapters/objective_ranker_adapter.py
+++ b/src/adapters/objective_ranker_adapter.py
@@ -16,6 +16,11 @@ from src.workflow.errors import FailureCode, FailureType, StepRunError
 __all__ = ["ObjectiveRankerAdapter"]
 
 _POSTERIOR_SCORE_SCHEMA_VERSION = "posterior_score.v1"
+_POSTERIOR_OBJECTIVE_SCHEMA_VERSION = "posterior_objective.v1"
+_POSTERIOR_OBJECTIVE_SOURCE_REFS = [
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+]
 _POSTERIOR_COMPONENTS = (
     "generic_objective",
     "stability",
@@ -309,6 +314,10 @@ def _score_candidate(
         evidence_refs=evidence_refs,
         warnings=warnings,
     )
+    posterior_objective = _normalize_posterior_objective(
+        posterior_score,
+        candidate=row,
+    )
     rank_reason = _rank_reason(
         candidate_id=candidate_id,
         objective_score=objective_score,
@@ -322,6 +331,7 @@ def _score_candidate(
         "objective_score": objective_score,
         "aggregate_score": objective_score,
         "posterior_score": posterior_score,
+        "posterior_objective": posterior_objective,
         "score_breakdown": score_breakdown,
         "component_scores": score_breakdown,
         "top_k_rank": index,
@@ -516,6 +526,68 @@ def _build_posterior_score(
     else:
         payload["evidence_status"] = "direct"
     return payload
+
+
+def _normalize_posterior_objective(
+    posterior_score: Dict[str, Any],
+    *,
+    candidate: Dict[str, Any],
+) -> Dict[str, Any]:
+    objective_type = posterior_score.get("objective_type")
+    evidence_sufficiency = _as_float(posterior_score.get("evidence_sufficiency"))
+    aggregate_score = _as_float(posterior_score.get("aggregate_score"))
+    components = {
+        key: dict(posterior_score[key])
+        for key in _POSTERIOR_COMPONENTS
+        if isinstance(posterior_score.get(key), dict)
+    }
+    raw_warnings = posterior_score.get("warnings")
+    warnings = [
+        item for item in raw_warnings if isinstance(item, str)
+    ] if isinstance(raw_warnings, list) else []
+    binding_proxy_fields: list[str] = []
+    binding_proxy_component: str | None = None
+    if objective_type == "binding":
+        binding_proxy_component = "generic_objective"
+        binding_proxy_fields = _present_fields(candidate, ("binding_score", "best_pose"))
+        binding_warning = (
+            "binding objective is represented through generic_objective proxy in v1"
+        )
+        if binding_warning not in warnings:
+            warnings.append(binding_warning)
+    raw_component_weights = posterior_score.get("component_weights")
+    component_weights = (
+        dict(raw_component_weights) if isinstance(raw_component_weights, dict) else {}
+    )
+    raw_evidence_refs = posterior_score.get("evidence_refs")
+    evidence_refs = (
+        list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else []
+    )
+    raw_evidence_status = posterior_score.get("evidence_status")
+    return {
+        "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
+        "aggregate_score": round(min(max(aggregate_score or 0.0, 0.0), 1.0), 6),
+        "components": components,
+        "component_weights": component_weights,
+        "evidence_sufficiency": round(
+            min(
+                max(
+                    evidence_sufficiency if evidence_sufficiency is not None else 0.0,
+                    0.0,
+                ),
+                1.0,
+            ),
+            6,
+        ),
+        "evidence_status": raw_evidence_status if isinstance(raw_evidence_status, str) else "degraded",
+        "objective_type": objective_type if isinstance(objective_type, str) else None,
+        "objective_source": "posterior_objective",
+        "binding_proxy_component": binding_proxy_component,
+        "binding_proxy_fields": binding_proxy_fields,
+        "warnings": warnings,
+        "evidence_refs": evidence_refs,
+        "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
+    }
 
 
 def _quality_score(candidate: Dict[str, Any]) -> float:

--- a/src/adapters/tool_schema_utils.py
+++ b/src/adapters/tool_schema_utils.py
@@ -394,17 +394,24 @@ def build_objective_outputs(
         if isinstance(row.get("evidence_refs"), list) and isinstance(ref, dict)
     ]
     posterior_scores: dict[str, Dict[str, Any]] = {}
+    posterior_objectives: dict[str, Dict[str, Any]] = {}
     for index, row in enumerate(scored_candidates, start=1):
+        candidate_id = str(row.get("candidate_id") or f"candidate_{index}")
         posterior_score = row.get("posterior_score")
         if isinstance(posterior_score, dict):
-            posterior_scores[
-                str(row.get("candidate_id") or f"candidate_{index}")
-            ] = dict(posterior_score)
+            posterior_scores[candidate_id] = dict(posterior_score)
+        posterior_objective = row.get("posterior_objective")
+        if isinstance(posterior_objective, dict):
+            posterior_objectives[candidate_id] = dict(posterior_objective)
     top_posterior_score: Dict[str, Any] = {}
+    top_posterior_objective: Dict[str, Any] = {}
     if top_k_rows:
         raw_top_posterior = top_k_rows[0].get("posterior_score")
         if isinstance(raw_top_posterior, dict):
             top_posterior_score = dict(raw_top_posterior)
+        raw_top_posterior_objective = top_k_rows[0].get("posterior_objective")
+        if isinstance(raw_top_posterior_objective, dict):
+            top_posterior_objective = dict(raw_top_posterior_objective)
     component_weights: Dict[str, Any] = {}
     raw_component_weights = top_posterior_score.get("component_weights")
     if isinstance(raw_component_weights, dict):
@@ -421,6 +428,8 @@ def build_objective_outputs(
         "component_scores": component_scores,
         "posterior_score": top_posterior_score,
         "posterior_scores": posterior_scores,
+        "posterior_objective": top_posterior_objective,
+        "posterior_objectives": posterior_objectives,
         "aggregate_score": top_score,
         "component_weights": component_weights,
         "default_recommendation": default_recommendation,

--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -30,6 +30,21 @@ from src.models.contracts import (
     STATIC_SCORE_METADATA_KEY,
 )
 
+_POSTERIOR_OBJECTIVE_SCHEMA_VERSION = "posterior_objective.v1"
+_POSTERIOR_SCORE_SCHEMA_VERSION = "posterior_score.v1"
+_POSTERIOR_OBJECTIVE_THRESHOLD = 0.30
+_POSTERIOR_OBJECTIVE_SOURCE_REFS = [
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+]
+_POSTERIOR_COMPONENT_KEYS = (
+    "generic_objective",
+    "stability",
+    "function",
+    "novelty",
+    "structure_quality",
+)
+
 
 class CandidateBuilder:
     """构造 PendingActionCandidate 及其审计 metadata。"""
@@ -160,6 +175,8 @@ class CandidateBuilder:
             )
         )
         payload_metadata = object_mapping(cast(object, payload.payload.metadata))
+        posterior_metadata = objective_metadata_from_payload_metadata(payload_metadata)
+        metadata.update(posterior_metadata)
         planner_route = payload_metadata.get("planner_route")
         if isinstance(planner_route, dict):
             metadata["planner_route"] = object_mapping(cast(object, planner_route))
@@ -252,3 +269,88 @@ class CandidateBuilder:
             6,
         )
         return {key: round(value, 6) for key, value in adjusted.items()}
+
+
+def _bounded_optional_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return min(max(parsed, 0.0), 1.0)
+
+
+def _normalize_posterior_objective(raw: object) -> Metadata | None:
+    if not isinstance(raw, Mapping):
+        return None
+    aggregate_score = _bounded_optional_float(raw.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(raw.get("evidence_sufficiency"))
+    if aggregate_score is None or evidence_sufficiency is None:
+        return None
+    schema_version = raw.get("schema_version")
+    if schema_version == _POSTERIOR_OBJECTIVE_SCHEMA_VERSION:
+        normalized = object_mapping(cast(object, raw))
+        normalized["aggregate_score"] = aggregate_score
+        normalized["evidence_sufficiency"] = evidence_sufficiency
+        return normalized
+    if schema_version not in {_POSTERIOR_SCORE_SCHEMA_VERSION, None}:
+        return None
+    components: Metadata = {}
+    for key in _POSTERIOR_COMPONENT_KEYS:
+        component = raw.get(key)
+        if isinstance(component, Mapping):
+            components[key] = object_mapping(cast(object, component))
+    raw_component_weights = raw.get("component_weights")
+    raw_warnings = raw.get("warnings")
+    raw_evidence_refs = raw.get("evidence_refs")
+    raw_evidence_status = raw.get("evidence_status")
+    objective_type = raw.get("objective_type")
+    return {
+        "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
+        "aggregate_score": aggregate_score,
+        "components": components,
+        "component_weights": object_mapping(cast(object, raw_component_weights))
+        if isinstance(raw_component_weights, Mapping)
+        else {},
+        "evidence_sufficiency": evidence_sufficiency,
+        "evidence_status": raw_evidence_status
+        if isinstance(raw_evidence_status, str)
+        else "degraded",
+        "objective_type": objective_type if isinstance(objective_type, str) else None,
+        "objective_source": "posterior_objective",
+        "binding_proxy_component": "generic_objective"
+        if objective_type == "binding"
+        else None,
+        "warnings": list(raw_warnings) if isinstance(raw_warnings, list) else [],
+        "evidence_refs": list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else [],
+        "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
+    }
+
+
+def objective_metadata_from_payload_metadata(payload_metadata: Metadata) -> Metadata:
+    raw = payload_metadata.get("posterior_objective") or payload_metadata.get("posterior_score")
+    posterior = _normalize_posterior_objective(raw)
+    if posterior is None:
+        return {
+            "objective_score_source": "prior_goal_fit",
+            "objective_evidence_sufficiency": 0.5,
+            "objective_evidence_status": "prior",
+        }
+    evidence_sufficiency = _bounded_optional_float(
+        posterior.get("evidence_sufficiency")
+    ) or 0.0
+    raw_evidence_status = posterior.get("evidence_status")
+    objective_source = (
+        "posterior_objective"
+        if evidence_sufficiency >= _POSTERIOR_OBJECTIVE_THRESHOLD
+        else "degraded_proxy"
+    )
+    return {
+        "posterior_objective": posterior,
+        "objective_score_source": objective_source,
+        "objective_evidence_sufficiency": evidence_sufficiency,
+        "objective_evidence_status": raw_evidence_status
+        if isinstance(raw_evidence_status, str)
+        else "degraded",
+    }

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -165,6 +165,20 @@ _SCORE_WEIGHT_KEY_ALIASES: dict[str, str] = {
     "readiness": "tool_readiness",
     "coverage": "tool_coverage",
 }
+_POSTERIOR_OBJECTIVE_SCHEMA_VERSION = "posterior_objective.v1"
+_POSTERIOR_SCORE_SCHEMA_VERSION = "posterior_score.v1"
+_POSTERIOR_OBJECTIVE_THRESHOLD = 0.30
+_POSTERIOR_OBJECTIVE_SOURCE_REFS = [
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+]
+_POSTERIOR_COMPONENT_KEYS = (
+    "generic_objective",
+    "stability",
+    "function",
+    "novelty",
+    "structure_quality",
+)
 
 _P0_CAPABILITY_REPLACEMENT_MATRIX: dict[str, tuple[str, ...]] = {
     # Requirement-2: P0 capability swap matrix (structure prediction core path)
@@ -2923,6 +2937,83 @@ def _patch_layer_rank(payload: Plan | PlanPatch) -> int:
     return 999
 
 
+def _bounded_optional_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return min(max(parsed, 0.0), 1.0)
+
+
+def _extract_posterior_objective(payload: Plan | PlanPatch) -> dict[str, object] | None:
+    metadata = payload.metadata if isinstance(payload.metadata, dict) else {}
+    raw = metadata.get("posterior_objective") or metadata.get("posterior_score")
+    if not isinstance(raw, dict):
+        return None
+    aggregate_score = _bounded_optional_float(raw.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(raw.get("evidence_sufficiency"))
+    if aggregate_score is None or evidence_sufficiency is None:
+        return None
+    schema_version = raw.get("schema_version")
+    if schema_version == _POSTERIOR_OBJECTIVE_SCHEMA_VERSION:
+        normalized = dict(raw)
+        normalized["aggregate_score"] = aggregate_score
+        normalized["evidence_sufficiency"] = evidence_sufficiency
+        return normalized
+    if schema_version not in {_POSTERIOR_SCORE_SCHEMA_VERSION, None}:
+        return None
+    components = {
+        key: dict(raw[key])
+        for key in _POSTERIOR_COMPONENT_KEYS
+        if isinstance(raw.get(key), dict)
+    }
+    raw_component_weights = raw.get("component_weights")
+    raw_warnings = raw.get("warnings")
+    raw_evidence_refs = raw.get("evidence_refs")
+    raw_evidence_status = raw.get("evidence_status")
+    objective_type = raw.get("objective_type")
+    return {
+        "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
+        "aggregate_score": aggregate_score,
+        "components": components,
+        "component_weights": dict(raw_component_weights)
+        if isinstance(raw_component_weights, dict)
+        else {},
+        "evidence_sufficiency": evidence_sufficiency,
+        "evidence_status": raw_evidence_status
+        if isinstance(raw_evidence_status, str)
+        else "degraded",
+        "objective_type": objective_type if isinstance(objective_type, str) else None,
+        "objective_source": "posterior_objective",
+        "binding_proxy_component": "generic_objective"
+        if objective_type == "binding"
+        else None,
+        "warnings": list(raw_warnings) if isinstance(raw_warnings, list) else [],
+        "evidence_refs": list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else [],
+        "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
+    }
+
+
+def _resolve_objective_score(
+    prior_objective: float,
+    posterior: dict[str, object] | None,
+) -> tuple[float, str, float, str]:
+    if posterior is None:
+        return prior_objective, "prior_goal_fit", 0.5, "prior"
+    aggregate_score = _bounded_optional_float(posterior.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(posterior.get("evidence_sufficiency"))
+    evidence_status_raw = posterior.get("evidence_status")
+    evidence_status = evidence_status_raw if isinstance(evidence_status_raw, str) else "degraded"
+    if aggregate_score is None or evidence_sufficiency is None:
+        return prior_objective, "prior_goal_fit", 0.5, "prior"
+    if evidence_sufficiency >= _POSTERIOR_OBJECTIVE_THRESHOLD:
+        return aggregate_score, "posterior_objective", evidence_sufficiency, evidence_status
+    blended = 0.70 * prior_objective + 0.30 * aggregate_score
+    return min(max(blended, 0.0), 1.0), "degraded_proxy", evidence_sufficiency, evidence_status
+
+
 def _score_payload(
     payload: Plan | PlanPatch,
     registry: Sequence[ToolSpec],
@@ -2958,9 +3049,17 @@ def _score_payload(
     recovery_complexity = max(0.0, min(1.0, 1.0 - fallback_depth))
 
     feasibility = min(1.0, max(0.0, 0.5 + 0.25 * tool_coverage + 0.25 * fallback_depth))
-    objective = min(
+    posterior = _extract_posterior_objective(payload)
+    prior_objective = min(
         1.0,
-        max(0.0, 1.0 - avg_cost * 0.3 + objective_bonus),
+        max(
+            0.0,
+            1.0 - avg_cost * 0.3 + (0.0 if posterior is not None else objective_bonus),
+        ),
+    )
+    objective, _objective_source, evidence_sufficiency, _evidence_status = _resolve_objective_score(
+        prior_objective,
+        posterior,
     )
     risk = max(0.0, 1.0 - avg_risk)
     cost = max(0.0, 1.0 - avg_cost)
@@ -2996,6 +3095,7 @@ def _score_payload(
         "tool_coverage": round(tool_coverage, 6),
         "fallback_depth": round(fallback_depth, 6),
         "recovery_complexity": round(recovery_complexity, 6),
+        "evidence_sufficiency": round(evidence_sufficiency, 6),
         "overall": round(overall, 6),
     }
 

--- a/tests/unit/test_extended_tool_adapters.py
+++ b/tests/unit/test_extended_tool_adapters.py
@@ -252,6 +252,39 @@ def test_objective_ranker_emits_posterior_score_schema_and_degraded_evidence() -
     assert weights["structure_quality"] == 0.3
     assert metrics["evidence_sufficiency"] == posterior["evidence_sufficiency"]
     assert "posterior_scores" in outputs
+    posterior_objective = cast(dict[str, object], top_k[0]["posterior_objective"])
+    assert posterior_objective["schema_version"] == "posterior_objective.v1"
+    assert posterior_objective["aggregate_score"] == posterior["aggregate_score"]
+    assert posterior_objective["source_refs"] == [
+        "sid:algo.posterior_objective_scoring",
+        "impl:posterior_score.v1",
+    ]
+    assert outputs["posterior_objective"] == posterior_objective
+    assert "posterior_objectives" in outputs
+
+
+def test_objective_ranker_binding_objective_marks_generic_proxy() -> None:
+    adapter = ObjectiveRankerAdapter()
+
+    outputs, _ = adapter.run_local(
+        {
+            "objective_type": "binding",
+            "candidates": [
+                {
+                    "candidate_id": "binder",
+                    "plddt": 82.0,
+                    "binding_score": -9.0,
+                    "best_pose": {"affinity": -9.0},
+                }
+            ],
+        }
+    )
+
+    top_k = cast(list[dict[str, object]], outputs["top_k"])
+    posterior_objective = cast(dict[str, object], top_k[0]["posterior_objective"])
+    assert posterior_objective["objective_type"] == "binding"
+    assert posterior_objective["binding_proxy_component"] == "generic_objective"
+    assert posterior_objective["binding_proxy_fields"] == ["binding_score", "best_pose"]
 
 
 def test_foldseek_adapter_uses_api_by_default_and_emits_structure_similarity_schema(

--- a/tests/unit/test_planner_posterior_objective_scoring.py
+++ b/tests/unit/test_planner_posterior_objective_scoring.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.agents.candidate_generator.builder import objective_metadata_from_payload_metadata
+from src.models.contracts import Plan, PlanStep
+
+
+def _registry() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("objective_scoring",),
+            inputs=("candidates",),
+            outputs=("top_k", "posterior_objective"),
+            cost=0.4,
+            safety_level=1,
+            io_type="candidates_to_objective_scores_topk",
+            adapter_mode="local",
+            priority="P0",
+        ),
+    ]
+
+
+def _plan(metadata: dict[str, object] | None = None) -> Plan:
+    return Plan(
+        task_id="posterior_scoring",
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="objective_ranker",
+                inputs={"candidates": []},
+            )
+        ],
+        metadata=metadata or {},
+    )
+
+
+def test_score_payload_uses_sufficient_posterior_objective() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+    plan = _plan(
+        {
+            "posterior_objective": {
+                "schema_version": "posterior_objective.v1",
+                "aggregate_score": 0.91,
+                "evidence_sufficiency": 0.73,
+                "evidence_status": "direct",
+            }
+        }
+    )
+
+    score = planner.score_candidate_payload(plan)
+
+    assert score["objective"] == pytest.approx(0.91)
+    assert score["evidence_sufficiency"] == pytest.approx(0.73)
+    assert score["overall"] < 0.91
+
+
+def test_score_payload_blends_degraded_posterior_objective_without_double_bonus() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+    plan = _plan(
+        {
+            "posterior_objective": {
+                "schema_version": "posterior_objective.v1",
+                "aggregate_score": 0.20,
+                "evidence_sufficiency": 0.10,
+                "evidence_status": "degraded",
+            }
+        }
+    )
+
+    score = planner.score_candidate_payload(plan)
+
+    avg_cost = 1.0 - score["cost"]
+    prior_without_objective_ranker_bonus = 1.0 - avg_cost * 0.3
+    expected = 0.70 * prior_without_objective_ranker_bonus + 0.30 * 0.20
+    assert score["objective"] == pytest.approx(expected)
+    assert score["objective"] < prior_without_objective_ranker_bonus
+    assert score["evidence_sufficiency"] == pytest.approx(0.10)
+
+
+def test_score_payload_keeps_prior_goal_fit_when_posterior_absent() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+
+    score = planner.score_candidate_payload(_plan())
+
+    avg_cost = 1.0 - score["cost"]
+    prior_with_objective_ranker_bonus = 1.0 - avg_cost * 0.3 + 0.08
+    assert score["objective"] == pytest.approx(min(1.0, prior_with_objective_ranker_bonus))
+    assert score["evidence_sufficiency"] == pytest.approx(0.5)
+
+
+def test_score_payload_accepts_legacy_posterior_score_metadata() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+    plan = _plan(
+        {
+            "posterior_score": {
+                "schema_version": "posterior_score.v1",
+                "aggregate_score": 0.77,
+                "evidence_sufficiency": 0.35,
+                "evidence_status": "partial",
+            }
+        }
+    )
+
+    score = planner.score_candidate_payload(plan)
+
+    assert score["objective"] == pytest.approx(0.77)
+    assert score["evidence_sufficiency"] == pytest.approx(0.35)
+
+
+def test_candidate_metadata_records_objective_provenance() -> None:
+    metadata = objective_metadata_from_payload_metadata(
+        {
+            "posterior_objective": {
+                "schema_version": "posterior_objective.v1",
+                "aggregate_score": 0.82,
+                "evidence_sufficiency": 0.44,
+                "evidence_status": "proxy",
+            }
+        }
+    )
+
+    assert metadata["objective_score_source"] == "posterior_objective"
+    assert metadata["objective_evidence_sufficiency"] == pytest.approx(0.44)
+    assert metadata["objective_evidence_status"] == "proxy"
+    posterior = metadata["posterior_objective"]
+    assert isinstance(posterior, dict)
+    assert posterior["schema_version"] == "posterior_objective.v1"
+
+
+def test_candidate_metadata_marks_degraded_proxy_source() -> None:
+    metadata = objective_metadata_from_payload_metadata(
+        {
+            "posterior_score": {
+                "schema_version": "posterior_score.v1",
+                "aggregate_score": 0.82,
+                "evidence_sufficiency": 0.12,
+                "evidence_status": "degraded",
+            }
+        }
+    )
+
+    assert metadata["objective_score_source"] == "degraded_proxy"
+    assert metadata["objective_evidence_sufficiency"] == pytest.approx(0.12)


### PR DESCRIPTION
## 背景 / 对应 Issue

- 对应 GitHub Issue: #335
- 本 PR 合入目标分支：`wave1-integration`
- Wave1 Lane B：posterior objective 接入 planner objective scoring
- 实现依据：
  - `docs/algorithm-and-llm/issues/2026-05-05-p0-03-posterior-objective-ranking.md`
  - `docs/algorithm-and-llm/implementation/2026-05-05-wave1-parallel-agent-guidance.md`
  - `docs/algorithm-and-llm/core-algorithm-code-gap-review.md`
  - `docs/algorithm-and-llm/core-algorithm-theory-v2.md`

## 目标

将后验目标函数 `G_post` 的实现结果接入 planner 排序中的：

```text
score_breakdown["objective"]
```

使候选排序能使用 evidence-aware posterior objective，而不是继续只依赖 prior / proxy objective。

## 主要改动

- `ObjectiveRankerAdapter` 输出新增：
  - `posterior_objective.v1`
  - 保留兼容旧 `posterior_score.v1`
- `tool_schema_utils.py` 汇总工具输出时传播：
  - `posterior_objective`
  - `posterior_objectives`
- `candidate_generator/builder.py` 从 payload metadata 中提取 posterior objective provenance，并写入候选 metadata。
- `planner.py::_score_payload()` 读取 payload metadata：
  - evidence 充足时：使用 `posterior_objective.aggregate_score` 作为 `score_breakdown["objective"]`；
  - evidence 降级时：使用 conservative blend：`0.70 * prior + 0.30 * posterior`；
  - posterior 缺失时：保留原 prior goal-fit 逻辑。
- 新增 `tests/unit/test_planner_posterior_objective_scoring.py`。
- 扩展 `tests/unit/test_extended_tool_adapters.py`，验证 ranker 输出 posterior objective schema。

## 关键约束

- 没有把字符串 provenance 写入 `score_breakdown`；`score_breakdown` 仍保持 `dict[str, float]`。
- `objective_score_source` / `objective_evidence_status` / `posterior_objective` 等非数值信息写入 candidate metadata。
- 没有直接覆盖 `overall`；仍通过现有 score weights 重新计算 overall。
- 降级证据不会直接替代 objective，而是 blended。
- 避免重复叠加旧 `objective_bonus`。

## 测试

已在 Lane B worktree 运行：

```bash
uv run pytest tests/unit/test_extended_tool_adapters.py tests/unit/test_planner_posterior_objective_scoring.py
```

结果：

```text
19 passed, 1 warning
```

Focused basedpyright 已尝试运行：

```bash
uv run basedpyright src/adapters/objective_ranker_adapter.py src/adapters/tool_schema_utils.py src/agents/planner.py src/agents/candidate_generator/builder.py tests/unit/test_planner_posterior_objective_scoring.py
```

结果：失败。主要原因是 `planner.py` / `objective_ranker_adapter.py` 存在大量既有类型债务与基线噪声。本 PR 已修正新增测试中直接使用 private helper 的问题；不建议在本 PR 中扩大范围修复全文件类型债务。

## 合并提示

建议本 PR 在 #337 和 #334 之后合入：

```text
#337 source refs -> #334 feasibility -> #335 posterior objective
```

注意：本 PR 与 #337 都会触达 `src/agents/planner.py`，合并到 `wave1-integration` 时需要人工处理 source refs 与 posterior objective helper 的行级冲突。