### PR TITLE
feat: clarify posterior binding evidence semantics as generic_objective proxy (#343)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
+++ b/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
@@ -504,9 +504,10 @@ DiversityPenalty(pi_i, pi_j)
 
 这样 Top-K 不只是排序，而是保留替代路径的探索价值。
 
-### P1-6：`binding` posterior component 需要检查输出一致性
+### P1-6：`binding` posterior component 需要检查输出一致性（已补齐）
 
-`_POSTERIOR_COMPONENTS` 包含 `binding`，但 `_build_posterior_score()` payload 中当前显式列出了：
+结论：当前版本不引入独立 `binding` posterior component。`_POSTERIOR_COMPONENTS`
+保持为：
 
 ```text
 generic_objective
@@ -516,13 +517,23 @@ novelty
 structure_quality
 ```
 
-建议确认是否遗漏：
+`binding` objective type 仍可作为权重预设存在，但 binding 证据通过
+`binding_score` / `best_pose` 折叠为 `generic_objective` 的 proxy evidence。
+为避免“权重存在但输出缺失”的歧义，posterior payload 显式记录：
 
 ```text
-binding: components["binding"]
+binding_policy = "folded_into_generic_objective"
+binding_evidence = {source, role, target_component, source_fields}
 ```
 
-如果遗漏，应修复；如果故意不输出，应在文档说明。
+这意味着论文/schema/测试的唯一表述是：
+
+```text
+binding ∉ M_v1
+binding_evidence -> generic_objective proxy
+```
+
+若未来要新增一等 `binding` component，必须作为 schema version 升级处理。
 
 ### P1-7：实验配置与 runtime policy mode 需要对应理论消融
 

--- a/docs/algorithm-and-llm/core-algorithm-literature-map.md
+++ b/docs/algorithm-and-llm/core-algorithm-literature-map.md
@@ -455,7 +455,8 @@ benchmark/evaluation metrics -> objective_score and evidence_sufficiency calibra
 当前代码已有：
 
 ```text
-components = generic_objective, stability, novelty, function, binding, structure_quality
+components = generic_objective, stability, novelty, function, structure_quality
+binding_policy = folded_into_generic_objective
 status = direct | proxy | degraded
 aggregate_score = sum component_weight * effective_score
 ```

--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -247,6 +247,25 @@ G_post(pi;g,o_t) = Σ_{m∈M(g)} λ_m(g) · ρ_m(o_t) · q_m(pi,o_t)
 - `ρ_m(o_t) ∈ [0,1]`：证据可靠性权重；
 - `o_t`：当前已获得观测。
 
+当前 `posterior_score.v1` 的显式 component 集合为：
+
+```text
+M_v1 = {generic_objective, stability, function, novelty, structure_quality}
+```
+
+`binding` 在 v1 中不是独立 component。若任务目标为 binding/interface quality，
+其权重通过 `objective_type="binding"` 映射到上述 component，实际 binding 观测
+`binding_score` / `best_pose` 作为 `generic_objective` 的 proxy evidence 进入
+`G_post`。因此 posterior payload 必须显式记录：
+
+```python
+"binding_policy": "folded_into_generic_objective"
+"binding_evidence": {"source": "binding_score|best_pose", "role": "proxy"}
+```
+
+若未来版本要把 `binding` 拆为独立 component，必须同步升级
+`posterior_score` / `posterior_objective` schema version，并重新定义权重与论文公式。
+
 ### 4.2 证据可靠性
 
 定义证据状态：

--- a/docs/algorithm-and-llm/issues/2026-05-05-p1-06-posterior-binding-output.md
+++ b/docs/algorithm-and-llm/issues/2026-05-05-p1-06-posterior-binding-output.md
@@ -6,7 +6,7 @@
 - Scope: algorithm / posterior objective / evidence semantics
 - Phase: CEBRA-WP P1 规划与实现准备
 - Body language: Chinese
-- 状态：待实现
+- 状态：已实现
 - 本文件定位：P1-6 的唯一实现参考来源；进入编码前以本文为准。
 
 ## 1. 背景
@@ -71,6 +71,8 @@ posterior_score["binding_policy"] = "folded_into_generic_objective"
 posterior_score["binding_evidence"] = {
     "source": "binding_score|best_pose",
     "role": "proxy",
+    "target_component": "generic_objective",
+    "source_fields": ["binding_score", "best_pose"],
 }
 ```
 

--- a/src/adapters/objective_ranker_adapter.py
+++ b/src/adapters/objective_ranker_adapter.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from time import perf_counter
-from typing import Any, Dict, Literal, Tuple, override
+from typing import Any, Dict, Literal, Tuple, cast, override
 
 from src.adapters.base_tool_adapter import BaseToolAdapter
 from src.adapters.tool_schema_utils import (
@@ -21,6 +22,10 @@ _POSTERIOR_OBJECTIVE_SOURCE_REFS = [
     "sid:algo.posterior_objective_scoring",
     "impl:posterior_score.v1",
 ]
+_BINDING_POLICY = "folded_into_generic_objective"
+_BINDING_PROXY_COMPONENT = "generic_objective"
+_BINDING_EVIDENCE_ROLE = "proxy"
+_BINDING_EVIDENCE_FIELDS = ("binding_score", "best_pose")
 _POSTERIOR_COMPONENTS = (
     "generic_objective",
     "stability",
@@ -507,6 +512,9 @@ def _build_posterior_score(
         warning = component.get("warning")
         if isinstance(warning, str) and warning not in posterior_warnings:
             posterior_warnings.append(warning)
+    binding_source_fields = _binding_source_fields_from_component(
+        components["generic_objective"],
+    )
     payload: Dict[str, Any] = {
         "schema_version": _POSTERIOR_SCORE_SCHEMA_VERSION,
         "objective_type": objective_type,
@@ -520,12 +528,76 @@ def _build_posterior_score(
         "evidence_refs": list(evidence_refs),
         "warnings": posterior_warnings,
         "evidence_sufficiency": round(min(direct_weight + (0.5 * proxy_weight), 1.0), 6),
+        "binding_policy": _BINDING_POLICY,
+        "binding_evidence": _binding_evidence_payload(binding_source_fields),
     }
     if posterior_warnings:
         payload["evidence_status"] = "degraded" if direct_weight < 0.8 else "partial"
     else:
         payload["evidence_status"] = "direct"
     return payload
+
+
+def _binding_source_fields_from_component(component: Mapping[str, object]) -> list[str]:
+    return _binding_source_fields_from_raw(component.get("source_fields"))
+
+
+def _binding_source_fields_from_raw(raw_fields: object) -> list[str]:
+    if not isinstance(raw_fields, list):
+        return []
+    source_fields: list[str] = []
+    for field in cast(list[object], raw_fields):
+        if isinstance(field, str) and field in _BINDING_EVIDENCE_FIELDS:
+            source_fields.append(field)
+    return source_fields
+
+
+def _binding_evidence_payload(source_fields: list[str]) -> dict[str, object]:
+    return {
+        "source": "|".join(source_fields) if source_fields else "not_present",
+        "role": _BINDING_EVIDENCE_ROLE,
+        "target_component": _BINDING_PROXY_COMPONENT,
+        "source_fields": list(source_fields),
+    }
+
+
+def _binding_source_fields_from_candidate(
+    candidate: Mapping[str, object],
+) -> list[str]:
+    return [
+        field
+        for field in _BINDING_EVIDENCE_FIELDS
+        if candidate.get(field) is not None
+    ]
+
+
+def _normalize_binding_evidence(
+    raw: object,
+    *,
+    candidate: Mapping[str, object],
+) -> dict[str, object]:
+    fallback = _binding_evidence_payload(
+        _binding_source_fields_from_candidate(candidate),
+    )
+    if not isinstance(raw, Mapping):
+        return fallback
+
+    raw_mapping = cast(Mapping[str, object], raw)
+    source_fields = _binding_source_fields_from_raw(raw_mapping.get("source_fields"))
+    if not source_fields:
+        source_fields = _binding_source_fields_from_raw(fallback.get("source_fields"))
+    raw_source = raw_mapping.get("source")
+    source = (
+        raw_source
+        if isinstance(raw_source, str) and raw_source
+        else fallback["source"]
+    )
+    return {
+        "source": source,
+        "role": _BINDING_EVIDENCE_ROLE,
+        "target_component": _BINDING_PROXY_COMPONENT,
+        "source_fields": source_fields,
+    }
 
 
 def _normalize_posterior_objective(
@@ -545,11 +617,17 @@ def _normalize_posterior_objective(
     warnings = [
         item for item in raw_warnings if isinstance(item, str)
     ] if isinstance(raw_warnings, list) else []
+    binding_evidence = _normalize_binding_evidence(
+        posterior_score.get("binding_evidence"),
+        candidate=candidate,
+    )
     binding_proxy_fields: list[str] = []
     binding_proxy_component: str | None = None
     if objective_type == "binding":
-        binding_proxy_component = "generic_objective"
-        binding_proxy_fields = _present_fields(candidate, ("binding_score", "best_pose"))
+        binding_proxy_component = _BINDING_PROXY_COMPONENT
+        binding_proxy_fields = _binding_source_fields_from_raw(
+            binding_evidence.get("source_fields"),
+        )
         binding_warning = (
             "binding objective is represented through generic_objective proxy in v1"
         )
@@ -582,6 +660,8 @@ def _normalize_posterior_objective(
         "evidence_status": raw_evidence_status if isinstance(raw_evidence_status, str) else "degraded",
         "objective_type": objective_type if isinstance(objective_type, str) else None,
         "objective_source": "posterior_objective",
+        "binding_policy": _BINDING_POLICY,
+        "binding_evidence": binding_evidence,
         "binding_proxy_component": binding_proxy_component,
         "binding_proxy_fields": binding_proxy_fields,
         "warnings": warnings,

--- a/tests/unit/test_extended_tool_adapters.py
+++ b/tests/unit/test_extended_tool_adapters.py
@@ -246,6 +246,13 @@ def test_objective_ranker_emits_posterior_score_schema_and_degraded_evidence() -
     assert posterior["schema_version"] == "posterior_score.v1"
     assert posterior["objective_type"] == "stability"
     assert posterior["aggregate_score"] == outputs["objective_score"]
+    assert "binding" not in posterior
+    assert posterior["binding_policy"] == "folded_into_generic_objective"
+    binding_evidence = cast(dict[str, object], posterior["binding_evidence"])
+    assert binding_evidence["source"] == "not_present"
+    assert binding_evidence["role"] == "proxy"
+    assert binding_evidence["target_component"] == "generic_objective"
+    assert binding_evidence["source_fields"] == []
     assert stability["score"] is None
     assert stability["evidence_status"] == "degraded"
     assert weights["stability"] == 0.7
@@ -255,6 +262,8 @@ def test_objective_ranker_emits_posterior_score_schema_and_degraded_evidence() -
     posterior_objective = cast(dict[str, object], top_k[0]["posterior_objective"])
     assert posterior_objective["schema_version"] == "posterior_objective.v1"
     assert posterior_objective["aggregate_score"] == posterior["aggregate_score"]
+    assert posterior_objective["binding_policy"] == "folded_into_generic_objective"
+    assert posterior_objective["binding_evidence"] == binding_evidence
     assert posterior_objective["source_refs"] == [
         "sid:algo.posterior_objective_scoring",
         "impl:posterior_score.v1",
@@ -281,8 +290,23 @@ def test_objective_ranker_binding_objective_marks_generic_proxy() -> None:
     )
 
     top_k = cast(list[dict[str, object]], outputs["top_k"])
+    posterior = cast(dict[str, object], top_k[0]["posterior_score"])
+    binding_evidence = cast(dict[str, object], posterior["binding_evidence"])
     posterior_objective = cast(dict[str, object], top_k[0]["posterior_objective"])
+    objective_binding_evidence = cast(
+        dict[str, object],
+        posterior_objective["binding_evidence"],
+    )
+    assert "binding" not in posterior
+    assert posterior["binding_policy"] == "folded_into_generic_objective"
+    assert binding_evidence["source"] == "binding_score|best_pose"
+    assert binding_evidence["role"] == "proxy"
+    assert binding_evidence["target_component"] == "generic_objective"
+    assert binding_evidence["source_fields"] == ["binding_score", "best_pose"]
     assert posterior_objective["objective_type"] == "binding"
+    assert posterior_objective["binding_policy"] == "folded_into_generic_objective"
+    assert objective_binding_evidence["source"] == "binding_score|best_pose"
+    assert objective_binding_evidence["role"] == "proxy"
     assert posterior_objective["binding_proxy_component"] == "generic_objective"
     assert posterior_objective["binding_proxy_fields"] == ["binding_score", "best_pose"]
 


### PR DESCRIPTION
## 变更概要

根据 issue #343 明确 posterior 中 binding 证据的语义处置策略：binding **不**作为独立 posterior component 存在，其证据通过 `binding_score` / `best_pose` 折叠为 `generic_objective` 的 proxy evidence，并在 payload 中显式记录 `binding_policy` 和 `binding_evidence` 字段消除歧义。

---

## 问题背景

`ObjectiveRankerAdapter` 的 posterior 体系存在一个模糊状态：

| 现象 | 含义 | 问题 |
|------|------|------|
| `_OBJECTIVE_TYPE_WEIGHT_PRESETS` 有 `binding` 权重 | 代码承认 binding 是一种 objective type | ✅ |
| `_POSTERIOR_COMPONENTS` 没有独立 `binding` | 代码不把 binding 视为独立 component | ✅ |
| posterior payload 没有 `binding` 字段 | 输出中看不到 binding 的处理说明 | ❌ **歧义** |
| binding 证据通过 `binding_score`/`best_pose` 折叠进 `generic_objective` | 代码实际上做了代理 | ❌ **不透明** |

核心问题：**"权重存在但组件缺失"** 导致论文、schema、测试三者无法对齐——论文以为 binding 是单独 component，代码其实没有单独输出。

**结论：** binding 不独立成 component，而是 `generic_objective` 的证据代理。显式记录策略。

---

## 变更分组

| # | Commit | 文件 | LOC | 说明 |
|---|--------|------|-----|------|
| 1 | `73c89cb` | `src/adapters/objective_ranker_adapter.py` | +83/-3 | 新增 6 个函数 + 2 个 payload 字段 |
| 2 | `3352eca` | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | +19 | §4.1 M_v1 + binding proxy 说明 |
| 3 | `ba385c7` | `docs/algorithm-and-llm/core-algorithm-code-gap-review.md` | +16/-5 | P1-6 标记完成 |
| 4 | `93240f3` | `docs/algorithm-and-llm/core-algorithm-literature-map.md` | +2/-1 | component 列表从 6 项改为 5 项 |
| 5 | `f3c4ee2` | `docs/algorithm-and-llm/issues/2026-05-05-p1-06-posterior-binding-output.md` | +4/-2 | 状态 → 已实现 |
| 6 | `8d08a0b` | `tests/unit/test_extended_tool_adapters.py` | +24 | 2 个测试 12 条新断言 |

---

## 关键设计

### 1. 核心策略：`binding ∉ M_v1`

```python
_BINDING_POLICY = "folded_into_generic_objective"
_BINDING_PROXY_COMPONENT = "generic_objective"
_BINDING_EVIDENCE_ROLE = "proxy"
_BINDING_EVIDENCE_FIELDS = ("binding_score", "best_pose")
```

论文公式中的 `M_v1`（posterior component 集合）保持为：

```text
M_v1 = {generic_objective, stability, function, novelty, structure_quality}
```

binding 不是 `M_v1` 的成员。若任务目标为 binding/interface quality，其权重通过 `objective_type="binding"` 映射到上述 component。实际 binding 观测值作为 `generic_objective` 的 proxy evidence 进入 `G_post`。

### 2. `binding_evidence` 元数据结构

posterior score payload 新增两个顶级字段：

```json
{
  "binding_policy": "folded_into_generic_objective",
  "binding_evidence": {
    "source": "binding_score|best_pose",
    "role": "proxy",
    "target_component": "generic_objective",
    "source_fields": ["binding_score", "best_pose"]
  }
}
```

**字段含义：**

| 字段 | 示例值 | 说明 |
|------|--------|------|
| `binding_policy` | `"folded_into_generic_objective"` | 设计决策声明，不变 |
| `binding_evidence.source` | `"binding_score\|best_pose"` \| `"not_present"` | 实际存在的 binding 证据来源（pipe 连接） |
| `binding_evidence.role` | `"proxy"` | binding 对目标 component 的角色 |
| `binding_evidence.target_component` | `"generic_objective"` | 证据折叠的目标 component |
| `binding_evidence.source_fields` | `["binding_score", "best_pose"]` \| `[]` | 实际存在的字段列表 |

**设计权衡：**

| 决定 | 理由 |
|------|------|
| 不把 binding 拆为独立 component | 拆分会改变 schema version、权重定义、planner 接口——超过 P1 范围 |
| 添加 binding_policy 和 binding_evidence 到 payload | 消除"权重存在但组件缺失"的歧义，一条 payload 可回答 binding 去哪了 |
| `source` 用 `|` 拼接字符串 | 保持人类可读，非 binding 任务返回 `"not_present"` |
| `source_fields` 用 list | 程序可遍历，空列表表示无 binding 证据 |

### 3. 规范化函数族

| 函数 | 用途 |
|------|------|
| `_binding_source_fields_from_component()` | 从 component dict 提取 binding 相关 source_fields |
| `_binding_source_fields_from_raw()` | 过滤 source_fields 列表，只保留 `_BINDING_EVIDENCE_FIELDS` 中的字段名 |
| `_binding_source_fields_from_candidate()` | 检查候选 dict 是否有 `binding_score`/`best_pose` 非 None 值 |
| `_binding_evidence_payload()` | 构建 binding_evidence 子 dict |
| `_normalize_binding_evidence()` | 规范化 binding_evidence（含回退到 candidate 级检查） |

**回退逻辑：** 当解析旧的 posterior payload（没有 binding_evidence）时，`_normalize_binding_evidence()` 通过检查 candidate 字典中的 `binding_score`/`best_pose` 字段推断来源。

### 4. `_normalize_posterior_objective()` 的变更

之前：

```python
binding_proxy_fields = _present_fields(candidate, ("binding_score", "best_pose"))
binding_proxy_component = "generic_objective"
```

之后：

```python
binding_evidence = _normalize_binding_evidence(posterior_score.get("binding_evidence"), candidate=candidate)
binding_proxy_fields = _binding_source_fields_from_raw(binding_evidence.get("source_fields"))
binding_proxy_component = _BINDING_PROXY_COMPONENT
```

同时新增输出字段 `binding_policy` 和 `binding_evidence`，与 `binding_proxy_fields`/`binding_proxy_component` 共存（向后兼容）。

### 5. 理论文档的表达

理论 §4.1 新增：

> *binding 在 v1 中不是独立 component。若任务目标为 binding/interface quality，其权重通过 objective_type='binding' 映射到上述 component，实际 binding 观测 binding_score / best_pose 作为 generic_objective 的 proxy evidence 进入 G_post。*
>
> *若未来版本要把 binding 拆为独立 component，必须同步升级 posterior_score / posterior_objective schema version，并重新定义权重与论文公式。*

这为未来的 schema 升级划清了边界。

---

## 测试覆盖

| 测试 | 新断言 | 验证点 |
|------|:------:|--------|
| `test_objective_ranker_emits_posterior_score_schema_and_degraded_evidence` | 7 条 | 非 binding 任务：`binding` key 不存在 + `binding_policy` + `binding_evidence` 空字段 |
| `test_objective_ranker_binding_objective_marks_generic_proxy` | 5 条 | binding 任务：`source=binding_score\|best_pose` + `source_fields` 完整 + `posterior_objective` 同步承载 |

---

## 验收对照

| 验收标准 | 状态 | 证据 |
|----------|------|------|
| binding 语义处置有唯一结论 | ✅ | `binding_policy = "folded_into_generic_objective"` |
| 论文表述、schema、测试三者一致 | ✅ | 理论 §4.1 + 代码 5 个常量 + 测试 12 条断言 |
| 不再处于"权重存在但组件缺失"的模糊状态 | ✅ | 每条 posterior payload 显式记录 `binding_evidence` |
| 未来可升级路径明确 | ✅ | 文档声明必须同步升级 schema version |

Closes #343