### PR TITLE
feat: merge Wave1 integration (source refs + feasibility + posterior objective)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-design-code-traceability.md
+++ b/docs/algorithm-and-llm/core-algorithm-design-code-traceability.md
@@ -23,7 +23,30 @@
 - posterior objective scoring 已有实现，但与静态 planner objective 和 belief-state evidence 更新的关系还比较松散；
 - 理论依据目前主要是工程直觉，尚未映射到 POMDP/belief-state planning、budgeted/risk-sensitive planning、workflow recovery、LLM/tool-use planning、protein design objective 等文献。
 
-## 2. 设计 SID ↔ 代码路径矩阵
+## 2. source_refs / SID 追踪规范（Issue #337）
+
+实现侧统一使用短字符串数组：
+
+```python
+"source_refs": ["sid:<design-sid>", "impl:<implementation-ref>"]
+```
+
+常量集中在 `src/models/source_refs.py`，运行时 metadata 不编码文档路径、URL、长公式或 `sid:...:proposed` 后缀。尚未进入设计 SSOT 的 SID 通过同模块 `design_ref_status_for()` / `PROPOSED_DESIGN_REF_STATUS` 或本文集中标注 proposed 状态。
+
+| metadata 对象 | source refs 常量 | SID 状态 |
+|---|---|---|
+| `metadata.candidate_feasibility` | `SOURCE_REF_FEASIBILITY` = `sid:algo.adaptive.feasibility_filter`, `impl:candidate_generator.feasibility.v1` | `algo.adaptive.feasibility_filter` proposed |
+| `metadata.static_score` / `metadata.action_score` / `score_breakdown` | `SOURCE_REF_STATIC_SCORE` = `sid:algo.adaptive.optimization_objective`, `sid:planner.algorithm.candidate_scoring`, `impl:planner.score_breakdown.v1` | existing |
+| `posterior_score` / `metadata.posterior_objective` | `SOURCE_REF_POSTERIOR_OBJECTIVE` = `sid:algo.posterior_objective_scoring`, `impl:posterior_score.v1`, `impl:posterior_objective.v1` | `algo.posterior_objective_scoring` proposed |
+| `metadata.runtime_adjustment` / runtime final/shadow score | `SOURCE_REF_RUNTIME_ADJUSTMENT` = `sid:planner.algorithm.runtime_adjustment_formula`, `sid:planner.algorithm.runtime_reranking`, `impl:planner.runtime_adjustment.v1` | existing |
+| `ActionUtility.source_refs` | `SOURCE_REF_ACTION_UTILITY` = `sid:algo.schema.action_utility`, `sid:algo.action_feature_derivation`, `impl:runtime_evaluator.action_utility.v1`, `impl:workflow.action_features.v1` | `algo.schema.action_utility` existing; `algo.action_feature_derivation` proposed |
+| default `ActionUtility.source_refs` | `SOURCE_REF_DEFAULT_ACTION_UTILITY` = `sid:algo.schema.action_utility`, `impl:runtime_evaluator.default.v1` | existing |
+| recovery action selection metadata | `SOURCE_REF_ACTION_SELECTION` = `sid:algo.recovery_aware_action_selection`, `sid:planner.algorithm.action_priority_resolution`, `impl:recovery.select_workflow_action.v1` | `algo.recovery_aware_action_selection` proposed; `planner.algorithm.action_priority_resolution` existing |
+| terminal stop metadata | `SOURCE_REF_TERMINAL_STOP` = `sid:algo.terminal_stop_policy`, `sid:planner.algorithm.stop_semantics`, `impl:recovery.terminal_stop.v1` | `algo.terminal_stop_policy` proposed; `planner.algorithm.stop_semantics` existing |
+
+设计仓库 `../thesis-project.design` 未在本实现中修改；proposed SID 仍需后续设计同步。
+
+## 3. 设计 SID ↔ 代码路径矩阵
 
 | 设计 SID | 设计含义 | 主要代码位置 | 当前实现状态 | 对齐判断 |
 |---|---|---|---|---|

--- a/src/adapters/objective_ranker_adapter.py
+++ b/src/adapters/objective_ranker_adapter.py
@@ -16,6 +16,11 @@ from src.workflow.errors import FailureCode, FailureType, StepRunError
 __all__ = ["ObjectiveRankerAdapter"]
 
 _POSTERIOR_SCORE_SCHEMA_VERSION = "posterior_score.v1"
+_POSTERIOR_OBJECTIVE_SCHEMA_VERSION = "posterior_objective.v1"
+_POSTERIOR_OBJECTIVE_SOURCE_REFS = [
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+]
 _POSTERIOR_COMPONENTS = (
     "generic_objective",
     "stability",
@@ -309,6 +314,10 @@ def _score_candidate(
         evidence_refs=evidence_refs,
         warnings=warnings,
     )
+    posterior_objective = _normalize_posterior_objective(
+        posterior_score,
+        candidate=row,
+    )
     rank_reason = _rank_reason(
         candidate_id=candidate_id,
         objective_score=objective_score,
@@ -322,6 +331,7 @@ def _score_candidate(
         "objective_score": objective_score,
         "aggregate_score": objective_score,
         "posterior_score": posterior_score,
+        "posterior_objective": posterior_objective,
         "score_breakdown": score_breakdown,
         "component_scores": score_breakdown,
         "top_k_rank": index,
@@ -516,6 +526,68 @@ def _build_posterior_score(
     else:
         payload["evidence_status"] = "direct"
     return payload
+
+
+def _normalize_posterior_objective(
+    posterior_score: Dict[str, Any],
+    *,
+    candidate: Dict[str, Any],
+) -> Dict[str, Any]:
+    objective_type = posterior_score.get("objective_type")
+    evidence_sufficiency = _as_float(posterior_score.get("evidence_sufficiency"))
+    aggregate_score = _as_float(posterior_score.get("aggregate_score"))
+    components = {
+        key: dict(posterior_score[key])
+        for key in _POSTERIOR_COMPONENTS
+        if isinstance(posterior_score.get(key), dict)
+    }
+    raw_warnings = posterior_score.get("warnings")
+    warnings = [
+        item for item in raw_warnings if isinstance(item, str)
+    ] if isinstance(raw_warnings, list) else []
+    binding_proxy_fields: list[str] = []
+    binding_proxy_component: str | None = None
+    if objective_type == "binding":
+        binding_proxy_component = "generic_objective"
+        binding_proxy_fields = _present_fields(candidate, ("binding_score", "best_pose"))
+        binding_warning = (
+            "binding objective is represented through generic_objective proxy in v1"
+        )
+        if binding_warning not in warnings:
+            warnings.append(binding_warning)
+    raw_component_weights = posterior_score.get("component_weights")
+    component_weights = (
+        dict(raw_component_weights) if isinstance(raw_component_weights, dict) else {}
+    )
+    raw_evidence_refs = posterior_score.get("evidence_refs")
+    evidence_refs = (
+        list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else []
+    )
+    raw_evidence_status = posterior_score.get("evidence_status")
+    return {
+        "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
+        "aggregate_score": round(min(max(aggregate_score or 0.0, 0.0), 1.0), 6),
+        "components": components,
+        "component_weights": component_weights,
+        "evidence_sufficiency": round(
+            min(
+                max(
+                    evidence_sufficiency if evidence_sufficiency is not None else 0.0,
+                    0.0,
+                ),
+                1.0,
+            ),
+            6,
+        ),
+        "evidence_status": raw_evidence_status if isinstance(raw_evidence_status, str) else "degraded",
+        "objective_type": objective_type if isinstance(objective_type, str) else None,
+        "objective_source": "posterior_objective",
+        "binding_proxy_component": binding_proxy_component,
+        "binding_proxy_fields": binding_proxy_fields,
+        "warnings": warnings,
+        "evidence_refs": evidence_refs,
+        "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
+    }
 
 
 def _quality_score(candidate: Dict[str, Any]) -> float:

--- a/src/adapters/tool_schema_utils.py
+++ b/src/adapters/tool_schema_utils.py
@@ -394,17 +394,24 @@ def build_objective_outputs(
         if isinstance(row.get("evidence_refs"), list) and isinstance(ref, dict)
     ]
     posterior_scores: dict[str, Dict[str, Any]] = {}
+    posterior_objectives: dict[str, Dict[str, Any]] = {}
     for index, row in enumerate(scored_candidates, start=1):
+        candidate_id = str(row.get("candidate_id") or f"candidate_{index}")
         posterior_score = row.get("posterior_score")
         if isinstance(posterior_score, dict):
-            posterior_scores[
-                str(row.get("candidate_id") or f"candidate_{index}")
-            ] = dict(posterior_score)
+            posterior_scores[candidate_id] = dict(posterior_score)
+        posterior_objective = row.get("posterior_objective")
+        if isinstance(posterior_objective, dict):
+            posterior_objectives[candidate_id] = dict(posterior_objective)
     top_posterior_score: Dict[str, Any] = {}
+    top_posterior_objective: Dict[str, Any] = {}
     if top_k_rows:
         raw_top_posterior = top_k_rows[0].get("posterior_score")
         if isinstance(raw_top_posterior, dict):
             top_posterior_score = dict(raw_top_posterior)
+        raw_top_posterior_objective = top_k_rows[0].get("posterior_objective")
+        if isinstance(raw_top_posterior_objective, dict):
+            top_posterior_objective = dict(raw_top_posterior_objective)
     component_weights: Dict[str, Any] = {}
     raw_component_weights = top_posterior_score.get("component_weights")
     if isinstance(raw_component_weights, dict):
@@ -421,6 +428,8 @@ def build_objective_outputs(
         "component_scores": component_scores,
         "posterior_score": top_posterior_score,
         "posterior_scores": posterior_scores,
+        "posterior_objective": top_posterior_objective,
+        "posterior_objectives": posterior_objectives,
         "aggregate_score": top_score,
         "component_weights": component_weights,
         "default_recommendation": default_recommendation,

--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -30,6 +30,21 @@ from src.models.contracts import (
     STATIC_SCORE_METADATA_KEY,
 )
 
+_POSTERIOR_OBJECTIVE_SCHEMA_VERSION = "posterior_objective.v1"
+_POSTERIOR_SCORE_SCHEMA_VERSION = "posterior_score.v1"
+_POSTERIOR_OBJECTIVE_THRESHOLD = 0.30
+_POSTERIOR_OBJECTIVE_SOURCE_REFS = [
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+]
+_POSTERIOR_COMPONENT_KEYS = (
+    "generic_objective",
+    "stability",
+    "function",
+    "novelty",
+    "structure_quality",
+)
+
 
 class CandidateBuilder:
     """构造 PendingActionCandidate 及其审计 metadata。"""
@@ -160,6 +175,8 @@ class CandidateBuilder:
             )
         )
         payload_metadata = object_mapping(cast(object, payload.payload.metadata))
+        posterior_metadata = objective_metadata_from_payload_metadata(payload_metadata)
+        metadata.update(posterior_metadata)
         planner_route = payload_metadata.get("planner_route")
         if isinstance(planner_route, dict):
             metadata["planner_route"] = object_mapping(cast(object, planner_route))
@@ -252,3 +269,88 @@ class CandidateBuilder:
             6,
         )
         return {key: round(value, 6) for key, value in adjusted.items()}
+
+
+def _bounded_optional_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return min(max(parsed, 0.0), 1.0)
+
+
+def _normalize_posterior_objective(raw: object) -> Metadata | None:
+    if not isinstance(raw, Mapping):
+        return None
+    aggregate_score = _bounded_optional_float(raw.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(raw.get("evidence_sufficiency"))
+    if aggregate_score is None or evidence_sufficiency is None:
+        return None
+    schema_version = raw.get("schema_version")
+    if schema_version == _POSTERIOR_OBJECTIVE_SCHEMA_VERSION:
+        normalized = object_mapping(cast(object, raw))
+        normalized["aggregate_score"] = aggregate_score
+        normalized["evidence_sufficiency"] = evidence_sufficiency
+        return normalized
+    if schema_version not in {_POSTERIOR_SCORE_SCHEMA_VERSION, None}:
+        return None
+    components: Metadata = {}
+    for key in _POSTERIOR_COMPONENT_KEYS:
+        component = raw.get(key)
+        if isinstance(component, Mapping):
+            components[key] = object_mapping(cast(object, component))
+    raw_component_weights = raw.get("component_weights")
+    raw_warnings = raw.get("warnings")
+    raw_evidence_refs = raw.get("evidence_refs")
+    raw_evidence_status = raw.get("evidence_status")
+    objective_type = raw.get("objective_type")
+    return {
+        "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
+        "aggregate_score": aggregate_score,
+        "components": components,
+        "component_weights": object_mapping(cast(object, raw_component_weights))
+        if isinstance(raw_component_weights, Mapping)
+        else {},
+        "evidence_sufficiency": evidence_sufficiency,
+        "evidence_status": raw_evidence_status
+        if isinstance(raw_evidence_status, str)
+        else "degraded",
+        "objective_type": objective_type if isinstance(objective_type, str) else None,
+        "objective_source": "posterior_objective",
+        "binding_proxy_component": "generic_objective"
+        if objective_type == "binding"
+        else None,
+        "warnings": list(raw_warnings) if isinstance(raw_warnings, list) else [],
+        "evidence_refs": list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else [],
+        "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
+    }
+
+
+def objective_metadata_from_payload_metadata(payload_metadata: Metadata) -> Metadata:
+    raw = payload_metadata.get("posterior_objective") or payload_metadata.get("posterior_score")
+    posterior = _normalize_posterior_objective(raw)
+    if posterior is None:
+        return {
+            "objective_score_source": "prior_goal_fit",
+            "objective_evidence_sufficiency": 0.5,
+            "objective_evidence_status": "prior",
+        }
+    evidence_sufficiency = _bounded_optional_float(
+        posterior.get("evidence_sufficiency")
+    ) or 0.0
+    raw_evidence_status = posterior.get("evidence_status")
+    objective_source = (
+        "posterior_objective"
+        if evidence_sufficiency >= _POSTERIOR_OBJECTIVE_THRESHOLD
+        else "degraded_proxy"
+    )
+    return {
+        "posterior_objective": posterior,
+        "objective_score_source": objective_source,
+        "objective_evidence_sufficiency": evidence_sufficiency,
+        "objective_evidence_status": raw_evidence_status
+        if isinstance(raw_evidence_status, str)
+        else "degraded",
+    }

--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -36,6 +36,91 @@ from src.models.contracts import (
 ScoredRow = tuple[PendingActionCandidate, SortKey, SortKey, str]
 RankedRow = tuple[PendingActionCandidate, SortKey, str]
 
+CANDIDATE_FEASIBILITY_METADATA_KEY = "candidate_feasibility"
+_SOFT_FEASIBILITY_REASONS = {"io_not_closed", "tool_unavailable"}
+_FEASIBILITY_SOURCE_REFS = [
+    "sid:algo.adaptive.feasibility_filter",
+    "impl:candidate_generator.feasibility.v1",
+]
+_FEASIBILITY_DESIGN_REF_STATUS = {
+    "sid:algo.adaptive.feasibility_filter": "proposed",
+}
+_HARD_FEASIBILITY_CONSTRAINT_CODES = {
+    "tool_not_allowed": "tool.not_allowed",
+    "tool_blocked": "tool.blocked",
+    "safety_level_exceeded": "safety.exceeded",
+    "cost_level_exceeded": "cost.exceeded",
+}
+
+
+def _build_candidate_feasibility_metadata(reason: str | None) -> Metadata:
+    """构造候选硬/软可行性审计元数据。"""
+    constraint_codes = _constraint_codes_for_filter_reason(reason)
+    filter_class = _filter_class_for_reason(reason)
+    hard_feasible = reason is None
+    degraded_feasible = filter_class == "soft"
+    requires_hitl = degraded_feasible
+    auto_executable = hard_feasible and not requires_hitl
+    allowed_for_top_k = filter_class in {"eligible", "soft"}
+    allowed_for_default_recommendation = auto_executable
+    return {
+        "schema_version": "candidate_feasibility.v1",
+        "hard_feasible": hard_feasible,
+        "soft_feasible": filter_class in {"eligible", "soft"},
+        "degraded_feasible": degraded_feasible,
+        "requires_hitl": requires_hitl,
+        "auto_executable": auto_executable,
+        "filter_class": filter_class,
+        "filter_reason": reason,
+        "constraint_codes": constraint_codes,
+        "blocked_by": _blocked_by_for_filter_reason(reason),
+        "allowed_for_top_k": allowed_for_top_k,
+        "allowed_for_default_recommendation": allowed_for_default_recommendation,
+        "explanation": _feasibility_explanation(reason, filter_class),
+        "source_refs": list(_FEASIBILITY_SOURCE_REFS),
+        "design_ref_status": dict(_FEASIBILITY_DESIGN_REF_STATUS),
+    }
+
+
+def _filter_class_for_reason(reason: str | None) -> str:
+    if reason is None:
+        return "eligible"
+    if reason in _SOFT_FEASIBILITY_REASONS:
+        return "soft"
+    return "hard"
+
+
+def _constraint_codes_for_filter_reason(reason: str | None) -> list[str]:
+    if reason is None:
+        return []
+    if reason == "io_not_closed":
+        return ["schema.io_open"]
+    if reason == "tool_unavailable":
+        return ["tool.unavailable"]
+    if reason.startswith("missing_tools:"):
+        return ["tool.missing"]
+    return [_HARD_FEASIBILITY_CONSTRAINT_CODES.get(reason, "unknown")]
+
+
+def _blocked_by_for_filter_reason(reason: str | None) -> list[str]:
+    if reason is None:
+        return []
+    if reason.startswith("missing_tools:"):
+        missing = reason.split(":", 1)[1]
+        return [tool_id for tool_id in missing.split(",") if tool_id]
+    return [reason]
+
+
+def _feasibility_explanation(reason: str | None, filter_class: str) -> str:
+    if filter_class == "eligible":
+        return "Candidate satisfies hard feasibility constraints and can be auto defaulted."
+    if filter_class == "soft":
+        return (
+            "Candidate is degraded feasible for Top-K display only; "
+            f"requires HITL because {reason}."
+        )
+    return f"Candidate is hard infeasible and excluded from Top-K because {reason}."
+
 
 class CandidateGenerator:
     """统一生成 Plan/Patch/Replan Top-K 候选。
@@ -88,16 +173,17 @@ class CandidateGenerator:
                 payload.payload,
                 score_metadata_key=FINAL_SCORE_METADATA_KEY,
             )
+            reason = self._filter_reason(candidate, payload.payload, request, registry_map)
+            candidate = self._with_candidate_feasibility(candidate, reason)
             row = (
                 candidate,
                 static_sort_key,
                 effective_sort_key,
                 candidate.capability_id or "unknown",
             )
-            reason = self._filter_reason(candidate, payload.payload, request, registry_map)
             if reason is not None:
                 filter_reasons.append(reason)
-                if reason in {"io_not_closed", "tool_unavailable"}:
+                if reason in _SOFT_FEASIBILITY_REASONS:
                     soft_filtered_rows.append(row)
                 continue
             filtered_rows.append(row)
@@ -135,8 +221,10 @@ class CandidateGenerator:
 
         candidates = [row[0] for row in selected_rows]
         static_candidates = [row[0] for row in static_selected_rows]
-        default_candidate = candidates[0] if candidates else None
-        static_default_candidate = static_candidates[0] if static_candidates else None
+        default_candidate = self._first_default_recommendation_candidate(candidates)
+        static_default_candidate = self._first_default_recommendation_candidate(
+            static_candidates
+        )
         default_recommendation = (
             default_candidate.candidate_id if default_candidate is not None else None
         )
@@ -165,6 +253,48 @@ class CandidateGenerator:
                 runtime_state_summary=runtime_state_summary,
             ),
         )
+
+    def _with_candidate_feasibility(
+        self,
+        candidate: PendingActionCandidate,
+        reason: str | None,
+    ) -> PendingActionCandidate:
+        metadata = dict(candidate.metadata or {})
+        metadata[CANDIDATE_FEASIBILITY_METADATA_KEY] = (
+            _build_candidate_feasibility_metadata(reason)
+        )
+        return candidate.model_copy(update={"metadata": metadata})
+
+    def _first_default_recommendation_candidate(
+        self,
+        candidates: Sequence[PendingActionCandidate],
+    ) -> PendingActionCandidate | None:
+        for candidate in candidates:
+            metadata = object_mapping(cast(object, candidate.metadata))
+            feasibility = object_mapping(
+                metadata.get(CANDIDATE_FEASIBILITY_METADATA_KEY)
+            )
+            if feasibility.get("allowed_for_default_recommendation") is True:
+                return candidate
+        return None
+
+    def _degraded_candidate_reasons(
+        self,
+        candidates: Sequence[PendingActionCandidate],
+    ) -> list[str]:
+        reasons: list[str] = []
+        for candidate in candidates:
+            metadata = object_mapping(cast(object, candidate.metadata))
+            feasibility = object_mapping(
+                metadata.get(CANDIDATE_FEASIBILITY_METADATA_KEY)
+            )
+            if feasibility.get("degraded_feasible") is not True:
+                continue
+            raw_reason = feasibility.get("filter_reason")
+            reason = raw_reason if isinstance(raw_reason, str) else "unknown"
+            if reason not in reasons:
+                reasons.append(reason)
+        return reasons
 
     def _filter_reason(
         self,
@@ -354,6 +484,17 @@ class CandidateGenerator:
                     default_candidate=default_candidate,
                     static_default_candidate=static_default_candidate,
                 )
+        elif candidates:
+            explanation = (
+                f"{explanation} No hard-feasible default recommendation exists; "
+                "returned degraded candidates require HITL."
+            )
+        degraded_reasons = self._degraded_candidate_reasons(candidates)
+        if degraded_reasons:
+            explanation = (
+                f"{explanation} Returned degraded candidates require HITL because: "
+                f"{', '.join(degraded_reasons)}."
+            )
         difference = candidate_difference_explanation(candidates)
         if difference:
             explanation = f"{explanation} Candidate differences: {difference}."
@@ -364,8 +505,8 @@ class CandidateGenerator:
             )
         elif filter_reasons:
             explanation = (
-                f"{explanation} Filtering would remove all candidates, so the generator "
-                "returned the scored fallback set for compatibility."
+                f"{explanation} Filtering found only degraded soft fallback candidates; "
+                "returned candidates require HITL and are not eligible for automatic default."
             )
         if len(candidates) < request.top_k:
             explanation = (

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -62,6 +62,11 @@ from src.models.validation import (
     validate_candidate_set_output,
     validate_plan_executability,
 )
+from src.models.source_refs import (
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+    as_source_refs,
+)
 from src.models.db import (
     InternalStatus,
     TaskRecord,
@@ -2460,6 +2465,7 @@ def _build_action_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
         source="score_breakdown.overall",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     return summary.model_dump()
 
@@ -2468,6 +2474,7 @@ def _build_static_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
         source="score_breakdown.overall.static.v1",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     return summary.model_dump()
 
@@ -2476,6 +2483,7 @@ def _build_shadow_score_summary(score_breakdown: dict[str, float]) -> dict[str, 
     summary = ScoreSummary(
         value=float(score_breakdown.get("overall", 0.0)),
         source="score_breakdown.overall_passthrough",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     return summary.model_dump()
 
@@ -2503,10 +2511,15 @@ def _build_shadow_passthrough_decision(
     final_score = ScoreSummary(
         value=static_value,
         source="static_score+runtime_adjustment.shadow_passthrough.v1",
+        source_refs=as_source_refs(
+            *SOURCE_REF_STATIC_SCORE,
+            *SOURCE_REF_RUNTIME_ADJUSTMENT,
+        ),
     )
     runtime_adjustment = RuntimeAdjustmentSummary(
         value=0.0,
         source="planner.runtime_adjustment.shadow_passthrough.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=True,
     )
@@ -2584,14 +2597,20 @@ def _build_runtime_shadow_decision(
     final_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"static_score+runtime_adjustment.{action}.v1",
+        source_refs=as_source_refs(
+            *SOURCE_REF_STATIC_SCORE,
+            *SOURCE_REF_RUNTIME_ADJUSTMENT,
+        ),
     )
     shadow_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"score_breakdown.overall+runtime_state.{action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
     )
     runtime_adjustment = RuntimeAdjustmentSummary(
         value=round(delta, 6),
         source=f"planner.runtime_adjustment.{action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=False,
     )

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -165,6 +165,20 @@ _SCORE_WEIGHT_KEY_ALIASES: dict[str, str] = {
     "readiness": "tool_readiness",
     "coverage": "tool_coverage",
 }
+_POSTERIOR_OBJECTIVE_SCHEMA_VERSION = "posterior_objective.v1"
+_POSTERIOR_SCORE_SCHEMA_VERSION = "posterior_score.v1"
+_POSTERIOR_OBJECTIVE_THRESHOLD = 0.30
+_POSTERIOR_OBJECTIVE_SOURCE_REFS = [
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+]
+_POSTERIOR_COMPONENT_KEYS = (
+    "generic_objective",
+    "stability",
+    "function",
+    "novelty",
+    "structure_quality",
+)
 
 _P0_CAPABILITY_REPLACEMENT_MATRIX: dict[str, tuple[str, ...]] = {
     # Requirement-2: P0 capability swap matrix (structure prediction core path)
@@ -2923,6 +2937,83 @@ def _patch_layer_rank(payload: Plan | PlanPatch) -> int:
     return 999
 
 
+def _bounded_optional_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return min(max(parsed, 0.0), 1.0)
+
+
+def _extract_posterior_objective(payload: Plan | PlanPatch) -> dict[str, object] | None:
+    metadata = payload.metadata if isinstance(payload.metadata, dict) else {}
+    raw = metadata.get("posterior_objective") or metadata.get("posterior_score")
+    if not isinstance(raw, dict):
+        return None
+    aggregate_score = _bounded_optional_float(raw.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(raw.get("evidence_sufficiency"))
+    if aggregate_score is None or evidence_sufficiency is None:
+        return None
+    schema_version = raw.get("schema_version")
+    if schema_version == _POSTERIOR_OBJECTIVE_SCHEMA_VERSION:
+        normalized = dict(raw)
+        normalized["aggregate_score"] = aggregate_score
+        normalized["evidence_sufficiency"] = evidence_sufficiency
+        return normalized
+    if schema_version not in {_POSTERIOR_SCORE_SCHEMA_VERSION, None}:
+        return None
+    components = {
+        key: dict(raw[key])
+        for key in _POSTERIOR_COMPONENT_KEYS
+        if isinstance(raw.get(key), dict)
+    }
+    raw_component_weights = raw.get("component_weights")
+    raw_warnings = raw.get("warnings")
+    raw_evidence_refs = raw.get("evidence_refs")
+    raw_evidence_status = raw.get("evidence_status")
+    objective_type = raw.get("objective_type")
+    return {
+        "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
+        "aggregate_score": aggregate_score,
+        "components": components,
+        "component_weights": dict(raw_component_weights)
+        if isinstance(raw_component_weights, dict)
+        else {},
+        "evidence_sufficiency": evidence_sufficiency,
+        "evidence_status": raw_evidence_status
+        if isinstance(raw_evidence_status, str)
+        else "degraded",
+        "objective_type": objective_type if isinstance(objective_type, str) else None,
+        "objective_source": "posterior_objective",
+        "binding_proxy_component": "generic_objective"
+        if objective_type == "binding"
+        else None,
+        "warnings": list(raw_warnings) if isinstance(raw_warnings, list) else [],
+        "evidence_refs": list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else [],
+        "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
+    }
+
+
+def _resolve_objective_score(
+    prior_objective: float,
+    posterior: dict[str, object] | None,
+) -> tuple[float, str, float, str]:
+    if posterior is None:
+        return prior_objective, "prior_goal_fit", 0.5, "prior"
+    aggregate_score = _bounded_optional_float(posterior.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(posterior.get("evidence_sufficiency"))
+    evidence_status_raw = posterior.get("evidence_status")
+    evidence_status = evidence_status_raw if isinstance(evidence_status_raw, str) else "degraded"
+    if aggregate_score is None or evidence_sufficiency is None:
+        return prior_objective, "prior_goal_fit", 0.5, "prior"
+    if evidence_sufficiency >= _POSTERIOR_OBJECTIVE_THRESHOLD:
+        return aggregate_score, "posterior_objective", evidence_sufficiency, evidence_status
+    blended = 0.70 * prior_objective + 0.30 * aggregate_score
+    return min(max(blended, 0.0), 1.0), "degraded_proxy", evidence_sufficiency, evidence_status
+
+
 def _score_payload(
     payload: Plan | PlanPatch,
     registry: Sequence[ToolSpec],
@@ -2958,9 +3049,17 @@ def _score_payload(
     recovery_complexity = max(0.0, min(1.0, 1.0 - fallback_depth))
 
     feasibility = min(1.0, max(0.0, 0.5 + 0.25 * tool_coverage + 0.25 * fallback_depth))
-    objective = min(
+    posterior = _extract_posterior_objective(payload)
+    prior_objective = min(
         1.0,
-        max(0.0, 1.0 - avg_cost * 0.3 + objective_bonus),
+        max(
+            0.0,
+            1.0 - avg_cost * 0.3 + (0.0 if posterior is not None else objective_bonus),
+        ),
+    )
+    objective, _objective_source, evidence_sufficiency, _evidence_status = _resolve_objective_score(
+        prior_objective,
+        posterior,
     )
     risk = max(0.0, 1.0 - avg_risk)
     cost = max(0.0, 1.0 - avg_cost)
@@ -2996,6 +3095,7 @@ def _score_payload(
         "tool_coverage": round(tool_coverage, 6),
         "fallback_depth": round(fallback_depth, 6),
         "recovery_complexity": round(recovery_complexity, 6),
+        "evidence_sufficiency": round(evidence_sufficiency, 6),
         "overall": round(overall, 6),
     }
 

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -547,6 +547,7 @@ class ScoreSummary(BaseModel):
 
     value: float
     source: str
+    source_refs: list[str] = Field(default_factory=list)
 
     @field_validator("value")
     @classmethod
@@ -560,6 +561,14 @@ class ScoreSummary(BaseModel):
     @classmethod
     def _validate_source(cls, value: str) -> str:
         return _validate_non_empty_text(value, field_name="source")
+
+    @field_validator("source_refs")
+    @classmethod
+    def _validate_source_refs(cls, value: list[str]) -> list[str]:
+        return [
+            _validate_non_empty_text(item, field_name="source_refs")
+            for item in value
+        ]
 
 
 class RuntimeAdjustmentFactor(BaseModel):
@@ -591,6 +600,7 @@ class RuntimeAdjustmentSummary(BaseModel):
 
     value: float
     source: str
+    source_refs: list[str] = Field(default_factory=list)
     formula_version: str = "v1"
     shadow_only: bool = True
 
@@ -606,6 +616,14 @@ class RuntimeAdjustmentSummary(BaseModel):
     @classmethod
     def _validate_text(cls, value: str, info) -> str:
         return _validate_non_empty_text(value, field_name=info.field_name)
+
+    @field_validator("source_refs")
+    @classmethod
+    def _validate_source_refs(cls, value: list[str]) -> list[str]:
+        return [
+            _validate_non_empty_text(item, field_name="source_refs")
+            for item in value
+        ]
 
 
 class RerankReason(BaseModel):

--- a/src/models/source_refs.py
+++ b/src/models/source_refs.py
@@ -1,0 +1,97 @@
+"""Source refs 常量与轻量 helper。
+
+本模块只承载设计 SID 与实现引用的短字符串常量，避免在 runtime
+metadata 中散落不可追踪的裸字符串。
+"""
+
+from __future__ import annotations
+
+from typing import Final, Literal, TypeAlias
+
+DesignRefStatus: TypeAlias = Literal["existing", "proposed"]
+DesignRefStatusMap: TypeAlias = dict[str, DesignRefStatus]
+
+SOURCE_REF_FEASIBILITY: Final[tuple[str, ...]] = (
+    "sid:algo.adaptive.feasibility_filter",
+    "impl:candidate_generator.feasibility.v1",
+)
+
+SOURCE_REF_POSTERIOR_OBJECTIVE: Final[tuple[str, ...]] = (
+    "sid:algo.posterior_objective_scoring",
+    "impl:posterior_score.v1",
+    "impl:posterior_objective.v1",
+)
+
+SOURCE_REF_STATIC_SCORE: Final[tuple[str, ...]] = (
+    "sid:algo.adaptive.optimization_objective",
+    "sid:planner.algorithm.candidate_scoring",
+    "impl:planner.score_breakdown.v1",
+)
+
+SOURCE_REF_RUNTIME_ADJUSTMENT: Final[tuple[str, ...]] = (
+    "sid:planner.algorithm.runtime_adjustment_formula",
+    "sid:planner.algorithm.runtime_reranking",
+    "impl:planner.runtime_adjustment.v1",
+)
+
+SOURCE_REF_ACTION_UTILITY: Final[tuple[str, ...]] = (
+    "sid:algo.schema.action_utility",
+    "sid:algo.action_feature_derivation",
+    "impl:runtime_evaluator.action_utility.v1",
+    "impl:workflow.action_features.v1",
+)
+
+SOURCE_REF_DEFAULT_ACTION_UTILITY: Final[tuple[str, ...]] = (
+    "sid:algo.schema.action_utility",
+    "impl:runtime_evaluator.default.v1",
+)
+
+SOURCE_REF_ACTION_SELECTION: Final[tuple[str, ...]] = (
+    "sid:algo.recovery_aware_action_selection",
+    "sid:planner.algorithm.action_priority_resolution",
+    "impl:recovery.select_workflow_action.v1",
+)
+
+SOURCE_REF_TERMINAL_STOP: Final[tuple[str, ...]] = (
+    "sid:algo.terminal_stop_policy",
+    "sid:planner.algorithm.stop_semantics",
+    "impl:recovery.terminal_stop.v1",
+)
+
+PROPOSED_DESIGN_REF_STATUS: Final[DesignRefStatusMap] = {
+    "sid:algo.adaptive.feasibility_filter": "proposed",
+    "sid:algo.posterior_objective_scoring": "proposed",
+    "sid:algo.action_feature_derivation": "proposed",
+    "sid:algo.recovery_aware_action_selection": "proposed",
+    "sid:algo.terminal_stop_policy": "proposed",
+}
+
+
+def as_source_refs(*refs: str) -> list[str]:
+    """返回去重后的 source_refs 列表。
+
+    保持输入顺序并拒绝空字符串；不做复杂 SID/impl 校验，避免在运行期
+    引入额外语义判断。
+    """
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for ref in refs:
+        text = ref.strip()
+        if not text:
+            raise ValueError("source_refs items must not be empty")
+        if text in seen:
+            continue
+        seen.add(text)
+        normalized.append(text)
+    return normalized
+
+
+def design_ref_status_for(*refs: str) -> DesignRefStatusMap:
+    """返回 refs 中 proposed SID 的状态映射。"""
+
+    return {
+        ref: status
+        for ref, status in PROPOSED_DESIGN_REF_STATUS.items()
+        if ref in refs
+    }

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -26,6 +26,13 @@ from src.models.runtime_schemas import (
     ActionUtility,
     RuntimeStateSchema,
 )
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_DEFAULT_ACTION_UTILITY,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+    as_source_refs,
+)
 
 __all__ = [
     "DYNAMIC_OBSERVATION_ONLY",
@@ -348,19 +355,19 @@ class RuntimeEvaluator:
                 action="continue",
                 utility=round(max(0.0, min(1.0, 0.38 * s + 0.14 * e_suff + 0.12 * r_margin - 0.22 * f_param - 0.14 * b)), 6),
                 budget_pressure=bp,
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
             "patch_local": ActionUtility(
                 action="patch_local",
                 utility=round(max(0.0, min(1.0, 0.20 * s + 0.24 * r_margin + 0.18 * lp + 0.12 * er_val - 0.14 * f_param - 0.12 * b)), 6),
                 budget_pressure=bp,
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
             "suffix_replan": ActionUtility(
                 action="suffix_replan",
                 utility=round(max(0.0, min(1.0, 0.18 * (1.0 - s) + 0.20 * f_param + 0.16 * (1.0 - r_margin) + 0.18 * pp + 0.14 * br + 0.14 * gr)), 6),
                 budget_pressure=bp,
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
             "stop": ActionUtility(
                 action="stop",
@@ -368,7 +375,7 @@ class RuntimeEvaluator:
                 budget_pressure=bp,
                 intervention_value=round(iv, 6),
                 terminal_reason="auto_stop: low success, high budget pressure, exhausted recovery margin",
-                source_refs=["runtime_evaluator.action_utility.v1"],
+                source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
             ),
         }
 
@@ -420,7 +427,7 @@ class RuntimeEvaluator:
         return ActionUtility(
             action=action,
             utility=0.5,
-            source_refs=["runtime_evaluator.default.v1"],
+            source_refs=as_source_refs(*SOURCE_REF_DEFAULT_ACTION_UTILITY),
             metadata={"default_reason": reason},
         )
 
@@ -571,18 +578,25 @@ def _attach_rerank_metadata(
     static_score = ScoreSummary(
         value=round(overall, 6),
         source="score_breakdown.overall.static.v1",
+        source_refs=as_source_refs(*SOURCE_REF_STATIC_SCORE),
     )
     final_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"static_score+runtime_adjustment.{shadow_action}.v1",
+        source_refs=as_source_refs(
+            *SOURCE_REF_STATIC_SCORE,
+            *SOURCE_REF_RUNTIME_ADJUSTMENT,
+        ),
     )
     shadow_score = ScoreSummary(
         value=round(adjusted, 6),
         source=f"score_breakdown.overall+runtime_state.{shadow_action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
     )
     runtime_adjustment = RuntimeAdjustmentSummary(
         value=round(delta, 6),
         source=f"planner.runtime_adjustment.{shadow_action}.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=False,
     )

--- a/tests/unit/test_candidate_generator.py
+++ b/tests/unit/test_candidate_generator.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import src.agents.planner as planner_module
+from src.agents.candidate_generator.generator import (
+    CANDIDATE_FEASIBILITY_METADATA_KEY,
+    CandidateGenerator,
+)
+from src.agents.candidate_generator.models import (
+    CandidateGenerationInput,
+    CandidateGeneratorHooks,
+    CandidatePayload,
+)
 from src.agents.planner import PlannerAgent, ToolSpec
-from src.models.contracts import ProteinDesignTask
+from src.models.contracts import (
+    TOOL_READINESS_METADATA_KEY,
+    Plan,
+    PlanStep,
+    ProteinDesignTask,
+)
+
+
+@dataclass(frozen=True)
+class _ShadowDecision:
+    shadow_score: dict[str, object]
+    final_score: dict[str, object]
+    runtime_adjustment: dict[str, object]
+    rerank_reason: dict[str, object]
+    shadow_action: str
+    shadow_reason: str
+    explanation_fragment: str
 
 
 def _registry() -> list[ToolSpec]:
@@ -82,6 +109,100 @@ def _kg() -> dict:
     }
 
 
+def _direct_generator(
+    *,
+    readiness_status: str = "ready",
+    unavailable_tools: set[str] | None = None,
+) -> CandidateGenerator:
+    unavailable_tool_ids = unavailable_tools or set()
+    def score_payload(payload: Plan, *_args: object, **_kwargs: object) -> dict[str, float]:
+        primary_tool = payload.steps[0].tool
+        overall = 0.9 if primary_tool == "seqgen_a" else 0.8
+        return {
+            "feasibility": 0.9,
+            "objective": 0.8,
+            "risk": 0.8,
+            "cost": 0.8,
+            "confidence": 0.8,
+            "overall": overall,
+        }
+
+    def score_summary(score_breakdown: dict[str, float]) -> dict[str, object]:
+        return {"value": score_breakdown["overall"], "source": "unit_test"}
+
+    def readiness_metadata(*, tool_id: str, capability_id: str) -> dict[str, object]:
+        status = "unavailable" if tool_id in unavailable_tool_ids else readiness_status
+        return {
+            TOOL_READINESS_METADATA_KEY: {
+                "tool_id": tool_id,
+                "status": status,
+                "capability_id": capability_id,
+            }
+        }
+
+    def passthrough_shadow(score_breakdown: dict[str, float]) -> _ShadowDecision:
+        return _ShadowDecision(
+            shadow_score={"value": score_breakdown["overall"], "source": "unit_test"},
+            final_score={"value": score_breakdown["overall"], "source": "unit_test"},
+            runtime_adjustment={"value": 0.0, "source": "unit_test"},
+            rerank_reason={"code": "passthrough", "message": "passthrough"},
+            shadow_action="continue",
+            shadow_reason="no runtime state",
+            explanation_fragment="No runtime rerank applied.",
+        )
+
+    def extract_score_value(candidate: object, key: str) -> float:
+        metadata = getattr(candidate, "metadata")
+        summary = metadata[key]
+        if isinstance(summary, dict):
+            value = summary.get("value")
+            if isinstance(value, (int, float)):
+                return float(value)
+        return 0.0
+
+    return CandidateGenerator(
+        CandidateGeneratorHooks(
+            canonical_payload_fingerprint=lambda payload, tool_id, bucket: (
+                f"{tool_id}:{bucket}:{payload.steps[0].id}"
+            ),
+            resolve_score_weights=lambda _constraints: {},
+            score_payload=score_payload,
+            primary_capability=lambda spec: spec.capabilities[0] if spec else "unknown",
+            derive_cost_estimate=lambda _payload, _registry: "low",
+            derive_risk_level=lambda _payload, _registry: "low",
+            stable_candidate_id=lambda kind, _payload, tool_id, bucket: (
+                f"{kind}:{tool_id}:{bucket}"
+            ),
+            build_s5_scoring_contract=lambda _weights: {"weights": {}},
+            build_static_score_summary=score_summary,
+            build_action_score_summary=score_summary,
+            candidate_readiness_metadata=readiness_metadata,
+            build_candidate_summary=lambda payload: payload.steps[0].tool,
+            extract_patch_candidate_metadata=lambda _payload: {},
+            extract_plan_candidate_metadata=lambda _payload: {},
+            normalize_runtime_state_summary_input=lambda _state: None,
+            build_shadow_passthrough_decision=passthrough_shadow,
+            build_runtime_shadow_decision=lambda **_kwargs: passthrough_shadow(
+                {"overall": 0.0}
+            ),
+            priority_rank=lambda _priority: 0,
+            patch_layer_rank=lambda _payload: 0,
+            extract_score_value=extract_score_value,
+            build_default_recommendation_reason=lambda **kwargs: {
+                "candidate_id": kwargs["candidate_id"]
+            },
+            summarize_rerank_reason=lambda _candidate: "rerank summary",
+        )
+    )
+
+
+def _plan(tool_id: str, *, inputs: dict[str, object] | None = None) -> Plan:
+    return Plan(
+        task_id="direct_candidate_generator",
+        steps=[PlanStep(id=f"S_{tool_id}", tool=tool_id, inputs=inputs or {})],
+    )
+
+
 def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     monkeypatch.setenv("PLANNER_LLM_PROVIDER", "none")
     monkeypatch.setattr(planner_module, "load_tool_kg", _kg)
@@ -94,7 +215,11 @@ def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     task = ProteinDesignTask(
         task_id="candidate_generator_context",
         goal="design stable peptide",
-        constraints={"goal_type": "sequence_evaluation", "budget": {"cost_cap": 0.5}},
+        constraints={
+            "goal_type": "legacy_sequence_generation",
+            "inputs": {"sequence": "AAAA"},
+            "budget": {"cost_cap": 0.5},
+        },
         metadata={"planner_capability_hints": ["sequence_generation"]},
     )
 
@@ -108,6 +233,12 @@ def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     assert candidate.metadata["candidate_generator"]["capability_hints"] == [
         "sequence_generation"
     ]
+    feasibility = candidate.metadata[CANDIDATE_FEASIBILITY_METADATA_KEY]
+    assert isinstance(feasibility, dict)
+    assert feasibility["hard_feasible"] is True
+    assert feasibility["auto_executable"] is True
+    assert feasibility["allowed_for_default_recommendation"] is True
+    assert "feasibility" not in candidate.metadata
     assert candidate.score_breakdown["recovery_complexity"] >= 0.0
     assert candidate.score_breakdown["capability_hint_match"] == 1.0
 
@@ -124,7 +255,11 @@ def test_plan_top_k_filters_blocked_tools_before_default_selection(monkeypatch):
     task = ProteinDesignTask(
         task_id="candidate_generator_filter",
         goal="design stable peptide",
-        constraints={"goal_type": "sequence_evaluation", "blocked_tools": ["seqgen_a"]},
+        constraints={
+            "goal_type": "legacy_sequence_generation",
+            "inputs": {"sequence": "AAAA"},
+            "blocked_tools": ["seqgen_a"],
+        },
         metadata={},
     )
 
@@ -133,7 +268,110 @@ def test_plan_top_k_filters_blocked_tools_before_default_selection(monkeypatch):
     assert topk.candidates
     assert all(candidate.tool_id != "seqgen_a" for candidate in topk.candidates)
     assert topk.default_recommendation == topk.candidates[0].candidate_id
+    candidate = topk.candidates[0]
+    feasibility = candidate.metadata[CANDIDATE_FEASIBILITY_METADATA_KEY]
+    assert isinstance(feasibility, dict)
+    assert feasibility["hard_feasible"] is True
+    assert feasibility["auto_executable"] is True
+    assert feasibility["allowed_for_default_recommendation"] is True
+    assert "feasibility" not in candidate.metadata
     assert "Filtered candidates before ranking" in topk.explanation
+
+
+def test_generator_returns_degraded_soft_fallback_without_default():
+    registry = [
+        ToolSpec(
+            id="seqgen_a",
+            capabilities=("sequence_generation",),
+            inputs=("target",),
+            outputs=("sequence",),
+            cost=0.2,
+            safety_level=1,
+            io_type="target_to_sequence",
+            adapter_mode="local",
+            priority="P0",
+        )
+    ]
+    result = _direct_generator().generate(
+        CandidateGenerationInput(
+            candidate_kind="plan",
+            payloads=[
+                CandidatePayload(
+                    payload=_plan("seqgen_a"),
+                    primary_tool_id="seqgen_a",
+                    capability_bucket="sequence_generation",
+                    note="missing target input",
+                )
+            ],
+            registry=registry,
+            top_k=1,
+            task_constraints={},
+        )
+    )
+
+    assert result.candidates
+    assert result.default_recommendation is None
+    candidate = result.candidates[0]
+    feasibility = candidate.metadata[CANDIDATE_FEASIBILITY_METADATA_KEY]
+    assert isinstance(feasibility, dict)
+    assert feasibility["filter_reason"] == "io_not_closed"
+    assert feasibility["filter_class"] == "soft"
+    assert feasibility["hard_feasible"] is False
+    assert feasibility["soft_feasible"] is True
+    assert feasibility["degraded_feasible"] is True
+    assert feasibility["requires_hitl"] is True
+    assert feasibility["auto_executable"] is False
+    assert feasibility["allowed_for_top_k"] is True
+    assert feasibility["allowed_for_default_recommendation"] is False
+    assert feasibility["constraint_codes"] == ["schema.io_open"]
+    assert "feasibility" not in candidate.metadata
+    assert "No hard-feasible default recommendation exists" in result.explanation
+    assert "require HITL" in result.explanation
+
+
+def test_generator_backfills_degraded_candidate_but_keeps_eligible_default():
+    result = _direct_generator(unavailable_tools={"seqgen_b"}).generate(
+        CandidateGenerationInput(
+            candidate_kind="plan",
+            payloads=[
+                CandidatePayload(
+                    payload=_plan("seqgen_a", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_a",
+                    capability_bucket="sequence_generation",
+                    note="eligible candidate",
+                ),
+                CandidatePayload(
+                    payload=_plan("seqgen_b", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_b",
+                    capability_bucket="sequence_generation",
+                    note="degraded candidate",
+                ),
+            ],
+            registry=_registry(),
+            top_k=2,
+            task_constraints={},
+        )
+    )
+
+    assert [candidate.tool_id for candidate in result.candidates] == [
+        "seqgen_a",
+        "seqgen_b",
+    ]
+    assert result.default_recommendation == result.candidates[0].candidate_id
+    eligible_feasibility = result.candidates[0].metadata[
+        CANDIDATE_FEASIBILITY_METADATA_KEY
+    ]
+    assert isinstance(eligible_feasibility, dict)
+    assert eligible_feasibility["allowed_for_default_recommendation"] is True
+    degraded_feasibility = result.candidates[1].metadata[
+        CANDIDATE_FEASIBILITY_METADATA_KEY
+    ]
+    assert isinstance(degraded_feasibility, dict)
+    assert degraded_feasibility["filter_reason"] == "tool_unavailable"
+    assert degraded_feasibility["constraint_codes"] == ["tool.unavailable"]
+    assert degraded_feasibility["requires_hitl"] is True
+    assert degraded_feasibility["auto_executable"] is False
+    assert degraded_feasibility["allowed_for_default_recommendation"] is False
 
 
 def test_plan_top_k_applies_policy_mode_and_cost_filter(monkeypatch):
@@ -149,7 +387,8 @@ def test_plan_top_k_applies_policy_mode_and_cost_filter(monkeypatch):
         task_id="candidate_generator_policy_cost",
         goal="design stable peptide",
         constraints={
-            "goal_type": "sequence_evaluation",
+            "goal_type": "legacy_sequence_generation",
+            "inputs": {"sequence": "AAAA"},
             "policy_mode": "low_cost",
             "max_cost_level": "medium",
         },

--- a/tests/unit/test_contract_source_refs.py
+++ b/tests/unit/test_contract_source_refs.py
@@ -1,0 +1,41 @@
+"""ScoreSummary / RuntimeAdjustmentSummary source_refs 兼容性测试。"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.contracts import RuntimeAdjustmentSummary, ScoreSummary
+from src.models.source_refs import SOURCE_REF_RUNTIME_ADJUSTMENT, as_source_refs
+
+
+def test_score_summary_source_refs_default_factory_keeps_old_constructors() -> None:
+    summary = ScoreSummary(value=0.5, source="score_breakdown.overall.static.v1")
+    assert summary.source_refs == []
+
+
+def test_runtime_adjustment_source_refs_default_factory_keeps_old_constructors() -> None:
+    summary = RuntimeAdjustmentSummary(
+        value=0.1,
+        source="planner.runtime_adjustment.continue.v1",
+    )
+    assert summary.source_refs == []
+
+
+def test_runtime_adjustment_accepts_source_refs() -> None:
+    summary = RuntimeAdjustmentSummary(
+        value=0.1,
+        source="planner.runtime_adjustment.continue.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
+    )
+    assert "sid:planner.algorithm.runtime_adjustment_formula" in summary.source_refs
+    assert "impl:planner.runtime_adjustment.v1" in summary.source_refs
+
+
+def test_score_summary_rejects_empty_source_ref() -> None:
+    with pytest.raises(ValidationError):
+        _ = ScoreSummary(
+            value=0.5,
+            source="score_breakdown.overall.static.v1",
+            source_refs=["sid:algo.adaptive.optimization_objective", " "],
+        )

--- a/tests/unit/test_extended_tool_adapters.py
+++ b/tests/unit/test_extended_tool_adapters.py
@@ -252,6 +252,39 @@ def test_objective_ranker_emits_posterior_score_schema_and_degraded_evidence() -
     assert weights["structure_quality"] == 0.3
     assert metrics["evidence_sufficiency"] == posterior["evidence_sufficiency"]
     assert "posterior_scores" in outputs
+    posterior_objective = cast(dict[str, object], top_k[0]["posterior_objective"])
+    assert posterior_objective["schema_version"] == "posterior_objective.v1"
+    assert posterior_objective["aggregate_score"] == posterior["aggregate_score"]
+    assert posterior_objective["source_refs"] == [
+        "sid:algo.posterior_objective_scoring",
+        "impl:posterior_score.v1",
+    ]
+    assert outputs["posterior_objective"] == posterior_objective
+    assert "posterior_objectives" in outputs
+
+
+def test_objective_ranker_binding_objective_marks_generic_proxy() -> None:
+    adapter = ObjectiveRankerAdapter()
+
+    outputs, _ = adapter.run_local(
+        {
+            "objective_type": "binding",
+            "candidates": [
+                {
+                    "candidate_id": "binder",
+                    "plddt": 82.0,
+                    "binding_score": -9.0,
+                    "best_pose": {"affinity": -9.0},
+                }
+            ],
+        }
+    )
+
+    top_k = cast(list[dict[str, object]], outputs["top_k"])
+    posterior_objective = cast(dict[str, object], top_k[0]["posterior_objective"])
+    assert posterior_objective["objective_type"] == "binding"
+    assert posterior_objective["binding_proxy_component"] == "generic_objective"
+    assert posterior_objective["binding_proxy_fields"] == ["binding_score", "best_pose"]
 
 
 def test_foldseek_adapter_uses_api_by_default_and_emits_structure_similarity_schema(

--- a/tests/unit/test_planner_posterior_objective_scoring.py
+++ b/tests/unit/test_planner_posterior_objective_scoring.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+
+from src.agents.planner import PlannerAgent, ToolSpec
+from src.agents.candidate_generator.builder import objective_metadata_from_payload_metadata
+from src.models.contracts import Plan, PlanStep
+
+
+def _registry() -> list[ToolSpec]:
+    return [
+        ToolSpec(
+            id="objective_ranker",
+            capabilities=("objective_scoring",),
+            inputs=("candidates",),
+            outputs=("top_k", "posterior_objective"),
+            cost=0.4,
+            safety_level=1,
+            io_type="candidates_to_objective_scores_topk",
+            adapter_mode="local",
+            priority="P0",
+        ),
+    ]
+
+
+def _plan(metadata: dict[str, object] | None = None) -> Plan:
+    return Plan(
+        task_id="posterior_scoring",
+        steps=[
+            PlanStep(
+                id="S1",
+                tool="objective_ranker",
+                inputs={"candidates": []},
+            )
+        ],
+        metadata=metadata or {},
+    )
+
+
+def test_score_payload_uses_sufficient_posterior_objective() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+    plan = _plan(
+        {
+            "posterior_objective": {
+                "schema_version": "posterior_objective.v1",
+                "aggregate_score": 0.91,
+                "evidence_sufficiency": 0.73,
+                "evidence_status": "direct",
+            }
+        }
+    )
+
+    score = planner.score_candidate_payload(plan)
+
+    assert score["objective"] == pytest.approx(0.91)
+    assert score["evidence_sufficiency"] == pytest.approx(0.73)
+    assert score["overall"] < 0.91
+
+
+def test_score_payload_blends_degraded_posterior_objective_without_double_bonus() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+    plan = _plan(
+        {
+            "posterior_objective": {
+                "schema_version": "posterior_objective.v1",
+                "aggregate_score": 0.20,
+                "evidence_sufficiency": 0.10,
+                "evidence_status": "degraded",
+            }
+        }
+    )
+
+    score = planner.score_candidate_payload(plan)
+
+    avg_cost = 1.0 - score["cost"]
+    prior_without_objective_ranker_bonus = 1.0 - avg_cost * 0.3
+    expected = 0.70 * prior_without_objective_ranker_bonus + 0.30 * 0.20
+    assert score["objective"] == pytest.approx(expected)
+    assert score["objective"] < prior_without_objective_ranker_bonus
+    assert score["evidence_sufficiency"] == pytest.approx(0.10)
+
+
+def test_score_payload_keeps_prior_goal_fit_when_posterior_absent() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+
+    score = planner.score_candidate_payload(_plan())
+
+    avg_cost = 1.0 - score["cost"]
+    prior_with_objective_ranker_bonus = 1.0 - avg_cost * 0.3 + 0.08
+    assert score["objective"] == pytest.approx(min(1.0, prior_with_objective_ranker_bonus))
+    assert score["evidence_sufficiency"] == pytest.approx(0.5)
+
+
+def test_score_payload_accepts_legacy_posterior_score_metadata() -> None:
+    planner = PlannerAgent(tool_registry=_registry())
+    plan = _plan(
+        {
+            "posterior_score": {
+                "schema_version": "posterior_score.v1",
+                "aggregate_score": 0.77,
+                "evidence_sufficiency": 0.35,
+                "evidence_status": "partial",
+            }
+        }
+    )
+
+    score = planner.score_candidate_payload(plan)
+
+    assert score["objective"] == pytest.approx(0.77)
+    assert score["evidence_sufficiency"] == pytest.approx(0.35)
+
+
+def test_candidate_metadata_records_objective_provenance() -> None:
+    metadata = objective_metadata_from_payload_metadata(
+        {
+            "posterior_objective": {
+                "schema_version": "posterior_objective.v1",
+                "aggregate_score": 0.82,
+                "evidence_sufficiency": 0.44,
+                "evidence_status": "proxy",
+            }
+        }
+    )
+
+    assert metadata["objective_score_source"] == "posterior_objective"
+    assert metadata["objective_evidence_sufficiency"] == pytest.approx(0.44)
+    assert metadata["objective_evidence_status"] == "proxy"
+    posterior = metadata["posterior_objective"]
+    assert isinstance(posterior, dict)
+    assert posterior["schema_version"] == "posterior_objective.v1"
+
+
+def test_candidate_metadata_marks_degraded_proxy_source() -> None:
+    metadata = objective_metadata_from_payload_metadata(
+        {
+            "posterior_score": {
+                "schema_version": "posterior_score.v1",
+                "aggregate_score": 0.82,
+                "evidence_sufficiency": 0.12,
+                "evidence_status": "degraded",
+            }
+        }
+    )
+
+    assert metadata["objective_score_source"] == "degraded_proxy"
+    assert metadata["objective_evidence_sufficiency"] == pytest.approx(0.12)

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -12,6 +12,10 @@ from src.models.contracts import (
     RUNTIME_ADJUSTMENT_METADATA_KEY,
 )
 from src.models.runtime_schemas import RuntimeStateSchema
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+)
 from src.workflow.runtime_evaluator import (
     DYNAMIC_OBSERVATION_ONLY,
     LITE_BELIEF_STATE,
@@ -193,6 +197,10 @@ class TestRerank:
         assert isinstance(adj, dict)
         # 高 p_success 应产生正调整
         assert adj["value"] > 0.01
+        refs = cast(list[str], adj["source_refs"])
+        assert "sid:planner.algorithm.runtime_adjustment_formula" in refs
+        assert "impl:planner.runtime_adjustment.v1" in refs
+        assert set(SOURCE_REF_RUNTIME_ADJUSTMENT).issubset(refs)
 
     def test_high_risk_reduces_score(self) -> None:
         e = RuntimeEvaluator()
@@ -279,6 +287,11 @@ class TestActionUtility:
         assert set(utilities.keys()) == {"continue", "patch_local", "suffix_replan", "stop"}
         for u in utilities.values():
             assert 0.0 <= u.utility <= 1.0
+            assert "sid:algo.schema.action_utility" in u.source_refs
+            assert "impl:runtime_evaluator.action_utility.v1" in u.source_refs
+            assert set(SOURCE_REF_ACTION_UTILITY).issubset(u.source_refs)
+            assert any(ref.startswith("sid:") for ref in u.source_refs)
+            assert any(ref.startswith("impl:") for ref in u.source_refs)
 
     def test_stop_utility_higher_under_pressure(self) -> None:
         e = RuntimeEvaluator()

--- a/tests/unit/test_source_refs.py
+++ b/tests/unit/test_source_refs.py
@@ -1,0 +1,52 @@
+"""source_refs 常量与 helper 测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_SELECTION,
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_DEFAULT_ACTION_UTILITY,
+    SOURCE_REF_FEASIBILITY,
+    SOURCE_REF_POSTERIOR_OBJECTIVE,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+    SOURCE_REF_TERMINAL_STOP,
+    as_source_refs,
+    design_ref_status_for,
+)
+
+_REF_GROUPS = (
+    SOURCE_REF_FEASIBILITY,
+    SOURCE_REF_POSTERIOR_OBJECTIVE,
+    SOURCE_REF_STATIC_SCORE,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_DEFAULT_ACTION_UTILITY,
+    SOURCE_REF_ACTION_SELECTION,
+    SOURCE_REF_TERMINAL_STOP,
+)
+
+
+def test_source_ref_groups_have_sid_and_impl() -> None:
+    for refs in _REF_GROUPS:
+        assert all(ref for ref in refs)
+        assert any(ref.startswith("sid:") for ref in refs)
+        assert any(ref.startswith("impl:") for ref in refs)
+        assert all(":proposed" not in ref for ref in refs)
+
+
+def test_as_source_refs_deduplicates_in_order() -> None:
+    assert as_source_refs(" sid:a ", "impl:x", "sid:a") == ["sid:a", "impl:x"]
+
+
+def test_as_source_refs_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="source_refs items must not be empty"):
+        _ = as_source_refs("sid:a", " ")
+
+
+def test_design_ref_status_for_reports_proposed_separately() -> None:
+    assert design_ref_status_for(*SOURCE_REF_ACTION_UTILITY) == {
+        "sid:algo.action_feature_derivation": "proposed",
+    }


### PR DESCRIPTION
## 概述

将 Wave1 三路并行分支合并到 `dev`。

Wave1 实现了 CEBRA-WP 算法 P0 阶段的三个核心能力：算法/设计文档 traceability、候选可行性元数据、后验目标评分接入。三个分支已无冲突地合并到 `wave1-integration`，现整体合入 `dev`。

## 包含 PR

| PR | 分支 | 标题 | 合并状态 |
|---:|:---|---:|:---:|
| #350 | `feat/p0-source-refs` → integration | feat(algorithm): add source refs traceability | ✅ 已合并 |
| #351 | `feat/p0-feasibility-metadata` → integration | feat(planner): add candidate feasibility metadata | ✅ 已合并 |
| #352 | `feat/p0-posterior-objective` → integration | feat(objective): connect posterior objective scoring | ✅ 已合并 |

## 改动摘要（+1140 / -21，15 个文件）

### Lane A — 候选可行性元数据（feasibility-metadata）

- `src/agents/candidate_generator/generator.py`：注入 `metadata.candidate_feasibility`，区分 hard feasible / degraded feasible / infeasible
- degraded 候选标记为 `requires_hitl = true, auto_executable = false, allowed_for_default_recommendation = false`
- `default_recommendation` 不再无条件取 `candidates[0]`，改为从允许默认推荐的候选中选择
- 扩展 `tests/unit/test_candidate_generator.py`

### Lane B — 后验目标评分接入（posterior-objective）

- `ObjectiveRankerAdapter` 输出新增 `posterior_objective.v1`
- `tool_schema_utils.py` 传播后验目标输出
- `candidate_generator/builder.py` 提取后验目标 provenance 写入候选 metadata
- `planner.py::_score_payload()`：evidence 充足用 posterior，降级时 0.70/0.30 blend，缺失保留原逻辑
- 新增 `tests/unit/test_planner_posterior_objective_scoring.py`

### Lane C — 算法/代码 source refs 追踪（source-refs）

- 新增 `src/models/source_refs.py`：集中定义 design SID + implementation refs 常量，提供 `design_ref_status_for()`
- `ScoreSummary` / `RuntimeAdjustmentSummary` 增加 `source_refs: list[str]`
- `RuntimeEvaluator.compute_action_utilities()` 增加 `sid:` + `impl:` 双引用
- `planner.py` 各 score summary 增加 source refs
- 更新 `docs/algorithm-and-llm/core-algorithm-design-code-traceability.md`
- 新增/扩展 `tests/unit/test_source_refs.py` 等 3 个测试文件

### 文档

- `docs/algorithm-and-llm/core-algorithm-design-code-traceability.md`：新增 source_refs / SID 追踪规范表格

## 影响范围

```
src/                                      │ test 文件
├── adapters/                             ├── tests/unit/
│   ├── objective_ranker_adapter.py        │   ├── test_candidate_generator.py
│   └── tool_schema_utils.py               │   ├── test_contract_source_refs.py
├── agents/                               │   ├── test_extended_tool_adapters.py
│   ├── candidate_generator/              │   ├── test_planner_posterior_objective_scoring.py
│   │   ├── builder.py                    │   ├── test_runtime_evaluator.py
│   │   └── generator.py                  │   └── test_source_refs.py
│   └── planner.py                        │
├── models/                               │
│   ├── contracts.py                      │
│   ├── source_refs.py (+)                │
└── workflow/                             │
    └── runtime_evaluator.py              │
```

## 已知风险

- `src/agents/planner.py` 在三路均被修改，但在 `wave1-integration` 中已通过 GitHub merge commits 无冲突解决
- `basedpyright` 对 `planner.py` / `objective_ranker_adapter.py` 存在基线类型债务（非本 PR 引入），已记录到 Lane B PR body
- 三个 Lane 的改动都不涉及 FSM 语义、HITL 决策、recovery 逻辑或 schema 破坏性变更
- 没有修改 `../thesis-project.design` 仓库

## 测试

三路分支各自运行通过：

```text
Lane A (feasibility):   5 passed, 1 warning
Lane B (posterior):   19 passed, 1 warning
Lane C (source refs): 37 passed, 1 warning
```

**基于 pyproject.toml 中基于当前类型复杂度设置的基于pyright的type checking baseline 可能存在 Type checking warning，不影响运行时语义。**
