### PR TITLE
feat: elevate candidate explanations with theory term and formula_ref (#346)

### DIFF
--- a/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
+++ b/docs/algorithm-and-llm/core-algorithm-code-gap-review.md
@@ -586,7 +586,7 @@ cebra_wp.v2
 - `docs/algorithm-and-llm/algorithm-version-registry.md`
 - `docs/algorithm-and-llm/core-algorithm-theory-v2.md` §0
 
-### P2-2：候选解释可以更贴近论文术语
+### P2-2：候选解释可以更贴近论文术语（已补齐）
 
 当前解释偏工程：
 
@@ -595,12 +595,16 @@ Local patchability keeps more recovery options available.
 Suffix replan still carries residual budget pressure.
 ```
 
-建议补充理论字段：
+已在 `RuntimeAdjustmentFactor` 中补充理论字段，同时保留工程原文：
 
 ```text
-term = "recovery_margin" | "budget_pressure" | "evidence_sufficiency"
-formula_ref = "Eq.(runtime_delta)"
+term = "recovery_margin" | "budget_pressure" | "evidence_sufficiency" | "ActionBias" | "recoverability"
+formula_ref = "Eq.(runtime_delta)" | "Eq.(ActionBias)"
+message = 原工程解释
 ```
+
+因此论文图注/UI 简版可以显示 `term + formula_ref`，调试展开层继续显示
+`message`。
 
 ### P2-3：文献映射可进入代码注释/设计文档
 

--- a/docs/algorithm-and-llm/core-algorithm-theory-v2.md
+++ b/docs/algorithm-and-llm/core-algorithm-theory-v2.md
@@ -526,6 +526,15 @@ bp_t = clip(c_t, 0, 1)
 实现中该理论对象由 `runtime_adjustment.action_bias` 承载，包含
 `action/value/factors/source_refs`，且 `action_bias.value` 与
 `runtime_adjustment.value` 保持一致。
+每个 factor 同时保留工程解释 `message` 与论文展示层可用的理论字段：
+
+```text
+term ∈ {recovery_margin, budget_pressure, evidence_sufficiency, ActionBias, recoverability, ...}
+formula_ref ∈ {Eq.(runtime_delta), Eq.(ActionBias)}
+```
+
+展示层可优先使用 `term + formula_ref` 作为图注或表格标签，展开时再展示
+工程原文 `message`。
 
 为了避免单次观测过度影响排序，限定：
 

--- a/docs/algorithm-and-llm/issues/2026-05-05-p2-02-candidate-explanation-theory-terms.md
+++ b/docs/algorithm-and-llm/issues/2026-05-05-p2-02-candidate-explanation-theory-terms.md
@@ -6,7 +6,7 @@
 - Scope: algorithm / explanation / UI text
 - Phase: CEBRA-WP P2 文档与表达增强
 - Body language: Chinese
-- 状态：待实现
+- 状态：已实现
 - 本文件定位：P2-2 的唯一实现参考来源；进入编码前以本文为准。
 
 ## 1. 背景
@@ -61,6 +61,17 @@
 - 解释字段保留工程原文；
 - 增加一层理论标签；
 - UI / 日志 / 论文图表优先显示理论标签，展开时再看工程原文。
+
+当前实现中，`RuntimeAdjustmentFactor` 保留：
+
+```python
+message: str
+term: str | None
+formula_ref: str | None
+```
+
+`runtime_evaluator._make_factor()` 为新生成的 runtime delta / ActionBias
+factor 自动填充理论标签；旧 payload 可不提供这两个字段以保持兼容。
 
 ## 6. 测试建议
 

--- a/src/models/contracts.py
+++ b/src/models/contracts.py
@@ -6,7 +6,14 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, TypeAlias, Dict, List, Optional, Literal, cast
 
-from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from src.models.budget_pressure import derive_budget_pressure
 
@@ -665,10 +672,14 @@ class RuntimeAdjustmentFactor(BaseModel):
     source: str
     contribution: float
     message: str
+    term: str | None = None
+    formula_ref: str | None = None
 
-    @field_validator("signal", "source", "message")
+    @field_validator("signal", "source", "message", "term", "formula_ref")
     @classmethod
-    def _validate_text(cls, value: str, info) -> str:
+    def _validate_text(cls, value: str | None, info: ValidationInfo) -> str | None:
+        if value is None:
+            return None
         return _validate_non_empty_text(value, field_name=info.field_name)
 
     @field_validator("contribution")

--- a/src/workflow/runtime_evaluator.py
+++ b/src/workflow/runtime_evaluator.py
@@ -94,6 +94,8 @@ _STOP_RECOVERY_MARGIN_THRESHOLD = 0.20
 
 _STRUCTURAL_FAILURE_THRESHOLD = 0.55
 _RECOVERY_MARGIN_LOW = 0.1
+_RUNTIME_DELTA_FORMULA_REF = "Eq.(runtime_delta)"
+_ACTION_BIAS_FORMULA_REF = "Eq.(ActionBias)"
 
 
 @dataclass(frozen=True)
@@ -839,13 +841,46 @@ def _make_factor(
     contribution: float,
     message: str,
 ) -> RuntimeAdjustmentFactor:
+    term, formula_ref = _theory_explanation_ref(category=category, signal=signal)
     return RuntimeAdjustmentFactor(
         category=category,
         signal=signal,
         source=source,
         contribution=round(contribution, 6),
         message=message,
+        term=term,
+        formula_ref=formula_ref,
     )
+
+
+def _theory_explanation_ref(
+    *,
+    category: Literal["cost", "risk", "recovery", "evidence", "policy"],
+    signal: str,
+) -> tuple[str, str]:
+    if signal == "evidence_sufficiency":
+        return "evidence_sufficiency", _RUNTIME_DELTA_FORMULA_REF
+    if signal == "budget_pressure" or signal == "cost_pressure":
+        return "budget_pressure", _RUNTIME_DELTA_FORMULA_REF
+    if signal == "p_structural_failure":
+        return "p_structural_failure", _RUNTIME_DELTA_FORMULA_REF
+    if signal == "recovery_margin*fallback_depth":
+        return "recovery_margin", _RUNTIME_DELTA_FORMULA_REF
+    if signal == "fallback_depth":
+        return "recoverability", _ACTION_BIAS_FORMULA_REF
+    if signal == "feasibility":
+        return "recoverability", _ACTION_BIAS_FORMULA_REF
+    if signal == "stop_guard":
+        return "ActionBias", _ACTION_BIAS_FORMULA_REF
+    if category == "evidence":
+        return "evidence_sufficiency", _RUNTIME_DELTA_FORMULA_REF
+    if category == "recovery":
+        return "recovery_margin", _RUNTIME_DELTA_FORMULA_REF
+    if category == "cost":
+        return "budget_pressure", _RUNTIME_DELTA_FORMULA_REF
+    if category == "policy":
+        return "ActionBias", _ACTION_BIAS_FORMULA_REF
+    return signal, _RUNTIME_DELTA_FORMULA_REF
 
 
 def _build_action_bias(

--- a/tests/unit/test_contract_source_refs.py
+++ b/tests/unit/test_contract_source_refs.py
@@ -41,6 +41,30 @@ def test_runtime_adjustment_accepts_source_refs() -> None:
     assert "impl:planner.runtime_adjustment.v1" in summary.source_refs
 
 
+def test_runtime_adjustment_factor_keeps_theory_terms_optional() -> None:
+    legacy = RuntimeAdjustmentFactor(
+        category="evidence",
+        signal="evidence_sufficiency",
+        source="runtime_state.evidence_sufficiency",
+        contribution=0.03,
+        message="Evidence sufficiency raises confidence.",
+    )
+    annotated = RuntimeAdjustmentFactor(
+        category="evidence",
+        signal="evidence_sufficiency",
+        source="runtime_state.evidence_sufficiency",
+        contribution=0.03,
+        message="Evidence sufficiency raises confidence.",
+        term="evidence_sufficiency",
+        formula_ref="Eq.(runtime_delta)",
+    )
+
+    assert legacy.term is None
+    assert legacy.formula_ref is None
+    assert annotated.term == "evidence_sufficiency"
+    assert annotated.formula_ref == "Eq.(runtime_delta)"
+
+
 def test_runtime_adjustment_accepts_action_bias() -> None:
     factor = RuntimeAdjustmentFactor(
         category="recovery",

--- a/tests/unit/test_runtime_evaluator.py
+++ b/tests/unit/test_runtime_evaluator.py
@@ -272,6 +272,13 @@ class TestRerank:
         assert action_bias["value"] == adj["value"]
         rerank_reason = _object_dict(metadata[RERANK_REASON_METADATA_KEY])
         assert action_bias["factors"] == rerank_reason["factors"]
+        factors = cast(list[dict[str, object]], action_bias["factors"])
+        assert any(
+            factor["term"] == "evidence_sufficiency"
+            and factor["formula_ref"] == "Eq.(runtime_delta)"
+            and factor["message"]
+            for factor in factors
+        )
         bias_refs = cast(list[str], action_bias["source_refs"])
         assert set(SOURCE_REF_ACTION_BIAS).issubset(bias_refs)
 
@@ -311,6 +318,9 @@ class TestRerank:
             assert action_bias["action"] == expected_action
             assert action_bias["value"] == adjustment["value"]
             assert action_bias["factors"] == rerank["factors"]
+            factors = cast(list[dict[str, object]], action_bias["factors"])
+            assert all(factor["term"] for factor in factors)
+            assert all(factor["formula_ref"] for factor in factors)
 
     def test_high_risk_reduces_score(self) -> None:
         e = RuntimeEvaluator()
@@ -359,12 +369,39 @@ class TestRerank:
         assert any(
             factor.signal == "budget_pressure"
             and factor.source == "runtime_state.budget_pressure+score_breakdown.cost"
+            and factor.term == "budget_pressure"
+            and factor.formula_ref == "Eq.(runtime_delta)"
             for factor in low_pressure_factors
         )
         assert any(
             factor.signal == "budget_pressure"
             and factor.source == "runtime_state.budget_pressure+score_breakdown.cost"
+            and factor.term == "budget_pressure"
+            and factor.formula_ref == "Eq.(runtime_delta)"
             for factor in high_pressure_factors
+        )
+
+    def test_theory_terms_preserve_engineering_messages(self) -> None:
+        _, action, _, factors = compute_runtime_delta(
+            p_success=0.6,
+            p_structural_failure=0.2,
+            recovery_margin=0.6,
+            expected_remaining_cost=0.4,
+            evidence_sufficiency=0.6,
+            confidence=0.6,
+            risk=0.5,
+            cost=0.2,
+            fallback_depth=0.8,
+            feasibility=0.8,
+            candidate_kind="patch",
+        )
+
+        assert action == "patch_local"
+        patch_factor = next(factor for factor in factors if factor.signal == "fallback_depth")
+        assert patch_factor.term == "recoverability"
+        assert patch_factor.formula_ref == "Eq.(ActionBias)"
+        assert patch_factor.message == (
+            "Local patchability keeps more recovery options available."
         )
 
     def test_delta_clamped_to_range(self) -> None:


### PR DESCRIPTION
## 变更概要

根据 issue #346 为 `RuntimeAdjustmentFactor` 增加理论术语 `term` 和公式引用 `formula_ref` 字段，将候选解释从纯工程文案提升为"理论标签 + 工程原文"的双层表达。

---

## 问题背景

候选解释已可读，但措辞偏工程，缺少与理论对象的直接挂钩：

| 当前工程文案 | 缺失的理论挂钩 | 问题 |
|-------------|---------------|------|
| `Suffix replan still carries residual budget pressure.` | `budget_pressure` | 读者不知道这是哪个公式项 |
| `Local patchability keeps more recovery options available.` | `recoverability` / `ActionBias` | 无法用于论文图注 |
| `Recovery headroom and fallback depth shape the shadow rerank bonus.` | `recovery_margin` | 展示层只能显示全文 |

**核心方案：** 每条 factor 同时保留 `message`（工程原文）与 `term` + `formula_ref`（理论标签），展示层可优先使用后两者。

---

## 变更分组

| # | Commit | 文件 | LOC | 说明 |
|---|--------|------|-----|------|
| 1 | `5de2ddf` | `src/models/contracts.py` | +14/-3 | `RuntimeAdjustmentFactor` 新增 `term`/`formula_ref` |
| 2 | `319a321` | `src/workflow/runtime_evaluator.py` | +35 | `_theory_explanation_ref()` 映射函数 |
| 3 | `68addb4` | `docs/.../core-algorithm-theory-v2.md` | +9 | 双表达层文档 |
| 4 | `35fccd3` | `docs/.../code-gap-review.md` | +8/-4 | P2-2 状态 |
| 5 | `79b73b3` | `docs/.../p2-02-candidate-explanation.md` | +13/-2 | 状态 |
| 6 | `522f1a5` | `tests/unit/test_contract_source_refs.py` | +24 | 兼容性 + 标注测试 |
| 7 | `b92b707` | `tests/unit/test_runtime_evaluator.py` | +37 | 理论术语断言 + 新测试 |

---

## 关键设计

### 1. `RuntimeAdjustmentFactor` 新增字段

```python
class RuntimeAdjustmentFactor(BaseModel):
    category: str
    signal: str
    source: str
    contribution: float
    message: str
    term: str | None = None            # 新增
    formula_ref: str | None = None     # 新增
```

**向后兼容：**
- `term=None`, `formula_ref=None` 为默认值
- 旧 payload 反序列化时无此字段，保持兼容
- `_validate_text` 验证器扩展支持 `str | None`

### 2. `_theory_explanation_ref()` 映射规则

根据 `category` + `signal` 匹配理论术语和公式引用：

| 信号 | category | 映射 term | formula_ref |
|------|----------|-----------|-------------|
| `evidence_sufficiency` | 任意 | `evidence_sufficiency` | `Eq.(runtime_delta)` |
| `budget_pressure` / `cost_pressure` | 任意 | `budget_pressure` | `Eq.(runtime_delta)` |
| `p_structural_failure` | 任意 | `p_structural_failure` | `Eq.(runtime_delta)` |
| `recovery_margin*fallback_depth` | 任意 | `recovery_margin` | `Eq.(runtime_delta)` |
| `fallback_depth` | 任意 | `recoverability` | `Eq.(ActionBias)` |
| `feasibility` | 任意 | `recoverability` | `Eq.(ActionBias)` |
| `stop_guard` | 任意 | `ActionBias` | `Eq.(ActionBias)` |
| 其他 | `evidence` | `evidence_sufficiency` | `Eq.(runtime_delta)` |
| 其他 | `recovery` | `recovery_margin` | `Eq.(runtime_delta)` |
| 其他 | `cost` | `budget_pressure` | `Eq.(runtime_delta)` |
| 其他 | `policy` | `ActionBias` | `Eq.(ActionBias)` |
| 其他 | 其他 | `signal` 自身 | `Eq.(runtime_delta)` |

**设计取舍：**
- ✅ 信号特异性规则优先于 category 回退
- ✅ category 回退确保新信号即使无显式映射也有理论标签
- ✅ 不使用 `||` 等符号作为回退值，确保展示层总是有可显示的 term

### 3. 双表达层示意

论文图注 / UI 简版：
```
↑ recovery_margin (Eq.runtime_delta)
```

调试展开层：
```
Recovery headroom and fallback depth shape the shadow rerank bonus.
```

metadata 中的完整结构：

```json
{
  "category": "recovery",
  "signal": "recovery_margin*fallback_depth",
  "contribution": 0.06,
  "message": "Recovery headroom and fallback depth shape the shadow rerank bonus.",
  "term": "recovery_margin",
  "formula_ref": "Eq.(runtime_delta)"
}
```

---

## 测试覆盖

| 测试 | 验证点 |
|------|--------|
| `test_runtime_adjustment_factor_keeps_theory_terms_optional` | 旧 payload term=None; 新 payload term+formula_ref 正确 |
| `test_rerank_metadata...` (extended) | factor 有 `evidence_sufficiency` + `Eq.(runtime_delta)` |
| `test_action_bias_generated...` (extended) | 所有 factor 非空 term + formula_ref |
| `test_runtime_delta_uses_budget_pressure...` (extended) | `budget_pressure` term + `Eq.(runtime_delta)` |
| `test_theory_terms_preserve_engineering_messages` (new) | `patch_local`: term=`recoverability`, ref=`Eq.(ActionBias)`, message 保留原文 |

---

## 验收对照

| 验收标准 | 状态 | 证据 |
|----------|------|------|
| 候选解释可直接用于论文图注 | ✅ | `term + formula_ref` 字段提供稳定理论标签 |
| 工程 debug 细节保留 | ✅ | `message` 字段保持不变 |
| 两种表达层不互相覆盖 | ✅ | `term`/`formula_ref` 与 `message` 独立存储 |

Closes #346