### PR TITLE
feat: map runtime policy modes to paper ablation groups (#344)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
+++ b/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
@@ -535,7 +535,7 @@ binding_evidence -> generic_objective proxy
 
 若未来要新增一等 `binding` component，必须作为 schema version 升级处理。
 
-### P1-7：实验配置与 runtime policy mode 需要对应理论消融
+### P1-7：实验配置与 runtime policy mode 需要对应理论消融（已补齐）
 
 `RuntimeEvaluator` 支持：
 
@@ -546,14 +546,16 @@ dynamic_observation_only
 lite_belief_state
 ```
 
-这是天然实验消融。建议 D2/D4 后续实验设计使用：
+这是天然实验消融。当前已固定代码 mode、论文组 ID、预期行为与重点指标的映射，
+代码侧 SSOT 为 `src.workflow.runtime_evaluator.RUNTIME_POLICY_ABLATION_GROUPS`，
+文档侧 SSOT 为 `docs/experiment/algorithm-group-paper-mapping.md`。
 
-| 模式 | 对应消融 |
-|---|---|
-| `static_top1` | 无 Top-K rerank |
-| `static_gate` | 只用静态过滤/静态评分 |
-| `dynamic_observation_only` | 有运行时观测但无 belief surrogate |
-| `lite_belief_state` | 完整 CEBRA-WP |
+| 代码 mode | 论文组 ID | 对应消融 |
+|---|---|---|
+| `static_top1` | `static_top1` | 静态单链基线 |
+| `static_gate` | `fixed_threshold_gate` | 静态门控基线 |
+| `dynamic_observation_only` | `dynamic_no_belief_state` | 动态观测但不使用 belief-state |
+| `lite_belief_state` | `lite_belief_state` | 完整 CEBRA-WP |
 
 ## 5. P2 差距
 

--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -888,7 +888,7 @@ We propose CEBRA-WP, a constraint- and evidence-aware, belief-guided, recovery-a
 4. 为 `local_patchability/evidence_reusability/prefix_preservability/budget_relief/goal_realignment` 补充稳定派生逻辑。
 5. 确认 `RuntimeEvaluator.select_action()` 与 `recovery.select_workflow_action()` 的主从关系。
 6. 为 `runtime_adjustment_formula` 补充设计文档正文，避免 SID 只有标题。
-7. 用实验对照验证 `static_top1`、`static_gate`、`dynamic_observation_only`、`lite_belief_state` 的差异。
+7. 用实验对照验证 `static_top1`、`static_gate`、`dynamic_observation_only`、`lite_belief_state` 的差异，并通过 `docs/experiment/algorithm-group-paper-mapping.md` 将其稳定映射到论文组。
 
 ## 13. 可直接放入论文的核心公式汇总
 

--- a/docs/algorithm-and-llm/issues/2026-05-05-p1-07-runtime-policy-ablation-mapping.md
+++ b/docs/algorithm-and-llm/issues/2026-05-05-p1-07-runtime-policy-ablation-mapping.md
@@ -6,7 +6,7 @@
 - Scope: algorithm / evaluation / ablation design
 - Phase: CEBRA-WP P1 规划与实现准备
 - Body language: Chinese
-- 状态：待实现
+- 状态：已实现
 - 本文件定位：P1-7 的唯一实现参考来源；进入编码前以本文为准。
 
 ## 1. 背景
@@ -80,6 +80,18 @@ mode / paper group / semantic meaning / expected effect / key metrics
 - `policy_mode` 枚举值不可再隐式扩展；
 - 新增 mode 必须同步更新测试和实验文档；
 - mode 名称尽量保持与论文一致。
+
+当前实现中，代码侧 SSOT 为：
+
+```python
+src.workflow.runtime_evaluator.RUNTIME_POLICY_ABLATION_GROUPS
+```
+
+本地实验文档为：
+
+```text
+docs/experiment/algorithm-group-paper-mapping.md
+```
 
 ## 6. 测试建议
 

--- a/docs/experiment/algorithm-group-paper-mapping.md
+++ b/docs/experiment/algorithm-group-paper-mapping.md
@@ -1,0 +1,41 @@
+# 算法实验分组与 runtime policy 映射
+
+## 1. 目的
+
+本文档固定论文主结果组与代码 `RuntimeEvaluator.policy_mode` 的一一对应关系。
+它与设计仓库 `../thesis-project.design/docs/experiment/algorithm-group-paper-mapping.md`
+保持同一叙事，但以当前代码可执行的 mode 为准，供评估脚本、论文表格和测试共享。
+
+## 2. 唯一映射表
+
+| 代码 mode | 论文组 ID | 论文组名 | 语义 | 回答的问题 | 预期效果 | 重点指标 |
+| --- | --- | --- | --- | --- | --- | --- |
+| `static_top1` | `static_top1` | 静态单链基线 | 仅采用静态最高分候选，不消费运行时观测做重排 | 静态单链路是否足够支撑高代价工作流 | 成本最低但最缺少失败恢复与替代路径收益 | success_rate, high_cost_call_count, early_failure_rate |
+| `static_gate` | `fixed_threshold_gate` | 静态门控基线 | 保留静态过滤/门控，但不启用运行时重排 | 简单静态门控是否已经足够 | 比 static_top1 更稳健，但无法利用运行时失败证据 | gate_pass_rate, manual_intervention_rate, wasted_call_rate |
+| `dynamic_observation_only` | `dynamic_no_belief_state` | 动态观测但不使用 belief-state | 保留动态 patch/replan 观测链路，但 runtime adjustment 为 passthrough | 仅有动态观测和恢复动作、没有 belief-state 是否足够 | 可隔离恢复机制收益，但不体现 belief-state 的重排增益 | patch_success_rate, replan_success_rate, recovery_cost |
+| `lite_belief_state` | `lite_belief_state` | 完整 CEBRA-WP | 启用 Lite belief-state、runtime adjustment 与 action utility | belief-state 是否带来最后一段 runtime 决策增益 | 应改善高代价调用控制、止损质量和整体成功率 | success_rate, high_cost_call_count, stop_quality, rerank_delta |
+
+## 3. 代码约束
+
+- `src.workflow.runtime_evaluator.RUNTIME_POLICY_ABLATION_GROUPS` 是评估脚本可读取的代码侧 SSOT。
+- 新增 `policy_mode` 时，必须同步更新映射表、本文档和 `tests/unit/test_runtime_evaluator.py::TestPolicyModes`。
+- `lite_belief_state` 是唯一 `full_runtime_adjustment=True` 的组。
+- `static_top1` 与 `static_gate` 都禁用 rerank，但论文组名与回答的问题不同，不得混用。
+- `dynamic_observation_only` 启用动态观测链路，但不使用 belief-state，也不产生非零 runtime adjustment。
+
+## 4. 与设计文档的关系
+
+设计仓库的论文主结果组写作名为：
+
+```text
+static_top1 / fixed_threshold_gate / dynamic_no_belief_state / lite_belief_state
+```
+
+当前代码中的可执行 mode 为：
+
+```text
+static_top1 / static_gate / dynamic_observation_only / lite_belief_state
+```
+
+因此本文保留 `paper_group_id` 来连接论文名，并保留 `policy_mode` 来连接运行配置。
+论文表格应展示 `paper_group_id` 或论文组名；评估配置应使用 `policy_mode`。

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Literal, cast
+from typing import Final, Literal, cast
 
 from src.models.contracts import (
     ActionBiasSummary,
@@ -49,6 +49,9 @@ from src.workflow.action_features import (
 __all__ = [
     "DYNAMIC_OBSERVATION_ONLY",
     "LITE_BELIEF_STATE",
+    "RUNTIME_POLICY_ABLATION_GROUPS",
+    "RUNTIME_POLICY_ABLATION_GROUP_BY_MODE",
+    "RuntimePolicyAblationGroup",
     "STATIC_GATE",
     "STATIC_TOP1",
     "RuntimeEvaluator",
@@ -56,13 +59,20 @@ __all__ = [
     "compute_runtime_delta",
     "evaluator_policy_trace",
     "policy_disables_rerank",
+    "runtime_policy_ablation_group",
 ]
 
 # -- policy mode constants ---------------------------------------------------
-STATIC_TOP1 = "static_top1"
-STATIC_GATE = "static_gate"
-DYNAMIC_OBSERVATION_ONLY = "dynamic_observation_only"
-LITE_BELIEF_STATE = "lite_belief_state"
+RuntimePolicyMode = Literal[
+    "static_top1",
+    "static_gate",
+    "dynamic_observation_only",
+    "lite_belief_state",
+]
+STATIC_TOP1: Final[RuntimePolicyMode] = "static_top1"
+STATIC_GATE: Final[RuntimePolicyMode] = "static_gate"
+DYNAMIC_OBSERVATION_ONLY: Final[RuntimePolicyMode] = "dynamic_observation_only"
+LITE_BELIEF_STATE: Final[RuntimePolicyMode] = "lite_belief_state"
 
 _POLICY_MODES = frozenset(
     {STATIC_TOP1, STATIC_GATE, DYNAMIC_OBSERVATION_ONLY, LITE_BELIEF_STATE}
@@ -86,6 +96,83 @@ _STRUCTURAL_FAILURE_THRESHOLD = 0.55
 _RECOVERY_MARGIN_LOW = 0.1
 
 
+@dataclass(frozen=True)
+class RuntimePolicyAblationGroup:
+    """论文消融组与 runtime policy mode 的稳定映射。"""
+
+    policy_mode: RuntimePolicyMode
+    paper_group_id: str
+    paper_group_name: str
+    semantic_meaning: str
+    question: str
+    expected_effect: str
+    key_metrics: tuple[str, ...]
+    rerank_enabled: bool
+    belief_state_enabled: bool
+    full_runtime_adjustment: bool
+    design_refs: tuple[str, ...] = (
+        "sid:experiment.group_mapping.overview",
+        "sid:planner.algorithm.runtime_reranking",
+        "sid:algo.schema.action_utility",
+    )
+
+
+RUNTIME_POLICY_ABLATION_GROUPS: tuple[RuntimePolicyAblationGroup, ...] = (
+    RuntimePolicyAblationGroup(
+        policy_mode=STATIC_TOP1,
+        paper_group_id="static_top1",
+        paper_group_name="静态单链基线",
+        semantic_meaning="仅采用静态最高分候选，不消费运行时观测做重排。",
+        question="静态单链路是否足够支撑高代价工作流？",
+        expected_effect="成本最低但最缺少失败恢复与替代路径收益。",
+        key_metrics=("success_rate", "high_cost_call_count", "early_failure_rate"),
+        rerank_enabled=False,
+        belief_state_enabled=False,
+        full_runtime_adjustment=False,
+    ),
+    RuntimePolicyAblationGroup(
+        policy_mode=STATIC_GATE,
+        paper_group_id="fixed_threshold_gate",
+        paper_group_name="静态门控基线",
+        semantic_meaning="保留静态过滤/门控，但不启用运行时重排。",
+        question="简单静态门控是否已经足够？",
+        expected_effect="比 static_top1 更稳健，但无法利用运行时失败证据。",
+        key_metrics=("gate_pass_rate", "manual_intervention_rate", "wasted_call_rate"),
+        rerank_enabled=False,
+        belief_state_enabled=False,
+        full_runtime_adjustment=False,
+    ),
+    RuntimePolicyAblationGroup(
+        policy_mode=DYNAMIC_OBSERVATION_ONLY,
+        paper_group_id="dynamic_no_belief_state",
+        paper_group_name="动态观测但不使用 belief-state",
+        semantic_meaning="保留动态 patch/replan 观测链路，但 runtime adjustment 为 passthrough。",
+        question="仅有动态观测和恢复动作、没有 belief-state 是否足够？",
+        expected_effect="可隔离恢复机制收益，但不体现 belief-state 的重排增益。",
+        key_metrics=("patch_success_rate", "replan_success_rate", "recovery_cost"),
+        rerank_enabled=True,
+        belief_state_enabled=False,
+        full_runtime_adjustment=False,
+    ),
+    RuntimePolicyAblationGroup(
+        policy_mode=LITE_BELIEF_STATE,
+        paper_group_id="lite_belief_state",
+        paper_group_name="完整 CEBRA-WP",
+        semantic_meaning="启用 Lite belief-state、runtime adjustment 与 action utility。",
+        question="belief-state 是否带来最后一段 runtime 决策增益？",
+        expected_effect="应改善高代价调用控制、止损质量和整体成功率。",
+        key_metrics=("success_rate", "high_cost_call_count", "stop_quality", "rerank_delta"),
+        rerank_enabled=True,
+        belief_state_enabled=True,
+        full_runtime_adjustment=True,
+    ),
+)
+RUNTIME_POLICY_ABLATION_GROUP_BY_MODE: dict[str, RuntimePolicyAblationGroup] = {
+    group.policy_mode: group
+    for group in RUNTIME_POLICY_ABLATION_GROUPS
+}
+
+
 # -- public helpers ----------------------------------------------------------
 
 
@@ -94,15 +181,25 @@ def policy_disables_rerank(policy_mode: str) -> bool:
     return policy_mode.strip().lower() in _RERANK_DISABLED_POLICIES
 
 
-def evaluator_policy_trace(policy_mode: str) -> dict[str, object]:
+def runtime_policy_ablation_group(policy_mode: str) -> RuntimePolicyAblationGroup:
+    """返回 policy mode 对应的论文消融组，未知 mode 回退到完整方法。"""
     normalized = policy_mode.strip().lower()
-    if normalized not in _POLICY_MODES:
-        normalized = LITE_BELIEF_STATE
+    return RUNTIME_POLICY_ABLATION_GROUP_BY_MODE.get(
+        normalized,
+        RUNTIME_POLICY_ABLATION_GROUP_BY_MODE[LITE_BELIEF_STATE],
+    )
+
+
+def evaluator_policy_trace(policy_mode: str) -> dict[str, object]:
+    group = runtime_policy_ablation_group(policy_mode)
+    normalized = group.policy_mode
     return {
         "policy_mode": normalized,
-        "rerank_enabled": not policy_disables_rerank(normalized),
-        "belief_state_enabled": normalized
-        not in {STATIC_TOP1, STATIC_GATE, DYNAMIC_OBSERVATION_ONLY},
+        "paper_group_id": group.paper_group_id,
+        "paper_group_name": group.paper_group_name,
+        "rerank_enabled": group.rerank_enabled,
+        "belief_state_enabled": group.belief_state_enabled,
+        "full_runtime_adjustment": group.full_runtime_adjustment,
     }
 
 

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -23,12 +23,15 @@ from src.models.source_refs import (
 from src.workflow.runtime_evaluator import (
     DYNAMIC_OBSERVATION_ONLY,
     LITE_BELIEF_STATE,
+    RUNTIME_POLICY_ABLATION_GROUPS,
+    RUNTIME_POLICY_ABLATION_GROUP_BY_MODE,
     STATIC_GATE,
     STATIC_TOP1,
     RuntimeEvaluator,
     compute_runtime_delta,
     evaluator_policy_trace,
     policy_disables_rerank,
+    runtime_policy_ablation_group,
 )
 from src.workflow.action_features import derive_action_features
 
@@ -109,10 +112,61 @@ def _state_dict(**overrides: float) -> dict[str, object]:
     return dict(defaults)
 
 
+def _object_dict(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return cast(dict[str, object], value)
+
+
 # -- policy mode tests -------------------------------------------------------
 
 
 class TestPolicyModes:
+    def test_policy_ablation_groups_are_complete_and_ordered(self) -> None:
+        modes = [group.policy_mode for group in RUNTIME_POLICY_ABLATION_GROUPS]
+        assert modes == [
+            STATIC_TOP1,
+            STATIC_GATE,
+            DYNAMIC_OBSERVATION_ONLY,
+            LITE_BELIEF_STATE,
+        ]
+        assert set(RUNTIME_POLICY_ABLATION_GROUP_BY_MODE) == set(modes)
+
+    @pytest.mark.parametrize(
+        ("mode", "paper_group_id", "name", "rerank", "belief", "full_adjustment"),
+        [
+            (STATIC_TOP1, "static_top1", "静态单链基线", False, False, False),
+            (STATIC_GATE, "fixed_threshold_gate", "静态门控基线", False, False, False),
+            (
+                DYNAMIC_OBSERVATION_ONLY,
+                "dynamic_no_belief_state",
+                "动态观测但不使用 belief-state",
+                True,
+                False,
+                False,
+            ),
+            (LITE_BELIEF_STATE, "lite_belief_state", "完整 CEBRA-WP", True, True, True),
+        ],
+    )
+    def test_policy_ablation_group_mapping(
+        self,
+        mode: str,
+        paper_group_id: str,
+        name: str,
+        rerank: bool,
+        belief: bool,
+        full_adjustment: bool,
+    ) -> None:
+        group = runtime_policy_ablation_group(mode)
+        assert group.paper_group_id == paper_group_id
+        assert group.paper_group_name == name
+        assert group.rerank_enabled is rerank
+        assert group.belief_state_enabled is belief
+        assert group.full_runtime_adjustment is full_adjustment
+        assert group.semantic_meaning
+        assert group.question
+        assert group.expected_effect
+        assert group.key_metrics
+
     def test_static_top1_disables_rerank(self) -> None:
         e = RuntimeEvaluator(policy_mode=STATIC_TOP1)
         candidates = [_candidate("a", overall=0.8), _candidate("b", overall=0.6)]
@@ -157,12 +211,16 @@ class TestPolicyModes:
     def test_invalid_policy_defaults_to_lite(self) -> None:
         e = RuntimeEvaluator(policy_mode="invalid_mode")
         assert e.policy_mode == LITE_BELIEF_STATE
+        assert runtime_policy_ablation_group("invalid_mode").policy_mode == LITE_BELIEF_STATE
 
     def test_policy_trace(self) -> None:
         trace = evaluator_policy_trace(STATIC_TOP1)
         assert trace["rerank_enabled"] is False
         assert trace["belief_state_enabled"] is False
         assert trace["policy_mode"] == STATIC_TOP1
+        assert trace["paper_group_id"] == "static_top1"
+        assert trace["paper_group_name"] == "静态单链基线"
+        assert trace["full_runtime_adjustment"] is False
 
     def test_empty_candidates(self) -> None:
         e = RuntimeEvaluator()
@@ -212,7 +270,8 @@ class TestRerank:
         action_bias = adj["action_bias"]
         assert isinstance(action_bias, dict)
         assert action_bias["value"] == adj["value"]
-        assert action_bias["factors"] == metadata[RERANK_REASON_METADATA_KEY]["factors"]
+        rerank_reason = _object_dict(metadata[RERANK_REASON_METADATA_KEY])
+        assert action_bias["factors"] == rerank_reason["factors"]
         bias_refs = cast(list[str], action_bias["source_refs"])
         assert set(SOURCE_REF_ACTION_BIAS).issubset(bias_refs)
 
@@ -386,10 +445,10 @@ class TestActionUtility:
             assert any(ref.startswith("sid:") for ref in u.source_refs)
             assert any(ref.startswith("impl:") for ref in u.source_refs)
             assert "derived_features" in u.metadata
-            derived = u.metadata["derived_features"]
-            assert isinstance(derived, dict)
+            derived = _object_dict(u.metadata["derived_features"])
             assert "local_patchability" in derived
-            assert "source" in derived["local_patchability"]
+            local_patchability = _object_dict(derived["local_patchability"])
+            assert "source" in local_patchability
 
     def test_stop_utility_higher_under_pressure(self) -> None:
         e = RuntimeEvaluator()
@@ -414,8 +473,9 @@ class TestActionUtility:
         assert high_cap["continue"].budget_pressure == pytest.approx(0.6)
         assert low_cap["continue"].budget_pressure == pytest.approx(1.5)
         assert low_cap["stop"].utility > high_cap["stop"].utility
-        derived = low_cap["stop"].metadata["derived_features"]
-        assert derived["budget_pressure"]["source_fields"] == [
+        derived = _object_dict(low_cap["stop"].metadata["derived_features"])
+        budget_pressure = _object_dict(derived["budget_pressure"])
+        assert budget_pressure["source_fields"] == [
             "runtime_state.expected_remaining_cost",
             "runtime_state.budget_cap",
         ]
@@ -444,8 +504,9 @@ class TestActionUtility:
 
         stop = utilities["stop"]
         assert stop.intervention_value == pytest.approx(0.5)
-        derived = stop.metadata["derived_features"]
-        assert derived["intervention_value"]["source"] == "default"
+        derived = _object_dict(stop.metadata["derived_features"])
+        intervention_value = _object_dict(derived["intervention_value"])
+        assert intervention_value["source"] == "default"
 
     def test_explicit_action_features_take_priority(self) -> None:
         e = RuntimeEvaluator()
@@ -466,12 +527,10 @@ class TestActionUtility:
 
         utilities = e.compute_action_utilities(state, action_features=action_features)
 
-        patch_feature = utilities["patch_local"].metadata["derived_features"][
-            "local_patchability"
-        ]
-        stop_feature = utilities["stop"].metadata["derived_features"][
-            "intervention_value"
-        ]
+        patch_features = _object_dict(utilities["patch_local"].metadata["derived_features"])
+        stop_features = _object_dict(utilities["stop"].metadata["derived_features"])
+        patch_feature = _object_dict(patch_features["local_patchability"])
+        stop_feature = _object_dict(stop_features["intervention_value"])
         assert patch_feature["value"] == pytest.approx(0.9)
         assert patch_feature["source"] == "observed"
         assert stop_feature["value"] == pytest.approx(0.8)


### PR DESCRIPTION
## 变更概要

根据 issue #344 将 `RuntimeEvaluator` 的 4 个 policy mode 映射为论文消融组，建立代码 mode ↔ 论文组 ID ↔ 预期行为的稳定 SSOT，使评估脚本、论文表格和测试共享同一张映射表。

---

## 问题背景

`RuntimeEvaluator` 已有 4 个 policy mode 天然支持消融实验，但存在以下差距：

| 问题 | 表现 | 影响 |
|------|------|------|
| 无统一映射表 | 代码 mode 名、论文组名、评估表名可能用三套名字 | 答辩/复现时需要反向映射，增加混淆风险 |
| 组名与行为混用 | `static_top1` 和 `static_gate` 都禁用 rerank，但回答的问题不同 | 消融设计可能混为一谈 |
| 无 SSOT | 实验脚本、文档、测试各自维护一份模式表 | 漂移后难以排查差异 |

**核心变化：** 代码侧 `RUNTIME_POLICY_ABLATION_GROUPS` + 文档侧 `docs/experiment/algorithm-group-paper-mapping.md` 双向 SSOT。

---

## 变更分组

| # | Commit | 文件 | LOC | 说明 |
|---|--------|------|-----|------|
| 1 | `45ed8d5` | `src/workflow/runtime_evaluator.py` | +108/-11 | `RuntimePolicyAblationGroup` + 4 组映射 + `runtime_policy_ablation_group()` + `evaluator_policy_trace()` 扩展 |
| 2 | `07adb53` | `docs/experiment/algorithm-group-paper-mapping.md` **(新)** | +41 | 实验映射表文档 |
| 3 | `8cf2f71` | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | +1/-1 | 引用映射文档 |
| 4 | `9d9d6f6` | `docs/algorithm-and-llm/core-algorithm-code-gap-review.md` | +10/-8 | P1-7 标记完成 |
| 5 | `23a7562` | `docs/algorithm-and-llm/issues/2026-05-05-p1-07-runtime-policy-ablation-mapping.md` | +14/-2 | 状态更新 + SSOT 引用 |
| 6 | `a866b28` | `tests/unit/test_runtime_evaluator.py` | +73/-14 | 完整性 + 参数化映射测试 |

---

## 关键设计

### 1. `RuntimePolicyAblationGroup`：消融组的完整描述

```python
@dataclass(frozen=True)
class RuntimePolicyAblationGroup:
    policy_mode: RuntimePolicyMode  # 代码可执行配置
    paper_group_id: str             # 论文唯一引用 ID
    paper_group_name: str           # 论文组中文名
    semantic_meaning: str           # 语义说明
    question: str                   # 该组回答的研究问题
    expected_effect: str            # 预期效果
    key_metrics: tuple[str, ...]    # 重点评估指标
    rerank_enabled: bool            # 是否启用 runtime rerank
    belief_state_enabled: bool      # 是否使用 belief-state
    full_runtime_adjustment: bool   # 是否产生非零 runtime adjustment
    design_refs: tuple[str, ...]    # SID 可追溯性
```

**4 组映射：**

| 代码 mode | 论文组 ID | 论文组名 | rerank | belief | full_adjust | 回答的问题 |
|-----------|-----------|----------|:------:|:-----:|:----------:|-----------|
| `static_top1` | `static_top1` | 静态单链基线 | ❌ | ❌ | ❌ | 静态单链路是否足够支撑高代价工作流？ |
| `static_gate` | `fixed_threshold_gate` | 静态门控基线 | ❌ | ❌ | ❌ | 简单静态门控是否已经足够？ |
| `dynamic_observation_only` | `dynamic_no_belief_state` | 动态观测但不使用 belief-state | ✅ | ❌ | ❌ | 仅有动态观测和恢复动作、没有 belief-state 是否足够？ |
| `lite_belief_state` | `lite_belief_state` | 完整 CEBRA-WP | ✅ | ✅ | ✅ | belief-state 是否带来最后一段 runtime 决策增益？ |

**设计取舍：**

| 决定 | 理由 |
|------|------|
| `paper_group_id` 与 `policy_mode` 不同（`static_gate` → `fixed_threshold_gate`） | 论文中 `static_gate` 易与 `static_top1` 混淆，`fixed_threshold_gate` 更准确地表达了"固定阈值门控"的含义 |
| `dynamic_observation_only` 的论文组 ID 为 `dynamic_no_belief_state` | 更精确——该组的本质是"有动态但没有 belief-state" |
| `key_metrics` 每组不同 | 确保消融实验针对每组的具体贡献设计指标 |
| `full_runtime_adjustment` 仅 `lite_belief_state=True` | 强调该属性是 CEBRA-WP 独有的能力 |

### 2. 三层命名策略

```
论文表格 → paper_group_id (如 fixed_threshold_gate)
    ↑
评估配置 → policy_mode (如 static_gate)
    ↑
运行日志 → policy_mode + paper_group_name + paper_group_id 共现于 evaluator_policy_trace()
```

`evaluator_policy_trace()` 扩展后输出：

```python
{
    "policy_mode": "static_gate",
    "paper_group_id": "fixed_threshold_gate",
    "paper_group_name": "静态门控基线",
    "rerank_enabled": False,
    "belief_state_enabled": False,
    "full_runtime_adjustment": False,
}
```

### 3. 双向 SSOT 策略

```text
代码侧 SSOT:  src.workflow.runtime_evaluator.RUNTIME_POLICY_ABLATION_GROUPS
文档侧 SSOT:  docs/experiment/algorithm-group-paper-mapping.md
测试验证:     test_policy_ablation_group_mapping (parametrized × 4)
```

论文表格 → 引用 `paper_group_id`
评估脚本 → 读取 `RUNTIME_POLICY_ABLATION_GROUPS`
实验设计 → 查阅 `algorithm-group-paper-mapping.md`

三者之间的绑定由参数化测试保证。

### 4. 约束规则

实验文档中声明了 4 条不可违反的约束：

1. `lite_belief_state` 是唯一 `full_runtime_adjustment=True` 的组
2. `static_top1` 与 `static_gate` 虽然都禁用 rerank，但论文组名与问题不同，**不得混用**
3. `dynamic_observation_only` 启用动态观测链路，但不产生非零 runtime adjustment
4. 新增 mode 必须同步更新映射表、本文档和测试

---

## 测试覆盖

| 测试 | 验证点 |
|------|--------|
| `test_policy_ablation_groups_are_complete_and_ordered` | 4 组顺序正确 + BY_MODE 字典全覆盖 |
| `test_policy_ablation_group_mapping` (parametrized × 4) | 每组 `paper_group_id`/`name`/rerank/belief/full_adjust + 非空字段 |
| `test_invalid_policy_defaults_to_lite` (扩展) | 未知 mode → `runtime_policy_ablation_group()` 回退到 `LITE_BELIEF_STATE` |
| `test_policy_trace` (扩展) | `evaluator_policy_trace()` 输出含 `paper_group_id`/`name`/`full_adjustment` |

**关键断言示例：**

```python
# 完整性
assert modes == [STATIC_TOP1, STATIC_GATE, DYNAMIC_OBSERVATION_ONLY, LITE_BELIEF_STATE]

# 参数化映射 × 4
assert group.paper_group_id == paper_group_id
assert group.rerank_enabled is rerank
assert group.full_runtime_adjustment is full_adjustment
assert group.key_metrics  # 非空

# 未知 mode 回退
assert runtime_policy_ablation_group("invalid_mode").policy_mode == LITE_BELIEF_STATE
```

---

## 验收对照

| 验收标准 | 状态 | 证据 |
|----------|------|------|
| 论文主结果组与代码 mode 一一对应 | ✅ | `RUNTIME_POLICY_ABLATION_GROUPS` × 4 |
| 消融定义稳定，不随实现细节漂移 | ✅ | 冻结 dataclass + SSOT 约束 |
| 评估脚本和论文表格共享同一映射表 | ✅ | 代码 SSOT + 文档 SSOT + 交叉测试 |
| 新增 mode 有扩展约束 | ✅ | 文档 4 条规则 |

Closes #344