### PR TITLE
feat: introduce ActionBias metadata layer for runtime adjustment (#339)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -435,6 +435,10 @@ bp_t = clip(c_t, 0, 1)
 - suffix_replan 在结构性失败压力高且保留前缀可行时加分；
 - stop 在低成功、高预算、低恢复余量时作为 terminal action，但对普通候选排序可施加保护性惩罚。
 
+实现中该理论对象由 `runtime_adjustment.action_bias` 承载，包含
+`action/value/factors/source_refs`，且 `action_bias.value` 与
+`runtime_adjustment.value` 保持一致。
+
 为了避免单次观测过度影响排序，限定：
 
 ```text
@@ -767,6 +771,7 @@ stop_auto ⇒ allow_auto_stop ∧ U_stop≥τ_stop ∧ s≤τ_s ∧ b≥τ_b ∧
 | `S_static` | `src/agents/planner.py::_score_payload()` | 已实现静态 score_breakdown |
 | `x_t` | `src/workflow/belief_state.py::update_runtime_state()` | 已实现五维 Lite belief-state |
 | `Δ(pi,x_t)` | `src/workflow/runtime_evaluator.py::compute_runtime_delta()` | 已实现 bounded runtime adjustment |
+| `ActionBias(pi,x_t)` | `metadata.runtime_adjustment.action_bias` | 已实现 action/value/factors/source_refs 统一承载 |
 | `U_pi` | `final_score = static_score + runtime_adjustment` | 已实现候选 rerank |
 | `U_a` | `RuntimeEvaluator.compute_action_utilities()` | 已实现四动作效用公式 |
 | hard priorities | `src/workflow/recovery.py::select_workflow_action()` | 已实现 safety/stop/patch/replan 规则 |

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -30,6 +30,7 @@ from src.agents.candidate_generator.recovery_complexity import (
 )
 from src.models.contracts import (
     ACTION_SCORE_METADATA_KEY,
+    ActionBiasSummary,
     CAPABILITY_READINESS_METADATA_KEY,
     DEFAULT_RECOMMENDATION_REASON_METADATA_KEY,
     FINAL_SCORE_METADATA_KEY,
@@ -66,6 +67,7 @@ from src.models.validation import (
     validate_plan_executability,
 )
 from src.models.source_refs import (
+    SOURCE_REF_ACTION_BIAS,
     SOURCE_REF_RUNTIME_ADJUSTMENT,
     SOURCE_REF_STATIC_SCORE,
     as_source_refs,
@@ -2539,6 +2541,7 @@ def _build_shadow_passthrough_decision(
         source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=True,
+        action_bias=_build_action_bias("continue", 0.0, []),
     )
     rerank_reason = RerankReason(
         code="shadow_passthrough",
@@ -2630,6 +2633,7 @@ def _build_runtime_shadow_decision(
         source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=False,
+        action_bias=_build_action_bias(action, delta, factors),
     )
     rerank_reason = RerankReason(
         code=f"shadow_{action}",
@@ -2689,6 +2693,19 @@ def _build_runtime_adjustment_factor(
         source=source,
         contribution=round(contribution, 6),
         message=message,
+    )
+
+
+def _build_action_bias(
+    action: Literal["continue", "patch_local", "suffix_replan", "stop"],
+    value: float,
+    factors: list[RuntimeAdjustmentFactor],
+) -> ActionBiasSummary:
+    return ActionBiasSummary(
+        action=action,
+        value=round(value, 6),
+        factors=factors,
+        source_refs=as_source_refs(*SOURCE_REF_ACTION_BIAS),
     )
 
 

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -593,6 +593,33 @@ class RuntimeAdjustmentFactor(BaseModel):
         return _validate_finite_float_value(value, field_name="contribution")
 
 
+class ActionBiasSummary(BaseModel):
+    """ActionBias 理论对象的运行时元数据承载。"""
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: Literal["continue", "patch_local", "suffix_replan", "stop"]
+    value: float
+    factors: List[RuntimeAdjustmentFactor] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+
+    @field_validator("value")
+    @classmethod
+    def _validate_value(cls, value: float) -> float:
+        normalized = _validate_finite_float_value(value, field_name="value")
+        if not -1.0 <= normalized <= 1.0:
+            raise ValueError("value must be between -1 and 1")
+        return normalized
+
+    @field_validator("source_refs")
+    @classmethod
+    def _validate_source_refs(cls, value: list[str]) -> list[str]:
+        return [
+            _validate_non_empty_text(item, field_name="source_refs")
+            for item in value
+        ]
+
+
 class RuntimeAdjustmentSummary(BaseModel):
     """运行时修正摘要。"""
 
@@ -603,6 +630,7 @@ class RuntimeAdjustmentSummary(BaseModel):
     source_refs: list[str] = Field(default_factory=list)
     formula_version: str = "v1"
     shadow_only: bool = True
+    action_bias: ActionBiasSummary | None = None
 
     @field_validator("value")
     @classmethod

--- a/src/models/source_refs.py
+++ b/src/models/source_refs.py
@@ -34,6 +34,11 @@ SOURCE_REF_RUNTIME_ADJUSTMENT: Final[tuple[str, ...]] = (
     "impl:planner.runtime_adjustment.v1",
 )
 
+SOURCE_REF_ACTION_BIAS: Final[tuple[str, ...]] = (
+    "sid:planner.algorithm.runtime_adjustment_formula",
+    "impl:runtime_evaluator.compute_runtime_delta.v1",
+)
+
 SOURCE_REF_ACTION_UTILITY: Final[tuple[str, ...]] = (
     "sid:algo.schema.action_utility",
     "sid:algo.action_feature_derivation",

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import Literal, cast
 
 from src.models.contracts import (
+    ActionBiasSummary,
     FINAL_SCORE_METADATA_KEY,
     RERANK_REASON_METADATA_KEY,
     RUNTIME_ADJUSTMENT_METADATA_KEY,
@@ -28,6 +29,7 @@ from src.models.runtime_schemas import (
     RuntimeStateSchema,
 )
 from src.models.source_refs import (
+    SOURCE_REF_ACTION_BIAS,
     SOURCE_REF_ACTION_UTILITY,
     SOURCE_REF_DEFAULT_ACTION_UTILITY,
     SOURCE_REF_RUNTIME_ADJUSTMENT,
@@ -61,6 +63,7 @@ _POLICY_MODES = frozenset(
     {STATIC_TOP1, STATIC_GATE, DYNAMIC_OBSERVATION_ONLY, LITE_BELIEF_STATE}
 )
 _RERANK_DISABLED_POLICIES = frozenset({STATIC_TOP1, STATIC_GATE})
+RuntimeActionName = Literal["continue", "patch_local", "suffix_replan", "stop"]
 
 # -- action space ------------------------------------------------------------
 _RUNTIME_ACTIONS = ("continue", "patch_local", "suffix_replan", "stop")
@@ -115,7 +118,7 @@ def compute_runtime_delta(
     feasibility: float,
     candidate_kind: str,
     replan_mode: str = "",
-) -> tuple[float, str, str, list[RuntimeAdjustmentFactor]]:
+) -> tuple[float, RuntimeActionName, str, list[RuntimeAdjustmentFactor]]:
     """计算单个候选的 runtime delta、shadow action、action reason 和因子列表。
 
     供 Planner shadow-rerank hooks 与 RuntimeEvaluator 共享公式。
@@ -555,7 +558,9 @@ def _apply_runtime_adjustment(
 
     return _attach_rerank_metadata(
         candidate, metadata, overall, delta, adjusted, rerank_reason,
-        action, action_reason,
+        action,
+        action_reason,
+        _build_action_bias(action, delta, factors),
     )
 
 
@@ -588,6 +593,7 @@ def _attach_passthrough_metadata(
     return _attach_rerank_metadata(
         candidate, metadata, overall, 0.0, overall, rerank_reason,
         "continue", "runtime_state is not available",
+        _build_action_bias("continue", 0.0, []),
     )
 
 
@@ -600,6 +606,7 @@ def _attach_rerank_metadata(
     rerank_reason: RerankReason,
     shadow_action: str,
     shadow_reason: str,
+    action_bias: ActionBiasSummary,
 ) -> PendingActionCandidate:
     static_score = ScoreSummary(
         value=round(overall, 6),
@@ -625,6 +632,7 @@ def _attach_rerank_metadata(
         source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
         formula_version="v1",
         shadow_only=False,
+        action_bias=action_bias,
     )
 
     metadata[STATIC_SCORE_METADATA_KEY] = static_score.model_dump()
@@ -650,7 +658,7 @@ def _resolve_candidate_action_from_signals(
     p_structural_failure: float,
     recovery_margin: float,
     budget_pressure: float,
-) -> tuple[str, str]:
+) -> tuple[RuntimeActionName, str]:
     if p_success <= _STOP_P_SUCCESS_THRESHOLD and budget_pressure >= _STOP_BUDGET_PRESSURE_THRESHOLD and recovery_margin <= _STOP_RECOVERY_MARGIN_THRESHOLD:
         return ("stop", "success probability is low, budget pressure is high, and recovery headroom is nearly exhausted")
     if candidate_kind == "patch":
@@ -721,6 +729,19 @@ def _make_factor(
         source=source,
         contribution=round(contribution, 6),
         message=message,
+    )
+
+
+def _build_action_bias(
+    action: RuntimeActionName,
+    value: float,
+    factors: list[RuntimeAdjustmentFactor],
+) -> ActionBiasSummary:
+    return ActionBiasSummary(
+        action=action,
+        value=round(value, 6),
+        factors=factors,
+        source_refs=as_source_refs(*SOURCE_REF_ACTION_BIAS),
     )
 
 

--- a/tests/unit/test_action_bias_metadata.py
+++ b/tests/unit/test_action_bias_metadata.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+import src.agents.planner as planner_module
+from src.models.contracts import Plan, PlanStep
+from src.models.source_refs import SOURCE_REF_ACTION_BIAS
+
+
+def test_planner_shadow_runtime_adjustment_carries_action_bias() -> None:
+    payload = Plan(
+        task_id="action_bias_shadow",
+        steps=[PlanStep(id="S1", tool="mock_tool", inputs={})],
+    )
+
+    decision = planner_module._build_runtime_shadow_decision(
+        candidate_kind="patch",
+        payload=payload,
+        score_breakdown={
+            "overall": 0.6,
+            "confidence": 0.7,
+            "risk": 0.5,
+            "cost": 0.5,
+            "fallback_depth": 0.8,
+            "feasibility": 0.7,
+        },
+        runtime_state_summary={
+            "schema_version": 1,
+            "p_success": 0.6,
+            "p_structural_failure": 0.2,
+            "recovery_margin": 0.6,
+            "expected_remaining_cost": 0.4,
+            "evidence_sufficiency": 0.6,
+        },
+    )
+
+    action_bias = decision.runtime_adjustment["action_bias"]
+
+    assert isinstance(action_bias, dict)
+    assert action_bias["action"] == "patch_local"
+    assert action_bias["value"] == pytest.approx(decision.runtime_adjustment["value"])
+    assert action_bias["factors"] == decision.rerank_reason["factors"]
+    assert set(SOURCE_REF_ACTION_BIAS).issubset(set(action_bias["source_refs"]))

--- a/tests/unit/test_contract_source_refs.py
+++ b/tests/unit/test_contract_source_refs.py
@@ -5,8 +5,17 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from src.models.contracts import RuntimeAdjustmentSummary, ScoreSummary
-from src.models.source_refs import SOURCE_REF_RUNTIME_ADJUSTMENT, as_source_refs
+from src.models.contracts import (
+    ActionBiasSummary,
+    RuntimeAdjustmentFactor,
+    RuntimeAdjustmentSummary,
+    ScoreSummary,
+)
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_BIAS,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    as_source_refs,
+)
 
 
 def test_score_summary_source_refs_default_factory_keeps_old_constructors() -> None:
@@ -30,6 +39,32 @@ def test_runtime_adjustment_accepts_source_refs() -> None:
     )
     assert "sid:planner.algorithm.runtime_adjustment_formula" in summary.source_refs
     assert "impl:planner.runtime_adjustment.v1" in summary.source_refs
+
+
+def test_runtime_adjustment_accepts_action_bias() -> None:
+    factor = RuntimeAdjustmentFactor(
+        category="recovery",
+        signal="fallback_depth",
+        source="score_breakdown.fallback_depth",
+        contribution=0.02,
+        message="Local recovery bias.",
+    )
+    action_bias = ActionBiasSummary(
+        action="patch_local",
+        value=0.02,
+        factors=[factor],
+        source_refs=as_source_refs(*SOURCE_REF_ACTION_BIAS),
+    )
+    summary = RuntimeAdjustmentSummary(
+        value=0.02,
+        source="planner.runtime_adjustment.patch_local.v1",
+        source_refs=as_source_refs(*SOURCE_REF_RUNTIME_ADJUSTMENT),
+        action_bias=action_bias,
+    )
+
+    assert summary.action_bias is not None
+    assert summary.action_bias.value == pytest.approx(summary.value)
+    assert "impl:runtime_evaluator.compute_runtime_delta.v1" in summary.action_bias.source_refs
 
 
 def test_score_summary_rejects_empty_source_ref() -> None:

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -11,10 +11,12 @@ from src.models.contracts import (
     PendingActionCandidate,
     Plan,
     PlanStep,
+    RERANK_REASON_METADATA_KEY,
     RUNTIME_ADJUSTMENT_METADATA_KEY,
 )
 from src.models.runtime_schemas import RuntimeStateSchema
 from src.models.source_refs import (
+    SOURCE_REF_ACTION_BIAS,
     SOURCE_REF_ACTION_UTILITY,
     SOURCE_REF_RUNTIME_ADJUSTMENT,
 )
@@ -204,6 +206,49 @@ class TestRerank:
         assert "sid:planner.algorithm.runtime_adjustment_formula" in refs
         assert "impl:planner.runtime_adjustment.v1" in refs
         assert set(SOURCE_REF_RUNTIME_ADJUSTMENT).issubset(refs)
+        action_bias = adj["action_bias"]
+        assert isinstance(action_bias, dict)
+        assert action_bias["value"] == adj["value"]
+        assert action_bias["factors"] == metadata[RERANK_REASON_METADATA_KEY]["factors"]
+        bias_refs = cast(list[str], action_bias["source_refs"])
+        assert set(SOURCE_REF_ACTION_BIAS).issubset(bias_refs)
+
+    def test_action_bias_generated_for_patch_replan_and_stop(self) -> None:
+        evaluator = RuntimeEvaluator()
+        cases = [
+            (
+                _candidate("patch", kind="patch", fallback_depth=0.8),
+                _state(p_success=0.6, recovery_margin=0.6),
+                "patch_local",
+            ),
+            (
+                _candidate("replan", kind="replan", fallback_depth=0.8),
+                _state(p_success=0.6, recovery_margin=0.6),
+                "suffix_replan",
+            ),
+            (
+                _candidate("stop", fallback_depth=0.8),
+                _state(
+                    p_success=0.1,
+                    recovery_margin=0.1,
+                    expected_remaining_cost=1.2,
+                ),
+                "stop",
+            ),
+        ]
+
+        for candidate, state, expected_action in cases:
+            result = evaluator.evaluate_candidates([candidate], state)
+            metadata = dict(result.candidates[0].metadata)
+            adjustment = metadata[RUNTIME_ADJUSTMENT_METADATA_KEY]
+            rerank = metadata[RERANK_REASON_METADATA_KEY]
+            assert isinstance(adjustment, dict)
+            assert isinstance(rerank, dict)
+            action_bias = adjustment["action_bias"]
+            assert isinstance(action_bias, dict)
+            assert action_bias["action"] == expected_action
+            assert action_bias["value"] == adjustment["value"]
+            assert action_bias["factors"] == rerank["factors"]
 
     def test_high_risk_reduces_score(self) -> None:
         e = RuntimeEvaluator()


### PR DESCRIPTION
## 变更概要

根据 issue #339 将运行时偏置统一包装为 `ActionBias` 理论对象，解决论文 `ActionBias(pi, x_t)` 与代码中分散的 `patch_bonus` / `replan_bonus` / `stop_penalty` 之间的命名断层。

---

## 问题背景

理论 v2 定义动作效用公式：

```
U_a = ... + k_a * ActionBias(pi, x_t)
```

当前代码中，`compute_runtime_delta()` 已有三类偏置（patch recovery bonus、suffix_replan 的 replan bonus/penalty、stop 的 guard penalty），但分散在 `factors`、`RerankReason` 和 `RuntimeAdjustmentSummary` 中，没有一个统一命名为 **ActionBias** 的承载点。

这导致：论文写 ActionBias，代码里是三套散装名字，审稿人难以追溯理论和实现的对应关系。

---

## 变更分组

| 批次 | 文件 | 变更类型 | 说明 |
|------|------|----------|------|
| 1 | `src/models/source_refs.py` | feat | 添加 `SOURCE_REF_ACTION_BIAS` |
| 2 | `src/models/contracts.py` | feat | 新增 `ActionBiasSummary` Pydantic 模型 |
| 3 | `src/workflow/runtime_evaluator.py` | feat | 三处 metadata 路径注入 ActionBias |
| 4 | `src/agents/planner.py` | feat | shadow decision 两处路径注入 ActionBias |
| 5 | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | docs | 理论文档更新 |
| 6 | `tests/unit/test_contract_source_refs.py` | test | ActionBiasSummary 模型验证 |
| 7 | `tests/unit/test_action_bias_metadata.py` (新) | test | planner 级影子决策测试 |
| 8 | `tests/unit/test_runtime_evaluator.py` | test | evaluator 级集成 + 3 种偏置场景测试 |

---

## 关键设计

### 1. ActionBiasSummary 模型

```python
class ActionBiasSummary(BaseModel):
    action: Literal["continue", "patch_local", "suffix_replan", "stop"]
    value: float          # [-1, 1], 与 runtime_adjustment.value 一致
    factors: list[RuntimeAdjustmentFactor]
    source_refs: list[str]
```

- `extra="forbid"` 防止字段泄漏
- value 在 [-1, 1] 范围内验证

### 2. 集成方式

`RuntimeAdjustmentSummary` 新增可选字段：

```python
action_bias: ActionBiasSummary | None = None
```

**设计取舍：**

- `action_bias.value === runtime_adjustment.value` — 单一数值真理，不重复表达两个不同数值
- `action_bias.factors === rerank_reason.factors` — factor 列表与 RerankReason 一致，避免 copy-paste 漂移
- 所有 metadata 构建路径（`_apply_runtime_adjustment`、`_attach_passthrough_metadata`、`_build_shadow_passthrough_decision`、`_build_runtime_shadow_decision`）均注入 ActionBias
- planner.py 和 runtime_evaluator.py 各有一个 `_build_action_bias()`（实现相同），有意不共享：planner 不依赖 evaluator 模块，避免循环导入风险

### 3. 为什么不把 ActionBias 放进 RerankReason？

RerankReason 是重排理由，而 ActionBias 是理论公式的一个独立项。把两者合并会模糊理论边界。分开保留：ActionBias 做公式对应，RerankReason 做人可读解释。

### 4. source_refs 链路

```text
论文 ActionBias(pi, x_t)
  -> sid:planner.algorithm.runtime_adjustment_formula  (理论公式引用)
  -> impl:runtime_evaluator.compute_runtime_delta.v1  (代码实现引用)
```

---

## 测试覆盖

| 测试 | 范围 | 验证点 |
|------|------|--------|
| `test_runtime_adjustment_accepts_action_bias` | 模型层 | ActionBiasSummary 绑定到 RuntimeAdjustmentSummary |
| `test_planner_shadow_runtime_adjustment_carries_action_bias` | planner 层 | value 一致、factors 一致、source_refs 正确 |
| `test_rerank_metadata_contains_runtime_adjustment` (扩展) | evaluator 层 | action_bias 集成到全部 rerank 元数据 |
| `test_action_bias_generated_for_patch_replan_and_stop` | evaluator 层 | 三种偏置场景均正确生成 |

---

## 验收对照

| 验收标准 | 状态 |
|----------|------|
| 论文 ActionBias 有唯一代码承载点 | `RuntimeAdjustmentSummary.action_bias` |
| factor 解释不再分散在多个字段 | 聚合到 `action_bias.factors` |
| runtime adjustment 理论/代码/测试一致 | 三方验证通过 |

Closes #339