### PR TITLE
feat: unify recovery_complexity definition with recoverability complement (#338)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -195,7 +195,7 @@ S_static(pi) = Σ_k w_k score_k(pi)
 | `G_prior` | `score_breakdown.objective` | 当前主要是低成本偏好 + objective_ranker bonus，需增强 |
 | `C_norm` | `1 - score_breakdown.cost` | 成本越高，cost score 越低 |
 | `R_norm` | `1 - score_breakdown.risk` | 风险越高，risk score 越低 |
-| `Rec` | `score_breakdown.recovery_complexity` | 当前等价于 `1 - fallback_depth` |
+| `Rec` | `score_breakdown.recovery_complexity` | 定义为 `1 - recoverability`，其中 `recoverability = 0.30*retry_budget_ratio + 0.30*local_patchability + 0.25*prefix_preservability + 0.15*evidence_reusability`；`fallback_depth` 仅作为 `retry_budget_ratio` 的兼容输入 |
 | `Q` | `confidence/tool_readiness/tool_coverage/fallback_depth` | 工程可靠性补充项 |
 | `S_static` | `score_breakdown.overall` / `static_score` | 静态总分 |
 

--- a/src/agents/candidate_generator/builder.py
+++ b/src/agents/candidate_generator/builder.py
@@ -17,6 +17,10 @@ from src.agents.candidate_generator.models import (
     RuntimeShadowDecisionLike,
     ToolSpecLike,
 )
+from src.agents.candidate_generator.recovery_complexity import (
+    RECOVERY_COMPLEXITY_METADATA_KEY,
+    derive_recovery_complexity,
+)
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     FINAL_SCORE_METADATA_KEY,
@@ -78,6 +82,7 @@ class CandidateBuilder:
             payload.payload,
             request.registry,
             score_weights=score_weights,
+            runtime_state_summary=runtime_state_summary,
         )
         score_breakdown = self._apply_generation_score_adjustments(
             score_breakdown,
@@ -93,6 +98,7 @@ class CandidateBuilder:
             adapter_mode=adapter_mode,
             score_breakdown=score_breakdown,
             score_weights=score_weights,
+            runtime_state_summary=runtime_state_summary,
         )
         shadow = self._build_shadow_metadata(
             payload=payload,
@@ -142,7 +148,10 @@ class CandidateBuilder:
         adapter_mode: str,
         score_breakdown: dict[str, float],
         score_weights: dict[str, float],
+        runtime_state_summary: Metadata | None,
     ) -> Metadata:
+        payload_metadata = object_mapping(cast(object, payload.payload.metadata))
+        posterior_metadata = objective_metadata_from_payload_metadata(payload_metadata)
         metadata: Metadata = {
             "candidate_kind": request.candidate_kind,
             "capability_bucket": capability_id,
@@ -167,6 +176,11 @@ class CandidateBuilder:
             ACTION_SCORE_METADATA_KEY: self._hooks.build_action_score_summary(
                 score_breakdown
             ),
+            RECOVERY_COMPLEXITY_METADATA_KEY: derive_recovery_complexity(
+                fallback_depth=score_breakdown.get("fallback_depth"),
+                runtime_state=runtime_state_summary,
+                candidate_summary=_recovery_candidate_summary(posterior_metadata),
+            ).to_metadata(),
         }
         metadata.update(
             self._hooks.candidate_readiness_metadata(
@@ -174,8 +188,6 @@ class CandidateBuilder:
                 capability_id=capability_id,
             )
         )
-        payload_metadata = object_mapping(cast(object, payload.payload.metadata))
-        posterior_metadata = objective_metadata_from_payload_metadata(payload_metadata)
         metadata.update(posterior_metadata)
         planner_route = payload_metadata.get("planner_route")
         if isinstance(planner_route, dict):
@@ -274,6 +286,8 @@ class CandidateBuilder:
 def _bounded_optional_float(value: object) -> float | None:
     if isinstance(value, bool):
         return None
+    if not isinstance(value, int | float | str):
+        return None
     try:
         parsed = float(value)
     except (TypeError, ValueError):
@@ -284,13 +298,16 @@ def _bounded_optional_float(value: object) -> float | None:
 def _normalize_posterior_objective(raw: object) -> Metadata | None:
     if not isinstance(raw, Mapping):
         return None
-    aggregate_score = _bounded_optional_float(raw.get("aggregate_score"))
-    evidence_sufficiency = _bounded_optional_float(raw.get("evidence_sufficiency"))
+    raw_mapping = cast(Mapping[str, object], raw)
+    aggregate_score = _bounded_optional_float(raw_mapping.get("aggregate_score"))
+    evidence_sufficiency = _bounded_optional_float(
+        raw_mapping.get("evidence_sufficiency")
+    )
     if aggregate_score is None or evidence_sufficiency is None:
         return None
-    schema_version = raw.get("schema_version")
+    schema_version = raw_mapping.get("schema_version")
     if schema_version == _POSTERIOR_OBJECTIVE_SCHEMA_VERSION:
-        normalized = object_mapping(cast(object, raw))
+        normalized = object_mapping(cast(object, raw_mapping))
         normalized["aggregate_score"] = aggregate_score
         normalized["evidence_sufficiency"] = evidence_sufficiency
         return normalized
@@ -298,14 +315,14 @@ def _normalize_posterior_objective(raw: object) -> Metadata | None:
         return None
     components: Metadata = {}
     for key in _POSTERIOR_COMPONENT_KEYS:
-        component = raw.get(key)
+        component = raw_mapping.get(key)
         if isinstance(component, Mapping):
             components[key] = object_mapping(cast(object, component))
-    raw_component_weights = raw.get("component_weights")
-    raw_warnings = raw.get("warnings")
-    raw_evidence_refs = raw.get("evidence_refs")
-    raw_evidence_status = raw.get("evidence_status")
-    objective_type = raw.get("objective_type")
+    raw_component_weights = raw_mapping.get("component_weights")
+    raw_warnings = raw_mapping.get("warnings")
+    raw_evidence_refs = raw_mapping.get("evidence_refs")
+    raw_evidence_status = raw_mapping.get("evidence_status")
+    objective_type = raw_mapping.get("objective_type")
     return {
         "schema_version": _POSTERIOR_OBJECTIVE_SCHEMA_VERSION,
         "aggregate_score": aggregate_score,
@@ -322,8 +339,12 @@ def _normalize_posterior_objective(raw: object) -> Metadata | None:
         "binding_proxy_component": "generic_objective"
         if objective_type == "binding"
         else None,
-        "warnings": list(raw_warnings) if isinstance(raw_warnings, list) else [],
-        "evidence_refs": list(raw_evidence_refs) if isinstance(raw_evidence_refs, list) else [],
+        "warnings": list(cast(list[object], raw_warnings))
+        if isinstance(raw_warnings, list)
+        else [],
+        "evidence_refs": list(cast(list[object], raw_evidence_refs))
+        if isinstance(raw_evidence_refs, list)
+        else [],
         "source_refs": list(_POSTERIOR_OBJECTIVE_SOURCE_REFS),
     }
 
@@ -354,3 +375,10 @@ def objective_metadata_from_payload_metadata(payload_metadata: Metadata) -> Meta
         if isinstance(raw_evidence_status, str)
         else "degraded",
     }
+
+
+def _recovery_candidate_summary(objective_metadata: Metadata) -> Metadata:
+    posterior = objective_metadata.get("posterior_objective")
+    if isinstance(posterior, Mapping):
+        return {"posterior_objective": object_mapping(cast(object, posterior))}
+    return {}

--- a/src/agents/candidate_generator/recovery_complexity.py
+++ b/src/agents/candidate_generator/recovery_complexity.py
@@ -1,0 +1,273 @@
+"""静态候选恢复复杂度的 recoverability 补量派生。"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from src.models.runtime_schemas import (
+    RECOVERY_COMPONENT_WEIGHTS,
+    JsonObject,
+    RecoverySchema,
+)
+from src.workflow.action_features import (
+    ACTION_FEATURE_SOURCE_REFS,
+    FeatureSource,
+    derive_action_features,
+)
+
+RECOVERY_COMPLEXITY_METADATA_KEY = "recovery_complexity_source"
+RECOVERY_COMPLEXITY_SCHEMA_VERSION = "recovery_complexity.v1"
+RECOVERY_COMPLEXITY_FORMULA_VERSION = "recoverability_complement.v1"
+RECOVERY_COMPLEXITY_SOURCE_REFS: tuple[str, ...] = (
+    "sid:algo.schema.recovery",
+    "sid:planner.algorithm.candidate_scoring",
+    "impl:candidate_generator.recovery_complexity.v1",
+)
+RECOVERY_COMPONENT_NAMES: tuple[str, ...] = (
+    "retry_budget_ratio",
+    "local_patchability",
+    "prefix_preservability",
+    "evidence_reusability",
+)
+
+
+@dataclass(frozen=True)
+class DerivedRecoveryComponent:
+    """恢复复杂度分量的值、权重与来源。"""
+
+    value: float
+    weight: float
+    source: FeatureSource
+    source_fields: tuple[str, ...]
+    reason: str
+
+    def to_metadata(self) -> JsonObject:
+        """返回可写入候选 metadata 的 JSON 结构。"""
+
+        return {
+            "value": round(self.value, 6),
+            "weight": self.weight,
+            "source": self.source,
+            "source_fields": list(self.source_fields),
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class RecoveryComplexityDerivation:
+    """恢复性与恢复复杂度的派生结果。"""
+
+    recoverability: float
+    recovery_complexity: float
+    components: dict[str, DerivedRecoveryComponent]
+    source_refs: tuple[str, ...] = RECOVERY_COMPLEXITY_SOURCE_REFS
+
+    def score_values(self) -> dict[str, float]:
+        """返回可并入 score_breakdown 的数值字段。"""
+
+        values = {
+            name: component.value for name, component in self.components.items()
+        }
+        values["recoverability"] = self.recoverability
+        values["recovery_complexity"] = self.recovery_complexity
+        return values
+
+    def to_metadata(self) -> JsonObject:
+        """返回 recovery_complexity 的审计 metadata。"""
+
+        return {
+            "schema_version": RECOVERY_COMPLEXITY_SCHEMA_VERSION,
+            "formula_version": RECOVERY_COMPLEXITY_FORMULA_VERSION,
+            "recoverability": round(self.recoverability, 6),
+            "recovery_complexity": round(self.recovery_complexity, 6),
+            "derived_from": list(RECOVERY_COMPONENT_NAMES),
+            "derived_from_defaults": any(
+                component.source in {"default", "unknown"}
+                for component in self.components.values()
+            ),
+            "fallback_depth_role": "compat_input.retry_budget_ratio",
+            "components": {
+                name: component.to_metadata()
+                for name, component in self.components.items()
+            },
+            "source_refs": list(self.source_refs),
+            "action_feature_source_refs": list(ACTION_FEATURE_SOURCE_REFS),
+        }
+
+
+def derive_recovery_complexity(
+    *,
+    fallback_depth: float | None,
+    runtime_state: Mapping[str, object] | None = None,
+    candidate_summary: Mapping[str, object] | None = None,
+) -> RecoveryComplexityDerivation:
+    """按 Recovery Schema 公式派生静态恢复复杂度。
+
+    Args:
+        fallback_depth: 兼容旧静态评分的 fallback 深度，只作为 retry_budget_ratio
+            的回退输入。
+        runtime_state: 可选运行时状态或 belief-state 摘要。
+        candidate_summary: 可选候选摘要，主要用于复用 posterior evidence。
+
+    Returns:
+        含 recoverability、recovery_complexity 和分量来源的派生结果。
+    """
+
+    normalized_runtime_state = runtime_state or {}
+    action_features = derive_action_features(
+        runtime_state=normalized_runtime_state,
+        candidate_summary=candidate_summary,
+    )
+    retry_budget_ratio = _derive_retry_budget_ratio(
+        fallback_depth=fallback_depth,
+        runtime_state=normalized_runtime_state,
+    )
+    components = {
+        "retry_budget_ratio": retry_budget_ratio,
+        "local_patchability": _action_feature_component(
+            "local_patchability",
+            action_features.features["local_patchability"].value,
+            action_features.features["local_patchability"].source,
+            action_features.features["local_patchability"].source_fields,
+            action_features.features["local_patchability"].reason,
+        ),
+        "prefix_preservability": _action_feature_component(
+            "prefix_preservability",
+            action_features.features["prefix_preservability"].value,
+            action_features.features["prefix_preservability"].source,
+            action_features.features["prefix_preservability"].source_fields,
+            action_features.features["prefix_preservability"].reason,
+        ),
+        "evidence_reusability": _action_feature_component(
+            "evidence_reusability",
+            action_features.features["evidence_reusability"].value,
+            action_features.features["evidence_reusability"].source,
+            action_features.features["evidence_reusability"].source_fields,
+            action_features.features["evidence_reusability"].reason,
+        ),
+    }
+    schema = RecoverySchema(
+        retry_budget_ratio=components["retry_budget_ratio"].value,
+        local_patchability=components["local_patchability"].value,
+        prefix_preservability=components["prefix_preservability"].value,
+        evidence_reusability=components["evidence_reusability"].value,
+    )
+    return RecoveryComplexityDerivation(
+        recoverability=schema.recoverability(),
+        recovery_complexity=schema.recovery_complexity(),
+        components=components,
+    )
+
+
+def _derive_retry_budget_ratio(
+    *,
+    fallback_depth: float | None,
+    runtime_state: Mapping[str, object],
+) -> DerivedRecoveryComponent:
+    observed = _observed_unit(runtime_state, "retry_budget_ratio")
+    if observed is not None:
+        return _component(
+            "retry_budget_ratio",
+            observed,
+            "observed",
+            ("runtime_state.retry_budget_ratio",),
+            "Runtime state provided retry budget ratio explicitly.",
+        )
+    nested = _nested_unit(runtime_state, ("recovery", "retry_budget_ratio"))
+    if nested is not None:
+        return _component(
+            "retry_budget_ratio",
+            nested,
+            "observed",
+            ("runtime_state.recovery.retry_budget_ratio",),
+            "Runtime recovery schema provided retry budget ratio explicitly.",
+        )
+    if fallback_depth is not None:
+        return _component(
+            "retry_budget_ratio",
+            fallback_depth,
+            "inferred",
+            ("score_breakdown.fallback_depth",),
+            "Fallback depth is retained only as a compatibility input for retry budget ratio.",
+        )
+    return _component(
+        "retry_budget_ratio",
+        0.5,
+        "default",
+        (),
+        "No retry budget signal is available, so retry budget ratio defaults to neutral 0.5.",
+    )
+
+
+def _action_feature_component(
+    name: str,
+    value: float,
+    source: FeatureSource,
+    source_fields: tuple[str, ...],
+    reason: str,
+) -> DerivedRecoveryComponent:
+    return _component(name, value, source, source_fields, reason)
+
+
+def _component(
+    name: str,
+    value: float,
+    source: FeatureSource,
+    source_fields: tuple[str, ...],
+    reason: str,
+) -> DerivedRecoveryComponent:
+    return DerivedRecoveryComponent(
+        value=round(_clip_unit(value), 6),
+        weight=RECOVERY_COMPONENT_WEIGHTS[name],
+        source=source,
+        source_fields=source_fields,
+        reason=reason,
+    )
+
+
+def _observed_unit(mapping: Mapping[str, object], key: str) -> float | None:
+    return _unit_or_none(mapping.get(key))
+
+
+def _nested_unit(mapping: Mapping[str, object], path: tuple[str, ...]) -> float | None:
+    current: object = mapping
+    for key in path:
+        current_mapping = _string_mapping(current)
+        if current_mapping is None:
+            return None
+        current = current_mapping.get(key)
+    return _unit_or_none(current)
+
+
+def _string_mapping(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    raw_mapping = cast(dict[object, object], value)
+    normalized: dict[str, object] = {}
+    for key, item in raw_mapping.items():
+        if not isinstance(key, str):
+            return None
+        normalized[key] = item
+    return normalized
+
+
+def _unit_or_none(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return _clip_unit(parsed)
+
+
+def _clip_unit(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -25,6 +25,9 @@ from src.agents.candidate_generator import (
     CandidatePayload,
     TopKResult,
 )
+from src.agents.candidate_generator.recovery_complexity import (
+    derive_recovery_complexity,
+)
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
     CAPABILITY_READINESS_METADATA_KEY,
@@ -3038,6 +3041,7 @@ def _score_payload(
     registry: Sequence[ToolSpec],
     *,
     score_weights: dict[str, float] | None = None,
+    runtime_state_summary: Mapping[str, object] | None = None,
 ) -> dict[str, float]:
     registry_map = {spec.id: spec for spec in registry}
     tool_ids = _extract_payload_tool_ids(payload)
@@ -3065,10 +3069,18 @@ def _score_payload(
     )
     tool_coverage = _tool_coverage_score(tool_ids, capabilities)
     fallback_depth = _fallback_depth_score(tool_ids, registry_map, registry)
-    recovery_complexity = max(0.0, min(1.0, 1.0 - fallback_depth))
-
     feasibility = min(1.0, max(0.0, 0.5 + 0.25 * tool_coverage + 0.25 * fallback_depth))
     posterior = _extract_posterior_objective(payload)
+    candidate_summary: dict[str, object] = {}
+    if posterior is not None:
+        candidate_summary["posterior_objective"] = posterior
+    recovery_derivation = derive_recovery_complexity(
+        fallback_depth=fallback_depth,
+        runtime_state=runtime_state_summary,
+        candidate_summary=candidate_summary,
+    )
+    recovery_score_values = recovery_derivation.score_values()
+    recovery_complexity = recovery_derivation.recovery_complexity
     prior_objective = min(
         1.0,
         max(
@@ -3113,6 +3125,17 @@ def _score_payload(
         "tool_readiness": round(tool_readiness, 6),
         "tool_coverage": round(tool_coverage, 6),
         "fallback_depth": round(fallback_depth, 6),
+        "recoverability": round(recovery_score_values["recoverability"], 6),
+        "retry_budget_ratio": round(recovery_score_values["retry_budget_ratio"], 6),
+        "local_patchability": round(recovery_score_values["local_patchability"], 6),
+        "prefix_preservability": round(
+            recovery_score_values["prefix_preservability"],
+            6,
+        ),
+        "evidence_reusability": round(
+            recovery_score_values["evidence_reusability"],
+            6,
+        ),
         "recovery_complexity": round(recovery_complexity, 6),
         "evidence_sufficiency": round(evidence_sufficiency, 6),
         "overall": round(overall, 6),

--- a/src/models/runtime_schemas.py
+++ b/src/models/runtime_schemas.py
@@ -23,6 +23,12 @@ OBSERVATION_SOURCE_TYPES = (
     "budget",
     "hitl_decision",
 )
+RECOVERY_COMPONENT_WEIGHTS = {
+    "retry_budget_ratio": 0.30,
+    "local_patchability": 0.30,
+    "prefix_preservability": 0.25,
+    "evidence_reusability": 0.15,
+}
 
 type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | JsonObject | JsonArray
@@ -35,6 +41,7 @@ __all__ = [
     "ObservationSchema",
     "ObservationSource",
     "RecoverySchema",
+    "RECOVERY_COMPONENT_WEIGHTS",
     "RiskSchema",
     "RuntimeSchemaFieldMapping",
     "RuntimeStateSchema",
@@ -255,12 +262,7 @@ class RecoverySchema(RuntimeContractBase):
 
         return round(
             _weighted_sum(
-                {
-                    "retry_budget_ratio": 0.30,
-                    "local_patchability": 0.30,
-                    "prefix_preservability": 0.25,
-                    "evidence_reusability": 0.15,
-                },
+                RECOVERY_COMPONENT_WEIGHTS,
                 {
                     "retry_budget_ratio": self.retry_budget_ratio,
                     "local_patchability": self.local_patchability,

--- a/tests/unit/test_candidate_generator.py
+++ b/tests/unit/test_candidate_generator.py
@@ -7,6 +7,9 @@ from src.agents.candidate_generator.generator import (
     CANDIDATE_FEASIBILITY_METADATA_KEY,
     CandidateGenerator,
 )
+from src.agents.candidate_generator.recovery_complexity import (
+    RECOVERY_COMPLEXITY_METADATA_KEY,
+)
 from src.agents.candidate_generator.models import (
     CandidateGenerationInput,
     CandidateGeneratorHooks,
@@ -240,6 +243,17 @@ def test_plan_top_k_uses_candidate_generator_context(monkeypatch):
     assert feasibility["allowed_for_default_recommendation"] is True
     assert "feasibility" not in candidate.metadata
     assert candidate.score_breakdown["recovery_complexity"] >= 0.0
+    recovery_source = candidate.metadata[RECOVERY_COMPLEXITY_METADATA_KEY]
+    assert isinstance(recovery_source, dict)
+    assert recovery_source["recovery_complexity"] == candidate.score_breakdown[
+        "recovery_complexity"
+    ]
+    assert recovery_source["derived_from"] == [
+        "retry_budget_ratio",
+        "local_patchability",
+        "prefix_preservability",
+        "evidence_reusability",
+    ]
     assert candidate.score_breakdown["capability_hint_match"] == 1.0
 
 

--- a/tests/unit/test_recovery_complexity.py
+++ b/tests/unit/test_recovery_complexity.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+import src.agents.planner as planner_module
+from src.agents.candidate_generator.recovery_complexity import (
+    RECOVERY_COMPLEXITY_SCHEMA_VERSION,
+    derive_recovery_complexity,
+)
+from src.agents.planner import ToolSpec
+from src.models.contracts import Plan, PlanStep
+
+
+def test_recovery_complexity_is_recoverability_complement() -> None:
+    derivation = derive_recovery_complexity(
+        fallback_depth=0.25,
+        runtime_state={
+            "local_patchability": 0.80,
+            "prefix_preservability": 0.70,
+            "evidence_reusability": 0.60,
+        },
+    )
+
+    expected_recoverability = 0.30 * 0.25 + 0.30 * 0.80 + 0.25 * 0.70 + 0.15 * 0.60
+
+    assert derivation.recoverability == pytest.approx(expected_recoverability)
+    assert derivation.recovery_complexity == pytest.approx(1.0 - expected_recoverability)
+    assert derivation.components["retry_budget_ratio"].source == "inferred"
+    assert derivation.components["retry_budget_ratio"].source_fields == (
+        "score_breakdown.fallback_depth",
+    )
+
+
+def test_observed_recovery_components_take_priority() -> None:
+    derivation = derive_recovery_complexity(
+        fallback_depth=0.1,
+        runtime_state={
+            "retry_budget_ratio": 0.9,
+            "local_patchability": 0.2,
+            "prefix_preservability": 0.3,
+            "evidence_reusability": 0.4,
+        },
+    )
+
+    assert derivation.components["retry_budget_ratio"].value == pytest.approx(0.9)
+    assert derivation.components["retry_budget_ratio"].source == "observed"
+    assert derivation.components["local_patchability"].source == "observed"
+
+
+def test_missing_evidence_reusability_is_explicit_default() -> None:
+    derivation = derive_recovery_complexity(
+        fallback_depth=0.5,
+        runtime_state={},
+    )
+
+    metadata = derivation.to_metadata()
+
+    assert metadata["schema_version"] == RECOVERY_COMPLEXITY_SCHEMA_VERSION
+    assert metadata["derived_from_defaults"] is True
+    components = metadata["components"]
+    assert isinstance(components, dict)
+    evidence = components["evidence_reusability"]
+    assert isinstance(evidence, dict)
+    assert evidence["source"] == "default"
+
+
+def test_lower_retry_budget_increases_recovery_complexity() -> None:
+    high_retry = derive_recovery_complexity(
+        fallback_depth=0.9,
+        runtime_state={"local_patchability": 0.6, "prefix_preservability": 0.6},
+    )
+    low_retry = derive_recovery_complexity(
+        fallback_depth=0.1,
+        runtime_state={"local_patchability": 0.6, "prefix_preservability": 0.6},
+    )
+
+    assert low_retry.recovery_complexity > high_retry.recovery_complexity
+
+
+def test_higher_local_patchability_lowers_recovery_complexity() -> None:
+    low_patch = derive_recovery_complexity(
+        fallback_depth=0.5,
+        runtime_state={"local_patchability": 0.2},
+    )
+    high_patch = derive_recovery_complexity(
+        fallback_depth=0.5,
+        runtime_state={"local_patchability": 0.8},
+    )
+
+    assert high_patch.recovery_complexity < low_patch.recovery_complexity
+
+
+def test_planner_score_payload_exposes_recoverability_components() -> None:
+    registry = [
+        ToolSpec(
+            id="seqgen_a",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence",),
+        ),
+        ToolSpec(
+            id="seqgen_b",
+            capabilities=("sequence_generation",),
+            inputs=("goal",),
+            outputs=("sequence",),
+        ),
+    ]
+    payload = Plan(
+        task_id="score_recovery_complexity",
+        steps=[PlanStep(id="S1", tool="seqgen_a", inputs={"goal": "stable"})],
+    )
+
+    score = planner_module._score_payload(
+        payload,
+        registry,
+        runtime_state_summary={
+            "p_success": 0.6,
+            "p_structural_failure": 0.1,
+            "recovery_margin": 0.7,
+            "expected_remaining_cost": 0.4,
+            "evidence_sufficiency": 0.8,
+        },
+    )
+
+    expected_recoverability = (
+        0.30 * score["retry_budget_ratio"]
+        + 0.30 * score["local_patchability"]
+        + 0.25 * score["prefix_preservability"]
+        + 0.15 * score["evidence_reusability"]
+    )
+
+    assert score["recoverability"] == pytest.approx(expected_recoverability)
+    assert score["recovery_complexity"] == pytest.approx(1.0 - expected_recoverability)
+    assert score["fallback_depth"] != pytest.approx(score["recoverability"])


### PR DESCRIPTION
## 变更概要

根据 issue #338 实现 recovery_complexity 的 recoverability 补量定义，消除 fallback_depth 作为唯一来源的退化。

### 变更分组

| 批次 | 文件 | 变更类型 |
|------|------|----------|
| 1 | `src/models/runtime_schemas.py` | refactor: `RECOVERY_COMPONENT_WEIGHTS` 常量化 |
| 2 | `src/agents/candidate_generator/recovery_complexity.py` **(新)** | feat: `derive_recovery_complexity()` + `RecoveryComplexityDerivation` |
| 3 | `src/agents/planner.py` | refactor: `_score_payload()` 接入新模块，扩展 score_breakdown |
| 4 | `src/agents/candidate_generator/builder.py` | feat: attach `recovery_complexity_source` metadata |
| 5 | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | docs: 更新 Rec 定义 |
| 6 | `tests/unit/test_recovery_complexity.py` **(新)** | test: 7 个 unit test |
| 7 | `tests/unit/test_candidate_generator.py` | test: 适配 metadata 断言 |

### 关键设计

- `RecoveryComplexityDerivation` 包装 recoverability、recovery_complexity、components（含 source tracking）
- `recovery_complexity = 1 - recoverability`, 其中 recoverability 是 4 个分量的加权和
- `fallback_depth` 仅作为 `retry_budget_ratio` 的兼容输入，不再是唯一来源
- 每个分量标来源：`observed` / `inferred` / `default`
- metadata 含 `derived_from_defaults` 标志

Closes #338