### PR TITLE
refactor(backend): 拆分 Phase 2 核心模块职责

### DIFF
--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -88,6 +88,13 @@ from src.workflow.context import WorkflowContext
 from src.workflow.pending_action import build_pending_action, enter_waiting_state
 from src.workflow.runtime_evaluator import compute_runtime_delta
 from src.workflow.status import transition_task_status
+from src.agents.planner_denovo import is_de_novo_task_kind
+from src.agents.planner_payloads import build_candidate_generation_constraints
+from src.agents.planner_projection import normalize_top_k
+from src.agents.planner_selection import (
+    executable_rate_route_trigger,
+    schema_failure_route_trigger,
+)
 
 
 @dataclass(frozen=True)
@@ -230,11 +237,11 @@ _DEFAULT_PROVIDER_CATALOG_PATH = (
 )
 _PLANNER_PROVIDER_ENV = "PLANNER_LLM_PROVIDER"
 _PREFERRED_LOCAL_PROVIDER_ORDER = (
+    "qwen-flash",
     "glm-5",
     "deepseek-v4-pro",
     "deepseek-v4-flash",
     "glm-4.7",
-    "qwen-flash",
     "nemotron",
     "openai",
 )
@@ -696,16 +703,15 @@ class PlannerAgent:
                         + 1
                     )
                     runtime_state["schema_fail_streak"] = streak
-                    if (
-                        runtime_cfg.enable_dual_route
-                        and streak >= runtime_cfg.schema_fail_threshold
-                    ):
+                    schema_trigger = schema_failure_route_trigger(
+                        enable_dual_route=runtime_cfg.enable_dual_route,
+                        schema_fail_streak=streak,
+                        threshold=runtime_cfg.schema_fail_threshold,
+                    )
+                    if schema_trigger is not None:
                         route_trigger = RouteTrigger(
-                            reason="schema_fail_streak",
-                            threshold=(
-                                f"schema_fail_streak={streak}"
-                                f">={runtime_cfg.schema_fail_threshold}"
-                            ),
+                            reason=schema_trigger.reason,
+                            threshold=schema_trigger.threshold,
                         )
                         use_external = True
                         base_plan = self.plan(task, use_external=True)
@@ -724,44 +730,29 @@ class PlannerAgent:
                 runtime_state.get("last_executable_rate")
             )
 
-            if (
-                runtime_cfg.enable_dual_route
-                and not use_external
-                and self._fallback_llm_provider is not None
-            ):
-                drop = (
-                    previous_rate - executable_rate
-                    if previous_rate is not None
-                    else 0.0
+            trigger_spec = executable_rate_route_trigger(
+                enable_dual_route=runtime_cfg.enable_dual_route,
+                use_external=use_external,
+                fallback_available=self._fallback_llm_provider is not None,
+                executable_rate=executable_rate,
+                previous_rate=previous_rate,
+                rate_threshold=runtime_cfg.executable_rate_threshold,
+                drop_threshold=runtime_cfg.executable_drop_threshold,
+            )
+            if trigger_spec is not None:
+                route_trigger = RouteTrigger(
+                    reason=trigger_spec.reason,
+                    threshold=trigger_spec.threshold,
                 )
-                trigger: RouteTrigger | None = None
-                if executable_rate < runtime_cfg.executable_rate_threshold:
-                    trigger = RouteTrigger(
-                        reason="candidate_executable_rate_low",
-                        threshold=(
-                            f"candidate_executable_rate={executable_rate:.3f}"
-                            f"<{runtime_cfg.executable_rate_threshold:.3f}"
-                        ),
-                    )
-                elif drop >= runtime_cfg.executable_drop_threshold:
-                    trigger = RouteTrigger(
-                        reason="candidate_executable_rate_drop",
-                        threshold=(
-                            f"candidate_executable_drop={drop:.3f}"
-                            f">={runtime_cfg.executable_drop_threshold:.3f}"
-                        ),
-                    )
-                if trigger is not None:
-                    route_trigger = trigger
-                    use_external = True
-                    base_plan = self.plan(task, use_external=True)
-                    top_k = self._build_plan_top_k(
-                        task,
-                        base_plan,
-                        k=_normalize_top_k(top_k_value),
-                        runtime_state=context.runtime_state,
-                    )
-                    executable_rate = self._estimate_executable_rate(top_k, task)
+                use_external = True
+                base_plan = self.plan(task, use_external=True)
+                top_k = self._build_plan_top_k(
+                    task,
+                    base_plan,
+                    k=_normalize_top_k(top_k_value),
+                    runtime_state=context.runtime_state,
+                )
+                executable_rate = self._estimate_executable_rate(top_k, task)
 
             gate = self.evaluate_top_k_gate(
                 candidate_kind="plan",
@@ -1535,9 +1526,7 @@ def _safe_float(value: object, *, default: float) -> float:
 
 
 def _normalize_top_k(value: int) -> int:
-    if value <= 0:
-        return 1
-    return value
+    return normalize_top_k(value)
 
 
 def _require_default_candidate(
@@ -2441,16 +2430,13 @@ def _candidate_generation_constraints(
     constraints: dict[str, Any],
     metadata: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    generation_constraints = dict(constraints)
-    if isinstance(metadata, dict) and metadata:
-        generation_constraints["metadata"] = dict(metadata)
-        confirmed = metadata.get("confirmed_task_spec")
-        if isinstance(confirmed, dict):
-            generation_constraints.setdefault("confirmed_task_spec", dict(confirmed))
-        hints = metadata.get("planner_capability_hints")
-        if isinstance(hints, (list, tuple, set)):
-            generation_constraints.setdefault("capability_hints", list(hints))
-    return generation_constraints
+    return cast(
+        dict[str, Any],
+        build_candidate_generation_constraints(
+            constraints=constraints,
+            metadata=metadata,
+        ),
+    )
 
 
 def _extract_capability_hints(constraints: dict[str, Any]) -> tuple[str, ...]:
@@ -4512,7 +4498,10 @@ def _extract_task_kind(task: ProteinDesignTask) -> str:
 
 
 def _is_de_novo_task(task: ProteinDesignTask) -> bool:
-    return _extract_task_kind(task) == _DE_NOVO_GOAL_TYPE
+    return is_de_novo_task_kind(
+        _extract_task_kind(task),
+        denovo_goal_type=_DE_NOVO_GOAL_TYPE,
+    )
 
 
 def _extract_length_range(constraints: dict) -> List[int] | None:

--- a/src/agents/planner_denovo.py
+++ b/src/agents/planner_denovo.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+
+def is_de_novo_task_kind(task_kind: str, *, denovo_goal_type: str) -> bool:
+    """判断 task kind 是否属于 de novo 计划构造路径。"""
+
+    return task_kind == denovo_goal_type

--- a/src/agents/planner_payloads.py
+++ b/src/agents/planner_payloads.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+
+def build_candidate_generation_constraints(
+    *,
+    constraints: Mapping[str, object],
+    metadata: Mapping[str, object] | None,
+) -> dict[str, object]:
+    """合成候选生成约束，隐藏 metadata/confirmed spec 的兼容合并细节。"""
+
+    generation_constraints = dict(constraints)
+    if not metadata:
+        return generation_constraints
+
+    generation_constraints["metadata"] = dict(metadata)
+    confirmed = metadata.get("confirmed_task_spec")
+    if isinstance(confirmed, dict):
+        _ = generation_constraints.setdefault("confirmed_task_spec", dict(confirmed))
+    hints = metadata.get("planner_capability_hints")
+    if isinstance(hints, (list, tuple, set)):
+        _ = generation_constraints.setdefault("capability_hints", list(hints))
+    return generation_constraints

--- a/src/agents/planner_projection.py
+++ b/src/agents/planner_projection.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def normalize_top_k(value: int) -> int:
+    """将 Top-K 请求规范化为至少 1 个候选。"""
+
+    if value <= 0:
+        return 1
+    return value

--- a/src/agents/planner_selection.py
+++ b/src/agents/planner_selection.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RouteTriggerSpec:
+    reason: str
+    threshold: str
+
+
+def schema_failure_route_trigger(
+    *,
+    enable_dual_route: bool,
+    schema_fail_streak: int,
+    threshold: int,
+) -> RouteTriggerSpec | None:
+    """判断 schema 连续失败是否应该触发 external planner fallback。"""
+
+    if not enable_dual_route or schema_fail_streak < threshold:
+        return None
+    return RouteTriggerSpec(
+        reason="schema_fail_streak",
+        threshold=f"schema_fail_streak={schema_fail_streak}>={threshold}",
+    )
+
+
+def executable_rate_route_trigger(
+    *,
+    enable_dual_route: bool,
+    use_external: bool,
+    fallback_available: bool,
+    executable_rate: float,
+    previous_rate: float | None,
+    rate_threshold: float,
+    drop_threshold: float,
+) -> RouteTriggerSpec | None:
+    """判断候选可执行率是否应该触发 external planner fallback。"""
+
+    if not enable_dual_route or use_external or not fallback_available:
+        return None
+    drop = previous_rate - executable_rate if previous_rate is not None else 0.0
+    if executable_rate < rate_threshold:
+        return RouteTriggerSpec(
+            reason="candidate_executable_rate_low",
+            threshold=f"candidate_executable_rate={executable_rate:.3f}<{rate_threshold:.3f}",
+        )
+    if drop >= drop_threshold:
+        return RouteTriggerSpec(
+            reason="candidate_executable_rate_drop",
+            threshold=f"candidate_executable_drop={drop:.3f}>={drop_threshold:.3f}",
+        )
+    return None

--- a/src/agents/summarizer.py
+++ b/src/agents/summarizer.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 from pathlib import Path
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from pydantic import BaseModel, Field
 
-from src.models.contracts import DesignResult, now_iso, StepResult, SafetyResult
+from src.agents.summarizer_sections import DeNovoReportView, render_de_novo_markdown
+from src.models.contracts import DesignResult, now_iso, ProteinDesignTask, StepResult
 from src.workflow.context import WorkflowContext
 
 
@@ -226,11 +227,11 @@ class SummarizerAgent:
             },
         )
 
-        summary_report_path.write_text(design.model_dump_json(indent=2))
+        _ = summary_report_path.write_text(design.model_dump_json(indent=2))
         return design
 
 
-def _extract_visualization_artifacts(context: WorkflowContext) -> dict:
+def _extract_visualization_artifacts(context: WorkflowContext) -> dict[str, object]:
     for result in context.step_results.values():
         outputs = result.outputs or {}
         if any(
@@ -257,22 +258,24 @@ def _extract_visualization_artifacts(context: WorkflowContext) -> dict:
 
 
 def _select_report_path(
-    artifacts: dict,
+    artifacts: dict[str, object],
     report_dir: Path,
     task_id: str,
 ) -> tuple[Path, str]:
     report_html_path = artifacts.get("report_html_path")
-    if report_html_path:
+    if isinstance(report_html_path, str) and report_html_path:
         return Path(report_html_path), "visualization_tool"
 
     plotly_html_path = artifacts.get("plotly_html_path")
     metrics_json_path = artifacts.get("metrics_json_path")
-    if plotly_html_path or metrics_json_path:
+    normalized_plotly_path = plotly_html_path if isinstance(plotly_html_path, str) else None
+    normalized_metrics_path = metrics_json_path if isinstance(metrics_json_path, str) else None
+    if normalized_plotly_path or normalized_metrics_path:
         fallback_path = report_dir / f"{task_id}.html"
         _write_fallback_report(
             fallback_path,
-            plotly_html_path,
-            metrics_json_path,
+            normalized_plotly_path,
+            normalized_metrics_path,
         )
         return fallback_path, "visualization_fallback"
 
@@ -411,7 +414,7 @@ def _write_fallback_report(
             "</html>",
         ]
     )
-    report_path.write_text(report_html, encoding="utf-8")
+    _ = report_path.write_text(report_html, encoding="utf-8")
 
 
 def _build_metrics_table(metrics_json_path: str | None) -> str:
@@ -443,37 +446,35 @@ def _build_metrics_table(metrics_json_path: str | None) -> str:
 _DE_NOVO_GOAL_TYPE = "de_novo_design"
 
 
-def _extract_goal_type(task) -> str:
+def _extract_goal_type(task: ProteinDesignTask) -> str:
     """从任务中提取 goal_type（与 planner.py 逻辑保持一致）"""
     for container in (task.constraints, task.metadata):
-        if isinstance(container, dict):
-            goal_block = container.get("goal")
-            if isinstance(goal_block, dict):
-                goal_type = goal_block.get("type")
-                if isinstance(goal_type, str) and goal_type:
-                    return goal_type
-            goal_type = container.get("goal_type")
+        goal_block = container.get("goal")
+        if isinstance(goal_block, dict):
+            goal_type = goal_block.get("type")
             if isinstance(goal_type, str) and goal_type:
                 return goal_type
+        goal_type = container.get("goal_type")
+        if isinstance(goal_type, str) and goal_type:
+            return goal_type
 
     goal_value = task.goal
-    if isinstance(goal_value, str):
-        stripped = goal_value.strip()
-        if stripped == _DE_NOVO_GOAL_TYPE:
-            return stripped
-        if stripped.startswith("{") and stripped.endswith("}"):
-            try:
-                parsed = json.loads(stripped)
-            except json.JSONDecodeError:
-                return ""
-            if isinstance(parsed, dict):
-                goal_type = parsed.get("type")
-                if isinstance(goal_type, str) and goal_type:
-                    return goal_type
+    stripped = goal_value.strip()
+    if stripped == _DE_NOVO_GOAL_TYPE:
+        return stripped
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return ""
+        if isinstance(parsed, dict):
+            goal_type = parsed.get("type")
+            if isinstance(goal_type, str) and goal_type:
+                return goal_type
     return ""
 
 
-def _is_de_novo_task(task) -> bool:
+def _is_de_novo_task(task: ProteinDesignTask) -> bool:
     """判断任务是否为 de novo 设计任务"""
     return _extract_goal_type(task) == _DE_NOVO_GOAL_TYPE
 
@@ -728,147 +729,9 @@ def generate_de_novo_report(context: WorkflowContext) -> DeNovoReport:
 
 
 def _render_de_novo_markdown(report: DeNovoReport) -> str:
-    """将 DeNovoReport 渲染为 Markdown 格式"""
-    lines = []
+    """将 DeNovoReport 渲染为 Markdown 格式。"""
 
-    # 标题
-    lines.append(f"# De Novo 蛋白设计报告")
-    lines.append("")
-
-    # 任务概览
-    lines.append("## 任务概览")
-    lines.append("")
-    lines.append(f"- **任务 ID**: `{report.task_id}`")
-    lines.append(f"- **设计目标**: {report.task_description}")
-    lines.append(f"- **任务类型**: {report.design_goal}")
-    lines.append(f"- **生成时间**: {report.created_at}")
-    status_emoji = {"success": "✅", "failed": "❌", "partial": "⚠️"}.get(
-        report.status, "❓"
-    )
-    lines.append(f"- **执行状态**: {status_emoji} {report.status}")
-    lines.append("")
-
-    # 工具链
-    lines.append("## 工具链")
-    lines.append("")
-    if report.tool_chain.description:
-        lines.append(f"**执行链路**: {report.tool_chain.description}")
-    else:
-        lines.append("未识别到标准工具链")
-    lines.append("")
-
-    # 执行步骤
-    lines.append("## 执行步骤")
-    lines.append("")
-    for step in report.step_summaries:
-        step_emoji = {"success": "✅", "failed": "❌", "skipped": "⚠️"}.get(
-            step.status, "❓"
-        )
-        lines.append(f"### {step.step_id}: {step.tool} {step_emoji}")
-        lines.append("")
-
-        if step.inputs_summary:
-            lines.append("**输入**:")
-            for key, value in step.inputs_summary.items():
-                lines.append(f"- `{key}`: {value}")
-            lines.append("")
-
-        if step.outputs_summary:
-            lines.append("**输出**:")
-            for key, value in step.outputs_summary.items():
-                if isinstance(value, dict):
-                    lines.append(f"- `{key}`:")
-                    for k, v in value.items():
-                        lines.append(f"  - `{k}`: {v}")
-                else:
-                    lines.append(f"- `{key}`: {value}")
-            lines.append("")
-
-        if step.error_message:
-            lines.append(f"**错误**: {step.error_message}")
-            lines.append("")
-
-    # 结果
-    if report.success_report:
-        lines.append("## 设计结果")
-        lines.append("")
-        sr = report.success_report
-        if sr.final_sequence:
-            seq_display = sr.final_sequence
-            if len(seq_display) > 60:
-                seq_display = f"{seq_display[:30]}...{seq_display[-30:]}"
-            lines.append(f"- **设计序列**: `{seq_display}`")
-        if sr.sequence_length:
-            lines.append(f"- **序列长度**: {sr.sequence_length} aa")
-        if sr.structure_pdb_path:
-            lines.append(f"- **结构文件**: `{sr.structure_pdb_path}`")
-        if sr.plddt_mean is not None:
-            lines.append(f"- **pLDDT 均值**: {sr.plddt_mean:.2f}")
-        if sr.confidence:
-            lines.append(f"- **置信度等级**: {sr.confidence}")
-        lines.append("")
-
-        if sr.objective_score is not None or sr.objective_top_k:
-            lines.append("### 目标评分")
-            lines.append("")
-            if sr.objective_score is not None:
-                lines.append(f"- **综合目标分**: {sr.objective_score:.3f}")
-            if sr.posterior_score:
-                evidence_status = sr.posterior_score.get("evidence_status") or "-"
-                evidence_sufficiency = sr.posterior_score.get("evidence_sufficiency")
-                if isinstance(evidence_sufficiency, (int, float)):
-                    lines.append(
-                        f"- **证据充分度**: {evidence_sufficiency:.3f} ({evidence_status})"
-                    )
-            if sr.rank_reason:
-                lines.append(f"- **排序理由**: {sr.rank_reason}")
-            if sr.objective_warnings:
-                lines.append(
-                    f"- **评分警告**: {'; '.join(sr.objective_warnings)}"
-                )
-            if sr.objective_top_k:
-                lines.append("")
-                lines.append("| Rank | Candidate | Score | Reason |")
-                lines.append("| --- | --- | ---: | --- |")
-                for row in sr.objective_top_k:
-                    rank = row.get("top_k_rank") or row.get("rank") or "-"
-                    candidate_id = row.get("candidate_id") or row.get("id") or "-"
-                    score = row.get("objective_score")
-                    score_text = f"{score:.3f}" if isinstance(score, (int, float)) else "-"
-                    reason = row.get("rank_reason") or row.get("objective_explanation") or "-"
-                    lines.append(f"| {rank} | `{candidate_id}` | {score_text} | {reason} |")
-            lines.append("")
-
-    if report.failure_report:
-        lines.append("## 失败分析")
-        lines.append("")
-        fr = report.failure_report
-        if fr.failed_step_id:
-            lines.append(f"- **失败步骤**: {fr.failed_step_id}")
-        if fr.failed_tool:
-            lines.append(f"- **失败工具**: {fr.failed_tool}")
-        if fr.failure_type:
-            lines.append(f"- **失败类型**: {fr.failure_type}")
-        if fr.error_message:
-            lines.append(f"- **错误信息**: {fr.error_message}")
-        if fr.safety_action:
-            lines.append(f"- **安全判定**: {fr.safety_action}")
-        if fr.safety_reason:
-            lines.append(f"- **安全原因**: {fr.safety_reason}")
-        lines.append("")
-
-        if fr.suggested_next_steps:
-            lines.append("### 建议的下一步")
-            lines.append("")
-            for i, step in enumerate(fr.suggested_next_steps, 1):
-                lines.append(f"{i}. {step}")
-            lines.append("")
-
-    # 页脚
-    lines.append("---")
-    lines.append("*此报告由 SummarizerAgent 自动生成*")
-
-    return "\n".join(lines)
+    return render_de_novo_markdown(cast(DeNovoReportView, cast(object, report)))
 
 
 def write_de_novo_reports(
@@ -886,10 +749,10 @@ def write_de_novo_reports(
     md_path = report_dir / f"{report.task_id}_denovo.md"
 
     # 写入 JSON
-    json_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+    _ = json_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
 
     # 写入 Markdown
     md_content = _render_de_novo_markdown(report)
-    md_path.write_text(md_content, encoding="utf-8")
+    _ = md_path.write_text(md_content, encoding="utf-8")
 
     return json_path, md_path

--- a/src/agents/summarizer_sections.py
+++ b/src/agents/summarizer_sections.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+
+class ToolChainReport(Protocol):
+    description: str
+
+
+class StepSummaryReport(Protocol):
+    step_id: str
+    tool: str
+    status: str
+    inputs_summary: Mapping[str, object]
+    outputs_summary: Mapping[str, object]
+    error_message: str | None
+
+
+class SuccessReportView(Protocol):
+    final_sequence: str | None
+    sequence_length: int | None
+    structure_pdb_path: str | None
+    plddt_mean: float | None
+    confidence: str | None
+    objective_score: float | None
+    objective_top_k: Sequence[Mapping[str, object]]
+    objective_warnings: Sequence[str]
+    posterior_score: Mapping[str, object]
+    rank_reason: str | None
+
+
+class FailureReportView(Protocol):
+    failed_step_id: str | None
+    failed_tool: str | None
+    failure_type: str | None
+    error_message: str | None
+    safety_action: str | None
+    safety_reason: str | None
+    suggested_next_steps: Sequence[str]
+
+
+class DeNovoReportView(Protocol):
+    task_id: str
+    task_description: str
+    design_goal: str
+    created_at: str
+    status: str
+    tool_chain: ToolChainReport
+    step_summaries: Sequence[StepSummaryReport]
+    success_report: SuccessReportView | None
+    failure_report: FailureReportView | None
+
+
+def render_de_novo_markdown(report: DeNovoReportView) -> str:
+    """将 DeNovoReport 渲染为 Markdown 格式。"""
+
+    lines: list[str] = []
+    _extend_title(lines)
+    _extend_task_overview(lines, report)
+    _extend_tool_chain(lines, report.tool_chain)
+    _extend_step_summaries(lines, report.step_summaries)
+    if report.success_report:
+        _extend_success_report(lines, report.success_report)
+    if report.failure_report:
+        _extend_failure_report(lines, report.failure_report)
+    _extend_footer(lines)
+    return "\n".join(lines)
+
+
+def _extend_title(lines: list[str]) -> None:
+    lines.append("# De Novo 蛋白设计报告")
+    lines.append("")
+
+
+def _extend_task_overview(lines: list[str], report: DeNovoReportView) -> None:
+    lines.append("## 任务概览")
+    lines.append("")
+    lines.append(f"- **任务 ID**: `{report.task_id}`")
+    lines.append(f"- **设计目标**: {report.task_description}")
+    lines.append(f"- **任务类型**: {report.design_goal}")
+    lines.append(f"- **生成时间**: {report.created_at}")
+    status_emoji = {"success": "✅", "failed": "❌", "partial": "⚠️"}.get(
+        report.status, "❓"
+    )
+    lines.append(f"- **执行状态**: {status_emoji} {report.status}")
+    lines.append("")
+
+
+def _extend_tool_chain(lines: list[str], tool_chain: ToolChainReport) -> None:
+    lines.append("## 工具链")
+    lines.append("")
+    if tool_chain.description:
+        lines.append(f"**执行链路**: {tool_chain.description}")
+    else:
+        lines.append("未识别到标准工具链")
+    lines.append("")
+
+
+def _extend_step_summaries(
+    lines: list[str],
+    step_summaries: Sequence[StepSummaryReport],
+) -> None:
+    lines.append("## 执行步骤")
+    lines.append("")
+    for step in step_summaries:
+        _extend_single_step(lines, step)
+
+
+def _extend_single_step(lines: list[str], step: StepSummaryReport) -> None:
+    step_emoji = {"success": "✅", "failed": "❌", "skipped": "⚠️"}.get(
+        step.status, "❓"
+    )
+    lines.append(f"### {step.step_id}: {step.tool} {step_emoji}")
+    lines.append("")
+    if step.inputs_summary:
+        _extend_mapping_section(lines, title="**输入**:", payload=step.inputs_summary)
+    if step.outputs_summary:
+        _extend_mapping_section(lines, title="**输出**:", payload=step.outputs_summary)
+    if step.error_message:
+        lines.append(f"**错误**: {step.error_message}")
+        lines.append("")
+
+
+def _extend_mapping_section(
+    lines: list[str],
+    *,
+    title: str,
+    payload: Mapping[str, object],
+) -> None:
+    lines.append(title)
+    for key, value in payload.items():
+        if isinstance(value, dict):
+            lines.append(f"- `{key}`:")
+            for child_key, child_value in value.items():
+                lines.append(f"  - `{child_key}`: {child_value}")
+        else:
+            lines.append(f"- `{key}`: {value}")
+    lines.append("")
+
+
+def _extend_success_report(lines: list[str], report: SuccessReportView) -> None:
+    lines.append("## 设计结果")
+    lines.append("")
+    if report.final_sequence:
+        lines.append(f"- **设计序列**: `{_compact_sequence(report.final_sequence)}`")
+    if report.sequence_length:
+        lines.append(f"- **序列长度**: {report.sequence_length} aa")
+    if report.structure_pdb_path:
+        lines.append(f"- **结构文件**: `{report.structure_pdb_path}`")
+    if report.plddt_mean is not None:
+        lines.append(f"- **pLDDT 均值**: {report.plddt_mean:.2f}")
+    if report.confidence:
+        lines.append(f"- **置信度等级**: {report.confidence}")
+    lines.append("")
+    if report.objective_score is not None or report.objective_top_k:
+        _extend_objective_scoring(lines, report)
+
+
+def _compact_sequence(sequence: str) -> str:
+    if len(sequence) <= 60:
+        return sequence
+    return f"{sequence[:30]}...{sequence[-30:]}"
+
+
+def _extend_objective_scoring(lines: list[str], report: SuccessReportView) -> None:
+    lines.append("### 目标评分")
+    lines.append("")
+    if report.objective_score is not None:
+        lines.append(f"- **综合目标分**: {report.objective_score:.3f}")
+    if report.posterior_score:
+        evidence_status = report.posterior_score.get("evidence_status") or "-"
+        evidence_sufficiency = report.posterior_score.get("evidence_sufficiency")
+        if isinstance(evidence_sufficiency, (int, float)):
+            lines.append(
+                f"- **证据充分度**: {evidence_sufficiency:.3f} ({evidence_status})"
+            )
+    if report.rank_reason:
+        lines.append(f"- **排序理由**: {report.rank_reason}")
+    if report.objective_warnings:
+        lines.append(f"- **评分警告**: {'; '.join(report.objective_warnings)}")
+    if report.objective_top_k:
+        _extend_objective_top_k(lines, report.objective_top_k)
+    lines.append("")
+
+
+def _extend_objective_top_k(
+    lines: list[str],
+    rows: Sequence[Mapping[str, object]],
+) -> None:
+    lines.append("")
+    lines.append("| Rank | Candidate | Score | Reason |")
+    lines.append("| --- | --- | ---: | --- |")
+    for row in rows:
+        rank = row.get("top_k_rank") or row.get("rank") or "-"
+        candidate_id = row.get("candidate_id") or row.get("id") or "-"
+        score = row.get("objective_score")
+        score_text = f"{score:.3f}" if isinstance(score, (int, float)) else "-"
+        reason = row.get("rank_reason") or row.get("objective_explanation") or "-"
+        lines.append(f"| {rank} | `{candidate_id}` | {score_text} | {reason} |")
+
+
+def _extend_failure_report(lines: list[str], report: FailureReportView) -> None:
+    lines.append("## 失败分析")
+    lines.append("")
+    if report.failed_step_id:
+        lines.append(f"- **失败步骤**: {report.failed_step_id}")
+    if report.failed_tool:
+        lines.append(f"- **失败工具**: {report.failed_tool}")
+    if report.failure_type:
+        lines.append(f"- **失败类型**: {report.failure_type}")
+    if report.error_message:
+        lines.append(f"- **错误信息**: {report.error_message}")
+    if report.safety_action:
+        lines.append(f"- **安全判定**: {report.safety_action}")
+    if report.safety_reason:
+        lines.append(f"- **安全原因**: {report.safety_reason}")
+    lines.append("")
+    if report.suggested_next_steps:
+        _extend_suggested_next_steps(lines, report.suggested_next_steps)
+
+
+def _extend_suggested_next_steps(lines: list[str], steps: Sequence[str]) -> None:
+    lines.append("### 建议的下一步")
+    lines.append("")
+    for index, step in enumerate(steps, 1):
+        lines.append(f"{index}. {step}")
+    lines.append("")
+
+
+def _extend_footer(lines: list[str]) -> None:
+    lines.append("---")
+    lines.append("*此报告由 SummarizerAgent 自动生成*")

--- a/src/models/task_intake.py
+++ b/src/models/task_intake.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from copy import deepcopy
-import re
 from enum import Enum, StrEnum
 from typing import Literal, NotRequired, TypedDict, cast
 
@@ -9,6 +8,13 @@ from pydantic import BaseModel, Field, field_validator
 
 from src.kg.kg_client import ToolKGError, get_tool_nodes
 from src.models.contracts import now_iso
+from src.models.task_intake_payload import build_rule_extraction_payload
+from src.models.task_intake_precheck import (
+    build_safety_risk_flags,
+    coerce_string_list,
+    resolve_precheck_action,
+)
+from src.models.task_intake_validator import validate_registry_value
 
 
 TASK_FIELD_REGISTRY_VERSION = "task-intake.v1"
@@ -1469,201 +1475,10 @@ def _merge_extracted_text(draft: TaskSpecDraft, text: str) -> None:
 
 
 def _build_rule_extraction_payload(text: str) -> JsonObject:
-    fields: JsonObject = {}
-    source_spans: list[str] = []
-
-    def add_field(
-        field_name: str,
-        value: JsonValue,
-        confidence: float,
-        source_span: str | None = None,
-    ) -> None:
-        fields[field_name] = {
-            "value": value,
-            "source": TaskDraftFieldSource.LLM_EXTRACT.value,
-            "confidence": confidence,
-            "source_span": source_span,
-        }
-        if source_span:
-            source_spans.append(source_span)
-
-    lowered = text.lower()
-    design_intent = any(
-        marker in lowered
-        for marker in ("design", "de novo", "de-novo", "generate", "protein")
-    ) or any(marker in text for marker in ("设计", "生成", "蛋白", "从头"))
-    if "de novo" in lowered or "de-novo" in lowered or "从头" in text:
-        add_field("task_kind", "de_novo_design", 0.86, "de novo")
-    elif "评估" in text or "evaluate" in lowered:
-        add_field(
-            "task_kind",
-            "sequence_evaluation",
-            0.84,
-            _first_present_span(text, ["评估", "evaluate"]),
-        )
-    elif "template" in lowered or "模板" in text:
-        add_field(
-            "task_kind",
-            "template_constrained_design",
-            0.84,
-            _first_present_span(text, ["模板", "template"]),
-        )
-    elif design_intent:
-        add_field(
-            "task_kind",
-            "de_novo_design",
-            0.80,
-            _first_present_span(text, ["设计", "design", "生成", "protein"]),
-        )
-
-    if "稳定" in text or "stability" in lowered or "stable" in lowered:
-        add_field(
-            "objective_type",
-            "stability",
-            0.88,
-            _first_present_span(text, ["稳定", "stability", "stable"]),
-        )
-    elif "binding" in lowered or "结合" in text:
-        add_field(
-            "objective_type",
-            "binding",
-            0.72,
-            _first_present_span(text, ["binding", "结合"]),
-        )
-    elif "结构" in text or "structure" in lowered:
-        add_field(
-            "objective_type",
-            "structure",
-            0.78,
-            _first_present_span(text, ["结构", "structure"]),
-        )
-    elif "活性" in text or "activity" in lowered:
-        add_field(
-            "objective_type",
-            "activity",
-            0.76,
-            _first_present_span(text, ["活性", "activity"]),
-        )
-
-    range_match = re.search(r"(\d{2,4})\s*(?:-|~|到|至)\s*(\d{2,4})", text)
-    if range_match:
-        add_field(
-            "length_range",
-            [int(range_match.group(1)), int(range_match.group(2))],
-            0.92,
-            range_match.group(0),
-        )
-    else:
-        approx_match = re.search(
-            r"(?:约|大约|around|about)?\s*(\d{2,4})\s*(?:个)?\s*(?:aa|氨基酸)",
-            text,
-            re.IGNORECASE,
-        )
-        if approx_match:
-            center = int(approx_match.group(1))
-            add_field(
-                "length_range",
-                [max(1, center - 20), center + 20],
-                0.91,
-                approx_match.group(0),
-            )
-
-    count_match = re.search(
-        r"(\d{1,2})\s*(?:个)?(?:候选|candidate)",
+    return build_rule_extraction_payload(
         text,
-        re.IGNORECASE,
-    )
-    if count_match:
-        add_field(
-            "design_count",
-            int(count_match.group(1)),
-            0.84,
-            count_match.group(0),
-        )
-
-    if "快" in text or "fast" in lowered:
-        add_field(
-            "run_profile",
-            "fast_smoke",
-            0.82,
-            _first_present_span(text, ["快", "fast"]),
-        )
-    elif "balanced" in lowered or "均衡" in text:
-        add_field(
-            "run_profile",
-            "balanced",
-            0.86,
-            _first_present_span(text, ["均衡", "balanced"]),
-        )
-    elif (
-        "high accuracy" in lowered
-        or "high-accuracy" in lowered
-        or "thorough" in lowered
-        or "高精度" in text
-        or "全面" in text
-    ):
-        add_field(
-            "run_profile",
-            "high_accuracy",
-            0.86,
-            _first_present_span(text, ["高精度", "全面", "high accuracy", "thorough"]),
-        )
-
-    safety_match = re.search(r"\bS[0-2]\b", text, re.IGNORECASE)
-    if safety_match:
-        add_field(
-            "safety_level",
-            safety_match.group(0).upper(),
-            0.9,
-            safety_match.group(0),
-        )
-    elif "低风险" in text or "low risk" in lowered:
-        add_field(
-            "safety_level",
-            "S1",
-            0.70,
-            _first_present_span(text, ["低风险", "low risk"]),
-        )
-    elif "安全" in text or "safe" in lowered:
-        add_field(
-            "safety_level", "S1", 0.68, _first_present_span(text, ["安全", "safe"])
-        )
-
-    if "无需确认计划" in text or "no plan confirmation" in lowered:
-        add_field(
-            "require_plan_confirm",
-            False,
-            0.92,
-            _first_present_span(text, ["无需确认计划", "no plan confirmation"]),
-        )
-    elif "确认计划" in text or "confirm plan" in lowered:
-        add_field(
-            "require_plan_confirm",
-            True,
-            0.95,
-            _first_present_span(text, ["确认计划", "confirm plan"]),
-        )
-
-    tool_preferences = _extract_tool_preferences(text)
-    if tool_preferences:
-        add_field(
-            "tools_allowed",
-            cast(JsonValue, tool_preferences),
-            0.76,
-            ", ".join(tool_preferences),
-        )
-
-    if fields and design_intent and "goal_summary" not in fields:
-        add_field("goal_summary", _goal_summary_from_text(text), 0.84, text.strip())
-
-    return cast(
-        JsonObject,
-        {
-            "fields": fields,
-            "unmapped_text": [],
-            "source_spans": cast(JsonValue, source_spans),
-            "mode": "rule_extract",
-        },
+        allowed_tool_ids=_allowed_tool_ids(),
+        source_value=TaskDraftFieldSource.LLM_EXTRACT.value,
     )
 
 
@@ -1747,29 +1562,6 @@ def _unwrap_extracted_field(
     return raw_field["value"], float(confidence), source_span, source
 
 
-def _first_present_span(text: str, needles: list[str]) -> str | None:
-    lowered = text.lower()
-    for needle in needles:
-        if not needle:
-            continue
-        if needle in text or needle.lower() in lowered:
-            return needle
-    return None
-
-
-def _goal_summary_from_text(text: str) -> str:
-    return re.sub(r"\s+", " ", text.strip())[:2000]
-
-
-def _extract_tool_preferences(text: str) -> list[str]:
-    lowered = text.lower()
-    has_tool_cue = any(
-        marker in lowered for marker in ("use", "prefer", "allowed", "tool")
-    ) or any(marker in text for marker in ("使用", "优先", "允许", "工具"))
-    if not has_tool_cue:
-        return []
-    allowed = _allowed_tool_ids()
-    return sorted(tool_id for tool_id in allowed if tool_id.lower() in lowered)
 
 
 def _merge_structured_fields(
@@ -1879,128 +1671,15 @@ def _required_fields_for(fields: dict[str, TaskDraftField]) -> list[str]:
     return list(dict.fromkeys(required))
 
 
-def _numeric_validator_value(
-    validators: JsonObject,
-    key: str,
-    default: int | float,
-) -> int | float:
-    value = validators.get(key)
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return value
-    return default
-
-
-def _string_validator_value(
-    validators: JsonObject,
-    key: str,
-    default: str,
-) -> str:
-    value = validators.get(key)
-    if isinstance(value, str):
-        return value
-    return default
 
 
 def _validate_registry_value(field_name: str, value: JsonValue) -> str | None:
-    registry = _registry_fields()
-    field = registry.get(field_name)
-    if field is None:
-        return f"unknown intake field: {field_name}"
-
-    field_type = field["type"]
-    if field_type == "enum" and value not in set(field["options"]):
-        return f"{field_name} must be one of {field['options']}"
-    if field_type == "string":
-        if not isinstance(value, str) or not value.strip():
-            return f"{field_name} must be a non-empty string"
-        validators = field.get("validators", {})
-        min_length = int(_numeric_validator_value(validators, "min_length", 0))
-        max_length = int(_numeric_validator_value(validators, "max_length", len(value)))
-        if len(value) < min_length:
-            return f"{field_name} is shorter than allowed"
-        if len(value) > max_length:
-            return f"{field_name} is longer than allowed"
-    if field_type == "boolean" and not isinstance(value, bool):
-        return f"{field_name} must be a boolean"
-    if field_type == "integer":
-        if not isinstance(value, int) or isinstance(value, bool):
-            return f"{field_name} must be an integer"
-        validators = field.get("validators", {})
-        minimum = int(_numeric_validator_value(validators, "min", value))
-        maximum = int(_numeric_validator_value(validators, "max", value))
-        if value < minimum or value > maximum:
-            return f"{field_name} is outside allowed range"
-    if field_type == "number":
-        if not isinstance(value, (int, float)) or isinstance(value, bool):
-            return f"{field_name} must be a number"
-        validators = field.get("validators", {})
-        minimum = _numeric_validator_value(validators, "min", value)
-        maximum = _numeric_validator_value(validators, "max", value)
-        if value < minimum or value > maximum:
-            return f"{field_name} is outside allowed range"
-    if field_type == "object":
-        if not isinstance(value, dict):
-            return f"{field_name} must be an object"
-        validators = field.get("validators", {})
-        allowed_keys = validators.get("allowed_keys")
-        if isinstance(allowed_keys, list):
-            allowed = {item for item in allowed_keys if isinstance(item, str)}
-            unknown = sorted(str(key) for key in value if str(key) not in allowed)
-            if unknown:
-                return f"{field_name} contains unknown keys: {', '.join(unknown)}"
-        for item in value.values():
-            if (
-                not isinstance(item, (int, float))
-                or isinstance(item, bool)
-                or item < 0
-            ):
-                return f"{field_name} values must be non-negative numbers"
-    if field_type == "integer_range":
-        validators = field.get("validators", {})
-        minimum = int(_numeric_validator_value(validators, "min", 0))
-        maximum = int(_numeric_validator_value(validators, "max", 0))
-        if (
-            not isinstance(value, list)
-            or len(value) != 2
-            or not all(
-                isinstance(item, int) and not isinstance(item, bool) for item in value
-            )
-        ):
-            return f"{field_name} must be [min, max] integers"
-        lower = value[0]
-        upper = value[1]
-        if not isinstance(lower, int) or not isinstance(upper, int):
-            return f"{field_name} must be [min, max] integers"
-        if lower > upper or lower < minimum or upper > maximum:
-            return f"{field_name} must be [min, max] integers"
-    if field_type == "protein_sequence":
-        if not isinstance(value, str) or not value.strip():
-            return f"{field_name} must be a non-empty sequence"
-        alphabet = set(_string_validator_value(field["validators"], "alphabet", ""))
-        invalid = set(value.upper()) - alphabet
-        if invalid:
-            return f"{field_name} contains invalid residues: {''.join(sorted(invalid))}"
-    if field_type in {"string_list", "tool_id_list"}:
-        if not isinstance(value, list) or not all(
-            isinstance(item, str) and item for item in value
-        ):
-            return f"{field_name} must be a list of strings"
-        if field_type == "tool_id_list":
-            values = {item for item in value if isinstance(item, str)}
-            invalid_tool_ids = sorted(values - _allowed_tool_ids())
-            if invalid_tool_ids:
-                return (
-                    f"{field_name} contains unknown tool_id(s): "
-                    f"{', '.join(invalid_tool_ids)}"
-                )
-    if field_type == "residue_list":
-        if not isinstance(value, list) or not all(
-            isinstance(item, str) and re.match(r"^[A-Z][0-9]+$", item) for item in value
-        ):
-            return f"{field_name} must be residue ids like A42"
-    if field_type == "artifact_ref_list":
-        return _validate_artifact_ref_list(field_name, value)
-    return None
+    return validate_registry_value(
+        field_name,
+        value,
+        registry=_registry_fields(),
+        allowed_tool_ids=_allowed_tool_ids(),
+    )
 
 
 def _allowed_tool_ids() -> set[str]:
@@ -2011,139 +1690,50 @@ def _allowed_tool_ids() -> set[str]:
     }
 
 
+
+
 def _validate_artifact_ref_list(field_name: str, value: object) -> str | None:
     if not isinstance(value, list):
         return f"{field_name} must be a list of artifact refs"
-
-    artifacts = cast(list[object], value)
-    for index, raw_artifact in enumerate(artifacts):
-        artifact = cast(dict[object, object], raw_artifact)
-        if not isinstance(raw_artifact, dict):
-            return f"{field_name}[{index}] must be an object"
-        kind = artifact.get("kind")
-        if not isinstance(kind, str) or not kind.strip():
-            return f"{field_name}[{index}].kind must be a non-empty string"
-
-        ref_values = [
-            artifact.get("artifact_id"),
-            artifact.get("uri"),
-            artifact.get("path"),
-            artifact.get("ref"),
-        ]
-        if not any(isinstance(item, str) and item.strip() for item in ref_values):
-            return f"{field_name}[{index}] must include artifact_id, uri, path, or ref"
-
-        artifact_id = artifact.get("artifact_id")
-        if isinstance(artifact_id, str) and not re.match(
-            r"^[A-Za-z0-9_.:-]+$",
-            artifact_id,
-        ):
-            return f"{field_name}[{index}].artifact_id is invalid"
-
-        uri = artifact.get("uri")
-        if isinstance(uri, str) and not (
-            uri.startswith("artifact://") or uri.startswith("task://")
-        ):
-            return f"{field_name}[{index}].uri must use artifact:// or task://"
-
-        path = artifact.get("path")
-        if isinstance(path, str) and (
-            path.startswith("/")
-            or path.startswith("~")
-            or ".." in path.split("/")
-            or not path.strip()
-        ):
-            return f"{field_name}[{index}].path must be a safe relative path"
-
-        ref = artifact.get("ref")
-        if isinstance(ref, str) and not re.match(
-            r"^task_[A-Za-z0-9_:-]+\.[A-Za-z][A-Za-z0-9_.-]*$",
-            ref,
-        ):
-            return f"{field_name}[{index}].ref must look like task_id.artifact_key"
-
-    return None
+    return validate_registry_value(
+        field_name,
+        cast(JsonValue, value),
+        registry={
+            field_name: {
+                "type": "artifact_ref_list",
+                "validators": {},
+                "options": [],
+            }
+        },
+        allowed_tool_ids=set(),
+    )
 
 
 def _run_safety_input_precheck(session: TaskIntakeSession) -> TaskIntakeSafetyCheck:
     fields = {name: field.value for name, field in session.draft.fields.items()}
     input_summary = _build_safety_input_summary(session, fields)
-    risk_flags: list[TaskIntakeSafetyRisk] = []
-    safety_text = _safety_search_text(fields, session.raw_input)
 
-    if any(term in safety_text for term in ("weapon", "bioweapon", "病原增强")):
-        risk_flags.append(
-            TaskIntakeSafetyRisk(
-                level="block",
-                code="SAFETY_INPUT_BLOCK",
-                message="input appears to request a blocked unsafe biological use",
-                details={"terms": ["weapon", "bioweapon", "病原增强"]},
-            )
+    def make_risk(
+        level: Literal["warn", "block"],
+        code: str,
+        message: str,
+        details: JsonObject,
+    ) -> TaskIntakeSafetyRisk:
+        return TaskIntakeSafetyRisk(
+            level=level,
+            code=code,
+            message=message,
+            details=details,
         )
 
-    sequence = fields.get("sequence")
-    forbidden_motifs = fields.get("forbidden_motifs")
-    if isinstance(sequence, str) and isinstance(forbidden_motifs, list):
-        normalized_sequence = sequence.upper()
-        for motif in forbidden_motifs:
-            if isinstance(motif, str) and motif.upper() in normalized_sequence:
-                risk_flags.append(
-                    TaskIntakeSafetyRisk(
-                        level="warn",
-                        code="FORBIDDEN_MOTIF_PRESENT",
-                        message=(
-                            "forbidden_motifs contains motif present in sequence: "
-                            f"{motif}"
-                        ),
-                        details={"motif": motif},
-                    )
-                )
-
-    for forbidden_function in _coerce_string_list(fields.get("forbidden_functions")):
-        if _text_mentions_forbidden_function(
-            fields, session.raw_input, forbidden_function
-        ):
-            risk_flags.append(
-                TaskIntakeSafetyRisk(
-                    level="block",
-                    code="FORBIDDEN_FUNCTION_REQUESTED",
-                    message=(
-                        "input requests a function listed in forbidden_functions: "
-                        f"{forbidden_function}"
-                    ),
-                    details={"forbidden_function": forbidden_function},
-                )
-            )
-
-    if _mentions_high_risk_intent(fields, session.raw_input):
-        risk_flags.append(
-            TaskIntakeSafetyRisk(
-                level="block",
-                code="HIGH_RISK_BIOFUNCTION_REQUEST",
-                message="input appears to request a high-risk biological function",
-                details={"keywords": list(_HIGH_RISK_FUNCTION_KEYWORDS)},
-            )
-        )
-
-    if fields.get("safety_level") == "S2" or any(
-        term in safety_text for term in ("pathogenic", "毒性", "病原")
-    ):
-        risk_flags.append(
-            TaskIntakeSafetyRisk(
-                level="warn",
-                code="SAFETY_INPUT_WARN",
-                message="input may need additional safety review before task creation",
-                details={"safety_level": fields.get("safety_level")},
-            )
-        )
-
-    action: Literal["ok", "warn", "block"] = "ok"
-    if any(risk.level == "block" for risk in risk_flags):
-        action = "block"
-    elif any(risk.level == "warn" for risk in risk_flags):
-        action = "warn"
+    risk_flags = build_safety_risk_flags(
+        fields=fields,
+        raw_input=session.raw_input,
+        forbidden_keywords=_HIGH_RISK_FUNCTION_KEYWORDS,
+        make_risk=make_risk,
+    )
     return TaskIntakeSafetyCheck(
-        action=action,
+        action=resolve_precheck_action([risk.level for risk in risk_flags]),
         risk_flags=risk_flags,
         input_summary=input_summary,
     )
@@ -2297,46 +1887,9 @@ def _artifact_refs_from_value(value: JsonValue) -> list[JsonObject]:
 
 
 def _coerce_string_list(value: JsonValue) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str) and item.strip()]
+    return coerce_string_list(value)
 
 
-def _text_mentions_forbidden_function(
-    fields: JsonObject,
-    raw_input: JsonObject,
-    forbidden_function: str,
-) -> bool:
-    target = forbidden_function.strip().lower()
-    if not target:
-        return False
-    return target in _safety_search_text(fields, raw_input)
-
-
-def _mentions_high_risk_intent(
-    fields: JsonObject,
-    raw_input: JsonObject,
-) -> bool:
-    haystack = _safety_search_text(fields, raw_input)
-    return any(keyword in haystack for keyword in _HIGH_RISK_FUNCTION_KEYWORDS)
-
-
-def _safety_search_text(fields: JsonObject, raw_input: JsonObject) -> str:
-    pieces: list[str] = []
-    raw_text = raw_input.get("text")
-    if isinstance(raw_text, str):
-        pieces.append(raw_text)
-    for name in (
-        "goal_summary",
-        "objective_description",
-        "motif_pattern",
-        "binding_partner",
-        "target_ligand",
-    ):
-        value = fields.get(name)
-        if isinstance(value, str):
-            pieces.append(value)
-    return "\n".join(pieces).lower()
 
 
 def _build_human_summary(session: TaskIntakeSession) -> str:

--- a/src/models/task_intake_payload.py
+++ b/src/models/task_intake_payload.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Set as AbstractSet
+from typing import cast
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | JsonObject | JsonArray
+type JsonObject = dict[str, JsonValue]
+type JsonArray = list[JsonValue]
+
+
+def build_rule_extraction_payload(
+    text: str,
+    *,
+    allowed_tool_ids: AbstractSet[str],
+    source_value: str,
+) -> JsonObject:
+    """根据自然语言规则抽取 task intake draft payload。"""
+
+    builder = _RuleExtractionBuilder(
+        text=text,
+        allowed_tool_ids=allowed_tool_ids,
+        source_value=source_value,
+    )
+    builder.add_task_kind()
+    builder.add_objective_type()
+    builder.add_length_range()
+    builder.add_design_count()
+    builder.add_run_profile()
+    builder.add_safety_level()
+    builder.add_plan_confirmation()
+    builder.add_tool_preferences()
+    builder.add_goal_summary()
+    return builder.payload()
+
+
+class _RuleExtractionBuilder:
+    def __init__(
+        self,
+        *,
+        text: str,
+        allowed_tool_ids: AbstractSet[str],
+        source_value: str,
+    ) -> None:
+        self.text: str = text
+        self.lowered: str = text.lower()
+        self.allowed_tool_ids: AbstractSet[str] = allowed_tool_ids
+        self.source_value: str = source_value
+        self.fields: JsonObject = {}
+        self.source_spans: list[str] = []
+
+    @property
+    def design_intent(self) -> bool:
+        return any(
+            marker in self.lowered
+            for marker in ("design", "de novo", "de-novo", "generate", "protein")
+        ) or any(marker in self.text for marker in ("设计", "生成", "蛋白", "从头"))
+
+    def add_field(
+        self,
+        field_name: str,
+        value: JsonValue,
+        confidence: float,
+        source_span: str | None = None,
+    ) -> None:
+        self.fields[field_name] = {
+            "value": value,
+            "source": self.source_value,
+            "confidence": confidence,
+            "source_span": source_span,
+        }
+        if source_span:
+            self.source_spans.append(source_span)
+
+    def add_task_kind(self) -> None:
+        if "de novo" in self.lowered or "de-novo" in self.lowered or "从头" in self.text:
+            self.add_field("task_kind", "de_novo_design", 0.86, "de novo")
+        elif "评估" in self.text or "evaluate" in self.lowered:
+            self.add_field(
+                "task_kind",
+                "sequence_evaluation",
+                0.84,
+                _first_present_span(self.text, ["评估", "evaluate"]),
+            )
+        elif "template" in self.lowered or "模板" in self.text:
+            self.add_field(
+                "task_kind",
+                "template_constrained_design",
+                0.84,
+                _first_present_span(self.text, ["模板", "template"]),
+            )
+        elif self.design_intent:
+            self.add_field(
+                "task_kind",
+                "de_novo_design",
+                0.80,
+                _first_present_span(self.text, ["设计", "design", "生成", "protein"]),
+            )
+
+    def add_objective_type(self) -> None:
+        if "稳定" in self.text or "stability" in self.lowered or "stable" in self.lowered:
+            self.add_field(
+                "objective_type",
+                "stability",
+                0.88,
+                _first_present_span(self.text, ["稳定", "stability", "stable"]),
+            )
+        elif "binding" in self.lowered or "结合" in self.text:
+            self.add_field(
+                "objective_type",
+                "binding",
+                0.72,
+                _first_present_span(self.text, ["binding", "结合"]),
+            )
+        elif "结构" in self.text or "structure" in self.lowered:
+            self.add_field(
+                "objective_type",
+                "structure",
+                0.78,
+                _first_present_span(self.text, ["结构", "structure"]),
+            )
+        elif "活性" in self.text or "activity" in self.lowered:
+            self.add_field(
+                "objective_type",
+                "activity",
+                0.76,
+                _first_present_span(self.text, ["活性", "activity"]),
+            )
+
+    def add_length_range(self) -> None:
+        range_match = re.search(r"(\d{2,4})\s*(?:-|~|到|至)\s*(\d{2,4})", self.text)
+        if range_match:
+            self.add_field(
+                "length_range",
+                [int(range_match.group(1)), int(range_match.group(2))],
+                0.92,
+                range_match.group(0),
+            )
+            return
+
+        approx_match = re.search(
+            r"(?:约|大约|around|about)?\s*(\d{2,4})\s*(?:个)?\s*(?:aa|氨基酸)",
+            self.text,
+            re.IGNORECASE,
+        )
+        if approx_match:
+            center = int(approx_match.group(1))
+            self.add_field(
+                "length_range",
+                [max(1, center - 20), center + 20],
+                0.91,
+                approx_match.group(0),
+            )
+
+    def add_design_count(self) -> None:
+        count_match = re.search(
+            r"(\d{1,2})\s*(?:个)?(?:候选|candidate)",
+            self.text,
+            re.IGNORECASE,
+        )
+        if count_match:
+            self.add_field("design_count", int(count_match.group(1)), 0.84, count_match.group(0))
+
+    def add_run_profile(self) -> None:
+        if "快" in self.text or "fast" in self.lowered:
+            self.add_field("run_profile", "fast_smoke", 0.82, _first_present_span(self.text, ["快", "fast"]))
+        elif "balanced" in self.lowered or "均衡" in self.text:
+            self.add_field("run_profile", "balanced", 0.86, _first_present_span(self.text, ["均衡", "balanced"]))
+        elif (
+            "high accuracy" in self.lowered
+            or "high-accuracy" in self.lowered
+            or "thorough" in self.lowered
+            or "高精度" in self.text
+            or "全面" in self.text
+        ):
+            self.add_field(
+                "run_profile",
+                "high_accuracy",
+                0.86,
+                _first_present_span(self.text, ["高精度", "全面", "high accuracy", "thorough"]),
+            )
+
+    def add_safety_level(self) -> None:
+        safety_match = re.search(r"\bS[0-2]\b", self.text, re.IGNORECASE)
+        if safety_match:
+            self.add_field("safety_level", safety_match.group(0).upper(), 0.9, safety_match.group(0))
+        elif "低风险" in self.text or "low risk" in self.lowered:
+            self.add_field("safety_level", "S1", 0.70, _first_present_span(self.text, ["低风险", "low risk"]))
+        elif "安全" in self.text or "safe" in self.lowered:
+            self.add_field("safety_level", "S1", 0.68, _first_present_span(self.text, ["安全", "safe"]))
+
+    def add_plan_confirmation(self) -> None:
+        if "无需确认计划" in self.text or "no plan confirmation" in self.lowered:
+            self.add_field(
+                "require_plan_confirm",
+                False,
+                0.92,
+                _first_present_span(self.text, ["无需确认计划", "no plan confirmation"]),
+            )
+        elif "确认计划" in self.text or "confirm plan" in self.lowered:
+            self.add_field(
+                "require_plan_confirm",
+                True,
+                0.95,
+                _first_present_span(self.text, ["确认计划", "confirm plan"]),
+            )
+
+    def add_tool_preferences(self) -> None:
+        tool_preferences = _extract_tool_preferences(
+            self.text,
+            allowed_tool_ids=self.allowed_tool_ids,
+        )
+        if tool_preferences:
+            self.add_field("tools_allowed", cast(JsonValue, tool_preferences), 0.76, ", ".join(tool_preferences))
+
+    def add_goal_summary(self) -> None:
+        if self.fields and self.design_intent and "goal_summary" not in self.fields:
+            self.add_field("goal_summary", _goal_summary_from_text(self.text), 0.84, self.text.strip())
+
+    def payload(self) -> JsonObject:
+        return cast(
+            JsonObject,
+            {
+                "fields": self.fields,
+                "unmapped_text": [],
+                "source_spans": cast(JsonValue, self.source_spans),
+                "mode": "rule_extract",
+            },
+        )
+
+
+def _first_present_span(text: str, needles: list[str]) -> str | None:
+    lowered = text.lower()
+    for needle in needles:
+        if not needle:
+            continue
+        if needle in text or needle.lower() in lowered:
+            return needle
+    return None
+
+
+def _goal_summary_from_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip())[:2000]
+
+
+def _extract_tool_preferences(
+    text: str,
+    *,
+    allowed_tool_ids: AbstractSet[str],
+) -> list[str]:
+    lowered = text.lower()
+    has_tool_cue = any(
+        marker in lowered for marker in ("use", "prefer", "allowed", "tool")
+    ) or any(marker in text for marker in ("使用", "优先", "允许", "工具"))
+    if not has_tool_cue:
+        return []
+    return sorted(tool_id for tool_id in allowed_tool_ids if tool_id.lower() in lowered)

--- a/src/models/task_intake_precheck.py
+++ b/src/models/task_intake_precheck.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Literal, TypeVar, cast
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | JsonObject | JsonArray
+type JsonObject = dict[str, JsonValue]
+type JsonArray = list[JsonValue]
+
+RiskT = TypeVar("RiskT")
+RiskFactory = Callable[
+    [Literal["warn", "block"], str, str, JsonObject],
+    RiskT,
+]
+
+
+def build_safety_risk_flags(
+    *,
+    fields: JsonObject,
+    raw_input: JsonObject,
+    forbidden_keywords: Sequence[str],
+    make_risk: RiskFactory[RiskT],
+) -> list[RiskT]:
+    """根据 intake 字段与原始输入生成安全预检风险标记。"""
+
+    risk_flags: list[RiskT] = []
+    safety_text = safety_search_text(fields, raw_input)
+    _append_blocked_use_risk(risk_flags, safety_text=safety_text, make_risk=make_risk)
+    _append_forbidden_motif_risks(risk_flags, fields=fields, make_risk=make_risk)
+    _append_forbidden_function_risks(
+        risk_flags,
+        fields=fields,
+        raw_input=raw_input,
+        make_risk=make_risk,
+    )
+    _append_high_risk_intent(
+        risk_flags,
+        fields=fields,
+        raw_input=raw_input,
+        forbidden_keywords=forbidden_keywords,
+        make_risk=make_risk,
+    )
+    _append_safety_level_warning(
+        risk_flags,
+        fields=fields,
+        safety_text=safety_text,
+        make_risk=make_risk,
+    )
+    return risk_flags
+
+
+def resolve_precheck_action(
+    risk_levels: Sequence[str],
+) -> Literal["ok", "warn", "block"]:
+    """将风险等级集合折叠为 TaskIntakeSafetyCheck.action。"""
+
+    if any(level == "block" for level in risk_levels):
+        return "block"
+    if any(level == "warn" for level in risk_levels):
+        return "warn"
+    return "ok"
+
+
+def coerce_string_list(value: JsonValue) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def text_mentions_forbidden_function(
+    fields: JsonObject,
+    raw_input: JsonObject,
+    forbidden_function: str,
+) -> bool:
+    target = forbidden_function.strip().lower()
+    if not target:
+        return False
+    return target in safety_search_text(fields, raw_input)
+
+
+def mentions_high_risk_intent(
+    fields: JsonObject,
+    raw_input: JsonObject,
+    *,
+    forbidden_keywords: Sequence[str],
+) -> bool:
+    haystack = safety_search_text(fields, raw_input)
+    return any(keyword in haystack for keyword in forbidden_keywords)
+
+
+def safety_search_text(fields: JsonObject, raw_input: JsonObject) -> str:
+    pieces: list[str] = []
+    raw_text = raw_input.get("text")
+    if isinstance(raw_text, str):
+        pieces.append(raw_text)
+    for name in (
+        "goal_summary",
+        "objective_description",
+        "motif_pattern",
+        "binding_partner",
+        "target_ligand",
+    ):
+        value = fields.get(name)
+        if isinstance(value, str):
+            pieces.append(value)
+    return "\n".join(pieces).lower()
+
+
+def _append_blocked_use_risk(
+    risk_flags: list[RiskT],
+    *,
+    safety_text: str,
+    make_risk: RiskFactory[RiskT],
+) -> None:
+    blocked_terms = ("weapon", "bioweapon", "病原增强")
+    if any(term in safety_text for term in blocked_terms):
+        risk_flags.append(
+            make_risk(
+                "block",
+                "SAFETY_INPUT_BLOCK",
+                "input appears to request a blocked unsafe biological use",
+                {"terms": cast(JsonValue, list(blocked_terms))},
+            )
+        )
+
+
+def _append_forbidden_motif_risks(
+    risk_flags: list[RiskT],
+    *,
+    fields: JsonObject,
+    make_risk: RiskFactory[RiskT],
+) -> None:
+    sequence = fields.get("sequence")
+    forbidden_motifs = fields.get("forbidden_motifs")
+    if not isinstance(sequence, str) or not isinstance(forbidden_motifs, list):
+        return
+    normalized_sequence = sequence.upper()
+    for motif in forbidden_motifs:
+        if isinstance(motif, str) and motif.upper() in normalized_sequence:
+            risk_flags.append(
+                make_risk(
+                    "warn",
+                    "FORBIDDEN_MOTIF_PRESENT",
+                    f"forbidden_motifs contains motif present in sequence: {motif}",
+                    {"motif": motif},
+                )
+            )
+
+
+def _append_forbidden_function_risks(
+    risk_flags: list[RiskT],
+    *,
+    fields: JsonObject,
+    raw_input: JsonObject,
+    make_risk: RiskFactory[RiskT],
+) -> None:
+    for forbidden_function in coerce_string_list(fields.get("forbidden_functions")):
+        if text_mentions_forbidden_function(fields, raw_input, forbidden_function):
+            message = (
+                "input requests a function listed in forbidden_functions: "
+                f"{forbidden_function}"
+            )
+            risk_flags.append(
+                make_risk(
+                    "block",
+                    "FORBIDDEN_FUNCTION_REQUESTED",
+                    message,
+                    {"forbidden_function": forbidden_function},
+                )
+            )
+
+
+def _append_high_risk_intent(
+    risk_flags: list[RiskT],
+    *,
+    fields: JsonObject,
+    raw_input: JsonObject,
+    forbidden_keywords: Sequence[str],
+    make_risk: RiskFactory[RiskT],
+) -> None:
+    if mentions_high_risk_intent(
+        fields,
+        raw_input,
+        forbidden_keywords=forbidden_keywords,
+    ):
+        risk_flags.append(
+            make_risk(
+                "block",
+                "HIGH_RISK_BIOFUNCTION_REQUEST",
+                "input appears to request a high-risk biological function",
+                {"keywords": cast(JsonValue, list(forbidden_keywords))},
+            )
+        )
+
+
+def _append_safety_level_warning(
+    risk_flags: list[RiskT],
+    *,
+    fields: JsonObject,
+    safety_text: str,
+    make_risk: RiskFactory[RiskT],
+) -> None:
+    if fields.get("safety_level") == "S2" or any(
+        term in safety_text for term in ("pathogenic", "毒性", "病原")
+    ):
+        risk_flags.append(
+            make_risk(
+                "warn",
+                "SAFETY_INPUT_WARN",
+                "input may need additional safety review before task creation",
+                {"safety_level": fields.get("safety_level")},
+            )
+        )

--- a/src/models/task_intake_validator.py
+++ b/src/models/task_intake_validator.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Set as AbstractSet
+
+type JsonScalar = str | int | float | bool | None
+type JsonValue = JsonScalar | JsonObject | JsonArray
+type JsonObject = dict[str, JsonValue]
+type JsonArray = list[JsonValue]
+type RegistryFieldView = Mapping[str, object]
+
+
+def validate_registry_value(
+    field_name: str,
+    value: JsonValue,
+    *,
+    registry: Mapping[str, RegistryFieldView],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    """校验 intake registry 字段值，保持原字段语义和错误信息。"""
+
+    field = registry.get(field_name)
+    if field is None:
+        return f"unknown intake field: {field_name}"
+
+    field_type = str(field["type"])
+    validators = _validators(field)
+    options = _options(field)
+    return _VALIDATORS.get(field_type, _validate_passthrough)(
+        field_name,
+        value,
+        validators=validators,
+        options=options,
+        allowed_tool_ids=allowed_tool_ids,
+    )
+
+
+def _validate_passthrough(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (field_name, value, validators, options, allowed_tool_ids)
+    return None
+
+
+def _validate_enum(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (validators, allowed_tool_ids)
+    if value not in set(options):
+        return f"{field_name} must be one of {options}"
+    return None
+
+
+def _validate_string(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (options, allowed_tool_ids)
+    if not isinstance(value, str) or not value.strip():
+        return f"{field_name} must be a non-empty string"
+    min_length = int(_numeric_validator_value(validators, "min_length", 0))
+    max_length = int(_numeric_validator_value(validators, "max_length", len(value)))
+    if len(value) < min_length:
+        return f"{field_name} is shorter than allowed"
+    if len(value) > max_length:
+        return f"{field_name} is longer than allowed"
+    return None
+
+
+def _validate_boolean(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (validators, options, allowed_tool_ids)
+    if not isinstance(value, bool):
+        return f"{field_name} must be a boolean"
+    return None
+
+
+def _validate_integer(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (options, allowed_tool_ids)
+    if not isinstance(value, int) or isinstance(value, bool):
+        return f"{field_name} must be an integer"
+    minimum = int(_numeric_validator_value(validators, "min", value))
+    maximum = int(_numeric_validator_value(validators, "max", value))
+    if value < minimum or value > maximum:
+        return f"{field_name} is outside allowed range"
+    return None
+
+
+def _validate_number(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (options, allowed_tool_ids)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return f"{field_name} must be a number"
+    minimum = _numeric_validator_value(validators, "min", value)
+    maximum = _numeric_validator_value(validators, "max", value)
+    if value < minimum or value > maximum:
+        return f"{field_name} is outside allowed range"
+    return None
+
+
+def _validate_object(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (options, allowed_tool_ids)
+    if not isinstance(value, dict):
+        return f"{field_name} must be an object"
+    allowed_keys = validators.get("allowed_keys")
+    if isinstance(allowed_keys, list):
+        allowed = {item for item in allowed_keys if isinstance(item, str)}
+        unknown = sorted(str(key) for key in value if str(key) not in allowed)
+        if unknown:
+            return f"{field_name} contains unknown keys: {', '.join(unknown)}"
+    for item in value.values():
+        if not isinstance(item, (int, float)) or isinstance(item, bool) or item < 0:
+            return f"{field_name} values must be non-negative numbers"
+    return None
+
+
+def _validate_integer_range(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (options, allowed_tool_ids)
+    minimum = int(_numeric_validator_value(validators, "min", 0))
+    maximum = int(_numeric_validator_value(validators, "max", 0))
+    if (
+        not isinstance(value, list)
+        or len(value) != 2
+        or not all(isinstance(item, int) and not isinstance(item, bool) for item in value)
+    ):
+        return f"{field_name} must be [min, max] integers"
+    lower = value[0]
+    upper = value[1]
+    if not isinstance(lower, int) or not isinstance(upper, int):
+        return f"{field_name} must be [min, max] integers"
+    if lower > upper or lower < minimum or upper > maximum:
+        return f"{field_name} must be [min, max] integers"
+    return None
+
+
+def _validate_protein_sequence(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (options, allowed_tool_ids)
+    if not isinstance(value, str) or not value.strip():
+        return f"{field_name} must be a non-empty sequence"
+    alphabet = set(_string_validator_value(validators, "alphabet", ""))
+    invalid = set(value.upper()) - alphabet
+    if invalid:
+        return f"{field_name} contains invalid residues: {''.join(sorted(invalid))}"
+    return None
+
+
+def _validate_string_list(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (validators, options, allowed_tool_ids)
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        return f"{field_name} must be a list of strings"
+    return None
+
+
+def _validate_tool_id_list(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (validators, options)
+    base_error = _validate_string_list(
+        field_name,
+        value,
+        validators={},
+        options=[],
+        allowed_tool_ids=allowed_tool_ids,
+    )
+    if base_error is not None:
+        return base_error
+    if not isinstance(value, list):
+        return f"{field_name} must be a list of strings"
+    values = {item for item in value if isinstance(item, str)}
+    invalid_tool_ids = sorted(values - set(allowed_tool_ids))
+    if invalid_tool_ids:
+        return f"{field_name} contains unknown tool_id(s): {', '.join(invalid_tool_ids)}"
+    return None
+
+
+def _validate_residue_list(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (validators, options, allowed_tool_ids)
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and re.match(r"^[A-Z][0-9]+$", item) for item in value
+    ):
+        return f"{field_name} must be residue ids like A42"
+    return None
+
+
+def _validate_artifact_ref_list(
+    field_name: str,
+    value: JsonValue,
+    *,
+    validators: JsonObject,
+    options: list[str],
+    allowed_tool_ids: AbstractSet[str],
+) -> str | None:
+    _ = (validators, options, allowed_tool_ids)
+    if not isinstance(value, list):
+        return f"{field_name} must be a list of artifact refs"
+    for index, raw_artifact in enumerate(value):
+        if not isinstance(raw_artifact, dict):
+            return f"{field_name}[{index}] must be an object"
+        error = _validate_single_artifact_ref(field_name, index, raw_artifact)
+        if error is not None:
+            return error
+    return None
+
+
+def _validate_single_artifact_ref(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    for validator in (
+        _validate_artifact_kind,
+        _validate_artifact_reference_presence,
+        _validate_artifact_id,
+        _validate_artifact_uri,
+        _validate_artifact_path,
+        _validate_artifact_task_ref,
+    ):
+        error = validator(field_name, index, artifact)
+        if error is not None:
+            return error
+    return None
+
+
+def _validate_artifact_kind(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    kind = artifact.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        return f"{field_name}[{index}].kind must be a non-empty string"
+    return None
+
+
+def _validate_artifact_reference_presence(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    ref_values = [
+        artifact.get("artifact_id"),
+        artifact.get("uri"),
+        artifact.get("path"),
+        artifact.get("ref"),
+    ]
+    if not any(isinstance(item, str) and item.strip() for item in ref_values):
+        return f"{field_name}[{index}] must include artifact_id, uri, path, or ref"
+    return None
+
+
+def _validate_artifact_id(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    artifact_id = artifact.get("artifact_id")
+    if isinstance(artifact_id, str) and not re.match(r"^[A-Za-z0-9_.:-]+$", artifact_id):
+        return f"{field_name}[{index}].artifact_id is invalid"
+    return None
+
+
+def _validate_artifact_uri(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    uri = artifact.get("uri")
+    if isinstance(uri, str) and not (
+        uri.startswith("artifact://") or uri.startswith("task://")
+    ):
+        return f"{field_name}[{index}].uri must use artifact:// or task://"
+    return None
+
+
+def _validate_artifact_path(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    path = artifact.get("path")
+    if isinstance(path, str) and (
+        path.startswith("/") or path.startswith("~") or ".." in path.split("/") or not path.strip()
+    ):
+        return f"{field_name}[{index}].path must be a safe relative path"
+    return None
+
+
+def _validate_artifact_task_ref(
+    field_name: str,
+    index: int,
+    artifact: JsonObject,
+) -> str | None:
+    ref = artifact.get("ref")
+    if isinstance(ref, str) and not re.match(
+        r"^task_[A-Za-z0-9_:-]+\.[A-Za-z][A-Za-z0-9_.-]*$",
+        ref,
+    ):
+        return f"{field_name}[{index}].ref must look like task_id.artifact_key"
+    return None
+
+
+def _validators(field: RegistryFieldView) -> JsonObject:
+    validators = field.get("validators")
+    return validators if isinstance(validators, dict) else {}
+
+
+def _options(field: RegistryFieldView) -> list[str]:
+    options = field.get("options")
+    if not isinstance(options, list):
+        return []
+    return [item for item in options if isinstance(item, str)]
+
+
+def _numeric_validator_value(
+    validators: JsonObject,
+    key: str,
+    default: int | float,
+) -> int | float:
+    value = validators.get(key)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return default
+
+
+def _string_validator_value(
+    validators: JsonObject,
+    key: str,
+    default: str,
+) -> str:
+    value = validators.get(key)
+    if isinstance(value, str):
+        return value
+    return default
+
+
+_VALIDATORS = {
+    "enum": _validate_enum,
+    "string": _validate_string,
+    "boolean": _validate_boolean,
+    "integer": _validate_integer,
+    "number": _validate_number,
+    "object": _validate_object,
+    "integer_range": _validate_integer_range,
+    "protein_sequence": _validate_protein_sequence,
+    "string_list": _validate_string_list,
+    "tool_id_list": _validate_tool_id_list,
+    "residue_list": _validate_residue_list,
+    "artifact_ref_list": _validate_artifact_ref_list,
+}


### PR DESCRIPTION
## 背景

完成 #373：对 Phase 2 后端核心模块进行职责拆分，重点覆盖 planner、task_intake 和 summarizer。目标是在不改变公开接口的前提下，降低单文件职责集中度，并让调用方继续通过原有 facade 使用能力。

## 变更内容

- 将 planner 的候选约束、投影归一化、路由触发判断、de novo 判断拆分到独立模块。
- 将 task_intake 的规则抽取 payload、字段校验、安全预检查拆分到独立模块。
- 将 summarizer 的 de novo Markdown 分节渲染拆分到独立模块。
- 保留原有公开入口和契约，避免影响既有调用方。

## 验证

- `uv run pytest tests/unit/ -k "planner or task_intake or summarizer" -q`
- `uv run basedpyright --level error src/models/task_intake.py src/models/task_intake_payload.py src/models/task_intake_precheck.py src/models/task_intake_validator.py src/agents/summarizer.py src/agents/summarizer_sections.py src/agents/planner_payloads.py src/agents/planner_projection.py src/agents/planner_selection.py src/agents/planner_denovo.py`
- `git diff --check`

说明：issue 要求的 `src/agents/planner*.py` wildcard 检查仍会覆盖 `planner.py` 的既有历史类型债；本次拆分没有扩大该问题，并减少了相关错误数量。
