### PR TITLE
docs: unify formula version / schema version / doc version hierarchy (#345)

### DIFF
--- a/docs/algorithm-and-llm/algorithm-version-registry.md
+++ b/docs/algorithm-and-llm/algorithm-version-registry.md
@@ -1,0 +1,43 @@
+# CEBRA-WP 算法版本 registry
+
+## 1. 总版本
+
+| 层级 | 版本 | 说明 | 代码位置 |
+| --- | --- | --- | --- |
+| 算法总版本 | `cebra_wp.v2` | 本论文核心算法的归档版本，对应 `core-algorithm-theory-v2.md` | `src/models/algorithm_versions.py` |
+| 文档版本 | `core-algorithm-theory-v2` | 理论章节当前可引用版本 | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` |
+
+`cebra_wp.v2` 不替代子 schema 的版本号。它只说明当前论文算法由下列子公式/schema
+组合而成；各子模块后续可以独立升级为 v2/v3，但必须重新归档到新的算法总版本。
+
+## 2. 子公式与 schema 版本
+
+| 子模块 | 子公式版本 | schema / payload 版本 | 实现引用 |
+| --- | --- | --- | --- |
+| 静态候选评分 | `static_score.v1` | `score_breakdown.v1` | `impl:planner.score_breakdown.v1` |
+| posterior objective scoring | `posterior_score.v1` | `posterior_score.v1`, `posterior_objective.v1` | `impl:posterior_score.v1`, `impl:posterior_objective.v1` |
+| runtime adjustment | `runtime_adjustment.v1` | `runtime_adjustment.v1` | `impl:planner.runtime_adjustment.v1` |
+| action utility | `action_utility.v1` | `action_utility.v1`, `action_features.v1` | `impl:runtime_evaluator.action_utility.v1`, `impl:workflow.action_features.v1` |
+| action bias | `action_bias.v1` | `action_bias.v1` | `impl:runtime_evaluator.compute_runtime_delta.v1` |
+
+## 3. 层级关系
+
+```text
+cebra_wp.v2
+├─ static_score.v1
+├─ posterior_score.v1
+│  ├─ posterior_score.v1
+│  └─ posterior_objective.v1
+├─ runtime_adjustment.v1
+├─ action_utility.v1
+│  ├─ action_utility.v1
+│  └─ action_features.v1
+└─ action_bias.v1
+```
+
+## 4. 维护规则
+
+- 不为整理文档而重命名现有 payload 的 `schema_version`。
+- 若某个子公式改变字段语义或公式含义，先升级子公式/schema 版本，再更新本 registry。
+- 若多个子公式版本组合发生变化，创建新的算法总版本，例如 `cebra_wp.v3`。
+- 论文正文引用算法整体时使用 `cebra_wp.v2`；复现实验或调试 payload 时引用具体子版本。

--- a/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
+++ b/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
@@ -557,7 +557,7 @@ lite_belief_state
 
 ## 5. P2 差距
 
-### P2-1：公式版本号和文档版本号可以统一
+### P2-1：公式版本号和文档版本号可以统一（已补齐）
 
 当前有：
 
@@ -567,14 +567,22 @@ planner.runtime_adjustment.*.v1
 runtime_evaluator.action_utility.v1
 ```
 
-建议建立统一版本表：
+已建立三级版本表：
 
 ```text
-CEBRA-WP formula version: cebra_wp.v2
-static_score: static_score.v1
-action_utility: action_utility.v1
-posterior_score: posterior_score.v1
+cebra_wp.v2
+├─ static_score.v1
+├─ posterior_score.v1
+├─ runtime_adjustment.v1
+├─ action_utility.v1
+└─ action_bias.v1
 ```
+
+总表位置：
+
+- `src.models.algorithm_versions`
+- `docs/algorithm-and-llm/algorithm-version-registry.md`
+- `docs/algorithm-and-llm/core-algorithm-theory-v2.md` §0
 
 ### P2-2：候选解释可以更贴近论文术语
 

--- a/docs/algorithm-and-llm/core-algorithm-design-code-traceability.md
+++ b/docs/algorithm-and-llm/core-algorithm-design-code-traceability.md
@@ -25,6 +25,11 @@
 
 ## 2. source_refs / SID 追踪规范（Issue #337）
 
+算法总版本为 `cebra_wp.v2`，子公式/schema 版本总表见
+`docs/algorithm-and-llm/algorithm-version-registry.md` 和代码侧
+`src.models.algorithm_versions`。`source_refs` 继续表达设计 SID 与实现引用，
+不替代 payload 内部的 `schema_version`。
+
 实现侧统一使用短字符串数组：
 
 ```python

--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -5,6 +5,8 @@
 - 方法暂名：**CEBRA-WP: Constraint- and Evidence-aware Belief-guided Recovery-adaptive Workflow Planning**
 - 中文名：**面向高代价蛋白质设计工作流的约束化、证据感知、信念引导、恢复自适应规划算法**
 - 本文定位：可作为论文“方法/核心算法”章节初稿；实现差距将在 D4 单独审查。
+- 算法总版本：`cebra_wp.v2`
+- 版本 registry：`docs/algorithm-and-llm/algorithm-version-registry.md`
 
 ## 摘要
 
@@ -13,6 +15,30 @@
 为解决上述问题，本文提出 CEBRA-WP。该算法将蛋白质设计工具链规划建模为一个受约束、部分可观测、证据感知且恢复自适应的工作流决策问题。算法首先基于任务目标、约束和工具能力图生成候选工具链集合；随后使用硬可行性谓词过滤不可执行候选，并以静态效用估计候选的先验质量；在执行过程中，算法维护一个低维 Lite belief-state，用于近似隐藏的工作流可行性、结构性失败压力、恢复余量、剩余成本和证据充分度；最终，算法根据运行时状态对候选效用进行有界修正，并在 continue、patch_local、suffix_replan 和 stop 四类控制动作之间做恢复感知选择。
 
 CEBRA-WP 的核心贡献不是提出新的蛋白生成模型，而是提出一种可解释、可审计、可工程落地的高代价蛋白质设计工具链编排算法。
+
+## 0. 版本体系
+
+本文对应算法总版本 `cebra_wp.v2`。该总版本不替代各 payload 的
+`schema_version`，而是把当前论文算法使用的子公式和实现引用归档到同一版本下：
+
+```text
+cebra_wp.v2
+├─ static_score.v1
+├─ posterior_score.v1
+├─ runtime_adjustment.v1
+├─ action_utility.v1
+└─ action_bias.v1
+```
+
+| 子公式 | schema / payload 版本 | 主要实现引用 |
+| --- | --- | --- |
+| `static_score.v1` | `score_breakdown.v1` | `impl:planner.score_breakdown.v1` |
+| `posterior_score.v1` | `posterior_score.v1`, `posterior_objective.v1` | `impl:posterior_score.v1`, `impl:posterior_objective.v1` |
+| `runtime_adjustment.v1` | `runtime_adjustment.v1` | `impl:planner.runtime_adjustment.v1` |
+| `action_utility.v1` | `action_utility.v1`, `action_features.v1` | `impl:runtime_evaluator.action_utility.v1`, `impl:workflow.action_features.v1` |
+| `action_bias.v1` | `action_bias.v1` | `impl:runtime_evaluator.compute_runtime_delta.v1` |
+
+代码侧 registry 为 `src.models.algorithm_versions`。若后续任一子公式改变字段语义或公式含义，应先升级子版本，再归档到新的算法总版本。
 
 ## 1. 问题定义
 

--- a/docs/algorithm-and-llm/issues/2026-05-05-p2-01-formula-version-unification.md
+++ b/docs/algorithm-and-llm/issues/2026-05-05-p2-01-formula-version-unification.md
@@ -6,7 +6,7 @@
 - Scope: algorithm / versioning / traceability
 - Phase: CEBRA-WP P2 文档与表达增强
 - Body language: Chinese
-- 状态：待实现
+- 状态：已实现
 - 本文件定位：P2-1 的唯一实现参考来源；进入编码前以本文为准。
 
 ## 1. 背景
@@ -50,6 +50,14 @@ cebra_wp.v2
 ├─ posterior_score.v1
 ├─ action_utility.v1
 └─ runtime_adjustment.v1
+```
+
+当前实现总表位于：
+
+```text
+src/models/algorithm_versions.py
+docs/algorithm-and-llm/algorithm-version-registry.md
+docs/algorithm-and-llm/core-algorithm-theory-v2.md
 ```
 
 ## 6. 测试建议

--- a/src/models/algorithm_versions.py
+++ b/src/models/algorithm_versions.py
@@ -1,0 +1,104 @@
+"""CEBRA-WP 算法版本与子公式版本 registry。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from src.models.source_refs import (
+    SOURCE_REF_ACTION_BIAS,
+    SOURCE_REF_ACTION_UTILITY,
+    SOURCE_REF_POSTERIOR_OBJECTIVE,
+    SOURCE_REF_RUNTIME_ADJUSTMENT,
+    SOURCE_REF_STATIC_SCORE,
+)
+
+CEBRA_WP_ALGORITHM_VERSION: Final = "cebra_wp.v2"
+CEBRA_WP_DOC_VERSION: Final = "core-algorithm-theory-v2"
+
+
+@dataclass(frozen=True)
+class FormulaVersionEntry:
+    """算法总版本下的子公式/schema 版本条目。"""
+
+    formula_id: str
+    formula_version: str
+    role: str
+    schema_versions: tuple[str, ...]
+    implementation_refs: tuple[str, ...]
+    design_refs: tuple[str, ...]
+
+
+CEBRA_WP_FORMULA_VERSION_ENTRIES: Final[tuple[FormulaVersionEntry, ...]] = (
+    FormulaVersionEntry(
+        formula_id="static_score",
+        formula_version="static_score.v1",
+        role="静态候选效用与 score_breakdown 归档版本。",
+        schema_versions=("score_breakdown.v1",),
+        implementation_refs=tuple(
+            ref for ref in SOURCE_REF_STATIC_SCORE if ref.startswith("impl:")
+        ),
+        design_refs=tuple(
+            ref for ref in SOURCE_REF_STATIC_SCORE if ref.startswith("sid:")
+        ),
+    ),
+    FormulaVersionEntry(
+        formula_id="posterior_score",
+        formula_version="posterior_score.v1",
+        role="证据加权 posterior objective scoring 归档版本。",
+        schema_versions=("posterior_score.v1", "posterior_objective.v1"),
+        implementation_refs=tuple(
+            ref for ref in SOURCE_REF_POSTERIOR_OBJECTIVE if ref.startswith("impl:")
+        ),
+        design_refs=tuple(
+            ref for ref in SOURCE_REF_POSTERIOR_OBJECTIVE if ref.startswith("sid:")
+        ),
+    ),
+    FormulaVersionEntry(
+        formula_id="runtime_adjustment",
+        formula_version="runtime_adjustment.v1",
+        role="基于 runtime state 的候选分数修正公式归档版本。",
+        schema_versions=("runtime_adjustment.v1",),
+        implementation_refs=tuple(
+            ref for ref in SOURCE_REF_RUNTIME_ADJUSTMENT if ref.startswith("impl:")
+        ),
+        design_refs=tuple(
+            ref for ref in SOURCE_REF_RUNTIME_ADJUSTMENT if ref.startswith("sid:")
+        ),
+    ),
+    FormulaVersionEntry(
+        formula_id="action_utility",
+        formula_version="action_utility.v1",
+        role="continue/patch_local/suffix_replan/stop 动作效用公式归档版本。",
+        schema_versions=("action_utility.v1", "action_features.v1"),
+        implementation_refs=tuple(
+            ref for ref in SOURCE_REF_ACTION_UTILITY if ref.startswith("impl:")
+        ),
+        design_refs=tuple(
+            ref for ref in SOURCE_REF_ACTION_UTILITY if ref.startswith("sid:")
+        ),
+    ),
+    FormulaVersionEntry(
+        formula_id="action_bias",
+        formula_version="action_bias.v1",
+        role="runtime delta 的动作偏置解释层归档版本。",
+        schema_versions=("action_bias.v1",),
+        implementation_refs=tuple(
+            ref for ref in SOURCE_REF_ACTION_BIAS if ref.startswith("impl:")
+        ),
+        design_refs=tuple(
+            ref for ref in SOURCE_REF_ACTION_BIAS if ref.startswith("sid:")
+        ),
+    ),
+)
+
+CEBRA_WP_FORMULA_VERSION_BY_ID: Final[dict[str, FormulaVersionEntry]] = {
+    entry.formula_id: entry
+    for entry in CEBRA_WP_FORMULA_VERSION_ENTRIES
+}
+
+
+def formula_version_entry(formula_id: str) -> FormulaVersionEntry:
+    """按公式 ID 返回版本条目。"""
+
+    return CEBRA_WP_FORMULA_VERSION_BY_ID[formula_id]

--- a/tests/unit/test_algorithm_versions.py
+++ b/tests/unit/test_algorithm_versions.py
@@ -1,0 +1,62 @@
+"""CEBRA-WP 算法版本 registry 测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.models.algorithm_versions import (
+    CEBRA_WP_ALGORITHM_VERSION,
+    CEBRA_WP_DOC_VERSION,
+    CEBRA_WP_FORMULA_VERSION_BY_ID,
+    CEBRA_WP_FORMULA_VERSION_ENTRIES,
+    formula_version_entry,
+)
+
+
+def test_cebra_wp_formula_versions_are_archived_under_algorithm_version() -> None:
+    assert CEBRA_WP_ALGORITHM_VERSION == "cebra_wp.v2"
+    assert CEBRA_WP_DOC_VERSION == "core-algorithm-theory-v2"
+    assert [entry.formula_id for entry in CEBRA_WP_FORMULA_VERSION_ENTRIES] == [
+        "static_score",
+        "posterior_score",
+        "runtime_adjustment",
+        "action_utility",
+        "action_bias",
+    ]
+
+
+def test_formula_version_registry_uses_stable_v1_children() -> None:
+    assert formula_version_entry("static_score").formula_version == "static_score.v1"
+    assert formula_version_entry("posterior_score").schema_versions == (
+        "posterior_score.v1",
+        "posterior_objective.v1",
+    )
+    assert formula_version_entry("runtime_adjustment").formula_version == (
+        "runtime_adjustment.v1"
+    )
+    assert formula_version_entry("action_utility").formula_version == "action_utility.v1"
+    assert formula_version_entry("action_bias").formula_version == "action_bias.v1"
+
+
+def test_formula_version_entries_link_design_and_impl_refs() -> None:
+    assert set(CEBRA_WP_FORMULA_VERSION_BY_ID) == {
+        entry.formula_id
+        for entry in CEBRA_WP_FORMULA_VERSION_ENTRIES
+    }
+    for entry in CEBRA_WP_FORMULA_VERSION_ENTRIES:
+        assert entry.implementation_refs
+        assert entry.design_refs
+        assert all(ref.startswith("impl:") for ref in entry.implementation_refs)
+        assert all(ref.startswith("sid:") for ref in entry.design_refs)
+
+
+def test_algorithm_version_registry_doc_mentions_code_registry_entries() -> None:
+    doc = Path("docs/algorithm-and-llm/algorithm-version-registry.md").read_text(
+        encoding="utf-8",
+    )
+    assert CEBRA_WP_ALGORITHM_VERSION in doc
+    assert CEBRA_WP_DOC_VERSION in doc
+    for entry in CEBRA_WP_FORMULA_VERSION_ENTRIES:
+        assert entry.formula_version in doc
+        for ref in entry.implementation_refs:
+            assert ref in doc


### PR DESCRIPTION
## 变更概要

根据 issue #345 建立三级版本体系，统一公式版本号、schema 版本号与文档版本号，解决"子模块版本各自前进，论文无法说明整套算法是哪一版"的问题。

---

## 问题背景

代码和文档中存在多种版本标记，但缺少统一框架：

| 现有版本号 | 所在位置 | 问题 |
|-----------|----------|------|
| `posterior_score.v1` | `objective_ranker_adapter.py` | ✅ 有版本，但无归属 |
| `runtime_adjustment.v1` | `runtime_evaluator.py` / `contracts.py` | ✅ 有版本，但无归属 |
| `action_utility.v1` | `runtime_evaluator.py` | ✅ 有版本，但无归属 |
| `static_score.v1` | `planner.py` / `source_refs.py` | ✅ 有版本，但无归属 |
| `action_bias.v1` | `contracts.py` (新增) | ✅ 有版本，但无归属 |
| **算法总版本** | **不存在** | ❌ 论文无法说明"这套算法是哪一版" |

**核心方案：** 三级版本体系

```text
A. 算法总版本: cebra_wp.v2
B. 子公式版本: static_score.v1 / posterior_score.v1 / ...
C. 实现引用: impl:<module>.<symbol>.v1 (来自 source_refs)
```

---

## 变更分组

| # | Commit | 文件 | LOC | 说明 |
|---|--------|------|-----|------|
| 1 | `06f92d9` | `src/models/algorithm_versions.py` **(新)** | +104 | `FormulaVersionEntry` + 5 条目 + `formula_version_entry()` |
| 2 | `d304e97` | `docs/algorithm-and-llm/algorithm-version-registry.md` **(新)** | +43 | 版本 registry 文档 SSOT |
| 3 | `6b7c120` | `docs/algorithm-and-llm/core-algorithm-theory-v2.md` | +26 | §0 版本层级小节 |
| 4 | `17972c6` | `docs/algorithm-and-llm/core-algorithm-code-gap-review.md` | +14/-6 | P2-1 标记完成 |
| 5 | `dabbd87` | `docs/algorithm-and-llm/core-algorithm-design-code-traceability.md` | +5 | 版本引用 |
| 6 | `eb12bcf` | `docs/algorithm-and-llm/issues/2026-05-05-p2-01-formula-version-unification.md` | +10/-2 | 状态更新 |
| 7 | `d21c502` | `tests/unit/test_algorithm_versions.py` **(新)** | +62 | 4 个测试 |

---

## 关键设计

### 1. 三级版本体系

| 层级 | 示例 | 载体 | 变更粒度 |
|------|------|------|----------|
| **A. 算法总版本** | `cebra_wp.v2` | `CEBRA_WP_ALGORITHM_VERSION` 常量 | 多个子公式版本组合变化时 |
| **B. 子公式版本** | `static_score.v1`, `action_utility.v1` | `FormulaVersionEntry.formula_version` | 单子公式字段语义或公式含义改变时 |
| **C. 实现引用** | `impl:planner.score_breakdown.v1` | `source_refs` 中的 `impl:` 前缀 | 实现细节变化但不影响公式语义时 |

### 2. `FormulaVersionEntry`：完整描述一个子公式版本

```python
@dataclass(frozen=True)
class FormulaVersionEntry:
    formula_id: str                     # static_score
    formula_version: str               # static_score.v1
    role: str                          # 中文说明
    schema_versions: tuple[str, ...]   # 关联的 payload schema 版本
    implementation_refs: tuple[str, ...]  # impl: 前缀引用
    design_refs: tuple[str, ...]       # sid: 前缀引用
```

**5 条目覆盖：**

| formula_id | formula_version | schema_versions | 实现引用数 |
|-----------|----------------|-----------------|:----------:|
| `static_score` | `static_score.v1` | `score_breakdown.v1` | 1 |
| `posterior_score` | `posterior_score.v1` | `posterior_score.v1`, `posterior_objective.v1` | 2 |
| `runtime_adjustment` | `runtime_adjustment.v1` | `runtime_adjustment.v1` | 1 |
| `action_utility` | `action_utility.v1` | `action_utility.v1`, `action_features.v1` | 2 |
| `action_bias` | `action_bias.v1` | `action_bias.v1` | 1 |

**设计取舍：**

| 决定 | 理由 |
|------|------|
| 不重命名现有 payload 的 `schema_version` | 向后兼容，registry 只是归档层 |
| `implementation_refs` 从已有 `SOURCE_REF_*` 过滤 | 避免重复维护，`source_refs` 已经是 SSOT |
| 代码 + 文档各一份 SSOT | 交叉测试保证两者不漂移 |

### 3. 层级树结构

```text
cebra_wp.v2
├─ static_score.v1
├─ posterior_score.v1
│  ├─ posterior_score.v1 (schema)
│  └─ posterior_objective.v1 (schema)
├─ runtime_adjustment.v1
├─ action_utility.v1
│  ├─ action_utility.v1 (schema)
│  └─ action_features.v1 (schema)
└─ action_bias.v1
```

这棵树的层次关系在 `algorithm-version-registry.md` 中以 ASCII 树表达，在 `core-algorithm-theory-v2.md` §0 中以 markdown 表格表达，两者相互引用。

### 4. 维护规则

```text
1. 不重命名现有 payload 的 schema_version。
2. 子公式改变字段语义或公式含义 → 先升级子公式/schema 版本，再更新 registry。
3. 多子公式版本组合变化 → 创建新的算法总版本（如 cebra_wp.v3）。
4. 论文正文引用算法整体用 cebra_wp.v2；复现实验引用具体子版本。
```

### 5. 论文中的引用位置

理论文档 §0 新增：

> *本文对应算法总版本 `cebra_wp.v2`。该总版本不替代各 payload 的 `schema_version`，而是把当前论文算法使用的子公式和实现引用归档到同一版本下。*

论文正文引用算法整体时使用 `cebra_wp.v2`；审计 payload 时引用具体 `schema_version`。

---

## 测试覆盖

| 测试 | 验证点 |
|------|--------|
| `test_cebra_wp_formula_versions_are_archived_under_algorithm_version` | 总版本 `cebra_wp.v2` + 5 个 formula_id 顺序 |
| `test_formula_version_registry_uses_stable_v1_children` | 每个公式版本字符串 + schema 版本元组 |
| `test_formula_version_entries_link_design_and_impl_refs` | 所有条目非空 + impl:/sid: 前缀 |
| `test_algorithm_version_registry_doc_mentions_code_registry_entries` | 代码 registry 的每个版本和引用出现在 doc 中 |

**文档对齐交叉测试：**

```python
doc = Path("docs/algorithm-and-llm/algorithm-version-registry.md").read_text()
assert CEBRA_WP_ALGORITHM_VERSION in doc
for entry in CEBRA_WP_FORMULA_VERSION_ENTRIES:
    assert entry.formula_version in doc
    for ref in entry.implementation_refs:
        assert ref in doc
```

---

## 验收对照

| 验收标准 | 状态 | 证据 |
|----------|------|------|
| 版本体系有总表 | ✅ | 代码 `algorithm_versions.py` + 文档 `algorithm-version-registry.md` |
| 子模块版本能归档到算法总版本 | ✅ | 5 个 `FormulaVersionEntry` 挂载在 `cebra_wp.v2` 下 |
| 后续论文引用时不再混乱 | ✅ | `impl:` / `sid:` / `schema_version` / `formula_version` 四层有独立语义 |

Closes #345