### PR TITLE
feat: separate expected_remaining_cost from budget_pressure semantics (#340)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -322,7 +322,7 @@ x_t = (s_t, f_t, r_t, c_t, e_t)
 - `s_t = p_success`：当前工作流最终成功概率的代理估计；
 - `f_t = p_structural_failure`：结构性失败压力；
 - `r_t = recovery_margin`：恢复余量；
-- `c_t = expected_remaining_cost`：预期剩余成本；
+- `c_t = expected_remaining_cost`：预期剩余成本，保持原始非负成本尺度，可大于 1；
 - `e_t = evidence_sufficiency`：当前证据充分度。
 
 取值范围：
@@ -331,6 +331,16 @@ x_t = (s_t, f_t, r_t, c_t, e_t)
 s_t, f_t, r_t, e_t ∈ [0,1]
 c_t ∈ R_{>=0}
 ```
+
+预算压力不是核心状态量本身，而是从剩余成本按需派生：
+
+```text
+budget_pressure =
+  clip(c_t / max(budget_cap, 0.1), 0, 1.5)  if budget_cap is available
+  clip(c_t, 0, 1.5)                          otherwise
+```
+
+因此 `expected_remaining_cost` 保留原始估计，`budget_pressure` 承担归一化后的预算压力语义。
 
 ### 5.2 为什么称为 Lite belief-state
 
@@ -515,7 +525,7 @@ s = s_t = p_success
 f = f_t = p_structural_failure
 r = r_t = recovery_margin
 e = e_t = evidence_sufficiency
-b = budget_pressure = clip(c_t,0,1)
+b = budget_pressure
 ```
 
 派生量：

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -61,6 +61,11 @@ from src.models.contracts import (
     WAITING_RUNTIME_SUMMARY_METADATA_KEY,
     now_iso,
 )
+from src.models.budget_pressure import (
+    coerce_optional_budget_cap,
+    coerce_optional_budget_pressure,
+    derive_budget_pressure,
+)
 from src.models.validation import (
     CandidateExecutionValidationError,
     validate_candidate_set_output,
@@ -2590,6 +2595,15 @@ def _build_runtime_shadow_decision(
         runtime_state_summary.get("evidence_sufficiency"),
         default=0.5,
     )
+    budget_cap = coerce_optional_budget_cap(runtime_state_summary.get("budget_cap"))
+    budget_pressure = coerce_optional_budget_pressure(
+        runtime_state_summary.get("budget_pressure")
+    )
+    if budget_pressure is None:
+        budget_pressure = derive_budget_pressure(
+            expected_remaining_cost=expected_remaining_cost,
+            budget_cap=budget_cap,
+        ).budget_pressure
     overall = _safe_float(score_breakdown.get("overall"), default=0.0)
     confidence = _safe_float(score_breakdown.get("confidence"), default=overall)
     risk = _safe_float(score_breakdown.get("risk"), default=overall)
@@ -2611,6 +2625,8 @@ def _build_runtime_shadow_decision(
         feasibility=feasibility,
         candidate_kind=candidate_kind,
         replan_mode=replan_mode,
+        budget_pressure=budget_pressure,
+        budget_cap=budget_cap,
     )
 
     adjusted = max(0.0, min(1.0, overall + delta))
@@ -2647,6 +2663,8 @@ def _build_runtime_shadow_decision(
             "runtime_state.p_structural_failure",
             "runtime_state.recovery_margin",
             "runtime_state.expected_remaining_cost",
+            "runtime_state.budget_pressure",
+            "runtime_state.budget_cap",
             "runtime_state.evidence_sufficiency",
         ],
         candidate_metric_fields=[
@@ -2665,6 +2683,7 @@ def _build_runtime_shadow_decision(
         f"static_score={overall:.2f}, runtime_adjustment={delta:.2f}, final_score={adjusted:.2f}; "
         f"signals use p_success={p_success:.2f}, p_structural_failure={p_structural_failure:.2f}, "
         f"recovery_margin={recovery_margin:.2f}, expected_remaining_cost={expected_remaining_cost:.2f}, "
+        f"budget_pressure={budget_pressure:.2f}, "
         f"evidence_sufficiency={evidence_sufficiency:.2f}; "
         f"shadow_action={action} because {reason}."
     )

--- a/src/models/budget_pressure.py
+++ b/src/models/budget_pressure.py
@@ -1,0 +1,110 @@
+"""预算压力的统一派生规则。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+BUDGET_PRESSURE_SOURCE_REFS: tuple[str, ...] = (
+    "sid:planner.runtime.belief_state_schema",
+    "impl:budget_pressure.v1",
+)
+BUDGET_PRESSURE_MAX = 1.5
+BUDGET_CAP_FLOOR = 0.1
+
+
+@dataclass(frozen=True)
+class BudgetPressureDerivation:
+    """预算压力派生结果。"""
+
+    expected_remaining_cost: float
+    budget_pressure: float
+    budget_cap: float | None
+    source_fields: tuple[str, ...]
+    reason: str
+
+
+def derive_budget_pressure(
+    *,
+    expected_remaining_cost: float,
+    budget_cap: float | None = None,
+) -> BudgetPressureDerivation:
+    """从原始剩余成本和可选预算上限派生预算压力。
+
+    Args:
+        expected_remaining_cost: 原始剩余成本暴露，允许大于 1。
+        budget_cap: 可选预算上限；存在时作为归一化分母。
+
+    Returns:
+        裁剪到 `[0, 1.5]` 的预算压力及其来源说明。
+    """
+
+    remaining = max(float(expected_remaining_cost), 0.0)
+    normalized_cap = _normalize_budget_cap(budget_cap)
+    if normalized_cap is None:
+        return BudgetPressureDerivation(
+            expected_remaining_cost=remaining,
+            budget_pressure=round(_clip_pressure(remaining), 6),
+            budget_cap=None,
+            source_fields=("runtime_state.expected_remaining_cost",),
+            reason=(
+                "Budget pressure falls back to clipped expected remaining cost "
+                "because no budget cap is available."
+            ),
+        )
+    return BudgetPressureDerivation(
+        expected_remaining_cost=remaining,
+        budget_pressure=round(_clip_pressure(remaining / normalized_cap), 6),
+        budget_cap=normalized_cap,
+        source_fields=(
+            "runtime_state.expected_remaining_cost",
+            "runtime_state.budget_cap",
+        ),
+        reason=(
+            "Budget pressure is expected remaining cost normalized by budget cap."
+        ),
+    )
+
+
+def coerce_optional_budget_cap(value: object) -> float | None:
+    """解析可选预算上限，非法或非正值按缺失处理。"""
+
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return _normalize_budget_cap(parsed)
+
+
+def coerce_optional_budget_pressure(value: object) -> float | None:
+    """解析可选预算压力，非法值按缺失处理。"""
+
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, int | float | str):
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return _clip_pressure(parsed)
+
+
+def _normalize_budget_cap(value: float | None) -> float | None:
+    if value is None:
+        return None
+    normalized = float(value)
+    if normalized <= 0.0:
+        return None
+    return max(normalized, BUDGET_CAP_FLOOR)
+
+
+def _clip_pressure(value: float) -> float:
+    if value < 0.0:
+        return 0.0
+    if value > BUDGET_PRESSURE_MAX:
+        return BUDGET_PRESSURE_MAX
+    return value

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -8,6 +8,8 @@ from typing import Any, TypeAlias, Dict, List, Optional, Literal, cast
 
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 
+from src.models.budget_pressure import derive_budget_pressure
+
 JsonMap: TypeAlias = dict[str, object]
 
 
@@ -311,6 +313,7 @@ class RuntimeStateUpdateInput(BaseModel):
     failure_context: RuntimeFailureContext | None = None
     completed_steps: int | None = None
     total_steps: int | None = None
+    budget_cap: float | None = None
 
     @field_validator("completed_steps", "total_steps")
     @classmethod
@@ -328,6 +331,16 @@ class RuntimeStateUpdateInput(BaseModel):
             raise ValueError(f"{info.field_name} must be >= 0")
         return normalized
 
+    @field_validator("budget_cap")
+    @classmethod
+    def _validate_optional_budget_cap(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float_value(value, field_name="budget_cap")
+        if normalized <= 0.0:
+            raise ValueError("budget_cap must be > 0")
+        return normalized
+
     @model_validator(mode="after")
     def _validate_bounds_and_observation(self) -> "RuntimeStateUpdateInput":
         if (
@@ -342,9 +355,10 @@ class RuntimeStateUpdateInput(BaseModel):
             and self.failure_context is None
             and self.completed_steps is None
             and self.total_steps is None
+            and self.budget_cap is None
         ):
             raise ValueError(
-                "at least one observation or progress counter must be provided"
+                "at least one observation, progress counter, or budget cap must be provided"
             )
         return self
 
@@ -356,12 +370,14 @@ class RuntimeStateUpdateInput(BaseModel):
         failure_context: RuntimeFailureContext | None = None,
         completed_steps: int | None = None,
         total_steps: int | None = None,
+        budget_cap: float | None = None,
     ) -> "RuntimeStateUpdateInput":
         return cls(
             step_result=step_result,
             failure_context=failure_context,
             completed_steps=completed_steps,
             total_steps=total_steps,
+            budget_cap=budget_cap,
         )
 
     @classmethod
@@ -372,12 +388,14 @@ class RuntimeStateUpdateInput(BaseModel):
         failure_context: RuntimeFailureContext | None = None,
         completed_steps: int | None = None,
         total_steps: int | None = None,
+        budget_cap: float | None = None,
     ) -> "RuntimeStateUpdateInput":
         return cls(
             safety_result=safety_result,
             failure_context=failure_context,
             completed_steps=completed_steps,
             total_steps=total_steps,
+            budget_cap=budget_cap,
         )
 
     def to_replay_payload(self) -> Dict[str, Any]:
@@ -398,6 +416,8 @@ class RuntimeState(BaseModel):
     recovery_margin: float
     expected_remaining_cost: float
     evidence_sufficiency: float = 0.5
+    budget_pressure: float | None = None
+    budget_cap: float | None = None
     last_update_source: str
     observation_summary: Dict[str, Any] = Field(default_factory=dict)
 
@@ -427,6 +447,26 @@ class RuntimeState(BaseModel):
             raise ValueError("expected_remaining_cost must be >= 0")
         return normalized
 
+    @field_validator("budget_pressure")
+    @classmethod
+    def _validate_budget_pressure(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float_value(value, field_name="budget_pressure")
+        if not 0.0 <= normalized <= 1.5:
+            raise ValueError("budget_pressure must be between 0 and 1.5")
+        return normalized
+
+    @field_validator("budget_cap")
+    @classmethod
+    def _validate_budget_cap(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float_value(value, field_name="budget_cap")
+        if normalized <= 0.0:
+            raise ValueError("budget_cap must be > 0")
+        return normalized
+
     @field_validator("last_update_source")
     @classmethod
     def _validate_last_update_source(cls, value: str) -> str:
@@ -446,13 +486,24 @@ class RuntimeState(BaseModel):
             raise ValueError("observation_summary must be JSON-serializable") from exc
         return value
 
+    @model_validator(mode="after")
+    def _derive_budget_pressure(self) -> "RuntimeState":
+        if self.budget_pressure is None:
+            self.budget_pressure = derive_budget_pressure(
+                expected_remaining_cost=self.expected_remaining_cost,
+                budget_cap=self.budget_cap,
+            ).budget_pressure
+        return self
+
     def to_snapshot_payload(self) -> Dict[str, Any]:
         """Serialize the stable persisted fields for TaskSnapshot.artifacts."""
-        return self.model_dump(exclude={"observation_summary"})
+        return self.model_dump(exclude={"observation_summary"}, exclude_none=True)
 
     def to_summary_payload(self) -> Dict[str, Any]:
         """Serialize the candidate-facing runtime state summary."""
-        return RuntimeStateSummary.from_runtime_state(self).model_dump()
+        return RuntimeStateSummary.from_runtime_state(self).model_dump(
+            exclude_none=True
+        )
 
 
 class RuntimeStateSummary(BaseModel):
@@ -466,6 +517,8 @@ class RuntimeStateSummary(BaseModel):
     recovery_margin: float
     expected_remaining_cost: float
     evidence_sufficiency: float = 0.5
+    budget_pressure: float | None = None
+    budget_cap: float | None = None
 
     @field_validator("schema_version")
     @classmethod
@@ -493,6 +546,35 @@ class RuntimeStateSummary(BaseModel):
             raise ValueError("expected_remaining_cost must be >= 0")
         return normalized
 
+    @field_validator("budget_pressure")
+    @classmethod
+    def _validate_budget_pressure(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float_value(value, field_name="budget_pressure")
+        if not 0.0 <= normalized <= 1.5:
+            raise ValueError("budget_pressure must be between 0 and 1.5")
+        return normalized
+
+    @field_validator("budget_cap")
+    @classmethod
+    def _validate_budget_cap(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float_value(value, field_name="budget_cap")
+        if normalized <= 0.0:
+            raise ValueError("budget_cap must be > 0")
+        return normalized
+
+    @model_validator(mode="after")
+    def _derive_budget_pressure(self) -> "RuntimeStateSummary":
+        if self.budget_pressure is None:
+            self.budget_pressure = derive_budget_pressure(
+                expected_remaining_cost=self.expected_remaining_cost,
+                budget_cap=self.budget_cap,
+            ).budget_pressure
+        return self
+
     @classmethod
     def from_runtime_state(cls, runtime_state: RuntimeState) -> "RuntimeStateSummary":
         return cls(
@@ -502,6 +584,8 @@ class RuntimeStateSummary(BaseModel):
             recovery_margin=runtime_state.recovery_margin,
             expected_remaining_cost=runtime_state.expected_remaining_cost,
             evidence_sufficiency=runtime_state.evidence_sufficiency,
+            budget_pressure=runtime_state.budget_pressure,
+            budget_cap=runtime_state.budget_cap,
         )
 
 
@@ -1107,9 +1191,11 @@ def _sync_adapter_mode(
 
 def _normalize_runtime_state_summary(summary_payload: Any) -> Dict[str, Any]:
     if isinstance(summary_payload, RuntimeStateSummary):
-        return summary_payload.model_dump()
+        return summary_payload.model_dump(exclude_none=True)
     if isinstance(summary_payload, dict):
-        return RuntimeStateSummary.model_validate(summary_payload).model_dump()
+        return RuntimeStateSummary.model_validate(summary_payload).model_dump(
+            exclude_none=True
+        )
     raise ValueError(f"metadata.{RUNTIME_STATE_SUMMARY_METADATA_KEY} must be a mapping")
 
 

--- a/src/models/runtime_schemas.py
+++ b/src/models/runtime_schemas.py
@@ -4,7 +4,19 @@ import json
 import math
 from typing import ClassVar, Literal, TypeGuard, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+
+from src.models.budget_pressure import (
+    BUDGET_PRESSURE_MAX,
+    derive_budget_pressure,
+)
 
 RUNTIME_SCHEMA_VERSION = 1
 RUNTIME_STATE_CORE_FIELDS = (
@@ -287,6 +299,8 @@ class RuntimeStateSchema(RuntimeContractBase):
     recovery_margin: float = 0.6
     expected_remaining_cost: float = 1.0
     evidence_sufficiency: float = 0.5
+    budget_pressure: float | None = None
+    budget_cap: float | None = None
     last_update_source: str = "runtime_bootstrap"
     observation_summary: JsonObject = Field(default_factory=dict)
 
@@ -308,6 +322,26 @@ class RuntimeStateSchema(RuntimeContractBase):
             raise ValueError("expected_remaining_cost must be >= 0")
         return normalized
 
+    @field_validator("budget_pressure")
+    @classmethod
+    def _validate_budget_pressure(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float(value, field_name="budget_pressure")
+        if not 0.0 <= normalized <= BUDGET_PRESSURE_MAX:
+            raise ValueError("budget_pressure must be between 0 and 1.5")
+        return normalized
+
+    @field_validator("budget_cap")
+    @classmethod
+    def _validate_budget_cap(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        normalized = _validate_finite_float(value, field_name="budget_cap")
+        if normalized <= 0.0:
+            raise ValueError("budget_cap must be > 0")
+        return normalized
+
     @field_validator("last_update_source")
     @classmethod
     def _validate_last_update_source(cls, value: str) -> str:
@@ -321,6 +355,15 @@ class RuntimeStateSchema(RuntimeContractBase):
     def _validate_observation_summary(cls, value: object) -> JsonObject:
         return _validate_json_mapping(value, field_name="observation_summary")
 
+    @model_validator(mode="after")
+    def _derive_budget_pressure(self) -> "RuntimeStateSchema":
+        if self.budget_pressure is None:
+            self.budget_pressure = derive_budget_pressure(
+                expected_remaining_cost=self.expected_remaining_cost,
+                budget_cap=self.budget_cap,
+            ).budget_pressure
+        return self
+
     @classmethod
     def from_snapshot_payload(cls, payload: object) -> "RuntimeStateSchema":
         """从新旧 snapshot.artifacts.runtime_state 载荷恢复状态契约。"""
@@ -333,15 +376,25 @@ class RuntimeStateSchema(RuntimeContractBase):
     def to_snapshot_payload(self) -> JsonObject:
         """输出 snapshot.artifacts.runtime_state 的稳定字段。"""
 
-        return cast(JsonObject, self.model_dump(exclude={"observation_summary"}))
+        return cast(
+            JsonObject,
+            self.model_dump(exclude={"observation_summary"}, exclude_none=True),
+        )
 
     def to_summary_payload(self) -> JsonObject:
         """输出 UI/CLI/Planner/EventLog 共用的轻量状态摘要。"""
 
-        return {
-            key: getattr(self, key)
-            for key in ("schema_version", *RUNTIME_STATE_CORE_FIELDS)
+        payload: JsonObject = {
+            "schema_version": self.schema_version,
+            "p_success": self.p_success,
+            "p_structural_failure": self.p_structural_failure,
+            "recovery_margin": self.recovery_margin,
+            "expected_remaining_cost": self.expected_remaining_cost,
+            "evidence_sufficiency": self.evidence_sufficiency,
+            "budget_pressure": self.budget_pressure,
+            "budget_cap": self.budget_cap,
         }
+        return {key: value for key, value in payload.items() if value is not None}
 
 
 class ObservationSource(BaseModel):
@@ -415,10 +468,18 @@ class ActionUtility(RuntimeContractBase):
     def _validate_utility(cls, value: float) -> float:
         return _validate_unit_interval(value, field_name="utility")
 
-    @field_validator("intervention_value", "budget_pressure")
+    @field_validator("intervention_value")
     @classmethod
     def _validate_unit_value(cls, value: float, info: ValidationInfo) -> float:
         return _validate_unit_interval(value, field_name=_validation_field_name(info))
+
+    @field_validator("budget_pressure")
+    @classmethod
+    def _validate_budget_pressure(cls, value: float) -> float:
+        normalized = _validate_finite_float(value, field_name="budget_pressure")
+        if not 0.0 <= normalized <= BUDGET_PRESSURE_MAX:
+            raise ValueError("budget_pressure must be between 0 and 1.5")
+        return normalized
 
     @field_validator("hard_constraints", "source_refs")
     @classmethod
@@ -471,6 +532,8 @@ RUNTIME_SCHEMA_FIELD_MAPPINGS: dict[str, RuntimeSchemaFieldMapping] = {
         snapshot_fields=[
             "artifacts.runtime_cost",
             "artifacts.runtime_state.expected_remaining_cost",
+            "artifacts.runtime_state.budget_pressure",
+            "artifacts.runtime_state.budget_cap",
         ],
         event_fields=[
             "data.runtime_cost",
@@ -480,6 +543,8 @@ RUNTIME_SCHEMA_FIELD_MAPPINGS: dict[str, RuntimeSchemaFieldMapping] = {
             "metadata.cost_schema",
             "metadata.score_breakdown.cost",
             "metadata.runtime_state_summary.expected_remaining_cost",
+            "metadata.runtime_state_summary.budget_pressure",
+            "metadata.runtime_state_summary.budget_cap",
         ],
         ui_summary_fields=["score_breakdown.cost", "cost_estimate"],
         cli_summary_fields=["score_breakdown.cost", "cost_estimate"],

--- a/src/workflow/action_features.py
+++ b/src/workflow/action_features.py
@@ -6,6 +6,12 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal, cast
 
+from src.models.budget_pressure import (
+    BUDGET_PRESSURE_SOURCE_REFS,
+    coerce_optional_budget_cap,
+    coerce_optional_budget_pressure,
+    derive_budget_pressure,
+)
 from src.models.runtime_schemas import JsonObject
 from src.workflow.errors import FailureType
 
@@ -25,6 +31,7 @@ ACTION_FEATURE_NAMES: tuple[str, ...] = (
 ACTION_FEATURE_SOURCE_REFS: tuple[str, ...] = (
     "sid:algo.action_feature_derivation",
     "impl:workflow.action_features.v1",
+    *BUDGET_PRESSURE_SOURCE_REFS,
 )
 
 
@@ -125,7 +132,9 @@ def derive_action_features(
 
     features: dict[str, DerivedActionFeature] = {}
 
-    budget_pressure = _observed_or_none(runtime_state, "budget_pressure")
+    budget_pressure = coerce_optional_budget_pressure(
+        runtime_state.get("budget_pressure")
+    )
     if budget_pressure is not None:
         features["budget_pressure"] = _feature(
             budget_pressure,
@@ -135,11 +144,15 @@ def derive_action_features(
             upper=1.5,
         )
     else:
+        budget_derivation = derive_budget_pressure(
+            expected_remaining_cost=expected_remaining_cost,
+            budget_cap=coerce_optional_budget_cap(runtime_state.get("budget_cap")),
+        )
         features["budget_pressure"] = _feature(
-            _clip(expected_remaining_cost, lower=0.0, upper=1.5),
+            budget_derivation.budget_pressure,
             "inferred" if "expected_remaining_cost" in runtime_state else "default",
-            ("runtime_state.expected_remaining_cost",),
-            "Budget pressure is clipped from expected remaining cost.",
+            budget_derivation.source_fields,
+            budget_derivation.reason,
             upper=1.5,
         )
 
@@ -419,6 +432,8 @@ def _has_contextual_signal(
         "recovery_margin",
         "expected_remaining_cost",
         "evidence_sufficiency",
+        "budget_pressure",
+        "budget_cap",
     }
     return (
         bool(core_fields.intersection(runtime_state.keys()))

--- a/src/workflow/belief_state.py
+++ b/src/workflow/belief_state.py
@@ -9,6 +9,7 @@ from src.models.contracts import (
     SafetyResult,
     StepResult,
 )
+from src.models.budget_pressure import derive_budget_pressure
 
 __all__ = ["extract_failure_context", "update_runtime_state"]
 
@@ -29,6 +30,7 @@ def update_runtime_state(
     failure_context: RuntimeFailureContext | Mapping[str, Any] | None = None,
     completed_steps: int | None = None,
     total_steps: int | None = None,
+    budget_cap: float | None = None,
 ) -> RuntimeState:
     """以确定性规则更新 Lite 版运行时 belief-state。
 
@@ -48,12 +50,14 @@ def update_runtime_state(
         failure_context=failure_context,
         completed_steps=completed_steps,
         total_steps=total_steps,
+        budget_cap=budget_cap,
     )
     step_result = update.step_result
     safety_result = update.safety_result
     failure_context = update.failure_context
     completed_steps = update.completed_steps
     total_steps = update.total_steps
+    budget_cap = update.budget_cap
 
     state = previous_state or RuntimeState(
         p_success=_BASELINE_P_SUCCESS,
@@ -64,6 +68,7 @@ def update_runtime_state(
             total_steps=total_steps,
         ),
         evidence_sufficiency=_BASELINE_EVIDENCE_SUFFICIENCY,
+        budget_cap=budget_cap,
         last_update_source="runtime_bootstrap",
         observation_summary={},
     )
@@ -73,6 +78,7 @@ def update_runtime_state(
     recovery_margin = _clamp_unit_interval(state.recovery_margin)
     expected_remaining_cost = state.expected_remaining_cost
     evidence_sufficiency = _clamp_unit_interval(state.evidence_sufficiency)
+    budget_cap = budget_cap if budget_cap is not None else state.budget_cap
     observation_summary = dict(state.observation_summary)
     last_update_source = state.last_update_source
     cost_penalty = 0.0
@@ -213,7 +219,16 @@ def update_runtime_state(
         previous_value=evidence_sufficiency,
         evidence_signal=evidence_signal,
     )
+    budget_derivation = derive_budget_pressure(
+        expected_remaining_cost=expected_remaining_cost,
+        budget_cap=budget_cap,
+    )
     observation_summary["evidence_signal"] = _round_metric(evidence_signal)
+    observation_summary["budget_pressure"] = _round_metric(
+        budget_derivation.budget_pressure
+    )
+    if budget_cap is not None:
+        observation_summary["budget_cap"] = budget_cap
 
     return RuntimeState(
         p_success=_round_metric(_clamp_unit_interval(p_success)),
@@ -223,6 +238,8 @@ def update_runtime_state(
         recovery_margin=_round_metric(_clamp_unit_interval(recovery_margin)),
         expected_remaining_cost=_round_metric(max(expected_remaining_cost, 0.0)),
         evidence_sufficiency=_round_metric(evidence_sufficiency),
+        budget_pressure=_round_metric(budget_derivation.budget_pressure),
+        budget_cap=budget_cap,
         last_update_source=last_update_source,
         observation_summary=_drop_none_values(observation_summary),
     )
@@ -281,6 +298,7 @@ def _coerce_update_input(
     failure_context: RuntimeFailureContext | Mapping[str, Any] | None,
     completed_steps: int | None,
     total_steps: int | None,
+    budget_cap: float | None,
 ) -> RuntimeStateUpdateInput:
     if update_input is not None:
         return update_input
@@ -290,6 +308,7 @@ def _coerce_update_input(
         failure_context=_coerce_failure_context(failure_context),
         completed_steps=completed_steps,
         total_steps=total_steps,
+        budget_cap=budget_cap,
     )
 
 

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -23,6 +23,11 @@ from src.models.contracts import (
     RuntimeAdjustmentSummary,
     ScoreSummary,
 )
+from src.models.budget_pressure import (
+    coerce_optional_budget_cap,
+    coerce_optional_budget_pressure,
+    derive_budget_pressure,
+)
 from src.models.runtime_schemas import (
     ActionUtility,
     JsonObject,
@@ -118,13 +123,21 @@ def compute_runtime_delta(
     feasibility: float,
     candidate_kind: str,
     replan_mode: str = "",
+    budget_pressure: float | None = None,
+    budget_cap: float | None = None,
 ) -> tuple[float, RuntimeActionName, str, list[RuntimeAdjustmentFactor]]:
     """计算单个候选的 runtime delta、shadow action、action reason 和因子列表。
 
     供 Planner shadow-rerank hooks 与 RuntimeEvaluator 共享公式。
     """
-    budget_pressure = min(max(expected_remaining_cost, 0.0), 1.5)
-    cost_pressure = min(budget_pressure, 1.0)
+    explicit_budget_pressure = coerce_optional_budget_pressure(budget_pressure)
+    if explicit_budget_pressure is None:
+        explicit_budget_pressure = derive_budget_pressure(
+            expected_remaining_cost=expected_remaining_cost,
+            budget_cap=budget_cap,
+        ).budget_pressure
+    budget_pressure_value = explicit_budget_pressure
+    cost_pressure = min(budget_pressure_value, 1.0)
     margin_signal = max(-1.0, min(recovery_margin, 1.0))
 
     action, action_reason = _resolve_candidate_action_from_signals(
@@ -133,7 +146,7 @@ def compute_runtime_delta(
         p_success=p_success,
         p_structural_failure=p_structural_failure,
         recovery_margin=recovery_margin,
-        budget_pressure=budget_pressure,
+        budget_pressure=budget_pressure_value,
     )
 
     evidence_effect = 0.18 * (p_success - 0.5) * confidence
@@ -171,13 +184,13 @@ def compute_runtime_delta(
             "score_breakdown.feasibility", replan_bonus,
             "Feasible suffix replacement preserves validated prefix value."))
         factors.append(_make_factor("cost", "cost_pressure",
-            "runtime_state.expected_remaining_cost", replan_penalty,
+            "runtime_state.budget_pressure", replan_penalty,
             "Suffix replan still carries residual budget pressure."))
     elif action == "stop":
         penalty = -(0.12 + 0.06 * cost_pressure)
         delta += penalty
         factors.append(_make_factor("policy", "stop_guard",
-            "runtime_state.p_success+runtime_state.expected_remaining_cost",
+            "runtime_state.p_success+runtime_state.budget_pressure",
             penalty,
             "Stop guard applies when success is low and cost pressure is already high."))
 
@@ -372,7 +385,7 @@ class RuntimeEvaluator:
             "action_feature_source_refs": list(derivation.source_refs),
         }
 
-        bp = round(min(max(b, 0.0), 1.0), 6)
+        bp = round(min(max(b, 0.0), 1.5), 6)
         return {
             "continue": ActionUtility(
                 action="continue",
@@ -507,6 +520,8 @@ def _apply_runtime_adjustment(
     recovery_margin = _safe_clip(state.get("recovery_margin"), 0.6)
     evidence_sufficiency = _safe_clip(state.get("evidence_sufficiency"), 0.5)
     expected_remaining_cost = max(_safe_float(state.get("expected_remaining_cost"), 1.0), 0.0)
+    budget_cap = coerce_optional_budget_cap(state.get("budget_cap"))
+    budget_pressure = coerce_optional_budget_pressure(state.get("budget_pressure"))
 
     confidence = float(score_breakdown.get("confidence", overall))
     risk = float(score_breakdown.get("risk", overall))
@@ -529,6 +544,8 @@ def _apply_runtime_adjustment(
         feasibility=feasibility,
         candidate_kind=candidate_kind,
         replan_mode=str(metadata.get("replan_mode", "")),
+        budget_pressure=budget_pressure,
+        budget_cap=budget_cap,
     )
 
     adjusted = max(_SCORE_CLAMP_MIN, min(_SCORE_CLAMP_MAX, overall + delta))
@@ -545,6 +562,8 @@ def _apply_runtime_adjustment(
             "runtime_state.p_structural_failure",
             "runtime_state.recovery_margin",
             "runtime_state.expected_remaining_cost",
+            "runtime_state.budget_pressure",
+            "runtime_state.budget_cap",
             "runtime_state.evidence_sufficiency",
         ],
         candidate_metric_fields=[
@@ -708,8 +727,8 @@ def _build_adjustment_factors(
             "Recovery headroom and fallback depth shape the shadow rerank bonus.",
         ),
         _make_factor(
-            "cost", "expected_remaining_cost",
-            "runtime_state.expected_remaining_cost+score_breakdown.cost",
+            "cost", "budget_pressure",
+            "runtime_state.budget_pressure+score_breakdown.cost",
             cost_effect,
             "Remaining cost pressure penalizes expensive suffixes.",
         ),

--- a/tests/unit/test_action_features.py
+++ b/tests/unit/test_action_features.py
@@ -111,6 +111,27 @@ def test_high_budget_pressure_does_not_default_to_high_budget_relief():
 
 
 @pytest.mark.unit
+def test_budget_pressure_uses_budget_cap_when_available():
+    high_cap = derive_action_features(
+        runtime_state={
+            "expected_remaining_cost": 1.2,
+            "budget_cap": 2.0,
+        }
+    )
+    low_cap = derive_action_features(
+        runtime_state={
+            "expected_remaining_cost": 1.2,
+            "budget_cap": 0.5,
+        }
+    )
+
+    assert high_cap.values["budget_pressure"] == pytest.approx(0.6)
+    assert low_cap.values["budget_pressure"] == pytest.approx(1.5)
+    assert "runtime_state.budget_cap" in high_cap.features["budget_pressure"].source_fields
+    assert high_cap.values["budget_relief"] == pytest.approx(low_cap.values["budget_relief"])
+
+
+@pytest.mark.unit
 def test_observed_values_take_priority():
     derivation = derive_action_features(
         runtime_state={

--- a/tests/unit/test_belief_state.py
+++ b/tests/unit/test_belief_state.py
@@ -108,6 +108,27 @@ def test_update_runtime_state_accepts_structured_update_input() -> None:
     assert state.evidence_sufficiency == 0.5015
 
 
+def test_update_runtime_state_derives_budget_pressure_from_budget_cap() -> None:
+    step_result = _build_failed_step_result()
+    update_input = RuntimeStateUpdateInput.from_step_result(
+        step_result=step_result,
+        failure_context=extract_failure_context(step_result),
+        completed_steps=1,
+        total_steps=4,
+        budget_cap=10.0,
+    )
+
+    state = update_runtime_state(
+        previous_state=None,
+        update_input=update_input,
+    )
+
+    assert state.expected_remaining_cost == pytest.approx(5.0)
+    assert state.budget_cap == pytest.approx(10.0)
+    assert state.budget_pressure == pytest.approx(0.5)
+    assert state.observation_summary["budget_pressure"] == pytest.approx(0.5)
+
+
 def test_runtime_state_consumes_objective_signal_without_overriding_safety_block() -> None:
     """objective gap/progress 可进入观测摘要，但安全阻断仍会降低成功概率。"""
 

--- a/tests/unit/test_budget_pressure.py
+++ b/tests/unit/test_budget_pressure.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from src.models.budget_pressure import derive_budget_pressure
+
+
+@pytest.mark.unit
+def test_budget_pressure_normalizes_by_budget_cap() -> None:
+    high_cap = derive_budget_pressure(
+        expected_remaining_cost=1.2,
+        budget_cap=2.0,
+    )
+    low_cap = derive_budget_pressure(
+        expected_remaining_cost=1.2,
+        budget_cap=0.5,
+    )
+
+    assert high_cap.expected_remaining_cost == pytest.approx(1.2)
+    assert high_cap.budget_pressure == pytest.approx(0.6)
+    assert low_cap.budget_pressure == pytest.approx(1.5)
+    assert high_cap.source_fields == (
+        "runtime_state.expected_remaining_cost",
+        "runtime_state.budget_cap",
+    )
+
+
+@pytest.mark.unit
+def test_budget_pressure_falls_back_to_clipped_remaining_cost() -> None:
+    derivation = derive_budget_pressure(expected_remaining_cost=2.2)
+
+    assert derivation.budget_pressure == pytest.approx(1.5)
+    assert derivation.budget_cap is None
+    assert derivation.source_fields == ("runtime_state.expected_remaining_cost",)

--- a/tests/unit/test_contracts.py
+++ b/tests/unit/test_contracts.py
@@ -180,7 +180,22 @@ class TestRuntimeState:
         assert state.schema_version == 1
         assert state.p_success == 0.8
         assert state.evidence_sufficiency == 0.5
+        assert state.budget_pressure == pytest.approx(1.5)
         assert state.observation_summary["completed_high_cost_steps"] == 1
+
+    def test_runtime_state_budget_pressure_uses_budget_cap(self):
+        state = RuntimeState(
+            p_success=0.8,
+            p_structural_failure=0.15,
+            recovery_margin=0.35,
+            expected_remaining_cost=4.5,
+            budget_cap=9.0,
+            last_update_source="step_result:S2",
+        )
+
+        assert state.expected_remaining_cost == pytest.approx(4.5)
+        assert state.budget_pressure == pytest.approx(0.5)
+        assert state.to_summary_payload()["budget_cap"] == pytest.approx(9.0)
 
     def test_runtime_state_rejects_invalid_probability(self):
         with pytest.raises(ValidationError):
@@ -209,6 +224,7 @@ class TestRuntimeState:
             "recovery_margin": 0.32,
             "expected_remaining_cost": 5.5,
             "evidence_sufficiency": 0.5,
+            "budget_pressure": 1.5,
         }
 
 
@@ -470,6 +486,7 @@ class TestCandidateSetContracts:
             "recovery_margin": 0.49,
             "expected_remaining_cost": 3.0,
             "evidence_sufficiency": 0.5,
+            "budget_pressure": 1.5,
         }
 
     def test_candidate_invalid_runtime_state_summary_rejected(

--- a/tests/unit/test_recovery_event_logs.py
+++ b/tests/unit/test_recovery_event_logs.py
@@ -149,6 +149,7 @@ def test_restore_context_from_snapshot_backfills_partial_runtime_state_payload()
         "remaining_steps": 1,
         "completed_ratio": 0.5,
         "evidence_signal": 0.465,
+        "budget_pressure": 1.0,
         "selected_candidate_id": "patch_a",
     }
 

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -26,6 +26,7 @@ from src.workflow.runtime_evaluator import (
     STATIC_GATE,
     STATIC_TOP1,
     RuntimeEvaluator,
+    compute_runtime_delta,
     evaluator_policy_trace,
     policy_disables_rerank,
 )
@@ -83,6 +84,8 @@ def _state(**overrides: float) -> RuntimeStateSchema:
         recovery_margin=overrides.get("recovery_margin", 0.6),
         expected_remaining_cost=overrides.get("expected_remaining_cost", 0.5),
         evidence_sufficiency=overrides.get("evidence_sufficiency", 0.65),
+        budget_cap=overrides.get("budget_cap"),
+        budget_pressure=overrides.get("budget_pressure"),
     )
 
 
@@ -263,6 +266,48 @@ class TestRerank:
         # 高 p_structural_failure + 高 cost pressure + 低 p_success → 负调整
         assert adj["value"] < -0.10
 
+    def test_runtime_delta_uses_budget_pressure_not_raw_remaining_cost(self) -> None:
+        low_pressure_delta, _, _, low_pressure_factors = compute_runtime_delta(
+            p_success=0.6,
+            p_structural_failure=0.2,
+            recovery_margin=0.6,
+            expected_remaining_cost=1.2,
+            evidence_sufficiency=0.6,
+            confidence=0.6,
+            risk=0.5,
+            cost=0.2,
+            fallback_depth=0.5,
+            feasibility=0.8,
+            candidate_kind="plan",
+            budget_cap=2.0,
+        )
+        high_pressure_delta, _, _, high_pressure_factors = compute_runtime_delta(
+            p_success=0.6,
+            p_structural_failure=0.2,
+            recovery_margin=0.6,
+            expected_remaining_cost=1.2,
+            evidence_sufficiency=0.6,
+            confidence=0.6,
+            risk=0.5,
+            cost=0.2,
+            fallback_depth=0.5,
+            feasibility=0.8,
+            candidate_kind="plan",
+            budget_cap=0.5,
+        )
+
+        assert low_pressure_delta > high_pressure_delta
+        assert any(
+            factor.signal == "budget_pressure"
+            and factor.source == "runtime_state.budget_pressure+score_breakdown.cost"
+            for factor in low_pressure_factors
+        )
+        assert any(
+            factor.signal == "budget_pressure"
+            and factor.source == "runtime_state.budget_pressure+score_breakdown.cost"
+            for factor in high_pressure_factors
+        )
+
     def test_delta_clamped_to_range(self) -> None:
         """delta 约束在 [-0.35, 0.35] 内。"""
         e = RuntimeEvaluator()
@@ -356,6 +401,24 @@ class TestActionUtility:
         )
         assert bad["stop"].utility > good["stop"].utility
         assert bad["continue"].utility < good["continue"].utility
+
+    def test_action_utility_derives_budget_pressure_from_budget_cap(self) -> None:
+        e = RuntimeEvaluator()
+        high_cap = e.compute_action_utilities(
+            _state_dict(expected_remaining_cost=1.2, budget_cap=2.0)
+        )
+        low_cap = e.compute_action_utilities(
+            _state_dict(expected_remaining_cost=1.2, budget_cap=0.5)
+        )
+
+        assert high_cap["continue"].budget_pressure == pytest.approx(0.6)
+        assert low_cap["continue"].budget_pressure == pytest.approx(1.5)
+        assert low_cap["stop"].utility > high_cap["stop"].utility
+        derived = low_cap["stop"].metadata["derived_features"]
+        assert derived["budget_pressure"]["source_fields"] == [
+            "runtime_state.expected_remaining_cost",
+            "runtime_state.budget_cap",
+        ]
 
     def test_patch_utility_scales_with_recovery(self) -> None:
         e = RuntimeEvaluator()

--- a/tests/unit/test_runtime_schemas.py
+++ b/tests/unit/test_runtime_schemas.py
@@ -65,6 +65,7 @@ def test_six_runtime_schemas_serialize_with_stable_defaults() -> None:
         "recovery_margin": 0.6,
         "expected_remaining_cost": 1.0,
         "evidence_sufficiency": 0.5,
+        "budget_pressure": 1.0,
     }
     assert StateSchema is RuntimeStateSchema
     assert observation.model_dump()["source_refs"][0]["source_type"] == "step_result"
@@ -80,7 +81,20 @@ def test_runtime_state_schema_restores_legacy_snapshot_payload() -> None:
     assert restored.p_success == pytest.approx(0.8)
     assert restored.p_structural_failure == pytest.approx(0.25)
     assert restored.evidence_sufficiency == pytest.approx(0.5)
+    assert restored.budget_pressure == pytest.approx(1.0)
     assert restored.to_snapshot_payload()["last_update_source"] == "runtime_bootstrap"
+
+
+def test_runtime_state_schema_derives_budget_pressure_from_budget_cap() -> None:
+    """预算压力使用预算上限归一化，原始剩余成本允许大于 1。"""
+
+    high_cap = RuntimeStateSchema(expected_remaining_cost=1.2, budget_cap=2.0)
+    low_cap = RuntimeStateSchema(expected_remaining_cost=1.2, budget_cap=0.5)
+
+    assert high_cap.expected_remaining_cost == pytest.approx(1.2)
+    assert high_cap.budget_pressure == pytest.approx(0.6)
+    assert low_cap.budget_pressure == pytest.approx(1.5)
+    assert low_cap.to_summary_payload()["budget_cap"] == pytest.approx(0.5)
 
 
 def test_observation_schema_rejects_unapproved_sources() -> None:

--- a/tests/unit/test_task_snapshot.py
+++ b/tests/unit/test_task_snapshot.py
@@ -245,6 +245,7 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
         "recovery_margin": 0.41,
         "expected_remaining_cost": 12.5,
         "evidence_sufficiency": 0.63,
+        "budget_pressure": 1.5,
         "last_update_source": "safety:post_step",
     }
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
@@ -257,6 +258,7 @@ def test_build_task_snapshot_persists_runtime_state_with_stable_keys():
         "recovery_margin": 0.41,
         "expected_remaining_cost": 12.5,
         "evidence_sufficiency": 0.63,
+        "budget_pressure": 1.5,
     }
 
 
@@ -288,11 +290,13 @@ def test_build_task_snapshot_waiting_bootstraps_runtime_state_when_missing():
         "recovery_margin": 0.6,
         "expected_remaining_cost": 1.0,
         "evidence_sufficiency": 0.5,
+        "budget_pressure": 1.0,
         "last_update_source": "runtime_bootstrap",
     }
     assert snapshot.artifacts[RUNTIME_OBSERVATION_SUMMARY_ARTIFACT_KEY] == {
         "completed_steps": 0,
         "evidence_signal": 0.5,
+        "budget_pressure": 1.0,
     }
     assert snapshot.artifacts[RUNTIME_STATE_SUMMARY_METADATA_KEY]["p_success"] == pytest.approx(0.5)
 


### PR DESCRIPTION
## 变更概要

根据 issue #340 将 `expected_remaining_cost` 与 `budget_pressure` 的语义彻底分离，消除"同一变量既是原始成本又是压力指数"的混用。

**核心公式变化：**

```
# 之前（混用）
budget_pressure = clip(expected_remaining_cost, 0, 1.0)   # 语义模糊，上限1.0错了
cost_pressure = min(budget_pressure, 1.0)                  # 再clip一次

# 之后（分离）
expected_remaining_cost = 原始估计，可 > 1
budget_pressure = clip(c_t / max(budget_cap, 0.1), 0, 1.5)  # 有预算上限时
                = clip(c_t, 0, 1.5)                           # 无上限时回退
cost_pressure = min(budget_pressure, 1.0)                    # 保留行为不变
```

---

## 问题背景

理论文档明确区分 `expected_remaining_cost`（原始成本估计，量纲未归一化）与 `budget_pressure`（归一化后的预算压力指数，范围 [0, 1.5]），但代码中存在以下问题：

| 问题 | 位置 | 影响 |
|------|------|------|
| `compute_action_utilities()` 直接用 `expected_remaining_cost` 当成本项 | `runtime_evaluator.py` | ActionUtility.budget_pressure 上限设为 1.0 而非 1.5，语义偏差 |
| `_build_adjustment_factors()` 用 `expected_remaining_cost` 作为 factor 的 signal 名 | `runtime_evaluator.py` | 审计日志看不出来用的是原始成本还是压力指数 |
| `compute_runtime_delta()` 内联 clip | `runtime_evaluator.py` | 没有统一的派生出入口，`budget_cap` 不存在 |
| `action_features.py` 同样内联 clip | `action_features.py` | 与 evaluator 的推导逻辑可能漂移 |
| 论文 `b_t` 对应不明 | 跨模块 | 审稿人难以追溯理论量到代码字段 |

**设计取舍：**
- 保留 `expected_remaining_cost` 为原始非负值（可 > 1），只用于审计/展示
- `budget_pressure` 统一从 `derive_budget_pressure()` 派生，有明确的 budget_cap 可配置入口
- 三个 Pydantic 模型（RuntimeStateSchema / RuntimeState / RuntimeStateSummary）各自 auto-derive 保持兼容
- 不引入 budget_cap 持久化到 belief_state 以外的工作流层——它是个配置参数，不是动态状态

---

## 变更分组

### 基础设施层（2 commits）

| # | Commit | 文件 | 变更类型 | 说明 |
|---|--------|------|----------|------|
| 1 | `981b30e` | `src/models/budget_pressure.py` **(新)** | feat | `derive_budget_pressure()` + `BudgetPressureDerivation` + `coerce_*` 辅助函数 |
| 2 | `0bf9e09` | `src/models/runtime_schemas.py` | feat | `RuntimeStateSchema` 新增 `budget_pressure`/`budget_cap` + auto-derive + `ActionUtility.budget_pressure` 验证修复为 [0, 1.5] |

### 模型契约层（2 commits）

| # | Commit | 文件 | 变更类型 | 说明 |
|---|--------|------|----------|------|
| 3 | `465ade9` | `src/models/contracts.py` | feat | `RuntimeState` / `RuntimeStateSummary` / `RuntimeStateUpdateInput` 均新增字段 + auto-derive + `exclude_none=True` 序列化 |
| 4 | `5f8c596` | `src/workflow/belief_state.py` | feat | `update_runtime_state()` 接收并传播 `budget_cap`，每轮重新派生 `budget_pressure` |

### 工作流消费层（3 commits）

| # | Commit | 文件 | 变更类型 | 说明 |
|---|--------|------|----------|------|
| 5 | `c690179` | `src/workflow/runtime_evaluator.py` | refactor | `compute_runtime_delta()` 改用 `derive_budget_pressure()`，factor signal 改为 `budget_pressure` |
| 6 | `2a99f10` | `src/workflow/action_features.py` | refactor | 使用 `derive_budget_pressure()` + `coerce_optional_budget_cap()` |
| 7 | `768504c` | `src/agents/planner.py` | refactor | shadow decision 使用 derive_budget_pressure + 传入 compute_runtime_delta |

### 文档（1 commit）

| # | Commit | 文件 | 变更类型 | 说明 |
|---|--------|------|----------|------|
| 8 | `c1b7a24` | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | docs | `c_t` 语义澄清 + `budget_pressure` 推导公式 + `b = budget_pressure` 简化 |

### 测试层（7 commits）

| # | Commit | 文件 | 变更类型 | 说明 |
|---|--------|------|----------|------|
| 9 | `d3aed92` | `tests/unit/test_budget_pressure.py` **(新)** | test | core 模块 2 个测试 |
| 10 | `3be7163` | `tests/unit/test_runtime_schemas.py` | test | RuntimeStateSchema auto-derive |
| 11 | `38888df` | `tests/unit/test_contracts.py` | test | RuntimeState budget_cap 测试 |
| 12 | `05f4bcd` | `tests/unit/test_belief_state.py` | test | update_runtime_state budget_cap 集成 |
| 13 | `5b3d496` | `tests/unit/test_action_features.py` | test | budget_cap 到 action feature |
| 14 | `647aa35` | `tests/unit/test_runtime_evaluator.py` | test | delta 语义 + action_utility budget_cap |
| 15 | `46bfcd2` | `tests/unit/test_recovery_event_logs.py` + `tests/unit/test_task_snapshot.py` | test | 序列化断言更新 |

---

## 关键设计

### 1. `derive_budget_pressure()`：唯一派生出入口

```python
@dataclass(frozen=True)
class BudgetPressureDerivation:
    expected_remaining_cost: float
    budget_pressure: float          # clip(c_t / max(cap, 0.1), 0, 1.5)
    budget_cap: float | None
    source_fields: tuple[str, ...]  # 追踪数据来源用于审计
    reason: str                     # 人可读的解释
```

**设计取舍：**
- ✅ `budget_cap < 0.1` 视为缺失（floor 保护，避免除以极小值得到离谱压力）
- ✅ 没有 budget_cap 时直接 clip 原始成本（行为不变，但语义显式化）
- ❌ 不引入 budget_cap 的默认值——它是可选的，且应当是外部配置而非硬编码

### 2. 三层 auto-derive 设计

三个 Pydantic 模型（`RuntimeStateSchema` / `RuntimeState` / `RuntimeStateSummary`）都通过 `model_validator(mode="after")` 在 `budget_pressure is None` 时自动派生：

```python
@model_validator(mode="after")
def _derive_budget_pressure(self):
    if self.budget_pressure is None:
        self.budget_pressure = derive_budget_pressure(
            expected_remaining_cost=self.expected_remaining_cost,
            budget_cap=self.budget_cap,
        ).budget_pressure
    return self
```

**为什么三个模型各一份而不是共享？**
- 三个模型有不同的字段集、序列化方式和验证规则
- 共享基类会引入不必要的耦合
- 验证器实现相同，已通过 `derive_budget_pressure()` 共享逻辑

### 3. `ActionUtility.budget_pressure` 验证修复

之前：`_validate_unit_value` 要求 `[0, 1]`，但 `budget_pressure` 是 `[0, 1.5]`

```python
# 之前（错）
@field_validator("intervention_value", "budget_pressure")  # 共享 unit_interval 验证
# 之后（对）
@field_validator("intervention_value")                     # [0, 1]
@field_validator("budget_pressure")                        # [0, 1.5] 独立验证
```

这是 issue 中提到的 "相同变量在不同地方用了不同范围" 的问题。修复后论文 `b_t` 与代码 `budget_pressure` 完全对应。

### 4. `exclude_none=True` 策略

所有新增的 `budget_pressure`/`budget_cap` 可选字段在序列化时使用 `exclude_none=True`，因为：
- `budget_cap` 经常缺席（大多数工作流不需要设预算上限）
- `budget_pressure` 不缺席（auto-derive 保证），但显式排除 None 确保序列化格式稳定
- 向下兼容：旧快照没有这些字段，反序列化后 auto-derive 填充

### 5. factor signal 名统一

| 之前 | 之后 | 原因 |
|------|------|------|
| `expected_remaining_cost` | `budget_pressure` | 论文 `b_t` 是预算压力，不是原始成本 |
| `runtime_state.expected_remaining_cost` | `runtime_state.budget_pressure+score_breakdown.cost` | 明确区分压力和成本两个来源 |

---

## 测试覆盖矩阵

测试名称通过 `budget_cap` 参数验证以下场景：

| 测试 | 验证点 |
|------|--------|
| `test_budget_pressure_normalizes_by_budget_cap` | 相同 `c_t` 不同 `budget_cap` -> 不同 `budget_pressure` |
| `test_budget_pressure_falls_back_to_clipped_remaining_cost` | 无 `budget_cap` -> `clip(c_t, 0, 1.5)` |
| `test_runtime_state_schema_derives_budget_pressure_from_budget_cap` | Schema auto-derive 正确，`c_t` 保持原始值 |
| `test_runtime_state_budget_pressure_uses_budget_cap` | RuntimeState 同样正确，`to_summary_payload` 包含 `budget_cap` |
| `test_update_runtime_state_derives_budget_pressure_from_budget_cap` | belief-state 集成链路完整 |
| `test_budget_pressure_uses_budget_cap_when_available` | action_features 链路 |
| `test_runtime_delta_uses_budget_pressure_not_raw_remaining_cost` | delta 在不同 budget_cap 下不同，factor 信号名正确 |
| `test_action_utility_derives_budget_pressure_from_budget_cap` | ActionUtility.budget_pressure 正确反映 cap 归一化 |

所有现有快照测试（`test_task_snapshot`、`test_recovery_event_logs`）断言同步更新，`budget_pressure` 出现在预期输出中。

---

## 验收对照

| 验收标准 | 状态 | 代码证据 |
|----------|------|----------|
| 两字段语义分开 | ✅ | `expected_remaining_cost`（原始，可>1） vs `budget_pressure`（归一化 [0,1.5]） |
| 论文 `b_t` 对应唯一代码字段 | ✅ | `ActionUtility.budget_pressure` 验证 [0, 1.5]；`derive_budget_pressure()` 统一派生 |
| 相同 `c_t` 不同 `budget_cap` 得不同 `b_t` | ✅ | 测试 `test_budget_pressure_normalizes_by_budget_cap` |
| 不再出现"同一变量既是原始成本又是压力指数" | ✅ | `compute_runtime_delta()` 不再内联 clip，统一用 `derive_budget_pressure()` |
| 论文文档公式与实现一致 | ✅ | `docs/core-algorithm-theory-v2.md` 新增推导公式，更新引用 |

Closes #340