### PR TITLE
feat: derive stable action-utility features from workflow state (#336)

### DIFF
--- a/src/workflow/action_features.py
+++ b/src/workflow/action_features.py
@@ -1,0 +1,501 @@
+"""恢复动作效用特征的确定性派生规则。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from src.models.runtime_schemas import JsonObject
+from src.workflow.errors import FailureType
+
+FeatureSource = Literal["observed", "inferred", "default", "unknown"]
+
+ACTION_FEATURE_NAMES: tuple[str, ...] = (
+    "budget_pressure",
+    "local_patchability",
+    "evidence_reusability",
+    "prefix_preservability",
+    "budget_relief",
+    "goal_realignment",
+    "safety_terminality",
+    "intervention_value",
+)
+
+ACTION_FEATURE_SOURCE_REFS: tuple[str, ...] = (
+    "sid:algo.action_feature_derivation",
+    "impl:workflow.action_features.v1",
+)
+
+
+@dataclass(frozen=True)
+class DerivedActionFeature:
+    """单个动作效用特征的值与来源。"""
+
+    value: float
+    source: FeatureSource
+    source_fields: tuple[str, ...]
+    reason: str
+
+    def to_metadata(self) -> JsonObject:
+        """返回可写入 ActionUtility metadata 的 JSON 结构。"""
+
+        return {
+            "value": round(self.value, 6),
+            "source": self.source,
+            "source_fields": list(self.source_fields),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class ActionFeatureDerivation:
+    """动作效用特征派生结果。"""
+
+    values: dict[str, float]
+    features: dict[str, DerivedActionFeature]
+    source_refs: tuple[str, ...] = ACTION_FEATURE_SOURCE_REFS
+
+    def features_metadata(self) -> JsonObject:
+        """返回全部派生特征的 JSON metadata。"""
+
+        return {name: feature.to_metadata() for name, feature in self.features.items()}
+
+    def to_metadata(self) -> JsonObject:
+        """返回派生结果的完整 JSON metadata。"""
+
+        return {
+            "features": self.features_metadata(),
+            "source_refs": list(self.source_refs),
+        }
+
+
+def derive_action_features(
+    *,
+    runtime_state: Mapping[str, object],
+    stage_id: str | None = None,
+    failure_type: FailureType | str | None = None,
+    retry_exhausted: bool = False,
+    safety_blocked: bool = False,
+    candidate_summary: Mapping[str, object] | None = None,
+    completed_step_count: int | None = None,
+    failed_step_index: int | None = None,
+) -> ActionFeatureDerivation:
+    """从运行时状态和失败上下文派生动作效用特征。
+
+    Args:
+        runtime_state: 当前运行时状态摘要。
+        stage_id: 失败或决策所在阶段。
+        failure_type: 失败类型。
+        retry_exhausted: 当前步骤是否已耗尽 retry。
+        safety_blocked: SafetyAgent 是否阻止继续。
+        candidate_summary: 候选或目标评分摘要。
+        completed_step_count: 已完成步骤数。
+        failed_step_index: 失败步骤索引。
+
+    Returns:
+        带 value/source/source_fields/reason 的派生结果。
+    """
+
+    normalized_failure_type = _normalize_failure_type(failure_type)
+    normalized_stage = _normalize_text(stage_id)
+    candidate = candidate_summary or {}
+
+    p_success = _unit_or_default(runtime_state.get("p_success"), 0.5)
+    p_structural_failure = _unit_or_default(
+        runtime_state.get("p_structural_failure"), 0.25
+    )
+    recovery_margin = _unit_or_default(runtime_state.get("recovery_margin"), 0.6)
+    expected_remaining_cost = _float_or_default(
+        runtime_state.get("expected_remaining_cost"), 1.0
+    )
+    evidence_sufficiency = _unit_or_default(
+        runtime_state.get("evidence_sufficiency"), 0.5
+    )
+    has_context = _has_contextual_signal(
+        runtime_state=runtime_state,
+        candidate_summary=candidate_summary,
+        stage_id=normalized_stage,
+        failure_type=normalized_failure_type,
+        retry_exhausted=retry_exhausted,
+        safety_blocked=safety_blocked,
+        completed_step_count=completed_step_count,
+        failed_step_index=failed_step_index,
+    )
+
+    features: dict[str, DerivedActionFeature] = {}
+
+    budget_pressure = _observed_or_none(runtime_state, "budget_pressure")
+    if budget_pressure is not None:
+        features["budget_pressure"] = _feature(
+            budget_pressure,
+            "observed",
+            ("runtime_state.budget_pressure",),
+            "Runtime state provided budget pressure explicitly.",
+            upper=1.5,
+        )
+    else:
+        features["budget_pressure"] = _feature(
+            _clip(expected_remaining_cost, lower=0.0, upper=1.5),
+            "inferred" if "expected_remaining_cost" in runtime_state else "default",
+            ("runtime_state.expected_remaining_cost",),
+            "Budget pressure is clipped from expected remaining cost.",
+            upper=1.5,
+        )
+
+    budget_pressure_value = features["budget_pressure"].value
+
+    local_patchability = _observed_or_none(runtime_state, "local_patchability")
+    if local_patchability is not None:
+        features["local_patchability"] = _feature(
+            local_patchability,
+            "observed",
+            ("runtime_state.local_patchability",),
+            "Runtime state provided local patchability explicitly.",
+        )
+    else:
+        patch_value = (
+            0.45 * recovery_margin
+            + 0.35 * (1.0 - p_structural_failure)
+            + 0.20 * evidence_sufficiency
+        )
+        if normalized_stage == "S1":
+            patch_value += 0.18
+        if normalized_failure_type in {FailureType.RETRYABLE, FailureType.TOOL_ERROR}:
+            patch_value += 0.10
+        if retry_exhausted and not safety_blocked:
+            patch_value += 0.05
+        if safety_blocked:
+            patch_value -= 0.25
+        if normalized_failure_type == FailureType.SAFETY_BLOCK:
+            patch_value -= 0.15
+        features["local_patchability"] = _feature(
+            patch_value,
+            "inferred" if has_context else "default",
+            (
+                "runtime_state.recovery_margin",
+                "runtime_state.p_structural_failure",
+                "runtime_state.evidence_sufficiency",
+                "failure_context.stage_id",
+                "failure_context.failure_type",
+                "failure_context.retry_exhausted",
+                "failure_context.safety_blocked",
+            ),
+            "Local patchability is inferred from recovery headroom, failure pressure, evidence, and failure locality.",
+        )
+
+    prefix_preservability = _observed_or_none(runtime_state, "prefix_preservability")
+    if prefix_preservability is not None:
+        features["prefix_preservability"] = _feature(
+            prefix_preservability,
+            "observed",
+            ("runtime_state.prefix_preservability",),
+            "Runtime state provided prefix preservability explicitly.",
+        )
+    else:
+        prefix_value = (
+            0.50 * recovery_margin
+            + 0.30 * evidence_sufficiency
+            + 0.20 * (1.0 - min(budget_pressure_value, 1.0))
+        )
+        source_fields = [
+            "runtime_state.recovery_margin",
+            "runtime_state.evidence_sufficiency",
+            "derived.budget_pressure",
+        ]
+        if failed_step_index is not None and failed_step_index > 0:
+            prefix_value += 0.10
+            source_fields.append("failure_context.failed_step_index")
+        elif failed_step_index == 0:
+            prefix_value -= 0.15
+            source_fields.append("failure_context.failed_step_index")
+        if completed_step_count is not None and completed_step_count > 0:
+            prefix_value += 0.08
+            source_fields.append("failure_context.completed_step_count")
+        features["prefix_preservability"] = _feature(
+            prefix_value,
+            "inferred" if has_context else "default",
+            tuple(source_fields),
+            "Prefix preservability is inferred from recovery margin, evidence sufficiency, budget pressure, and known execution progress.",
+        )
+
+    evidence_reusability = _observed_or_none(runtime_state, "evidence_reusability")
+    if evidence_reusability is not None:
+        features["evidence_reusability"] = _feature(
+            evidence_reusability,
+            "observed",
+            ("runtime_state.evidence_reusability",),
+            "Runtime state provided evidence reusability explicitly.",
+        )
+    else:
+        candidate_evidence = _nested_numeric(
+            candidate,
+            ("posterior_objective", "evidence_sufficiency"),
+        )
+        if candidate_evidence is not None:
+            features["evidence_reusability"] = _feature(
+                candidate_evidence,
+                "observed",
+                ("candidate_summary.posterior_objective.evidence_sufficiency",),
+                "Candidate posterior objective provided reusable evidence sufficiency.",
+            )
+        else:
+            features["evidence_reusability"] = _feature(
+                0.65 * evidence_sufficiency
+                + 0.35 * features["prefix_preservability"].value,
+                "inferred" if has_context else "default",
+                (
+                    "runtime_state.evidence_sufficiency",
+                    "derived.prefix_preservability",
+                ),
+                "Evidence reusability is inferred from evidence sufficiency and prefix preservability.",
+            )
+
+    budget_relief = _observed_or_none(runtime_state, "budget_relief")
+    if budget_relief is not None:
+        features["budget_relief"] = _feature(
+            budget_relief,
+            "observed",
+            ("runtime_state.budget_relief",),
+            "Runtime state provided budget relief explicitly.",
+        )
+    else:
+        if expected_remaining_cost >= 1.0 and features["prefix_preservability"].value >= 0.55:
+            relief_value = 0.60
+        elif expected_remaining_cost >= 1.0:
+            relief_value = 0.45
+        else:
+            relief_value = 0.35
+        features["budget_relief"] = _feature(
+            relief_value,
+            "inferred" if "expected_remaining_cost" in runtime_state else "default",
+            (
+                "runtime_state.expected_remaining_cost",
+                "derived.prefix_preservability",
+            ),
+            "Budget relief is conservative because suffix replan is not assumed to be free.",
+        )
+
+    goal_realignment = _observed_or_none(runtime_state, "goal_realignment")
+    if goal_realignment is not None:
+        features["goal_realignment"] = _feature(
+            goal_realignment,
+            "observed",
+            ("runtime_state.goal_realignment",),
+            "Runtime state provided goal realignment explicitly.",
+        )
+    else:
+        realignment_value = (
+            0.40 * (1.0 - p_success)
+            + 0.30 * p_structural_failure
+            + 0.30 * (1.0 - evidence_sufficiency)
+        )
+        objective_gap = _nested_numeric(candidate, ("objective_gap",))
+        objective_gap_source = "candidate_summary.objective_gap"
+        if objective_gap is None:
+            objective_gap = _nested_numeric(
+                candidate,
+                ("posterior_objective", "objective_gap"),
+            )
+            objective_gap_source = "candidate_summary.posterior_objective.objective_gap"
+        source_fields = [
+            "runtime_state.p_success",
+            "runtime_state.p_structural_failure",
+            "runtime_state.evidence_sufficiency",
+        ]
+        if objective_gap is not None:
+            realignment_value = max(realignment_value, objective_gap)
+            source_fields.append(objective_gap_source)
+        features["goal_realignment"] = _feature(
+            realignment_value,
+            "inferred" if has_context else "default",
+            tuple(source_fields),
+            "Goal realignment is inferred from low success, structural pressure, missing evidence, and optional objective gap.",
+        )
+
+    safety_terminality = _observed_or_none(runtime_state, "safety_terminality")
+    if safety_terminality is not None:
+        features["safety_terminality"] = _feature(
+            safety_terminality,
+            "observed",
+            ("runtime_state.safety_terminality",),
+            "Runtime state provided safety terminality explicitly.",
+        )
+    else:
+        safety_value = 1.0 if (
+            safety_blocked or normalized_failure_type == FailureType.SAFETY_BLOCK
+        ) else 0.0
+        features["safety_terminality"] = _feature(
+            safety_value,
+            "inferred" if safety_value > 0.0 else "default",
+            (
+                "failure_context.safety_blocked",
+                "failure_context.failure_type",
+            ),
+            "Safety terminality is only high when safety blocks continuation.",
+        )
+
+    intervention_value = _observed_or_none(runtime_state, "intervention_value")
+    if intervention_value is not None:
+        features["intervention_value"] = _feature(
+            intervention_value,
+            "observed",
+            ("runtime_state.intervention_value",),
+            "Runtime state provided intervention value explicitly.",
+        )
+    elif not has_context:
+        features["intervention_value"] = _feature(
+            0.5,
+            "default",
+            (),
+            "No reliable runtime context is available, so intervention value defaults to neutral 0.5.",
+        )
+    else:
+        uncertainty = _clip(
+            1.0 - abs(p_success - (1.0 - p_structural_failure))
+        )
+        manual_salvageability = _clip(
+            0.55 * features["local_patchability"].value
+            + 0.45 * features["prefix_preservability"].value
+        )
+        artifact_salience = _clip(
+            0.60 * evidence_sufficiency + 0.40 * recovery_margin
+        )
+        decision_gap = _clip(
+            0.50 + 0.25 * recovery_margin - 0.25 * min(budget_pressure_value, 1.0)
+        )
+        features["intervention_value"] = _feature(
+            0.30 * uncertainty
+            + 0.25 * manual_salvageability
+            + 0.25 * artifact_salience
+            + 0.20 * decision_gap,
+            "inferred",
+            (
+                "runtime_state.p_success",
+                "runtime_state.p_structural_failure",
+                "runtime_state.evidence_sufficiency",
+                "runtime_state.recovery_margin",
+                "derived.local_patchability",
+                "derived.prefix_preservability",
+                "derived.budget_pressure",
+            ),
+            "Intervention value is inferred from uncertainty, salvageability, artifact salience, and decision gap.",
+        )
+
+    values = {name: features[name].value for name in ACTION_FEATURE_NAMES}
+    return ActionFeatureDerivation(values=values, features=features)
+
+
+def _feature(
+    value: float,
+    source: FeatureSource,
+    source_fields: tuple[str, ...],
+    reason: str,
+    *,
+    upper: float = 1.0,
+) -> DerivedActionFeature:
+    return DerivedActionFeature(
+        value=round(_clip(value, lower=0.0, upper=upper), 6),
+        source=source,
+        source_fields=source_fields,
+        reason=reason,
+    )
+
+
+def _has_contextual_signal(
+    *,
+    runtime_state: Mapping[str, object],
+    candidate_summary: Mapping[str, object] | None,
+    stage_id: str | None,
+    failure_type: FailureType | None,
+    retry_exhausted: bool,
+    safety_blocked: bool,
+    completed_step_count: int | None,
+    failed_step_index: int | None,
+) -> bool:
+    core_fields = {
+        "p_success",
+        "p_structural_failure",
+        "recovery_margin",
+        "expected_remaining_cost",
+        "evidence_sufficiency",
+    }
+    return (
+        bool(core_fields.intersection(runtime_state.keys()))
+        or bool(candidate_summary)
+        or stage_id is not None
+        or failure_type is not None
+        or retry_exhausted
+        or safety_blocked
+        or completed_step_count is not None
+        or failed_step_index is not None
+    )
+
+
+def _observed_or_none(payload: Mapping[str, object], field: str) -> float | None:
+    value = payload.get(field)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return float(value)
+
+
+def _nested_numeric(payload: Mapping[str, object], path: tuple[str, ...]) -> float | None:
+    current: object = dict(payload)
+    for key in path:
+        mapping = _string_mapping(current)
+        if mapping is None:
+            return None
+        current = mapping.get(key)
+    if isinstance(current, bool) or not isinstance(current, int | float):
+        return None
+    return float(current)
+
+
+def _string_mapping(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    raw_mapping = cast(dict[object, object], value)
+    normalized: dict[str, object] = {}
+    for key, item in raw_mapping.items():
+        if not isinstance(key, str):
+            return None
+        normalized[key] = item
+    return normalized
+
+
+def _unit_or_default(value: object, default: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return default
+    return _clip(float(value))
+
+
+def _float_or_default(value: object, default: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return default
+    return float(value)
+
+
+def _clip(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    if value < lower:
+        return lower
+    if value > upper:
+        return upper
+    return value
+
+
+def _normalize_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _normalize_failure_type(value: FailureType | str | None) -> FailureType | None:
+    if isinstance(value, FailureType):
+        return value
+    if isinstance(value, str):
+        try:
+            return FailureType(value)
+        except ValueError:
+            return None
+    return None

--- a/src/workflow/recovery.py
+++ b/src/workflow/recovery.py
@@ -35,6 +35,7 @@ from src.models.runtime_schemas import ActionUtility
 from src.models.source_refs import SOURCE_REF_ACTION_SELECTION, as_source_refs
 from src.storage.log_store import DEFAULT_LOG_DIR, read_event_logs
 from src.storage.snapshot_store import read_latest_snapshot, DEFAULT_SNAPSHOT_DIR
+from src.workflow.action_features import derive_action_features
 from src.workflow.belief_state import update_runtime_state
 from src.workflow.context import WorkflowContext
 from src.workflow.errors import FailureType
@@ -211,31 +212,32 @@ def select_workflow_action(
         runtime_summary.get("recovery_margin"),
         default=0.6,
     )
-    expected_remaining_cost = _safe_float(
-        runtime_summary.get("expected_remaining_cost"),
-        default=1.0,
-    )
     evidence_sufficiency = _safe_float(
         runtime_summary.get("evidence_sufficiency"),
         default=0.5,
     )
-    derived_runtime_features = _derive_runtime_action_features(
-        runtime_summary=runtime_summary,
-        p_success=p_success,
-        p_structural_failure=p_structural_failure,
-        recovery_margin=recovery_margin,
-        expected_remaining_cost=expected_remaining_cost,
-        evidence_sufficiency=evidence_sufficiency,
+    action_feature_derivation = derive_action_features(
+        runtime_state=runtime_summary,
         stage_id=selector_input.stage_id,
         failure_type=selector_input.failure_type,
         retry_exhausted=bool(selector_input.retry_exhausted),
         safety_blocked=bool(selector_input.safety_blocked),
     )
+    derived_runtime_features = action_feature_derivation.values
     budget_pressure = derived_runtime_features["budget_pressure"]
     intervention_value = derived_runtime_features["intervention_value"]
     prefix_preservability = derived_runtime_features["prefix_preservability"]
     local_patchability = derived_runtime_features["local_patchability"]
-    u_stop = derived_runtime_features["u_stop"]
+    safety_terminality = derived_runtime_features["safety_terminality"]
+    u_stop = _clip_float(
+        0.32 * (1.0 - p_success)
+        + 0.24 * min(budget_pressure, 1.0)
+        + 0.18 * (1.0 - recovery_margin)
+        + 0.16 * safety_terminality
+        + 0.10 * (1.0 - intervention_value),
+        lower=0.0,
+        upper=1.0,
+    )
     allow_auto_stop = _safe_bool(
         runtime_summary.get("allow_auto_stop"),
         default=False,
@@ -378,7 +380,10 @@ def select_workflow_action(
         action_utility_source = "input"
     elif runtime_summary:
         evaluator = RuntimeEvaluator(policy_mode=runtime_policy)
-        action_utilities = evaluator.compute_action_utilities(runtime_summary)
+        action_utilities = evaluator.compute_action_utilities(
+            runtime_summary,
+            action_features=action_feature_derivation,
+        )
         action_utility_source = "computed"
     else:
         action_utilities = {}
@@ -411,6 +416,8 @@ def select_workflow_action(
             "local_patchability": local_patchability,
             "allow_auto_stop": allow_auto_stop,
             "u_stop": u_stop,
+            "derived_features": action_feature_derivation.features_metadata(),
+            "action_feature_source_refs": list(action_feature_derivation.source_refs),
             "runtime_policy": runtime_policy,
             "belief_state_enabled": not observation_only,
             "runtime_state_summary": runtime_summary or None,
@@ -584,119 +591,6 @@ def _normalize_runtime_state_summary(
     return dict(payload)
 
 
-def _derive_runtime_action_features(
-    *,
-    runtime_summary: dict[str, Any],
-    p_success: float,
-    p_structural_failure: float,
-    recovery_margin: float,
-    expected_remaining_cost: float,
-    evidence_sufficiency: float,
-    stage_id: str | None,
-    failure_type: FailureType | str | None,
-    retry_exhausted: bool,
-    safety_blocked: bool,
-) -> dict[str, float]:
-    budget_pressure = _safe_float(
-        runtime_summary.get("budget_pressure"),
-        default=_clip_float(expected_remaining_cost, lower=0.0, upper=1.5),
-    )
-    local_patchability = _safe_optional_float(
-        runtime_summary.get("local_patchability")
-    )
-    if local_patchability is None:
-        stage_locality_bonus = 0.0
-        normalized_stage = _normalize_text(stage_id)
-        normalized_failure_type = _normalize_failure_type(failure_type)
-        if normalized_stage == "S1":
-            stage_locality_bonus += 0.18
-        if normalized_failure_type in {
-            FailureType.RETRYABLE,
-            FailureType.TOOL_ERROR,
-            FailureType.NON_RETRYABLE,
-        } and not safety_blocked:
-            stage_locality_bonus += 0.08
-        if retry_exhausted and not safety_blocked:
-            stage_locality_bonus += 0.06
-        local_patchability = _clip_float(
-            0.45 * recovery_margin
-            + 0.35 * (1.0 - p_structural_failure)
-            + 0.20 * evidence_sufficiency,
-            lower=0.0,
-            upper=1.0,
-        )
-        local_patchability = _clip_float(
-            local_patchability + stage_locality_bonus,
-            lower=0.0,
-            upper=1.0,
-        )
-    prefix_preservability = _safe_optional_float(
-        runtime_summary.get("prefix_preservability")
-    )
-    if prefix_preservability is None:
-        prefix_preservability = _clip_float(
-            0.50 * recovery_margin
-            + 0.30 * evidence_sufficiency
-            + 0.20 * (1.0 - min(budget_pressure, 1.0)),
-            lower=0.0,
-            upper=1.0,
-        )
-    intervention_value = _safe_optional_float(
-        runtime_summary.get("intervention_value")
-    )
-    if intervention_value is None:
-        uncertainty = _clip_float(
-            1.0 - abs(p_success - (1.0 - p_structural_failure)),
-            lower=0.0,
-            upper=1.0,
-        )
-        manual_salvageability = _clip_float(
-            0.55 * local_patchability + 0.45 * prefix_preservability,
-            lower=0.0,
-            upper=1.0,
-        )
-        artifact_salience = _clip_float(
-            0.60 * evidence_sufficiency + 0.40 * recovery_margin,
-            lower=0.0,
-            upper=1.0,
-        )
-        decision_gap = _clip_float(
-            0.50 + 0.25 * recovery_margin - 0.25 * min(budget_pressure, 1.0),
-            lower=0.0,
-            upper=1.0,
-        )
-        # 中文注释：这里把派生量限制在动作选择现场计算，避免将其误固化为新的主状态。
-        intervention_value = _clip_float(
-            0.30 * uncertainty
-            + 0.25 * manual_salvageability
-            + 0.25 * artifact_salience
-            + 0.20 * decision_gap,
-            lower=0.0,
-            upper=1.0,
-        )
-    u_stop = _safe_optional_float(runtime_summary.get("u_stop"))
-    if u_stop is None:
-        safety_terminality = 1.0 if (
-            safety_blocked or _normalize_failure_type(failure_type) == FailureType.SAFETY_BLOCK
-        ) else 0.0
-        u_stop = _clip_float(
-            0.32 * (1.0 - p_success)
-            + 0.24 * min(budget_pressure, 1.0)
-            + 0.18 * (1.0 - recovery_margin)
-            + 0.16 * safety_terminality
-            + 0.10 * (1.0 - intervention_value),
-            lower=0.0,
-            upper=1.0,
-        )
-    return {
-        "budget_pressure": budget_pressure,
-        "intervention_value": intervention_value,
-        "prefix_preservability": prefix_preservability,
-        "local_patchability": local_patchability,
-        "u_stop": u_stop,
-    }
-
-
 def _normalize_text(value: object) -> str | None:
     if not isinstance(value, str):
         return None
@@ -711,15 +605,6 @@ def _safe_float(value: object, *, default: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
-
-
-def _safe_optional_float(value: object) -> float | None:
-    try:
-        if value is None:
-            return None
-        return float(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _safe_bool(value: object, *, default: bool) -> bool:

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -24,6 +24,7 @@ from src.models.contracts import (
 )
 from src.models.runtime_schemas import (
     ActionUtility,
+    JsonObject,
     RuntimeStateSchema,
 )
 from src.models.source_refs import (
@@ -32,6 +33,10 @@ from src.models.source_refs import (
     SOURCE_REF_RUNTIME_ADJUSTMENT,
     SOURCE_REF_STATIC_SCORE,
     as_source_refs,
+)
+from src.workflow.action_features import (
+    ActionFeatureDerivation,
+    derive_action_features,
 )
 
 __all__ = [
@@ -287,7 +292,11 @@ class RuntimeEvaluator:
             return self._default_action_utility("continue", reason="no runtime state")
 
         # 计算四动作效用
-        utilities = self.compute_action_utilities(state)
+        action_features = derive_action_features(runtime_state=state)
+        utilities = self.compute_action_utilities(
+            state,
+            action_features=action_features,
+        )
 
         # 解析候选建议
         suggested = _top_candidate_action(candidates) if candidates else None
@@ -296,7 +305,7 @@ class RuntimeEvaluator:
         if safety_blocked and "suffix_replan" in _RUNTIME_ACTIONS:
             replan_util = utilities.get("suffix_replan")
             if replan_util is not None and not self._should_auto_stop(
-                utilities, state, allow_auto_stop
+                utilities, state, allow_auto_stop, action_features=action_features
             ):
                 return self._with_hard_constraint(
                     replan_util,
@@ -305,7 +314,9 @@ class RuntimeEvaluator:
                 )
 
         # 硬约束: auto-stop
-        if self._should_auto_stop(utilities, state, allow_auto_stop):
+        if self._should_auto_stop(
+            utilities, state, allow_auto_stop, action_features=action_features
+        ):
             stop_util = utilities.get("stop")
             if stop_util is not None:
                 return self._with_hard_constraint(
@@ -323,6 +334,8 @@ class RuntimeEvaluator:
     def compute_action_utilities(
         self,
         runtime_state: RuntimeStateSchema | Mapping[str, object],
+        *,
+        action_features: ActionFeatureDerivation | None = None,
     ) -> dict[str, ActionUtility]:
         """计算全部四个动作的标准化效用值。
 
@@ -341,16 +354,20 @@ class RuntimeEvaluator:
         f_param = _safe_clip(state.get("p_structural_failure"), 0.25)
         r_margin = _safe_clip(state.get("recovery_margin"), 0.6)
         e_suff = _safe_clip(state.get("evidence_sufficiency"), 0.5)
-        ec = _safe_float(state.get("expected_remaining_cost"), 1.0)
-        b = min(max(ec, 0.0), 1.5)
-
-        lp = _safe_float(state.get("local_patchability"), 0.5)
-        er_val = _safe_float(state.get("evidence_reusability"), 0.5)
-        pp = _safe_float(state.get("prefix_preservability"), 0.5)
-        br = _safe_float(state.get("budget_relief"), 0.5)
-        gr = _safe_float(state.get("goal_realignment"), 0.5)
-        safety_term = _safe_float(state.get("safety_terminality"), 0.0)
-        iv = _safe_float(state.get("intervention_value"), 0.0)
+        derivation = action_features or derive_action_features(runtime_state=state)
+        feature_values = derivation.values
+        lp = feature_values["local_patchability"]
+        er_val = feature_values["evidence_reusability"]
+        pp = feature_values["prefix_preservability"]
+        br = feature_values["budget_relief"]
+        gr = feature_values["goal_realignment"]
+        safety_term = feature_values["safety_terminality"]
+        iv = feature_values["intervention_value"]
+        b = feature_values["budget_pressure"]
+        utility_metadata: JsonObject = {
+            "derived_features": derivation.features_metadata(),
+            "action_feature_source_refs": list(derivation.source_refs),
+        }
 
         bp = round(min(max(b, 0.0), 1.0), 6)
         return {
@@ -359,18 +376,21 @@ class RuntimeEvaluator:
                 utility=round(max(0.0, min(1.0, 0.38 * s + 0.14 * e_suff + 0.12 * r_margin - 0.22 * f_param - 0.14 * b)), 6),
                 budget_pressure=bp,
                 source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
+                metadata=utility_metadata,
             ),
             "patch_local": ActionUtility(
                 action="patch_local",
                 utility=round(max(0.0, min(1.0, 0.20 * s + 0.24 * r_margin + 0.18 * lp + 0.12 * er_val - 0.14 * f_param - 0.12 * b)), 6),
                 budget_pressure=bp,
                 source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
+                metadata=utility_metadata,
             ),
             "suffix_replan": ActionUtility(
                 action="suffix_replan",
                 utility=round(max(0.0, min(1.0, 0.18 * (1.0 - s) + 0.20 * f_param + 0.16 * (1.0 - r_margin) + 0.18 * pp + 0.14 * br + 0.14 * gr)), 6),
                 budget_pressure=bp,
                 source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
+                metadata=utility_metadata,
             ),
             "stop": ActionUtility(
                 action="stop",
@@ -379,6 +399,7 @@ class RuntimeEvaluator:
                 intervention_value=round(iv, 6),
                 terminal_reason="auto_stop: low success, high budget pressure, exhausted recovery margin",
                 source_refs=as_source_refs(*SOURCE_REF_ACTION_UTILITY),
+                metadata=utility_metadata,
             ),
         }
 
@@ -389,6 +410,8 @@ class RuntimeEvaluator:
         utilities: dict[str, ActionUtility],
         state: dict[str, object],
         allow_auto_stop: bool,
+        *,
+        action_features: ActionFeatureDerivation | None = None,
     ) -> bool:
         if not allow_auto_stop:
             return False
@@ -396,10 +419,10 @@ class RuntimeEvaluator:
         if stop_u is None:
             return False
         s = _safe_clip(state.get("p_success"), 0.5)
-        ec = _safe_float(state.get("expected_remaining_cost"), 1.0)
-        b = min(max(ec, 0.0), 1.5)
         r_margin = _safe_clip(state.get("recovery_margin"), 0.6)
-        iv = _safe_float(state.get("intervention_value"), 0.0)
+        derivation = action_features or derive_action_features(runtime_state=state)
+        b = derivation.values["budget_pressure"]
+        iv = derivation.values["intervention_value"]
         return (
             stop_u.utility >= 0.72
             and s <= _STOP_P_SUCCESS_THRESHOLD

--- a/tests/unit/test_action_features.py
+++ b/tests/unit/test_action_features.py
@@ -1,0 +1,130 @@
+import pytest
+
+from src.workflow.action_features import ACTION_FEATURE_NAMES, derive_action_features
+from src.workflow.errors import FailureType
+
+
+@pytest.mark.unit
+def test_derives_all_required_features_with_sources():
+    derivation = derive_action_features(runtime_state={})
+
+    assert set(derivation.values) == set(ACTION_FEATURE_NAMES)
+    assert derivation.values["intervention_value"] == pytest.approx(0.5)
+    for name in ACTION_FEATURE_NAMES:
+        feature = derivation.features[name]
+        assert 0.0 <= feature.value <= 1.5
+        assert feature.source in {"observed", "inferred", "default", "unknown"}
+        assert isinstance(feature.source_fields, tuple)
+        assert feature.reason
+
+
+@pytest.mark.unit
+def test_intervention_value_is_inferred_when_context_is_available():
+    derivation = derive_action_features(
+        runtime_state={
+            "p_success": 0.18,
+            "p_structural_failure": 0.62,
+            "recovery_margin": 0.12,
+            "expected_remaining_cost": 1.1,
+            "evidence_sufficiency": 0.66,
+        },
+        failure_type=FailureType.NON_RETRYABLE,
+        retry_exhausted=True,
+    )
+
+    feature = derivation.features["intervention_value"]
+    assert feature.source == "inferred"
+    assert feature.value > 0.0
+    assert "derived.local_patchability" in feature.source_fields
+
+
+@pytest.mark.unit
+def test_safety_block_sets_safety_terminality():
+    derivation = derive_action_features(
+        runtime_state={"p_success": 0.5},
+        failure_type=FailureType.SAFETY_BLOCK,
+        safety_blocked=True,
+    )
+
+    feature = derivation.features["safety_terminality"]
+    assert feature.value == pytest.approx(1.0)
+    assert feature.source == "inferred"
+
+
+@pytest.mark.unit
+def test_retryable_tool_error_increases_local_patchability():
+    base = derive_action_features(
+        runtime_state={
+            "recovery_margin": 0.4,
+            "p_structural_failure": 0.4,
+            "evidence_sufficiency": 0.5,
+        }
+    )
+    retryable = derive_action_features(
+        runtime_state={
+            "recovery_margin": 0.4,
+            "p_structural_failure": 0.4,
+            "evidence_sufficiency": 0.5,
+        },
+        failure_type=FailureType.TOOL_ERROR,
+        retry_exhausted=True,
+    )
+
+    assert retryable.values["local_patchability"] > base.values["local_patchability"]
+
+
+@pytest.mark.unit
+def test_failed_suffix_step_increases_prefix_preservability():
+    first_step = derive_action_features(
+        runtime_state={
+            "recovery_margin": 0.5,
+            "evidence_sufficiency": 0.5,
+            "expected_remaining_cost": 0.5,
+        },
+        failed_step_index=0,
+    )
+    suffix_step = derive_action_features(
+        runtime_state={
+            "recovery_margin": 0.5,
+            "evidence_sufficiency": 0.5,
+            "expected_remaining_cost": 0.5,
+        },
+        completed_step_count=2,
+        failed_step_index=2,
+    )
+
+    assert suffix_step.values["prefix_preservability"] > first_step.values["prefix_preservability"]
+
+
+@pytest.mark.unit
+def test_high_budget_pressure_does_not_default_to_high_budget_relief():
+    derivation = derive_action_features(
+        runtime_state={
+            "expected_remaining_cost": 1.2,
+            "recovery_margin": 0.1,
+            "evidence_sufficiency": 0.2,
+        }
+    )
+
+    assert derivation.values["budget_relief"] == pytest.approx(0.45)
+    assert derivation.features["budget_relief"].source == "inferred"
+
+
+@pytest.mark.unit
+def test_observed_values_take_priority():
+    derivation = derive_action_features(
+        runtime_state={
+            "local_patchability": 0.2,
+            "intervention_value": 0.1,
+            "safety_terminality": 0.0,
+        },
+        failure_type=FailureType.SAFETY_BLOCK,
+        safety_blocked=True,
+    )
+
+    assert derivation.values["local_patchability"] == pytest.approx(0.2)
+    assert derivation.features["local_patchability"].source == "observed"
+    assert derivation.values["intervention_value"] == pytest.approx(0.1)
+    assert derivation.features["intervention_value"].source == "observed"
+    assert derivation.values["safety_terminality"] == pytest.approx(0.0)
+    assert derivation.features["safety_terminality"].source == "observed"

--- a/tests/unit/test_recovery_selector.py
+++ b/tests/unit/test_recovery_selector.py
@@ -89,9 +89,15 @@ def test_selector_derives_runtime_features_from_core_belief_state_only():
     assert decision.action == "suffix_replan"
     assert decision.evidence_source["budget_pressure"] == pytest.approx(1.1)
     assert decision.evidence_source["evidence_sufficiency"] == pytest.approx(0.66)
-    assert decision.evidence_source["local_patchability"] == pytest.approx(0.459, rel=1e-3)
+    assert decision.evidence_source["local_patchability"] == pytest.approx(0.369, rel=1e-3)
     assert decision.evidence_source["prefix_preservability"] == pytest.approx(0.258, rel=1e-3)
-    assert decision.evidence_source["intervention_value"] == pytest.approx(0.4991375, rel=1e-3)
+    assert decision.evidence_source["intervention_value"] == pytest.approx(0.4867625, rel=1e-3)
+    derived = decision.evidence_source["derived_features"]
+    assert derived["local_patchability"]["source"] == "inferred"
+    assert derived["intervention_value"]["source"] == "inferred"
+    assert "sid:algo.action_feature_derivation" in decision.evidence_source[
+        "action_feature_source_refs"
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import cast
 
+import pytest
+
 from src.models.contracts import (
     FINAL_SCORE_METADATA_KEY,
     PendingActionCandidate,
@@ -25,6 +27,7 @@ from src.workflow.runtime_evaluator import (
     evaluator_policy_trace,
     policy_disables_rerank,
 )
+from src.workflow.action_features import derive_action_features
 
 
 def _plan_payload(task_id: str = "test_task") -> Plan:
@@ -292,6 +295,11 @@ class TestActionUtility:
             assert set(SOURCE_REF_ACTION_UTILITY).issubset(u.source_refs)
             assert any(ref.startswith("sid:") for ref in u.source_refs)
             assert any(ref.startswith("impl:") for ref in u.source_refs)
+            assert "derived_features" in u.metadata
+            derived = u.metadata["derived_features"]
+            assert isinstance(derived, dict)
+            assert "local_patchability" in derived
+            assert "source" in derived["local_patchability"]
 
     def test_stop_utility_higher_under_pressure(self) -> None:
         e = RuntimeEvaluator()
@@ -321,6 +329,44 @@ class TestActionUtility:
         assert set(utilities.keys()) == {"continue", "patch_local", "suffix_replan", "stop"}
         for u in utilities.values():
             assert 0.0 <= u.utility <= 1.0
+
+    def test_missing_intervention_value_uses_neutral_default(self) -> None:
+        e = RuntimeEvaluator()
+        utilities = e.compute_action_utilities({})
+
+        stop = utilities["stop"]
+        assert stop.intervention_value == pytest.approx(0.5)
+        derived = stop.metadata["derived_features"]
+        assert derived["intervention_value"]["source"] == "default"
+
+    def test_explicit_action_features_take_priority(self) -> None:
+        e = RuntimeEvaluator()
+        state = {
+            "p_success": 0.6,
+            "p_structural_failure": 0.2,
+            "recovery_margin": 0.6,
+            "expected_remaining_cost": 0.4,
+            "evidence_sufficiency": 0.6,
+        }
+        action_features = derive_action_features(
+            runtime_state={
+                **state,
+                "local_patchability": 0.9,
+                "intervention_value": 0.8,
+            }
+        )
+
+        utilities = e.compute_action_utilities(state, action_features=action_features)
+
+        patch_feature = utilities["patch_local"].metadata["derived_features"][
+            "local_patchability"
+        ]
+        stop_feature = utilities["stop"].metadata["derived_features"][
+            "intervention_value"
+        ]
+        assert patch_feature["value"] == pytest.approx(0.9)
+        assert patch_feature["source"] == "observed"
+        assert stop_feature["value"] == pytest.approx(0.8)
 
     def test_compatibility_select_action_returns_best(self) -> None:
         e = RuntimeEvaluator()


### PR DESCRIPTION
## 变更概要

根据 issue #336 实现稳定的 action-utility features 派生模块，消除硬编码默认值。

### 变更分组

| 批次 | 文件 | 变更类型 |
|------|------|----------|
| 1 | `src/workflow/action_features.py` **(新)** | feat: 新增 `derive_action_features()` + `ActionFeatureDerivation` |
| 2 | `src/workflow/recovery.py` | refactor: 替换 `_derive_runtime_action_features` 为外部模块 |
| 3 | `src/workflow/runtime_evaluator.py` | feat: 集成 `ActionFeatureDerivation`，添加 metadata |
| 4 | `tests/unit/test_action_features.py` **(新)** | test: 新模块单元测试 |
| 5 | `tests/unit/test_recovery_selector.py`, `tests/unit/test_runtime_evaluator.py` | test: 适配新结构和新增测试 case |

### 关键设计

- `ActionFeatureDerivation` 包装 `.values` (dict[str, float]) + `.features_metadata()` (per-feature source tracking) + `.source_refs`
- 每个 feature 标出来源：`observed`（来自 runtime_summary）、`inferred`（公式计算）、`default`（中性回退）
- 消除 `intervention_value=0.0` 的硬编码默认值
- metadata 写入每个 `ActionUtility`，可通过 evidence_source 溯源

Closes #336