### PR TITLE
feat: formalize Top-K diversity as SelectDiverseTopK with capability_coverage (#342)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
+++ b/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
@@ -477,9 +477,20 @@ budget_pressure: 归一化 [0,1] 或 clipped [0,1.5]
 
 ### P1-5：Top-K diversity 的理论解释可以增强
 
-当前候选生成使用 `_select_diverse_top_k()`，这是很好的工程点。但理论 v2 只写了 Top-K，没有形式化 diversity 约束。
+状态：已补齐。理论 v2 已将 Top-K 写为：
 
-建议后续加入：
+```text
+TopK_t = SelectDiverseTopK(Pi_t, U_pi, k, capability_coverage)
+```
+
+工程侧 `_select_diverse_top_k()` 继续使用 capability-bucket round-robin，
+并在候选 metadata 中写入 `topk_diversity`，记录 `strategy`、
+`selected_by`、`diversity_signals`、`selection_mode` 和退化原因。
+
+当前候选生成使用 `_select_diverse_top_k()`，这不再只是工程点，而是 CEBRA-WP
+保留替代路径、降低单一路径偏置的 Top-K 约束。
+
+等价的论文表述可写为：
 
 ```text
 TopK_t = arg top-k under U_pi with capability diversity constraint

--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -519,8 +519,25 @@ pi_t^* = argmax_{pi ∈ Pi_t} S_static(pi)
 CEBRA-WP 不只输出单个 `pi_t^*`，还输出 Top-K：
 
 ```text
-TopK_t = top_k(Pi_t, U_pi)
+TopK_t = SelectDiverseTopK(Pi_t, U_pi, k, capability_coverage)
 ```
+
+其中 `SelectDiverseTopK` 先按 `U_pi` 或 `S_static` 建立稳定排序，再按
+capability bucket 执行 round-robin 选择。等价地，可把它理解为在高分候选中加入
+能力覆盖约束：
+
+```text
+TopK_t = arg top-k under U_pi subject to capability_coverage(TopK_t)
+```
+
+这使 Top-K 不只是“分数最高的 k 个候选”，而是同时保留：
+
+- 不同 capability bucket 的替代路径；
+- 不同失败恢复路径；
+- 不同成本/风险层级下的候选解释空间。
+
+若候选缺少 capability bucket，或所有候选落在同一个 bucket，选择退化为稳定分数排序；
+工程 metadata 必须标记该退化路径，避免把纯排序误解释为 diversity 增益。
 
 并记录：
 
@@ -528,6 +545,7 @@ TopK_t = top_k(Pi_t, U_pi)
 - `runtime_adjustment`；
 - `final_score`；
 - `rerank_reason`；
+- `topk_diversity`；
 - `default_recommendation_reason`。
 
 这使 HITL 能看到为什么候选被推荐、为什么被 runtime rerank 改变。
@@ -735,7 +753,7 @@ Algorithm CEBRA-WP(g, C, K, h_t, o_t, x_t)
 24:     U_pi(pi,x_{t+1}) ← clip(S_static(pi)+Δ(pi,x_{t+1}),0,1)
 25: end for
 
-26: TopK_t ← SelectDiverseTopK(Pi_t, U_pi, k)
+26: TopK_t ← SelectDiverseTopK(Pi_t, U_pi, k, capability_coverage)
 27: pi_t^* ← argmax_{pi∈TopK_t} U_pi(pi,x_{t+1})
 
 28: for each a in {continue, patch_local, suffix_replan, stop} do

--- a/src/agents/candidate_generator/generator.py
+++ b/src/agents/candidate_generator/generator.py
@@ -37,10 +37,15 @@ ScoredRow = tuple[PendingActionCandidate, SortKey, SortKey, str]
 RankedRow = tuple[PendingActionCandidate, SortKey, str]
 
 CANDIDATE_FEASIBILITY_METADATA_KEY = "candidate_feasibility"
+TOPK_DIVERSITY_METADATA_KEY = "topk_diversity"
 _SOFT_FEASIBILITY_REASONS = {"io_not_closed", "tool_unavailable"}
 _FEASIBILITY_SOURCE_REFS = [
     "sid:algo.adaptive.feasibility_filter",
     "impl:candidate_generator.feasibility.v1",
+]
+_TOPK_DIVERSITY_SOURCE_REFS = [
+    "sid:planner.contracts.candidate_schema",
+    "impl:candidate_generator.topk_diversity.v1",
 ]
 _FEASIBILITY_DESIGN_REF_STATUS = {
     "sid:algo.adaptive.feasibility_filter": "proposed",
@@ -120,6 +125,31 @@ def _feasibility_explanation(reason: str | None, filter_class: str) -> str:
             f"requires HITL because {reason}."
         )
     return f"Candidate is hard infeasible and excluded from Top-K because {reason}."
+
+
+def _normalize_capability_bucket(value: str | None) -> str:
+    if value is None:
+        return "unknown"
+    normalized = value.strip()
+    return normalized or "unknown"
+
+
+def _topk_diversity_explanation(
+    *,
+    capability_bucket: str,
+    diversity_degraded: bool,
+    fallback_reason: str | None,
+) -> str:
+    if diversity_degraded:
+        reason = fallback_reason or "insufficient_diversity_signal"
+        return (
+            "Selected by score ranking fallback because Top-K diversity could "
+            f"not distinguish capability buckets: {reason}."
+        )
+    return (
+        "Selected by capability-bucket round-robin to preserve an alternative "
+        f"path for capability {capability_bucket}."
+    )
 
 
 class CandidateGenerator:
@@ -219,7 +249,14 @@ class CandidateGenerator:
             )
             selected_rows = sorted(selected_rows, key=lambda row: row[1])
 
-        candidates = [row[0] for row in selected_rows]
+        candidates = self._attach_topk_diversity_metadata(
+            selected_rows=selected_rows,
+            available_rows=available_rows,
+            top_k=request.top_k,
+            ranking_basis=(
+                "final_score" if runtime_state_summary is not None else "static_score"
+            ),
+        )
         static_candidates = [row[0] for row in static_selected_rows]
         default_candidate = self._first_default_recommendation_candidate(candidates)
         static_default_candidate = self._first_default_recommendation_candidate(
@@ -454,6 +491,75 @@ class CandidateGenerator:
                 break
         return selected
 
+    def _attach_topk_diversity_metadata(
+        self,
+        *,
+        selected_rows: Sequence[RankedRow],
+        available_rows: Sequence[ScoredRow],
+        top_k: int,
+        ranking_basis: str,
+    ) -> list[PendingActionCandidate]:
+        selected_capabilities = [
+            _normalize_capability_bucket(row[2]) for row in selected_rows
+        ]
+        available_capabilities = [
+            _normalize_capability_bucket(row[3]) for row in available_rows
+        ]
+        unique_available_capabilities = sorted(set(available_capabilities))
+        unique_selected_capabilities = sorted(set(selected_capabilities))
+        missing_diversity_signal = all(
+            capability == "unknown" for capability in available_capabilities
+        )
+        diversity_degraded = (
+            missing_diversity_signal or len(unique_available_capabilities) <= 1
+        )
+        if missing_diversity_signal:
+            fallback_reason = "missing_capability_bucket"
+        elif diversity_degraded:
+            fallback_reason = "single_capability_bucket"
+        else:
+            fallback_reason = None
+
+        candidates: list[PendingActionCandidate] = []
+        for selection_rank, row in enumerate(selected_rows, start=1):
+            candidate = row[0]
+            capability_bucket = _normalize_capability_bucket(row[2])
+            metadata = dict(candidate.metadata or {})
+            metadata[TOPK_DIVERSITY_METADATA_KEY] = {
+                "schema_version": "topk_diversity.v1",
+                "strategy": "capability_coverage",
+                "selected_by": "_select_diverse_top_k",
+                "ranking_basis": ranking_basis,
+                "selection_mode": (
+                    "score_ranking_fallback"
+                    if diversity_degraded
+                    else "capability_bucket_round_robin"
+                ),
+                "selection_rank": selection_rank,
+                "requested_top_k": top_k,
+                "available_candidate_count": len(available_rows),
+                "selected_candidate_count": len(selected_rows),
+                "capability_bucket": capability_bucket,
+                "covered_capabilities": unique_selected_capabilities,
+                "available_capabilities": unique_available_capabilities,
+                "diversity_signals": [
+                    "candidate.capability_id",
+                    "candidate.metadata.capability_bucket",
+                    "score_breakdown.overall",
+                    "metadata.final_score",
+                ],
+                "diversity_degraded": diversity_degraded,
+                "fallback_reason": fallback_reason,
+                "source_refs": list(_TOPK_DIVERSITY_SOURCE_REFS),
+                "explanation": _topk_diversity_explanation(
+                    capability_bucket=capability_bucket,
+                    diversity_degraded=diversity_degraded,
+                    fallback_reason=fallback_reason,
+                ),
+            }
+            candidates.append(candidate.model_copy(update={"metadata": metadata}))
+        return candidates
+
     def _build_explanation(
         self,
         *,
@@ -472,7 +578,7 @@ class CandidateGenerator:
             f"{request.candidate_kind} Top-K generated by CandidateGenerator "
             f"(requested={request.top_k}, returned={len(candidates)}). "
             f"Ranking uses {ranking_basis} desc + stable tie-break; "
-            "selection uses capability-bucket round-robin."
+            "selection uses SelectDiverseTopK capability-bucket round-robin."
         )
         if default_candidate is not None:
             explanation = (

--- a/tests/unit/test_candidate_generator.py
+++ b/tests/unit/test_candidate_generator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import src.agents.planner as planner_module
 from src.agents.candidate_generator.generator import (
     CANDIDATE_FEASIBILITY_METADATA_KEY,
+    TOPK_DIVERSITY_METADATA_KEY,
     CandidateGenerator,
 )
 from src.agents.candidate_generator.recovery_complexity import (
@@ -56,6 +57,23 @@ def _registry() -> list[ToolSpec]:
             cost=0.3,
             safety_level=1,
             io_type="goal_to_sequence",
+            adapter_mode="local",
+            priority="P1",
+        ),
+    ]
+
+
+def _diverse_registry() -> list[ToolSpec]:
+    return [
+        *_registry(),
+        ToolSpec(
+            id="qc_a",
+            capabilities=("quality_qc",),
+            inputs=("goal",),
+            outputs=("qc_report",),
+            cost=0.4,
+            safety_level=1,
+            io_type="goal_to_qc",
             adapter_mode="local",
             priority="P1",
         ),
@@ -116,11 +134,17 @@ def _direct_generator(
     *,
     readiness_status: str = "ready",
     unavailable_tools: set[str] | None = None,
+    score_overrides: dict[str, float] | None = None,
 ) -> CandidateGenerator:
     unavailable_tool_ids = unavailable_tools or set()
+    score_by_tool = score_overrides or {}
+
     def score_payload(payload: Plan, *_args: object, **_kwargs: object) -> dict[str, float]:
         primary_tool = payload.steps[0].tool
-        overall = 0.9 if primary_tool == "seqgen_a" else 0.8
+        overall = score_by_tool.get(
+            primary_tool,
+            0.9 if primary_tool == "seqgen_a" else 0.8,
+        )
         return {
             "feasibility": 0.9,
             "objective": 0.8,
@@ -386,6 +410,96 @@ def test_generator_backfills_degraded_candidate_but_keeps_eligible_default():
     assert degraded_feasibility["requires_hitl"] is True
     assert degraded_feasibility["auto_executable"] is False
     assert degraded_feasibility["allowed_for_default_recommendation"] is False
+
+
+def test_generator_records_topk_diversity_metadata_with_score_fallback():
+    result = _direct_generator().generate(
+        CandidateGenerationInput(
+            candidate_kind="plan",
+            payloads=[
+                CandidatePayload(
+                    payload=_plan("seqgen_a", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_a",
+                    capability_bucket="sequence_generation",
+                    note="eligible candidate",
+                ),
+                CandidatePayload(
+                    payload=_plan("seqgen_b", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_b",
+                    capability_bucket="sequence_generation",
+                    note="eligible candidate",
+                ),
+            ],
+            registry=_registry(),
+            top_k=2,
+            task_constraints={},
+        )
+    )
+
+    for index, candidate in enumerate(result.candidates, start=1):
+        diversity = candidate.metadata[TOPK_DIVERSITY_METADATA_KEY]
+        assert isinstance(diversity, dict)
+        assert diversity["schema_version"] == "topk_diversity.v1"
+        assert diversity["strategy"] == "capability_coverage"
+        assert diversity["selected_by"] == "_select_diverse_top_k"
+        assert diversity["selection_mode"] == "score_ranking_fallback"
+        assert diversity["selection_rank"] == index
+        assert diversity["diversity_degraded"] is True
+        assert diversity["fallback_reason"] == "single_capability_bucket"
+        assert diversity["covered_capabilities"] == ["sequence_generation"]
+        assert "impl:candidate_generator.topk_diversity.v1" in diversity["source_refs"]
+
+
+def test_generator_selects_diverse_capability_bucket_over_pure_score_topk():
+    result = _direct_generator(
+        score_overrides={
+            "seqgen_a": 0.90,
+            "seqgen_b": 0.86,
+            "qc_a": 0.80,
+        }
+    ).generate(
+        CandidateGenerationInput(
+            candidate_kind="plan",
+            payloads=[
+                CandidatePayload(
+                    payload=_plan("seqgen_a", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_a",
+                    capability_bucket="sequence_generation",
+                    note="best sequence candidate",
+                ),
+                CandidatePayload(
+                    payload=_plan("seqgen_b", inputs={"goal": "design"}),
+                    primary_tool_id="seqgen_b",
+                    capability_bucket="sequence_generation",
+                    note="second sequence candidate",
+                ),
+                CandidatePayload(
+                    payload=_plan("qc_a", inputs={"goal": "design"}),
+                    primary_tool_id="qc_a",
+                    capability_bucket="quality_qc",
+                    note="diverse quality candidate",
+                ),
+            ],
+            registry=_diverse_registry(),
+            top_k=2,
+            task_constraints={},
+        )
+    )
+
+    assert [candidate.tool_id for candidate in result.candidates] == [
+        "seqgen_a",
+        "qc_a",
+    ]
+    assert "seqgen_b" not in {candidate.tool_id for candidate in result.candidates}
+    diversity = result.candidates[1].metadata[TOPK_DIVERSITY_METADATA_KEY]
+    assert isinstance(diversity, dict)
+    assert diversity["selection_mode"] == "capability_bucket_round_robin"
+    assert diversity["diversity_degraded"] is False
+    assert diversity["covered_capabilities"] == [
+        "quality_qc",
+        "sequence_generation",
+    ]
+    assert "SelectDiverseTopK" in result.explanation
 
 
 def test_plan_top_k_applies_policy_mode_and_cost_filter(monkeypatch):


### PR DESCRIPTION
## 变更概要

根据 issue #342 将 Top-K diversity 从工程实现细节提升为理论约束，使论文 `TopK_t` 从简单的 `top_k(Pi_t, U_pi)` 变为有形式化 diversity 表达的 `SelectDiverseTopK(Pi_t, U_pi, k, capability_coverage)`。

---

## 问题背景

代码中 `_select_diverse_top_k()` 已经实现了 capability-bucket round-robin 选择，但理论 v2 中对 Top-K 的描述停留在：

```text
TopK_t = top_k(Pi_t, U_pi)
```

这不足以表达多样性约束的理论价值，导致：

| 问题 | 影响 |
|------|------|
| 理论层只写 Top-K，没有显式 diversity term | 论文只能讲排序，不能讲多样性收益 |
| 工程层做 diversified selection，论文无法引用 | 实验无法区分"排序收益"和"多样性收益" |
| `_select_diverse_top_k()` 看起来像实现技巧 | 审稿人可能认为它只是工程 hack 而非算法部分 |

**核心变化：**

```
# 之前
TopK_t = top_k(Pi_t, U_pi)

# 之后
TopK_t = SelectDiverseTopK(Pi_t, U_pi, k, capability_coverage)
```

---

## 变更分组

| # | Commit | 文件 | LOC | 说明 |
|---|--------|------|-----|------|
| 1 | `47315c8` | `src/agents/candidate_generator/generator.py` | +108/-2 | `_attach_topk_diversity_metadata()` + helper 函数 |
| 2 | `0efb6d0` | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | +20/-2 | 更新 SelectDiverseTopK 理论表达 + 算法伪代码 |
| 3 | `75f9dff` | `docs/algorithm-and-llm/core-algorithm-code-gap-review.md` | +13/-2 | P1-5 标记已完成 |
| 4 | `c45681f` | `tests/unit/test_candidate_generator.py` | +115/-1 | 2 个 diversity 集成测试 |

---

## 关键设计

### 1. 理论表达：`SelectDiverseTopK` 的双层语义

论文中 `SelectDiverseTopK` 被定义为：

> **工程层**：先按 `U_pi` 或 `S_static` 建立稳定排序，再按 capability bucket 执行 round-robin 选择。
>
> **等价理论层**：在高分候选中加入能力覆盖约束——
>
> ```text
> TopK_t = arg top-k under U_pi subject to capability_coverage(TopK_t)
> ```

这使 Top-K 不只是"分数最高的 k 个候选"，而是同时保留：

- 不同 capability bucket 的替代路径
- 不同失败恢复路径（patch 候选 vs replan 候选）
- 不同成本/风险层级下的候选解释空间

### 2. `topk_diversity` 元数据结构

每条被选中的候选的 `metadata["topk_diversity"]` 包含以下字段：

```json
{
  "schema_version": "topk_diversity.v1",
  "strategy": "capability_coverage",
  "selected_by": "_select_diverse_top_k",
  "ranking_basis": "final_score",
  "selection_mode": "capability_bucket_round_robin",
  "selection_rank": 1,
  "requested_top_k": 3,
  "available_candidate_count": 5,
  "selected_candidate_count": 3,
  "capability_bucket": "sequence_generation",
  "covered_capabilities": ["quality_qc", "sequence_generation"],
  "available_capabilities": ["quality_qc", "sequence_generation"],
  "diversity_signals": [
    "candidate.capability_id",
    "candidate.metadata.capability_bucket",
    "score_breakdown.overall",
    "metadata.final_score"
  ],
  "diversity_degraded": false,
  "fallback_reason": null,
  "source_refs": [
    "sid:planner.contracts.candidate_schema",
    "impl:candidate_generator.topk_diversity.v1"
  ],
  "explanation": "Selected by capability-bucket round-robin to preserve an alternative path for capability quality_qc."
}
```

**设计取舍：**

| 决定 | 理由 |
|------|------|
| 每条候选独立记录 metadata | 每条候选有自己的 selection_rank、capability_bucket、explanation |
| 全局字段（covered/available capabilities）记录在每条上 | 方便审计时直接从任一条候选读取总体 diversity 状态 |
| 退化检测在 `_attach_topk_diversity_metadata` | 不侵入 `_select_diverse_top_k()` 的排序逻辑 |
| 仅检测 `capability_bucket` 维度 | 最稳定且可审计的信号，其他维度（成本、风险）暂不形式化 |

### 3. 退化路径

当多样性信号不足时，选择退化为稳定分数排序，且 metadata 必须明确标记：

| 退化原因 | 条件 | `selection_mode` | `diversity_degraded` |
|----------|------|------------------|:--------------------:|
| `missing_capability_bucket` | 所有候选 capability_bucket 均为 `unknown` | `score_ranking_fallback` | `true` |
| `single_capability_bucket` | 只有一个唯一 capability bucket | `score_ranking_fallback` | `true` |
| 正常选择 | 多个不同 bucket | `capability_bucket_round_robin` | `false` |

### 4. 退化测试：分数相近时保留不同 capability

测试 `test_generator_selects_diverse_capability_bucket_over_pure_score_topk` 验证了关键行为：

```
候选队列（按分数排序）：
  seqgen_a (score=0.90, bucket=sequence_generation)
  seqgen_b (score=0.86, bucket=sequence_generation)
  qc_a     (score=0.80, bucket=quality_qc)

top_k=2 → 选择 seqgen_a + qc_a
          （qc_a 虽然分数最低，但因提供唯一 capability 被选中；
            seqgen_b 被淘汰）
```

这证明了 diversity 约束确实改变了选择结果——不再是纯分数排序。

---

## 测试覆盖

| 测试 | 验证点 |
|------|--------|
| `test_generator_records_topk_diversity_metadata_with_score_fallback` | 单 bucket 场景 → 退化标记 + metadata 结构完整 |
| `test_generator_selects_diverse_capability_bucket_over_pure_score_topk` | 多 bucket 场景 → 低分跨 bucket 候选入选 + mode 非退化 |

**关键断言：**

```python
# 退化场景：所有候选单 bucket
assert diversity["selection_mode"] == "score_ranking_fallback"
assert diversity["diversity_degraded"] is True
assert diversity["fallback_reason"] == "single_capability_bucket"

# 正常选择：低分跨 bucket 入选
assert result.candidates[1].tool_id == "qc_a"   # score 0.80 > seqgen_b 0.86
assert diversity["selection_mode"] == "capability_bucket_round_robin"
assert diversity["covered_capabilities"] == ["quality_qc", "sequence_generation"]
```

---

## 验收对照

| 验收标准 | 状态 | 证据 |
|----------|------|------|
| 理论有明确 diversity 表达 | ✅ | `SelectDiverseTopK(Pi_t, U_pi, k, capability_coverage)` |
| 工程实现能解释"为什么保留这些候选" | ✅ | `metadata.topk_diversity.explanation` per candidate |
| 消融可区分 diversity 与 score ranking | ✅ | `diversity_degraded` flag 标记退化路径 |
| 算法伪代码同步更新 | ✅ | 算法第 26 行 `capability_coverage` 参数 |

Closes #342